### PR TITLE
Add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Keep GitHub Actions versions current. The repo's lint workflow uses
+  # actions/checkout and actions/setup-python; when a new major version
+  # ships, Dependabot opens a PR with release notes attached.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Denver"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
Adds `.github/dependabot.yml` for weekly GitHub Actions version updates.

Configuration: weekly cadence (Mondays 09:00 America/Denver), max 5 open PRs, `ci` commit prefix, labels for filtering.

This PR also exercises the newly created `main protection` ruleset. Do not merge until the user has verified:
- Only "Squash and merge" button is visible
- Required status check appears (Validate catalog structure) — assuming it was added during ruleset setup; if not yet, check is not required
- Status check runs and passes (lint script touches skills/, no changes there)
- Branch deletes cleanly after merge

Once verified, squash-merge with the commit message in the original commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)