### PR TITLE
feat(creative-direction): add showcase deep-links to SKILL.md and references

### DIFF
--- a/skills/creative-direction/SKILL.md
+++ b/skills/creative-direction/SKILL.md
@@ -11,6 +11,10 @@ This skill turns vague creative intent into a structured brief that downstream s
 
 ---
 
+> **See it in action.** The [creative-direction showcase](https://rampstack.co/showcase/creative-direction#examples) demonstrates this framework applied across thirty fictional brands. Each axis position below links to the showcase pre-filtered to examples matching that position, so you can see what the abstract axis labels look like as real brand executions.
+
+---
+
 ## When to use
 
 - The start of a multi-touchpoint project (website, brand, campaign, product launch) where aesthetic coherence matters
@@ -52,10 +56,10 @@ How formal is the work? How much heat does the language carry?
 
 **Positions:**
 
-- **Professional.** Measured, precise, low-register. Trusts the reader to do work. Restraint is the signal.
-- **Conversational.** Warmer, more personal, comfortable with first-person and contractions. Reads like a thoughtful person talking.
-- **Playful.** Wit, surprise, willingness to break form for effect. Risks the reader missing the point if not earned.
-- **Provocative.** Pointed, opinionated, willing to take a position other brands will not. Risks alienating people who do not share the position.
+- **[Professional](https://rampstack.co/showcase/creative-direction?tone=professional#examples).** Measured, precise, low-register. Trusts the reader to do work. Restraint is the signal.
+- **[Conversational](https://rampstack.co/showcase/creative-direction?tone=conversational#examples).** Warmer, more personal, comfortable with first-person and contractions. Reads like a thoughtful person talking.
+- **[Playful](https://rampstack.co/showcase/creative-direction?tone=playful#examples).** Wit, surprise, willingness to break form for effect. Risks the reader missing the point if not earned.
+- **[Provocative](https://rampstack.co/showcase/creative-direction?tone=provocative#examples).** Pointed, opinionated, willing to take a position other brands will not. Risks alienating people who do not share the position.
 
 **How to choose:** What does the audience already get too much of, and what too little? If the category is dry, conversational or playful is differentiation. If the category is loud, professional restraint is differentiation.
 
@@ -65,10 +69,10 @@ How much visual density does the work carry? How much does each element earn its
 
 **Positions:**
 
-- **Editorial Restrained.** Generous white space, single definitive image instead of grids, considered typography, low color count. Signals confidence and patience.
-- **Polished Standard.** Modern SaaS aesthetic. Clean grids, balanced contrast, expected proportions. Signals competence and professionalism.
-- **Controlled Maximalist.** High visual density where every element is intentional. Loud but engineered. Signals craft and conviction.
-- **Expressive Maximalist.** Visual abundance, willingness to be loud, willing to clash. Signals energy and ambition. Hardest to execute well.
+- **[Editorial Restrained](https://rampstack.co/showcase/creative-direction?aesthetic=editorial-restrained#examples).** Generous white space, single definitive image instead of grids, considered typography, low color count. Signals confidence and patience.
+- **[Polished Standard](https://rampstack.co/showcase/creative-direction?aesthetic=polished-standard#examples).** Modern SaaS aesthetic. Clean grids, balanced contrast, expected proportions. Signals competence and professionalism.
+- **[Controlled Maximalist](https://rampstack.co/showcase/creative-direction?aesthetic=controlled-maximalist#examples).** High visual density where every element is intentional. Loud but engineered. Signals craft and conviction.
+- **[Expressive Maximalist](https://rampstack.co/showcase/creative-direction?aesthetic=expressive-maximalist#examples).** Visual abundance, willingness to be loud, willing to clash. Signals energy and ambition. Hardest to execute well.
 
 **How to choose:** What is the project saying about the brand's relationship to attention? Restrained earns attention by deserving it. Maximalist captures attention by not letting it leave.
 
@@ -78,10 +82,10 @@ How does the brand position itself relative to the reader?
 
 **Positions:**
 
-- **Authority.** We tell you what is true. Implicit hierarchy, expertise on display, reader is the learner.
-- **Peer.** We are figuring this out together. Equal footing, shared vocabulary, reader is the co-thinker.
-- **Companion.** We walk with you. Lower hierarchy than authority, more presence than peer, reader is the protagonist of their own work.
-- **Coach.** We challenge you. The brand pushes the reader toward something they would not push themselves toward alone, reader is the trainee.
+- **[Authority](https://rampstack.co/showcase/creative-direction?relationship=authority#examples).** We tell you what is true. Implicit hierarchy, expertise on display, reader is the learner.
+- **[Peer](https://rampstack.co/showcase/creative-direction?relationship=peer#examples).** We are figuring this out together. Equal footing, shared vocabulary, reader is the co-thinker.
+- **[Companion](https://rampstack.co/showcase/creative-direction?relationship=companion#examples).** We walk with you. Lower hierarchy than authority, more presence than peer, reader is the protagonist of their own work.
+- **[Coach](https://rampstack.co/showcase/creative-direction?relationship=coach#examples).** We challenge you. The brand pushes the reader toward something they would not push themselves toward alone, reader is the trainee.
 
 **How to choose:** What does the audience need most? Audiences who feel lost want authority or coach. Audiences who feel patronized want peer or companion. The wrong choice patronizes or abandons the reader.
 
@@ -91,9 +95,9 @@ How much is the work asking of the reader emotionally?
 
 **Positions:**
 
-- **Functional.** Get a job done. Reader gets in, gets the answer, gets out. Aesthetics serve clarity. Most utility tools live here.
-- **Considered.** Reader notices the craft. Aesthetic choices are visible without being the point. Most premium brands live here.
-- **Resonant.** Reader feels something specific the brand architected. Aesthetics carry meaning. Hardest to produce. Most editorial and narrative brands aspire here.
+- **[Functional](https://rampstack.co/showcase/creative-direction?sensory=functional#examples).** Get a job done. Reader gets in, gets the answer, gets out. Aesthetics serve clarity. Most utility tools live here.
+- **[Considered](https://rampstack.co/showcase/creative-direction?sensory=considered#examples).** Reader notices the craft. Aesthetic choices are visible without being the point. Most premium brands live here.
+- **[Resonant](https://rampstack.co/showcase/creative-direction?sensory=resonant#examples).** Reader feels something specific the brand architected. Aesthetics carry meaning. Hardest to produce. Most editorial and narrative brands aspire here.
 
 **How to choose:** What does the audience deserve from this experience? Functional respects time. Resonant respects feeling. The wrong choice either wastes attention or fails to deliver utility.
 

--- a/skills/creative-direction/references/axes-explained.md
+++ b/skills/creative-direction/references/axes-explained.md
@@ -2,6 +2,8 @@
 
 Each axis is a spectrum. Pick a position knowing it excludes adjacent positions for this project. Reference brands are illustrative, not prescriptive.
 
+> **See the framework rendered as real brands.** The [creative-direction showcase](https://rampstack.co/showcase/creative-direction#examples) demonstrates this framework applied across thirty fictional brands. Each axis position below links to the showcase pre-filtered to examples matching that position. Most rare-but-powerful combinations have no example yet, which is the point: the framework is generative, the showcase is illustrative.
+
 ---
 
 ## Axis 1: Tone Register
@@ -9,6 +11,8 @@ Each axis is a spectrum. Pick a position knowing it excludes adjacent positions 
 How formal is the language? How much heat does it carry?
 
 ### Professional
+
+*[See examples](https://rampstack.co/showcase/creative-direction?tone=professional#examples)*
 
 Measured, precise, low-register. Trusts the reader to do the work of meaning. Restraint is the signal.
 
@@ -22,6 +26,8 @@ Measured, precise, low-register. Trusts the reader to do the work of meaning. Re
 
 ### Conversational
 
+*[See examples](https://rampstack.co/showcase/creative-direction?tone=conversational#examples)*
+
 Warmer, more personal, comfortable with first-person and contractions. Reads like a thoughtful person talking, not an institution speaking.
 
 **What this signals:** Approachability without sacrificing competence. A brand that respects the reader as a person, not a target.
@@ -34,6 +40,8 @@ Warmer, more personal, comfortable with first-person and contractions. Reads lik
 
 ### Playful
 
+*[See examples](https://rampstack.co/showcase/creative-direction?tone=playful#examples)*
+
 Wit, surprise, willingness to break form for effect. Visible craft in the language itself.
 
 **What this signals:** Confidence, creative ambition, willingness to risk being misread. The brand is having fun and inviting the reader to as well.
@@ -45,6 +53,8 @@ Wit, surprise, willingness to break form for effect. Visible craft in the langua
 **Common failure:** Forcing humor that does not earn its place. Playful only works when it is actually funny. Otherwise it reads as desperate.
 
 ### Provocative
+
+*[See examples](https://rampstack.co/showcase/creative-direction?tone=provocative#examples)*
 
 Pointed, opinionated, willing to take a position other brands will not. Says what others soften.
 
@@ -64,6 +74,8 @@ How much visual density does the work carry? How much does each element earn its
 
 ### Editorial Restrained
 
+*[See examples](https://rampstack.co/showcase/creative-direction?aesthetic=editorial-restrained#examples)*
+
 Generous white space, single definitive image instead of grids, considered typography, low color count, deliberate slowness.
 
 **What this signals:** Confidence and patience. The brand is willing to under-fill space because it trusts the reader to fill it with attention.
@@ -75,6 +87,8 @@ Generous white space, single definitive image instead of grids, considered typog
 **Common failure:** Restraint that reads as absence. Restraint earns its place when every remaining element is exquisite. Strip too much and the page reads as unfinished.
 
 ### Polished Standard
+
+*[See examples](https://rampstack.co/showcase/creative-direction?aesthetic=polished-standard#examples)*
 
 Modern SaaS aesthetic. Clean grids, balanced contrast, expected proportions, conventional component patterns.
 
@@ -88,6 +102,8 @@ Modern SaaS aesthetic. Clean grids, balanced contrast, expected proportions, con
 
 ### Controlled Maximalist
 
+*[See examples](https://rampstack.co/showcase/creative-direction?aesthetic=controlled-maximalist#examples)*
+
 High visual density where every element is intentional. Loud, but engineered. The page is full because each thing earns its place.
 
 **What this signals:** Craft and conviction. The brand has thought about every pixel and chose density on purpose.
@@ -99,6 +115,8 @@ High visual density where every element is intentional. Loud, but engineered. Th
 **Common failure:** Density without intent. Controlled Maximalist requires every element to defend its existence. Lazy density reads as cluttered, not crafted.
 
 ### Expressive Maximalist
+
+*[See examples](https://rampstack.co/showcase/creative-direction?aesthetic=expressive-maximalist#examples)*
 
 Visual abundance, willingness to be loud, willing to clash. Energy over restraint.
 
@@ -118,6 +136,8 @@ How does the brand position itself relative to the reader?
 
 ### Authority
 
+*[See examples](https://rampstack.co/showcase/creative-direction?relationship=authority#examples)*
+
 We tell you what is true. Expertise on display. Hierarchy implicit and accepted.
 
 **What this signals:** Earned expertise. The reader came here to learn from someone who knows more than they do.
@@ -129,6 +149,8 @@ We tell you what is true. Expertise on display. Hierarchy implicit and accepted.
 **Common failure:** Authority without earned credibility reads as arrogance. The brand needs to actually know more than the reader.
 
 ### Peer
+
+*[See examples](https://rampstack.co/showcase/creative-direction?relationship=peer#examples)*
 
 We are figuring this out together. Equal footing, shared vocabulary.
 
@@ -142,6 +164,8 @@ We are figuring this out together. Equal footing, shared vocabulary.
 
 ### Companion
 
+*[See examples](https://rampstack.co/showcase/creative-direction?relationship=companion#examples)*
+
 We walk with you. Lower hierarchy than authority, more presence than peer.
 
 **What this signals:** Sustained accompaniment. The brand is here for the long arc, not just the transaction.
@@ -153,6 +177,8 @@ We walk with you. Lower hierarchy than authority, more presence than peer.
 **Common failure:** Companion without substance reads as performative warmth. The brand needs to actually do something useful to earn the relationship.
 
 ### Coach
+
+*[See examples](https://rampstack.co/showcase/creative-direction?relationship=coach#examples)*
 
 We challenge you. The brand pushes the reader toward something they would not push themselves toward alone.
 
@@ -172,6 +198,8 @@ How much is the work asking of the reader emotionally?
 
 ### Functional
 
+*[See examples](https://rampstack.co/showcase/creative-direction?sensory=functional#examples)*
+
 Get a job done. Reader gets in, gets the answer, gets out. Aesthetics serve clarity, not feeling.
 
 **What this signals:** Respect for time. The brand assumes the reader has somewhere else to be.
@@ -184,6 +212,8 @@ Get a job done. Reader gets in, gets the answer, gets out. Aesthetics serve clar
 
 ### Considered
 
+*[See examples](https://rampstack.co/showcase/creative-direction?sensory=considered#examples)*
+
 Reader notices the craft. Aesthetic choices are visible without being the point.
 
 **What this signals:** Attention to detail without flexing it. The brand cares, and the reader can tell.
@@ -195,6 +225,8 @@ Reader notices the craft. Aesthetic choices are visible without being the point.
 **Common failure:** Considered work that drifts toward decorative. If the craft is visible without earning its place, it reads as fussy.
 
 ### Resonant
+
+*[See examples](https://rampstack.co/showcase/creative-direction?sensory=resonant#examples)*
 
 Reader feels something specific the brand architected. Aesthetics carry meaning. The work is asking the reader to feel.
 
@@ -214,15 +246,15 @@ Some combinations are common, some are rare-but-doable, some are contradictory.
 
 **Common combinations:**
 
-- Conversational / Polished Standard / Peer / Considered = the modern B2B SaaS default
-- Professional / Editorial Restrained / Authority / Considered = premium consultancy default
-- Conversational / Polished Standard / Companion / Considered = wellness or healthcare default
+- [Conversational / Polished Standard / Peer / Considered](https://rampstack.co/showcase/creative-direction?tone=conversational&aesthetic=polished-standard&relationship=peer&sensory=considered#examples) = the modern B2B SaaS default
+- [Professional / Editorial Restrained / Authority / Considered](https://rampstack.co/showcase/creative-direction?tone=professional&aesthetic=editorial-restrained&relationship=authority&sensory=considered#examples) = premium consultancy default
+- [Conversational / Polished Standard / Companion / Considered](https://rampstack.co/showcase/creative-direction?tone=conversational&aesthetic=polished-standard&relationship=companion&sensory=considered#examples) = wellness or healthcare default
 
 **Rare but powerful:**
 
-- Provocative / Editorial Restrained / Coach / Resonant = the "Patagonia at full conviction" register
-- Conversational / Controlled Maximalist / Peer / Resonant = the "BUCK or top creative agency" register
-- Provocative / Controlled Maximalist / Coach / Resonant = the "high-stakes brand revival" register
+- [Provocative / Editorial Restrained / Coach / Resonant](https://rampstack.co/showcase/creative-direction?tone=provocative&aesthetic=editorial-restrained&relationship=coach&sensory=resonant#examples) = the "Patagonia at full conviction" register
+- [Conversational / Controlled Maximalist / Peer / Resonant](https://rampstack.co/showcase/creative-direction?tone=conversational&aesthetic=controlled-maximalist&relationship=peer&sensory=resonant#examples) = the "BUCK or top creative agency" register
+- [Provocative / Controlled Maximalist / Coach / Resonant](https://rampstack.co/showcase/creative-direction?tone=provocative&aesthetic=controlled-maximalist&relationship=coach&sensory=resonant#examples) = the "high-stakes brand revival" register
 
 **Difficult combinations to flag:**
 

--- a/skills/creative-direction/references/example-aesthetic-brief.md
+++ b/skills/creative-direction/references/example-aesthetic-brief.md
@@ -2,6 +2,8 @@
 
 A representative completed brief, modeled on a realistic project. Showing how the abstract axes translate into concrete creative direction.
 
+> **See this brief rendered.** This brief produced [Observatory Editorial](https://rampstack.co/showcase/creative-direction/observatory-editorial), one of twelve Observatory archetypes in the live showcase. The site at that link is what "Conversational + Editorial Restrained + Peer + Considered" looks like as a real implementation. Compare the brief below to the rendered output to see how the abstract axes translate.
+
 ---
 
 # Observatory Marketing Site Brief
@@ -20,19 +22,19 @@ A representative completed brief, modeled on a realistic project. Showing how th
 
 ## The four axes
 
-### Tone Register: Conversational
+### Tone Register: [Conversational](https://rampstack.co/showcase/creative-direction?tone=conversational#examples)
 
 The audience is fatigued by both stiff vendor copy ("enterprise-grade reliability") and aggressive performance copy ("10x your observability"). Conversational treats the reader as a peer engineer who can read between the lines.
 
-### Aesthetic Philosophy: Editorial Restrained
+### Aesthetic Philosophy: [Editorial Restrained](https://rampstack.co/showcase/creative-direction?aesthetic=editorial-restrained#examples)
 
 The category is visually loud. Dashboards, gradient heroes, neon accents, animated charts. The differentiation is opposite: low color count, generous white space, considered typography, single definitive image instead of dashboard screenshots above the fold. The site reads like documentation that decided to be a marketing site, not the other way around.
 
-### Audience Relationship: Peer
+### Audience Relationship: [Peer](https://rampstack.co/showcase/creative-direction?relationship=peer#examples)
 
 These engineers do not need to be educated on observability. They need to be respected as practitioners. Authority voice would be condescending. Companion voice would be saccharine. Peer voice acknowledges that we and they are figuring out the same hard problems.
 
-### Sensory Ambition: Considered
+### Sensory Ambition: [Considered](https://rampstack.co/showcase/creative-direction?sensory=considered#examples)
 
 Functional would underdeliver; the audience expects a marketing site to be more than a feature list. Resonant is too much; this is not a brand campaign, it is a tool evaluation. Considered means the craft is visible (typography, restraint, the right photograph in the right place) without the site asking for an emotional response.
 


### PR DESCRIPTION
Lands the showcase integration that has been orphaned on the
`add-creative-direction-skill` branch since before the showcase
launched.

## What changes
- `SKILL.md`: adds a "See it in action" callout linking to the showcase,
  plus hyperlinks on every axis position label (15 links across 4 axes)
  pointing to pre-filtered showcase views.
- `references/axes-explained.md`: equivalent integration applied to the
  deeper-reference file.
- `references/example-aesthetic-brief.md`: showcase references added.

## Why this is a new branch instead of a merge
The orphan branch is 5 behind main. Linear-history ruleset on main
prevents merging stale branches without a rebase, and a content-only
diff applies cleanly enough on current main that a fresh PR is the
simplest path. Original orphan branch will be deleted after this PR
merges.

## Verification
- [x] Em-dash audit clean
- [x] Lint passes
- [x] All four sample deep-link URLs return 200 OK on production
- [x] Manually verified the additions are content-only (no body
  rewrites)

## Related
- README's filter section: "Pre-filtered URLs deep-link from the
  SKILL.md and axes-explained reference, so you can read about a
  position and click straight through to the rendered examples." That
  claim becomes true on production after this lands.