### PR TITLE
feat(skills): add experiment-design (7th flagship, PM-experimentation suite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-61-blue.svg)](#the-61-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-62-blue.svg)](#the-62-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -18,7 +18,7 @@
 
 </div>
 
-> 61 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 62 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
 
@@ -32,7 +32,7 @@
 - [Getting started](#getting-started)
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
-- [The 61-skill catalog](#the-61-skill-catalog)
+- [The 62-skill catalog](#the-62-skill-catalog)
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
 - [Repository structure](#repository-structure)
@@ -58,7 +58,7 @@ This is not a curated list of other people's skills. It is a single, opinionated
 
 What you get:
 
-- **61 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
+- **62 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
 - **98 reference files** (templates, checklists, decision matrices, worked examples)
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -246,9 +246,9 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 
 ---
 
-## The 61-skill catalog
+## The 62-skill catalog
 
-All 61 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 62 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 
 ### Strategy and discovery (5)
 
@@ -314,76 +314,77 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 29 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
 | 30 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
-### Product (2)
+### Product (3)
 
 | # | Skill | What it does |
 |---|---|---|
 | 31 | [`pm-spec-writing`](skills/pm-spec-writing/SKILL.md) | PRDs, user stories, acceptance criteria, dev briefs |
 | 32 | [`roadmap-planning`](skills/roadmap-planning/SKILL.md) | Quarterly planning, prioritization, dependency mapping |
+| 33 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 33 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 34 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 35 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 36 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 34 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 35 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 36 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 37 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 37 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 38 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 38 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 39 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 40 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 41 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 42 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 43 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 44 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 45 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 46 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 39 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 40 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 41 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 42 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 43 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 44 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 45 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 46 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 47 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 47 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 48 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 48 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 49 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 49 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 50 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 51 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 50 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 51 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 52 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 52 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 53 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 54 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 55 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 56 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 53 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 54 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 55 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 56 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 57 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 57 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 58 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 59 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 60 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 61 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 58 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 59 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 60 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 61 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 62 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-62-blue.svg)](#the-62-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-63-blue.svg)](#the-62-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -32,7 +32,7 @@
 - [Getting started](#getting-started)
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
-- [The 62-skill catalog](#the-62-skill-catalog)
+- [The 63-skill catalog](#the-62-skill-catalog)
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
 - [Repository structure](#repository-structure)
@@ -58,7 +58,7 @@ This is not a curated list of other people's skills. It is a single, opinionated
 
 What you get:
 
-- **62 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
+- **63 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
 - **98 reference files** (templates, checklists, decision matrices, worked examples)
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -246,9 +246,9 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 
 ---
 
-## The 62-skill catalog
+## The 63-skill catalog
 
-All 62 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 63 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 
 ### Strategy and discovery (5)
 
@@ -314,77 +314,78 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 29 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
 | 30 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
-### Product (3)
+### Product (4)
 
 | # | Skill | What it does |
 |---|---|---|
 | 31 | [`pm-spec-writing`](skills/pm-spec-writing/SKILL.md) | PRDs, user stories, acceptance criteria, dev briefs |
 | 32 | [`roadmap-planning`](skills/roadmap-planning/SKILL.md) | Quarterly planning, prioritization, dependency mapping |
 | 33 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
+| 34 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 34 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 35 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 36 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 37 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 35 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 36 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 37 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 38 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 38 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 39 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 39 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 40 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 41 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 42 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 43 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 44 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 45 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 46 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 47 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 40 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 41 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 42 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 43 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 44 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 45 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 46 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 47 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 48 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 48 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 49 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 49 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 50 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 50 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 51 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 52 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 51 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 52 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 53 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 53 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 54 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 55 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 56 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 57 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 54 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 55 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 56 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 57 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 58 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 58 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 59 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 60 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 61 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 62 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 59 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 60 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 61 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 62 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 63 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 
 ---
 

--- a/skills/experiment-design/SKILL.md
+++ b/skills/experiment-design/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: experiment-design
+description: A discipline for designing experiments (A/B tests, multivariate, holdouts) so the results actually answer the question you asked. Hypothesis writing, sample size, duration, segment analysis, interpretation, decision-making, and the common failure modes that produce confidently wrong shipping decisions.
+---
+
+# Experiment Design
+
+A senior product manager's playbook for running experiments that produce trustworthy decisions.
+
+The default state of experimentation in most companies is sloppy. PMs run tests against vague hypotheses, look at results too early, ignore guardrails, stratify into noise, and ship features whose lift is mostly measurement error. The cost is real: ship the wrong thing, kill the right thing, learn the wrong lesson, repeat.
+
+This skill is the discipline that prevents most of those mistakes. It assumes you have a working experimentation platform (Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon; the platform does not matter for the principles). It assumes you have product-design and engineering pipelines that can deliver real treatment changes. The hard part is the thinking, and that is what is here.
+
+When to use this skill: any time you are about to design or interpret an experiment. Read the relevant section before you start, not after the test is running.
+
+---
+
+## What this skill covers
+
+The skill spans the full experiment lifecycle. Pre-experiment readiness (is this thing even worth testing). Hypothesis design (cause, effect, magnitude, mechanism). Sample size and minimum detectable effect (do you have enough traffic to learn anything). Duration (how long is long enough, when does the cycle bias the result). Running discipline (no peeking, guardrails, sequential testing). Interpretation (the three buckets and the inconclusive case). Decision-making (matching the result to a pre-committed rule).
+
+The skill does not cover feature flag operational mechanics; those live in the `feature-flagging` skill, which handles flag taxonomy, environment management, and stale-flag cleanup as a separate discipline. The skill does not cover statistical analysis depth; for delta methods, variance reduction techniques like CUPED, and Bayesian alternatives, see the `experimentation-analytics` skill. The skill does not cover platform-specific tooling; for that, pair with the relevant `/integrations/{platform}` microsite on rampstack.co. The microsite shows the MCP commands, auth model, and example prompts for the platform; this skill produces the design that the MCP commands implement.
+
+For the orchestration layer above (which experiments to run, in what order, with what cadence), see the forthcoming `experimentation-platform-orchestrator` skill. That skill schedules; this skill designs.
+
+---
+
+## The framework: 12 considerations for trustworthy experiment results
+
+A defensible experiment design sits at the intersection of twelve considerations. Each is covered in detail in its own section below.
+
+1. **Hypothesis discipline.** Cause, effect, magnitude, and mechanism. The hypothesis names what is being tested, what should move, by how much, and why.
+2. **Sample size and minimum detectable effect (MDE).** Whether the test has enough traffic to detect the effect at the chosen power. Refuse to run underpowered tests.
+3. **Test duration.** Longer of the sample-size-hit duration and a full weekly cycle. UI/UX changes need at least 14 days regardless.
+4. **What NOT to A/B test.** UX bugs, legal-required changes, brand-philosophy questions, decisions already made, designs whose randomization cannot be clean.
+5. **Segment analysis.** Pre-registered segments are evidence; post-hoc segments are noise mining. The multiple comparisons problem is real.
+6. **Interaction effects.** Concurrent tests on the same surface can interfere. Mutex enforcement or coordination required.
+7. **Ratio metrics and variance estimation.** Naive variance estimators on ratios understate uncertainty. Confirm the platform uses a ratio-aware estimator.
+8. **Network effects and two-sided markets.** Treatment can leak into control via interference. Cluster randomization, switchback, or geographic isolation when needed.
+9. **Sequential testing and the peeking problem.** Daily peeking inflates false positive rates. Use sequential testing methods when available; pre-commit otherwise.
+10. **Pre-commitment vs p-hacking.** Write down the primary metric, MDE, duration, segments, and decision rule before launch. Apply mechanically when results come in.
+11. **Reading results and making the call.** Three buckets: clear win, clear loss, inconclusive. The inconclusive bucket exists for a reason; resist the pull to ship anyway.
+12. **Common failures and fixes.** A short rapid-fire pattern catalog, expanded in `references/common-failures.md`.
+
+The sections below cover each consideration in turn. Read the relevant section before running the experiment, not after.
+
+---
+
+## Hypothesis discipline
+
+The most important section in the skill. Most experiment failures trace back to a vague hypothesis.
+
+A real hypothesis has four parts: cause, effect, magnitude, mechanism. Cause is the change you are making. Effect is the metric you expect to move. Magnitude is how much you expect it to move and from what baseline. Mechanism is why you expect this change to produce this effect.
+
+Bad hypothesis, common shape: "We think the new pricing page will increase conversions." What is wrong with it: no magnitude (how much), no mechanism (why), and the metric is "conversions" rather than a specific event with a clear definition. The team will run this test, look at the result, and argue about what counts as a win. Pre-commitment is impossible because nothing was committed.
+
+Good hypothesis, same domain: "Replacing the three-tier pricing comparison with a single recommended tier will increase signup-to-paid conversion by 8 percent (currently 12 percent, target 13 percent) by reducing decision friction for users who already know they want to subscribe." Cause is the tier replacement. Effect is signup-to-paid conversion, defined as the user reaches the paywall and completes payment within seven days. Magnitude is 8 percent relative lift, taking the rate from 12 to 13 percent absolute. Mechanism is decision friction reduction. Now the team has something to test, a number to hit, and a story to falsify.
+
+Primary metric vs guardrails. The primary metric is the thing you are trying to move. Guardrails are the things that must not break: revenue, retention, support ticket volume, page load time, error rates. Pick exactly one primary metric. Pick three to five guardrails. Multiple primary metrics destroy the discipline because they let you cherry-pick the favorable one when results come in.
+
+Falsifiability test. Before launching the experiment, write down what would make you NOT ship this. If the answer is "nothing, we are committed to the change regardless," the hypothesis is not real and the experiment is theater. Skip the test, save the engineering time, and just ship the change.
+
+Directional vs magnitude distinction. Knowing the change moves the needle is different from knowing it moves the needle enough to matter. A 0.3 percent absolute lift on signup conversion may be statistically significant with enough traffic and still not justify the engineering cost of maintaining the change. Magnitude matters as much as direction; the hypothesis names the magnitude that would justify shipping.
+
+For templates and worked examples across common metric types, see `references/hypothesis-templates.md`.
+
+---
+
+## Sample size and minimum detectable effect
+
+Sample size grows with the inverse square of the effect you want to detect. Detecting a 1 percent lift requires roughly one hundred times the sample needed to detect a 10 percent lift. Most PMs underestimate this.
+
+The basic decision rule: if your minimum detectable effect (MDE) at current traffic and a reasonable test duration is greater than 5 percent absolute lift, you probably need a bigger MDE. Tiny changes that need huge samples to detect are usually not worth shipping anyway. The change is small either because the underlying mechanism is weak or because the implementation is timid. A weak mechanism is not worth a launch. A timid implementation should be made bolder before testing.
+
+The "we do not have enough traffic" trap. Real for very small products. Lazy for everyone else. If you have ten thousand users a week and you are trying to detect a half-percent absolute lift, you are not running an experiment, you are sampling noise. Pick changes whose expected effect is large enough to detect at your traffic level. If the change is genuinely small, ship it without a test (small upside, small downside, low cost) or do not ship it at all.
+
+Power. The test's ability to detect an effect that is actually present. The conventional floor is 80 percent. Below that, you are rolling dice; the test will frequently miss real effects. Higher power costs more sample. Most platforms default to 80; if you change it, document why.
+
+One-sided vs two-sided. Most PM tests are two-sided despite the temptation to claim otherwise. A one-sided test says "I only care about the positive direction; if the change makes things worse, I do not need to detect it." That is rarely true. If the new pricing page tanks conversion, you want to know. Default to two-sided. If you genuinely want one-sided, document the asymmetry before running.
+
+For pre-calculated sample size tables across common conversion rate baselines and MDEs, see `references/sample-size-tables.md`. The tables are starting points, not substitutes for running the math against your specific traffic and metric.
+
+---
+
+## Test duration
+
+Minimum duration is the longer of two constraints. Constraint one: the sample size hits the calculated requirement. Constraint two: the test runs at least one full weekly cycle. Testing only Monday through Wednesday misses weekend behavior, which on most consumer products differs meaningfully from weekday behavior.
+
+Novelty effects. New things attract attention. The first few days of a winning test often overstate the lift. Users notice the change, click it, and produce a temporary effect that fades as the novelty wears off. Run long enough to see if the lift survives the novelty period. Two weeks is the conventional minimum for any UI/UX experiment, even if the sample size hits faster.
+
+Primacy effects. The opposite problem. Existing users may resist the change in week one and adapt by week three. Common in UI rearrangement tests. Killing the test in week one because the result looks negative misses the point that primacy is bigger than the underlying effect at that timescale.
+
+Holdout periods. If the experiment changes a permanent feature (notification frequency, default settings, search ranking), keep a holdout group OFF the new behavior for at least a month after launch. The holdout measures long-term effect, not just the day-1 lift. Long-term effects are often different from short-term effects: a notification change that increases day-1 engagement may decrease month-three retention.
+
+Maximum duration. Usually four to six weeks. Beyond that, the world changes around the test. Seasonality shifts. Marketing campaigns launch. The product evolves. The comparison between treatment and control stops being clean because the underlying user population is no longer comparable across the test window. If the test needs to run longer than six weeks to hit power, the MDE is probably wrong; the change is too small to detect cleanly.
+
+---
+
+## What NOT to A/B test
+
+This is a section many discussions of experimentation skip. Worth being direct about.
+
+UX bug fixes. If the current behavior is objectively broken (button does not work, copy says the wrong thing, accessibility fails), fix it. A/B testing it is theater. The right answer is not "let's see if our users prefer a working button"; the right answer is to ship the working button.
+
+Legal-required changes. GDPR consent flows, accessibility compliance, regulatory disclaimers. Ship them. The lift is irrelevant; the compliance is the point. A/B testing whether to comply with the law is not a serious question.
+
+Strategic or philosophical brand questions. "Should our voice be playful or serious?" is not an A/B test question; it is a brand strategy question that needs to be made by humans with context, weighed against brand equity, audience expectation, and long-term positioning. Picking the variant with the higher click-through rate does not answer it because click-through rate was not the brand decision. Use the experiment data as one input to the brand decision, not as the decision itself.
+
+Things you have already decided. If leadership has committed to a direction regardless of test result, do not run an experiment. A/B testing as theater (running tests where the outcome does not change the decision) corrodes trust in the experimentation discipline overall. Other PMs see the test, see the result ignored, and conclude that experiment results do not matter at this company. Then they stop pre-committing. Then the discipline collapses.
+
+Things where the test design is impossible. Cross-device experiences, network effects, internal tooling for a ten-person ops team, anything where the sample size is fundamentally too small or the randomization is fundamentally contaminated. Sometimes the right answer is qualitative research, longitudinal cohort analysis, or just shipping and watching. An experiment that cannot be designed cleanly will not produce a clean answer.
+
+---
+
+## Segment analysis
+
+Pre-registered segments versus post-hoc segments. Declaring before the test runs that "we will look at the result for new users versus returning users" is fine. Discovering after the test that "users from California who signed up on Tuesdays via mobile" had a huge lift is almost always noise mining.
+
+The multiple comparisons problem. Every additional segment you analyze increases the probability of finding a "significant" result by chance. With twenty independent segments at p equals 0.05, you expect one false positive purely by chance. With fifty segments, two or three. Do not analyze fifty segments and report the one that hit significance.
+
+When stratification helps versus misleads. Stratification is useful when three things are true. The segment was pre-registered. There is a real prior reason to expect different behavior in this segment. There is enough sample within the segment to detect the effect at the chosen power. If any of the three is missing, stratification is noise mining. The default posture should be: report the overall result. Report pre-registered segments as additional context. Do not report unplanned segments.
+
+The "weighted average" reframe. If a treatment is positive for one segment and negative for another, the right question is "what is the weighted average effect across the population we will actually ship to" not "let's just ship to the segment where it works." Shipping to a segment usually requires UI complexity, audience targeting infrastructure, and ongoing maintenance that the segment-specific lift does not justify. The bias against segment-specific shipping is healthy.
+
+---
+
+## Interaction effects
+
+The classic problem: you are running five concurrent A/B tests on the checkout flow. Each test individually shows a small lift. Together, the combinations may not multiply cleanly. They may not even sum cleanly. They may interfere in ways the individual tests cannot reveal.
+
+Pre-experiment hygiene. Before launching a new experiment, check what other experiments are running on the same surface. Ask the other PM owners. Coordinate on which tests are mutually exclusive and which can overlap.
+
+Mutex (mutually exclusive) experiment groups. Most platforms support exclusion rules so users in test A are not also in test B. Use them when interactions are likely. The cost is sample size; the benefit is interpretable results. For a small set of high-stakes tests, mutex is the right call. For dozens of lower-stakes tests, full mutex is impractical; coordinate and document overlap instead.
+
+The "we will analyze it later" fallacy. Post-hoc detangling of overlapping experiments is hard, expensive, and usually inconclusive. The factorial design that would isolate interaction effects requires sample sizes most products do not have. Coordinate up front rather than untangle afterwards.
+
+---
+
+## Ratio metrics and the delta method
+
+The trap. Conversion rate is a ratio: conversions divided by users. Standard deviation calculations for raw counts do not apply directly to ratios. A naive variance estimate on a ratio metric tends to be too narrow, leading to overstated confidence and false-positive ship decisions.
+
+Why it matters. Many experimentation platforms quietly use the delta method (or bootstrap, or some other ratio-aware estimator) for ratio metrics. If yours does not, your confidence intervals are wrong. Wrong in the direction that matters: you ship things that look significant but are not.
+
+How to check. Ask your platform vendor: "What is your variance estimator for ratio metrics?" If the answer is "standard t-test on proportions," that is wrong for any ratio that is not a simple binary conversion (converted yes or no, with one row per user). If the answer is "delta method" or "bootstrap with re-sampling at the user level" or "linearization with Taylor expansion," that is correct. Other reasonable answers exist; the test is whether the platform team can articulate a ratio-aware estimator at all.
+
+Worked example. Revenue per user is a ratio: total revenue divided by total users. RPU lift estimates that do not use a ratio-aware estimator tend to overstate confidence. A 5 percent reported lift with p equals 0.04 might actually be a 5 percent point estimate with no statistical significance once the variance is computed correctly. Shipping based on the wrong math means shipping changes that do not produce the claimed effect in production.
+
+For deeper coverage of variance reduction (CUPED, stratified sampling, control variates), see the `experimentation-analytics` skill when it ships.
+
+---
+
+## Network effects and two-sided markets
+
+The interference problem. In a two-sided marketplace (Uber, Airbnb, eBay, DoorDash, any platform with buyers and sellers), a treatment for buyers may affect sellers regardless of which group is in the test. A treatment that increases buyer demand changes seller behavior. The "control" buyers, who are competing for the same sellers, see different supply because of treatment buyers' actions. The test no longer measures the treatment effect cleanly; it measures treatment effect plus interference.
+
+Common pattern. Marketplace experiments where the control group is contaminated. The test reports a small effect because half the effect leaked into the control. The team underestimates the true effect, kills a winning idea, and learns the wrong lesson.
+
+Mitigations, none perfect. Cluster randomization assigns whole markets (cities, regions, market segments) to treatment or control rather than individual users. Eliminates within-cluster interference but reduces effective sample size by orders of magnitude. Switchback experiments alternate the entire population between treatment and control across time windows (week 1 treatment, week 2 control, week 3 treatment, etc.). Eliminates cross-user interference but requires careful temporal modeling. Geographic isolation runs the experiment in one city while keeping the rest of the network on the original behavior. Eliminates interference but is expensive and slow.
+
+When to call qualitative. If interference is severe and randomization cannot isolate it, the test will not tell you what you want to know. Switch to user research, longitudinal cohort analysis, or a phased rollout with careful instrumentation. The decision is "do we believe this works enough to invest in the rollout monitoring" rather than "did the lift hit significance."
+
+---
+
+## Sequential testing and the peeking problem
+
+The peeking problem. If you check results every day and stop the test as soon as you see significance, your false positive rate is much higher than the nominal 5 percent. Standard statistical tests assume one analysis at the end of the test. Multiple analyses inflate alpha.
+
+The math. With one analysis, false positive rate is 5 percent (at alpha equals 0.05). With three analyses spread across the test, false positive rate climbs toward 14 percent. With daily peeking on a 28-day test, false positive rate can exceed 30 percent. You will see "significant" results that are not real, ship them, and watch them fail to replicate in production.
+
+Sequential testing methods. Most modern platforms (Statsig, Eppo, parts of PostHog, GrowthBook with mSPRT) support sequential testing that adjusts the math to allow daily peeking without inflating alpha. The methods include sequential probability ratio tests, group sequential designs, and always-valid p-values via mixture sequential probability ratio tests (mSPRT). Use them when the platform offers them. They cost some statistical power in exchange for valid mid-test inference.
+
+Pre-registered stopping rules. If the platform does not support sequential testing, declare the planned analysis date before the test runs. Save the pre-commitment. Do not look at results until that date. If you must look (some platforms make it hard not to), do not make decisions based on what you see. The decision happens at the pre-committed analysis date, not when the early peek looks favorable.
+
+The "ship early because results look great" trap. Results almost always look more dramatic on day 3 than they do at day 14. Regression to the mean kicks in. Novelty fades. The metric stabilizes. The tests that survive the full window and still look great are the ones worth shipping. The ones that "looked great early" and were shipped early are disproportionately the ones that disappointed in production.
+
+---
+
+## Pre-commitment vs p-hacking
+
+The p-hacking inventory. Things people do, often unconsciously, when results do not come out the way they hoped:
+
+- Run additional segments until something hits significance
+- Drop "outliers" until the headline result moves
+- Switch the primary metric mid-flight
+- Extend the test duration "just a bit longer"
+- Reframe the hypothesis to match what the data showed
+- Combine multiple inconclusive tests into a "directional pattern" that justifies shipping
+
+Each individually feels like a small judgment call. Cumulatively they destroy the discipline. The result is not "we found a real effect"; the result is "we ran enough analytical knobs that something looked significant."
+
+The pre-commitment fix. Before the test runs, write down: the primary metric and how it is computed; the MDE you are powered to detect; the duration in calendar days; the segments you will analyze (if any); the decision rule that maps each possible result to a ship or kill. Save the pre-commitment somewhere with a timestamp. The PR description that ships the experiment configuration. A signed Slack message. A pinned ticket. Anywhere that makes it immutable.
+
+When the results come in, follow the pre-commitment. If the result was clean and you want to ship, file the launch. If the result was bad and you want to kill, kill. If the result was inconclusive, follow the inconclusive resolution path described below; do not invent new analyses.
+
+The "we learned so much" trap. If the test ran and produced an inconclusive result, the answer is "inconclusive." Not "we learned that the underlying mechanism is more nuanced than expected" or "we discovered a fascinating segment dynamic." Inconclusive is inconclusive. The lesson, if there is one, is for the next hypothesis, not retrofitted onto this one.
+
+---
+
+## Reading results and making the call
+
+Three buckets. Clear win: ship. Clear loss: kill. Inconclusive: the hardest case.
+
+Inconclusive resolution paths, ranked from most acceptable to least:
+
+1. Ship anyway because the change is cheap and reversible (defensible only if guardrails are clean and you genuinely have no information that the change is harmful). The bar here is high; "the directional movement was favorable" is not enough.
+2. Run a bigger version: more traffic, longer duration, larger MDE if the change can be made bolder. Use the inconclusive result as evidence that the original was underpowered or the effect is smaller than expected.
+3. Kill the idea. The most common right answer; the hardest to do because PMs have invested in the hypothesis.
+4. Iterate the hypothesis and re-test. Use the inconclusive result to refine the mechanism. The new test is a new test, not a continuation; pre-commit again.
+
+Bayesian thinking layer. If your prior was strong (this should obviously work, given everything we know about user behavior), an inconclusive result should still update your belief somewhat. The prior was wrong, or the effect is smaller than expected, or the implementation was too timid to capture it. If your prior was weak (we genuinely had no idea what would happen), an inconclusive result means inconclusive; the prior was already uncertain and the result did not narrow it.
+
+The hardest version. Positive primary metric, ambiguous guardrail. Revenue went up but support tickets ticked up. Conversion went up but session length went down. Use the pre-committed decision rule. If you did not pre-commit on the guardrail trade-off, default to "do not ship." The guardrails exist because you cared about them before you saw the result. Do not lower the bar after the fact.
+
+For a step-by-step results-reading checklist, see `references/results-interpretation-checklist.md`.
+
+---
+
+## Common failures and fixes
+
+Rapid-fire reference. Each pattern is described in more detail in `references/common-failures.md`.
+
+- "We did not have enough traffic" means the MDE was too small. Pick bigger changes worth detecting.
+- "The lift disappeared after launch" means the test ran for 5 days and caught a novelty effect. Run longer next time; minimum two weeks for UI changes.
+- "It worked for new users but not returning users" means the segment was post-hoc, probably noise. Ship to all or kill, do not ship to the segment.
+- "The p-value crept up to 0.04 after 12 days of peeking" means the false-positive rate is much higher than nominal. Pre-commit and use sequential testing.
+- "Revenue went up but retention went down" means a guardrail was violated. Do not ship.
+- "We cannot replicate the result" means the original was probably noise or platform-bug. Investigate before re-running.
+- "Conversion went up but only because of the bot traffic from the new ad campaign" means the result was confounded by an external event. Pause campaigns during sensitive tests, or stratify by acquisition source.
+- "We ran the test, it was inconclusive, but the trend was directional so we shipped" means you ignored your own discipline. The inconclusive bucket exists for a reason; do not let directional patterns substitute for evidence.
+
+---
+
+## Reference files
+
+- `references/hypothesis-templates.md`. Concrete formats for writing hypotheses that pass the cause-effect-magnitude-mechanism test, with worked examples across conversion, engagement, revenue, retention, and funnel-step metric types.
+- `references/sample-size-tables.md`. Pre-calculated sample size tables for the most common conversion-rate experiments, with how-to-use guidance and the common pitfalls in sample-size planning.
+- `references/common-failures.md`. Fifteen anti-patterns that produce wrong shipping decisions, each with symptom, root cause, fix, and prevention.
+- `references/results-interpretation-checklist.md`. Step-by-step checklist for reading results, the three-bucket decision matrix (win, loss, inconclusive), and the post-launch monitoring discipline.
+- `references/platform-comparison.md`. Profiles of the major experimentation platforms (Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon) with strengths, gotchas, and a decision matrix for choosing.
+- `references/pre-experiment-readiness-checklist.md`. Ten-item go/no-go checklist run through before launch.
+- `references/post-experiment-decision-framework.md`. The moment-of-decision framework: confirm pre-commitment, apply rule mechanically, route to ship/kill/inconclusive paths, write the post-mortem within a week.
+
+---
+
+## Closing: when in doubt
+
+Default conservative posture. When results are unclear, do not ship. The cost of a false negative (you did not ship a real win) is usually smaller than the cost of a false positive (you shipped something that does not actually work and now you have to maintain it forever). The maintenance cost compounds; the missed-opportunity cost does not, because you can always test again.
+
+The discipline of experiment design is the discipline of saying "I do not know" out loud when you do not know. Saying it is often the most consequential thing a PM does in a given week. The instinct is to pretend the result is more conclusive than it is, ship to look decisive, and absorb the failure quietly when the change does not work in production. The discipline is to say "the test was inconclusive, here is what I would change to get a real answer, here is the new test plan." Saying that is professional. Pretending otherwise is theater.
+
+For platform-specific patterns (which platform handles which experiment type best, what the MCP commands look like, where the gotchas live), pair this skill with the `/integrations/{platform}` microsite for your stack. For the operational layer below this skill (managing flags, retiring stale ones, coordinating environments), see the `feature-flagging` skill. For the analytical layer above this skill (variance reduction, Bayesian alternatives, sequential testing math), see the `experimentation-analytics` skill.

--- a/skills/experiment-design/references/common-failures.md
+++ b/skills/experiment-design/references/common-failures.md
@@ -1,0 +1,183 @@
+# Common failures and fixes
+
+Anti-patterns that produce confidently wrong shipping decisions, with the symptom you observe, the root cause, the fix that resolves it, and the prevention that stops it from recurring.
+
+---
+
+## 1. The vague hypothesis
+
+**Symptom.** "We think the new pricing page will increase conversions." The team runs the test, the result is ambiguous, and a heated meeting follows about whether to ship.
+
+**Root cause.** The hypothesis lacks magnitude and mechanism. When the result comes in, there is no pre-committed bar to compare against, so the decision becomes political.
+
+**Fix.** Rewrite the hypothesis with the cause-effect-magnitude-mechanism format from SKILL.md. Save it before launching.
+
+**Prevention.** Make hypothesis review part of the experiment kickoff. A peer reads the hypothesis and confirms all four parts are present before the test launches.
+
+---
+
+## 2. The novelty effect ship
+
+**Symptom.** Test ran for 5 days, lift looked great, the team shipped, and the lift disappeared in production within two weeks.
+
+**Root cause.** Users notice new things and click them disproportionately during the novelty window. The early lift was novelty, not durable preference.
+
+**Fix.** Re-test the change with at least a two-week test window. Most novelty effects fade in 7-10 days. If the lift survives 14 days, it is likely durable.
+
+**Prevention.** Set minimum test duration of 14 days for any UI/UX change, regardless of how fast sample size hits. Document the rule and enforce it.
+
+---
+
+## 3. The post-hoc segment win
+
+**Symptom.** Test was inconclusive overall, but "users from California who signed up via mobile on Tuesdays" had a huge lift. The team wants to ship to that segment.
+
+**Root cause.** Multiple comparisons. With enough segments analyzed, one will hit "significance" by chance. The California-mobile-Tuesday segment is almost certainly noise.
+
+**Fix.** Do not ship to the segment. Either ship to all (if guardrails hold), or kill, or re-test with the segment pre-registered as a hypothesis.
+
+**Prevention.** Pre-register the segments to be analyzed. Limit to three to five segments per test, each with a real prior reason to differ from the population.
+
+---
+
+## 4. The peeking creep
+
+**Symptom.** P-value drifted around 0.06 for the first week, then crept to 0.04 on day 12, the team called it significant and shipped.
+
+**Root cause.** The platform did not use sequential testing. Daily peeking inflated the false positive rate. The "significance" on day 12 was a peeking artifact.
+
+**Fix.** Either use a platform with sequential testing, or pre-commit to a single end-of-test analysis. If you peeked and the test is over, treat the result as inconclusive and consider rerunning.
+
+**Prevention.** If your platform supports sequential testing (mSPRT, group sequential), enable it. If not, set up the test with calendar reminders for the analysis date, not before.
+
+---
+
+## 5. The guardrail violation overlook
+
+**Symptom.** Primary metric (revenue) went up. Retention dropped. The team shipped because revenue was the headline metric.
+
+**Root cause.** Guardrails were defined but not treated as binding. When the primary metric looked favorable, the team rationalized the guardrail violation as acceptable.
+
+**Fix.** Do not ship. Investigate the retention drop. The change may be capturing short-term revenue at the cost of long-term value, which is a worse trade than no change at all.
+
+**Prevention.** Pre-commit on the guardrail trade-off. Write down explicitly: "We will not ship if retention drops by more than X." If you cannot specify the bar in advance, you do not understand the trade-off well enough to test it.
+
+---
+
+## 6. The non-replicable result
+
+**Symptom.** Test reported a 5 percent lift. The team shipped. A month later the same change tested with a holdout group shows no effect.
+
+**Root cause.** Could be many things: original test was a false positive, platform bug, external event during the test window, contamination. Without investigation, you do not know which.
+
+**Fix.** Stop, investigate, find the cause. Possible findings: the metric was computed differently in the test versus production; the test exposure was lower than reported; an unrelated change confounded the result. Do not "just rerun and hope."
+
+**Prevention.** Schedule a post-launch holdout test for any change with a reported lift greater than 3 percent. Confirm the production behavior matches the test before declaring the win.
+
+---
+
+## 7. The campaign confound
+
+**Symptom.** Test launched the same week as a major marketing campaign. Test reported a huge lift. The team shipped. The lift was the campaign's traffic mix, not the treatment.
+
+**Root cause.** The campaign brought a different user mix into the test population: higher-intent visitors, different geographies, different device types. Treatment and control both saw the campaign traffic, but the campaign-driven users may have responded differently to the variants than the baseline population would.
+
+**Fix.** Pause campaigns during sensitive tests, or stratify the analysis by acquisition source so campaign traffic is analyzed separately from baseline traffic.
+
+**Prevention.** Coordinate with the marketing team before launching tests. Maintain a calendar of upcoming campaigns and avoid launching experiments on the same surfaces during major pushes.
+
+---
+
+## 8. The directional ship
+
+**Symptom.** Test was inconclusive. Primary metric trended up but did not hit significance. The team shipped because "the trend was directional."
+
+**Root cause.** Directional trend without significance is noise that happens to point in a flattering direction. Treating it as evidence is exactly the discipline failure that erodes experimentation rigor.
+
+**Fix.** Do not ship based on directional trends. Either run a bigger test (more traffic, longer duration), kill, or accept inconclusive as the answer.
+
+**Prevention.** Pre-commit to the decision rule. "Inconclusive" as a category requires acceptance, not creative reframing.
+
+---
+
+## 9. The interaction effect blind spot
+
+**Symptom.** Five concurrent tests on the checkout flow. Each individually reported a small lift. Combined, total checkout conversion did not move.
+
+**Root cause.** Interactions between concurrent tests. The lifts did not multiply or even sum. Some may have canceled out, some may have interfered with each other.
+
+**Fix.** Roll back, run tests with mutex enforcement, or run them sequentially. Re-test the combination as a multivariate.
+
+**Prevention.** Maintain an experiment registry per surface. Before launching a new test, check which others are running on the same surface and coordinate. Use mutex when interactions are likely.
+
+---
+
+## 10. The selection bias ship
+
+**Symptom.** ARPU went up. The team shipped. After launch, MAU dropped because the lowest-revenue users churned.
+
+**Root cause.** The treatment caused selection: lower-value users left, higher-value users stayed. ARPU went up arithmetically because the denominator shrank, not because anyone made more money.
+
+**Fix.** Pair ARPU primary metrics with retention or MAU guardrails. Investigate the source of the lift before shipping.
+
+**Prevention.** When the primary metric is a ratio, always pair with absolute count guardrails. ARPU plus revenue. Conversion rate plus conversion count. Engagement rate plus DAU.
+
+---
+
+## 11. The internal traffic contamination
+
+**Symptom.** Test reported strong lift in the first week. Investigation showed half the test users were internal employees clicking around the new feature.
+
+**Root cause.** Internal traffic was not excluded from the test population. Employees behave differently from real users.
+
+**Fix.** Re-bucket the test excluding internal IPs and employee accounts. Re-analyze.
+
+**Prevention.** Maintain an internal-traffic exclusion list at the platform level. Apply it to all experiments by default. Audit the user counts on test launch to confirm internal traffic is excluded.
+
+---
+
+## 12. The metric definition mismatch
+
+**Symptom.** Test reported a 5 percent lift in "conversion." Production analytics reported a 0.5 percent lift. The team blamed the platform.
+
+**Root cause.** The conversion event was defined differently in the test platform versus production analytics. Different conversion windows, different deduplication rules, different user-identity logic.
+
+**Fix.** Reconcile the metric definitions before re-running. Document the canonical definition and confirm both systems produce matching numbers on a known historical period.
+
+**Prevention.** Maintain a metric dictionary. Before adding a metric to an experimentation platform, document the canonical definition and validate against production analytics. Treat the metric definition as a versioned artifact.
+
+---
+
+## 13. The ratio metric variance error
+
+**Symptom.** Test reported a "significant" lift in revenue per user with p equals 0.04. Production rollout produced no measurable change.
+
+**Root cause.** The platform used a naive variance estimator on a ratio metric. Confidence interval was too narrow; the "significance" was an artifact of bad math.
+
+**Fix.** Switch to a platform that uses a ratio-aware estimator (delta method, bootstrap). Re-run the test or confirm via holdout.
+
+**Prevention.** Audit your platform's variance estimator. Ask the vendor what they use for ratio metrics. If the answer is "standard t-test on proportions" for anything other than simple binary conversion, plan a workaround.
+
+---
+
+## 14. The "we will fix it later" rollout
+
+**Symptom.** Test was inconclusive but engineering had already deployed the change. Rolling back was hard. The team shipped because the cost of rollback was higher than the expected cost of shipping.
+
+**Root cause.** The rollout was not gated on the experiment result. Engineering shipped to production before the test had concluded.
+
+**Fix.** Roll back if possible. If not, accept the change is shipped and instrument production carefully to confirm whether it actually works.
+
+**Prevention.** Gate rollouts behind experiment conclusions. Use feature flags so the change can be toggled off without a code revert. Coordinate engineering schedules with experiment timelines.
+
+---
+
+## 15. The retroactive hypothesis
+
+**Symptom.** Test was set up to validate "the new homepage increases signups." Result showed signups flat but engagement up. The team rewrote the hypothesis as "the new homepage drives engagement" and shipped.
+
+**Root cause.** Hypothesis was changed after the result was visible. This is p-hacking even if no statistical math was changed.
+
+**Fix.** The original hypothesis was inconclusive on signups. Either kill, or run a new test with the engagement hypothesis pre-registered.
+
+**Prevention.** Pre-commit the primary metric and stick with it. If the data suggests a different metric is more interesting, treat that as the hypothesis for the next test, not a rewrite of the current one.

--- a/skills/experiment-design/references/hypothesis-templates.md
+++ b/skills/experiment-design/references/hypothesis-templates.md
@@ -1,0 +1,95 @@
+# Hypothesis templates
+
+Concrete formats for writing hypotheses that pass the cause-effect-magnitude-mechanism test from SKILL.md. Each template names the right shape, shows two or three worked examples in different domains, and calls out the most common mistakes specific to that template type.
+
+The unifying format across all templates: replace [bracketed slots] with concrete project-specific values. If a slot reads as a vague phrase after replacement, the hypothesis is not specific enough.
+
+---
+
+## Template 1: Conversion rate change
+
+**Format.** Replacing [current treatment] with [new treatment] will increase [conversion event] by [magnitude] (current [baseline rate], target [target rate]) by [mechanism].
+
+**Worked example, e-commerce.** Replacing the multi-step shipping selector with an inline shipping summary on the cart page will increase cart-to-purchase conversion by 6 percent (currently 14.2 percent, target 15.1 percent) by reducing the cognitive load at the moment users are deciding whether to complete checkout.
+
+**Worked example, SaaS.** Replacing the three-tier pricing comparison with a single recommended tier on the pricing page will increase signup-to-paid conversion by 8 percent (currently 12 percent, target 13 percent) by reducing decision friction for users who already know they want to subscribe.
+
+**Worked example, marketplace.** Replacing the "browse all categories" landing page with a personalized recommendation grid will increase landing-to-listing-click conversion by 12 percent (currently 18 percent, target 20.2 percent) by surfacing relevant inventory before users have to specify intent.
+
+**Common mistakes specific to this template.**
+- Naming the metric as "conversions" without specifying the conversion event. "Conversion" alone is ambiguous; cart-to-purchase, signup-to-paid, and landing-to-listing-click are different metrics with different baselines and different relevant timescales.
+- Stating relative lift without absolute. "10 percent lift" sounds bigger than "1 percent absolute lift on a 10 percent baseline" but is the same thing; state both so the reader knows what is being claimed.
+- Skipping the mechanism. "Will increase conversion by 8 percent" is a target, not a hypothesis. The why is what makes it falsifiable.
+
+---
+
+## Template 2: Engagement metric change (DAU, sessions, time-on-task)
+
+**Format.** Adding [new feature or affordance] will increase [engagement metric] by [magnitude] (current [baseline], target [target]) by [mechanism].
+
+**Worked example, content product.** Adding a "save for later" button to article cards will increase weekly active users by 5 percent (currently 1.2 million, target 1.26 million) by giving users a reason to return to articles they have started reading.
+
+**Worked example, productivity tool.** Adding inline comments on document blocks will increase sessions per week per active team by 15 percent (currently 4.2, target 4.8) by enabling asynchronous collaboration that previously required separate communication channels.
+
+**Common mistakes specific to this template.**
+- Engagement metrics are not always good. A feature that increases sessions but decreases task completion is making the product worse, not better. Pair engagement primary metrics with task-completion guardrails.
+- "Time on task" is ambiguous. More time can mean engagement or confusion. Specify whether longer or shorter is the desired direction and why.
+- Treating engagement lift as a leading indicator without evidence that it is. Increased DAU does not always lead to increased revenue; sometimes it lags it, sometimes it has no relationship.
+
+---
+
+## Template 3: Revenue metric change (ARPU, AOV, RPU)
+
+**Format.** Implementing [new pricing or merchandising change] will increase [revenue metric] by [magnitude] (current [baseline], target [target]) by [mechanism].
+
+**Worked example, subscription product.** Adding an annual prepay option at 10 percent discount will increase average revenue per user by 4 percent (currently $87, target $90.50) by shifting price-sensitive users from monthly to annual billing, which has lower churn.
+
+**Worked example, e-commerce.** Adding a "frequently bought together" bundle on product detail pages will increase average order value by 8 percent (currently $42, target $45.40) by surfacing relevant add-on items at the moment of purchase decision.
+
+**Common mistakes specific to this template.**
+- Revenue is a ratio metric (revenue divided by users or orders). Naive variance estimators understate the variance and overstate confidence. Confirm your platform uses the delta method or an equivalent ratio-aware estimator.
+- ARPU lifts can come from selection effects: if the treatment moves the lowest-revenue users away (they churn), ARPU goes up without anyone making more money. Pair ARPU primary metrics with retention guardrails.
+- Revenue lifts can be driven by a small number of high-value users. Confidence intervals are wide. Run longer than you think you need to.
+
+---
+
+## Template 4: Retention metric change
+
+**Format.** Changing [interaction or feature] will increase [retention metric] by [magnitude] (current [baseline], target [target]) by [mechanism].
+
+**Worked example, mobile app.** Changing the day-3 push notification copy from generic to personalized recommendations will increase day-7 retention by 3 percent (currently 38 percent, target 39.1 percent) by reminding users of specific value they can return to.
+
+**Worked example, SaaS onboarding.** Replacing the static onboarding checklist with a guided in-product tour will increase day-30 active retention by 5 percent (currently 22 percent, target 23.1 percent) by getting more users to the activation event during their first session.
+
+**Common mistakes specific to this template.**
+- Retention takes time to measure. A test of day-30 retention requires at least 30 days of treatment exposure plus the test duration. Plan accordingly.
+- Day-N retention is a moving definition. Day-7 active means different things in different products; specify the activity that defines "active" before running.
+- Retention lifts often shrink over time. A treatment that improves day-7 retention may have no effect on day-90 retention. Decide which timescale matters for the business and measure that, not just the convenient short one.
+
+---
+
+## Template 5: Funnel-step abandonment reduction
+
+**Format.** Modifying [specific funnel step] will reduce abandonment at that step by [magnitude] (current [baseline rate], target [target rate]) by [mechanism].
+
+**Worked example, signup funnel.** Removing the phone number field from the signup form will reduce signup-form abandonment by 20 percent (currently 35 percent, target 28 percent) by removing a high-friction field that is not required for account creation.
+
+**Worked example, checkout funnel.** Adding guest checkout above the account creation prompt will reduce account-creation-step abandonment by 25 percent (currently 18 percent, target 13.5 percent) by giving purchase-intent users a path that does not require account creation.
+
+**Common mistakes specific to this template.**
+- Reducing abandonment at one step often shifts abandonment to the next step. The right metric is downstream conversion, not just step-level abandonment. Pair step-level primary metrics with full-funnel guardrails.
+- Signup abandonment can be measured noisily; users who abandon the form may return later. Define the conversion window (5 minutes, 24 hours, 7 days) before testing.
+- Reducing friction is not always good. A signup form that is too short produces low-quality signups: trial users who never return, fake accounts, support load. Pair friction-reduction tests with downstream-quality guardrails.
+
+---
+
+## Anti-templates: hypotheses that should be rejected
+
+Examples of hypotheses that fail the format and should be rewritten before launching:
+
+- "We think the new pricing page will increase conversions." Missing magnitude, mechanism, and a specific conversion event. Rewrite using Template 1.
+- "Users will love the redesign." Missing everything. Not testable. Pick a metric.
+- "The new flow is faster, so more people will complete it." Missing baseline, target, and a defined "complete" event. The mechanism (faster) is plausible but not specific.
+- "We want to see if dark mode improves engagement." Vague metric (engagement), no magnitude, and dark mode is binary not a multivariate. Pick a specific engagement metric and pre-register the segments where dark mode users are likely to differ from light-mode users (mobile evening sessions, for example).
+
+If your draft hypothesis sounds like one of the anti-templates, rewrite it using one of the five templates above before running the test.

--- a/skills/experiment-design/references/platform-comparison.md
+++ b/skills/experiment-design/references/platform-comparison.md
@@ -1,0 +1,133 @@
+# Platform comparison
+
+A practical guide to choosing an experimentation platform. Each platform has a distinct profile (statistical defaults, primary audience, integration model, pricing shape). Picking well saves quarters of friction; picking badly creates ongoing pain.
+
+This reference assumes the team is in the position of choosing or reconsidering. For platform-specific MCP commands, auth models, and example prompts, pair this reference with the matching `/integrations/{platform}` page on rampstack.co.
+
+---
+
+## Statsig
+
+**Profile.** Modern feature management plus experimentation platform. Built CUPED-first, holdouts as a first-class concept, warehouse-native with optional event ingestion. Fast-growing customer base including OpenAI, Notion, Brex, Whatnot.
+
+**Strengths.** CUPED variance reduction is the default, not an opt-in. Strong holdout analysis with built-in long-term measurement. Mature MCP exposing full CRUD across experiments, gates, dynamic configs, layers, and segments. Setup guides for ChatGPT, Cursor, Claude Code, Codex.
+
+**Best for.** Fast-growing companies that want one platform for both feature flags and experiments. Engineering-led teams comfortable with code-first configuration. Teams that need to run many concurrent experiments and care about variance reduction.
+
+**Gotchas.** Pricing scales with events, which can compound for high-traffic products. The breadth of the MCP can crowd context windows on smaller models; scoping helps. Best-in-class statistical defaults are nice but require the team to actually understand them.
+
+**Pair with.** `/integrations/statsig` on rampstack.co for MCP setup and example prompts.
+
+---
+
+## PostHog
+
+**Profile.** Open-source product OS combining product analytics, experiments, feature flags, surveys, session replays, error tracking, and LLM analytics in one platform. Self-host or cloud. Customer base skews toward PLG products and developer tools.
+
+**Strengths.** Combines analytics and experimentation in one platform, eliminating the metric-definition mismatch between systems. Full event-level data in the warehouse. 200+ MCP tools across the entire product, the largest surface of any vendor in this list.
+
+**Best for.** Product-led growth products that benefit from full-funnel context across analytics, experiments, and session replays. Teams that want one platform for everything rather than a stack of specialized tools.
+
+**Gotchas.** The breadth of the MCP requires scoping with `?features=` query parameters; without scoping, the agent gets 200+ tools and tool selection accuracy degrades on smaller models. Self-host adds operational complexity. Some experiment features lag behind specialized platforms.
+
+**Pair with.** `/integrations/posthog` on rampstack.co for scoping notes and example prompts.
+
+---
+
+## GrowthBook
+
+**Profile.** Open-source warehouse-native experimentation. Runs SQL on the team's existing data warehouse. Customer base skews data-mature: Dropbox, Khan Academy, Mistral. Claims the first open-source production MCP for experimentation.
+
+**Strengths.** Data stays in the team's warehouse; no event ingestion to a vendor. Strong cost control because the math runs on infrastructure the team already pays for. 100 percent open source under MIT, with self-host or cloud options.
+
+**Best for.** Data-mature teams that already own a warehouse (Snowflake, BigQuery, Redshift, ClickHouse, Postgres). Regulated industries where data residency matters. Teams that want full control over the statistical math.
+
+**Gotchas.** More setup overhead than hosted platforms. Requires SQL fluency for advanced analyses. Smaller community than the bigger commercial vendors.
+
+**Pair with.** `/integrations/growthbook` on rampstack.co for self-host MCP setup.
+
+---
+
+## Optimizely
+
+**Profile.** Long-time enterprise leader in personalization and experimentation. Web Experimentation and Feature Experimentation as separate but linked products. Customer base skews enterprise marketing and e-commerce.
+
+**Strengths.** Deep targeting, audience management, multivariate testing. Visual editor accessible to non-technical users (marketers can build variants without engineering). Mature personalization and recommendation engine. Hosted Remote MCP works in browser-based ChatGPT and Claude.ai with OAuth.
+
+**Best for.** Marketing-led organizations where non-technical teams need to author variants. Enterprises with deep personalization needs. E-commerce sites with established A/B testing programs.
+
+**Gotchas.** Expensive at the enterprise tier. Visual editor produces JS that ships at runtime, which can affect page performance. Less ergonomic for engineering-led teams that prefer code-first configuration.
+
+**Pair with.** `/integrations/optimizely` on rampstack.co for the hosted MCP setup.
+
+---
+
+## Amplitude
+
+**Profile.** Behavioral analytics platform with experiments and feature flags layered on top. Customer base skews product analytics teams that adopted Amplitude before adding experimentation.
+
+**Strengths.** Deep cohort analysis and behavioral segmentation. Native ChatGPT connector. Hosted MCP available to all customers including the free tier. Integrates tightly with the analytics layer that PMs already use.
+
+**Best for.** Teams that already use Amplitude for analytics and want to add experiments without introducing a new platform. Product analytics teams that need behavioral cohort segmentation as part of the experiment workflow.
+
+**Gotchas.** Experiments are a secondary feature, not the platform's center of gravity. Variance reduction options are more limited than dedicated experimentation platforms. Beta status of the MCP means the API surface may evolve.
+
+**Pair with.** `/integrations/amplitude` on rampstack.co for MCP setup and example prompts.
+
+---
+
+## Eppo
+
+**Profile.** Warehouse-native experimentation platform with strong statistical defaults. Customer base skews data-team-led organizations: Twitch, DraftKings, Perplexity. Best-in-class statistical rigor.
+
+**Strengths.** Best-in-class statistical defaults: variance reduction, sequential testing, contextual bandits, lifecycle experimentation. Warehouse-native means data stays in the team's stack. Strong explainability features for tracing reported lifts back to underlying SQL.
+
+**Best for.** Data-team-led organizations where data scientists own the experimentation discipline. Companies with mature warehouses and strict statistical rigor requirements. Teams running contextual bandits or other advanced experiment designs.
+
+**Gotchas.** No first-party MCP server as of May 2026. Programmatic access is REST API only; teams that want agentic workflows today need to build a custom MCP adapter or wait. Pricing reflects the data-science-focused product positioning.
+
+**Pair with.** `/integrations/eppo` on rampstack.co for the REST API patterns and the wait-for-MCP framing.
+
+---
+
+## Kameleoon
+
+**Profile.** AI-driven personalization platform with a specialized MCP focused on the convert-and-promote workflow. The MCP pulls raw variation code from winning experiments and helps refactor it into production-ready React components.
+
+**Strengths.** Sharp, narrow MCP (seven specialized tools) focused on a specific job: take a winning marketing-site variation and ship it as permanent product code. Hosted MCP via OAuth. Avoids the broad-CRUD complexity that crowds context windows on other platforms.
+
+**Best for.** Teams that test on the marketing site and need to convert wins into permanent React components. Hybrid marketing-and-product setups where the experiment lives in JS/CSS and the win needs to ship as a product feature.
+
+**Gotchas.** The narrow MCP scope is intentional but limits broader CRUD work. For everyday flag management, teams use the Kameleoon dashboard or REST API rather than the MCP.
+
+**Pair with.** `/integrations/kameleoon` on rampstack.co for the convert-and-promote workflow.
+
+---
+
+## Decision matrix
+
+A short matrix for the first-pass platform decision. Tradeoffs are oversimplified; verify against the team's specific constraints.
+
+| Situation | Pick |
+|---|---|
+| Pure SaaS, fast-growing, want one platform for flags + experiments | Statsig or PostHog |
+| Open-source preference, warehouse-native | GrowthBook or Eppo |
+| Enterprise, marketing-led, non-technical variant authoring | Optimizely |
+| Already using Amplitude for analytics, want experiments without new platform | Amplitude |
+| Convert marketing-site experiment wins into permanent product code | Kameleoon |
+| Data-team-led, statistical rigor is non-negotiable, can wait for MCP | Eppo |
+| Open-source AND warehouse-native AND need MCP today | GrowthBook |
+
+Beyond these defaults, the right choice depends on the team's existing stack, the experimentation maturity, and the budget. The "best" platform for one team is wrong for another; pick based on the team's actual constraints, not the platform's marketing.
+
+---
+
+## Switching costs
+
+Once a team has adopted a platform, switching is expensive. Existing experiments need to be re-run on the new platform. The metric definitions need to be reconciled. The team needs to retrain on a new tool. Plan accordingly:
+
+- **Easy switches.** Visual A/B testing tools that ship JS at runtime (Optimizely Web, AB Tasty, VWO classic). Switching is mostly tag-replacement.
+- **Medium switches.** Warehouse-native to warehouse-native (GrowthBook to Eppo, or vice versa). The data layer is shared; the configuration migrates.
+- **Hard switches.** Anything to or from event-ingestion platforms (Statsig, Amplitude). The historical event data does not transfer cleanly; the team starts fresh on metric history.
+
+If the team is choosing now and might need to switch later, lean toward warehouse-native options. Data ownership is the most expensive thing to switch.

--- a/skills/experiment-design/references/post-experiment-decision-framework.md
+++ b/skills/experiment-design/references/post-experiment-decision-framework.md
@@ -1,0 +1,91 @@
+# Post-experiment decision framework
+
+The moment-of-decision framework for what to do when a test ends. Each step builds on the prior; do not skip ahead. The discipline at this stage is what separates teams that learn from experiments from teams that confirm their priors.
+
+---
+
+## Step 1: Confirm pre-commitment was followed
+
+Before reading the results, pull up the pre-commitment document. Verify:
+- The test ran for the pre-committed duration (not stopped early, not extended).
+- The primary metric was the one pre-committed (not silently swapped).
+- The segments analyzed were the ones pre-committed (not new ones discovered post-hoc).
+- The guardrails are the ones pre-committed (not narrowed or widened after the fact).
+
+If any item failed the check, the result is compromised. Treat as inconclusive at minimum; consider re-running.
+
+---
+
+## Step 2: Apply the pre-committed decision rule mechanically
+
+The pre-commitment mapped each possible result to a ship-or-kill decision. Find the bucket the result falls into. Apply the rule.
+
+Resist the temptation to add new analysis "just to be sure." If new analysis is required to make a decision, the pre-commitment was inadequate; the lesson is for next time, not a license to dig until the answer feels right.
+
+The mechanical-application discipline is the most important habit at this step. Teams that deliberate about whether to follow their own pre-commitment have already lost the discipline. Apply the rule. Document any second-guessing as feedback for the next pre-commitment.
+
+---
+
+## Step 3a: If decision is "ship"
+
+1. File the launch ticket. Include: the test ID, the primary metric lift, confidence interval, guardrails status, segments status, and a link to the pre-commitment.
+2. Schedule post-launch monitoring at +7 days, +30 days, +60 days. Calendar reminders, not "I'll check it later."
+3. Confirm the launch removes the experiment infrastructure (the flag, the variant code paths) on the schedule the team has for stale-flag cleanup. See the `feature-flagging` skill for the cleanup discipline.
+4. Post a brief launch summary to the team's experiment log.
+
+---
+
+## Step 3b: If decision is "kill"
+
+1. Document the learning. What did the team predict? What happened? What is the most likely reason for the gap?
+2. Propose a follow-up hypothesis if applicable. The hypothesis can be "we should not test this idea again" if the test was definitive in the negative direction. It can be "let's iterate the mechanism" if the test was inconclusive and the team has a clearer story now.
+3. Archive the experiment infrastructure: remove the flag, clean up the variant code, remove instrumentation that was specific to this test.
+4. Post the kill summary to the team's experiment log. Killed experiments are as valuable as winning experiments; they prevent the team from repeating the mistake.
+
+---
+
+## Step 3c: If decision is "inconclusive"
+
+The inconclusive path is the hardest. The temptation is to ship anyway because the team has invested in the hypothesis. Resist it.
+
+Run through the resolution paths in order:
+
+1. **Was the MDE realistic?** If the test was underpowered (you needed a 5 percent lift to be detectable, and you got a 2 percent point estimate with a confidence interval crossing zero), the right answer may be to redesign the test with a bolder change and rerun. Do not extend the existing test; that produces a peeking artifact. Plan a new test, pre-commit, run.
+2. **Was the test contaminated?** If a confounder (campaign, outage, instrumentation bug) is identifiable, fix and rerun. Do not handwave the confounder.
+3. **Is the change cheap and reversible?** If the change is small, easy to maintain, and easy to roll back, shipping despite an inconclusive result is defensible. The bar is high; the change has to be genuinely cheap, and the guardrails have to be clean. If the change is expensive to maintain (additional UI complexity, additional code paths, additional analytics surface), ship is the wrong call.
+4. **Otherwise: kill, document, move on.** The discipline of accepting inconclusive results as inconclusive is what makes experimentation a learning system. Treating every inconclusive result as a "we just need more data" justification destroys the discipline.
+
+---
+
+## Step 4: Write the post-mortem within one week
+
+Regardless of the decision, write a short post-mortem within one week. The post-mortem covers:
+
+- The hypothesis (cause, effect, magnitude, mechanism)
+- The pre-commitment (primary metric, MDE, duration, decision rule)
+- The result (lift, CI, guardrails, segments)
+- The decision (ship / kill / inconclusive)
+- The action taken (launch, archive, redesign)
+- The learning (what would the team do differently next time)
+
+Keep post-mortems short: half a page is plenty. Long post-mortems do not get written; short ones do. The compounding value of a written experiment log over years is enormous; the compounding value of a vague memory of past tests is zero.
+
+---
+
+## Post-launch monitoring (the 30-day rule)
+
+Even shipped experiments need monitoring. The first 30 days after launch are when the production behavior diverges from the test behavior, if it is going to.
+
+Schedule a review at:
+
+- **Day 7.** Production metric matches the experiment lift within reasonable tolerance. If it does not, investigate before declaring the launch successful.
+- **Day 14.** Lift has not decayed (which would suggest novelty effect that the test underweighted) or amplified (which would suggest the change interacts with something the test could not capture).
+- **Day 30.** Long-term metrics (retention, downstream conversion, support load) are not eroding. The change continues to deliver value, not just an initial bump.
+
+If the production behavior diverges materially from the test behavior at any review:
+
+1. Quantify the divergence. Is it within statistical noise, or is it a real effect?
+2. Investigate the cause. Common ones: novelty wore off, segment distribution shifted, instrumentation bug, interaction with another concurrent change.
+3. Decide: roll back, hot-fix, or accept and document. Most successful tests behave the same way in production as in the test; the ones that diverge are usually telling you something is wrong.
+
+The 30-day rule prevents the "we shipped, it worked, then it stopped working but nobody noticed" failure mode. Most teams skip post-launch monitoring; the ones that do it consistently learn faster.

--- a/skills/experiment-design/references/pre-experiment-readiness-checklist.md
+++ b/skills/experiment-design/references/pre-experiment-readiness-checklist.md
@@ -1,0 +1,108 @@
+# Pre-experiment readiness checklist
+
+A go/no-go decision checklist to run through before launching any experiment. If any item is "no," delay the launch until it is "yes." Running an experiment without these in place produces results that cannot be defended, decisions that get second-guessed, and a long-term erosion of trust in the experimentation discipline.
+
+The checklist takes ten to fifteen minutes per experiment. The cost of skipping it is much higher.
+
+---
+
+## 1. Hypothesis written in cause-effect-magnitude-mechanism format
+
+The hypothesis names: what change is being made (cause), what metric will move (effect), how much you expect it to move with what baseline and target (magnitude), and why you expect this change to produce this effect (mechanism).
+
+If the draft hypothesis is missing any of the four parts, rewrite using one of the templates from `hypothesis-templates.md` before launch.
+
+---
+
+## 2. Primary metric defined with success threshold
+
+Exactly one primary metric. Specified with the same precision the platform's metric configuration requires (event name, deduplication window, user identity logic). Success threshold pre-committed: the lift you would consider sufficient to ship.
+
+If multiple metrics feel "primary," collapse to one and demote the others to guardrails.
+
+---
+
+## 3. Guardrails defined (3 to 5)
+
+Three to five guardrail metrics that must not break: revenue, retention, support tickets, page load time, error rate, satisfaction scores. Each with a tolerance threshold pre-committed.
+
+Avoid: more than five guardrails (creates analysis paralysis), or zero guardrails (the test cannot detect collateral damage), or vague guardrails like "user happiness" (not measurable).
+
+---
+
+## 4. Sample size calculated for chosen MDE
+
+The required sample size for the chosen minimum detectable effect, at standard alpha (0.05) and power (0.80), through your platform's calculator or via a stats library. Documented in the pre-commitment.
+
+If the math says "you need 200,000 users to detect this lift and you have 5,000 a week," accept a larger MDE or do not run the test. Do not run an underpowered test and hope for the best.
+
+---
+
+## 5. Duration committed (longer of sample-size-hit and full weekly cycle)
+
+Calendar duration committed in advance. The longer of: time to hit the calculated sample size at expected daily traffic, or one full weekly cycle (typically 7 days). UI/UX changes get a 14-day minimum regardless.
+
+If the duration is "we will see how long it takes," that is not a duration. Pick a date.
+
+---
+
+## 6. Segments pre-registered (if any)
+
+If you plan to analyze segment-level results, name the segments before launch. Three to five maximum, each with a real prior reason to expect different behavior in that segment.
+
+If you do not plan to analyze segments, write that down too. The pre-commitment to "no segment analysis" is itself a defense against post-hoc segment mining.
+
+---
+
+## 7. Decision rule pre-committed (saved with timestamp)
+
+Map each possible result to a decision:
+- Result above target threshold + guardrails clean: ship
+- Result below MDE: kill
+- Result inconclusive (point above zero, CI crosses zero): default to do not ship; document next-step options
+- Guardrail violation: do not ship regardless of primary
+
+Save the decision rule somewhere immutable: the PR description, a pinned ticket, a signed Slack message, anywhere with a timestamp.
+
+---
+
+## 8. No conflicting concurrent experiments on the same surface
+
+Check the experiment registry for what else is running on the same surface (checkout flow, signup form, pricing page). If there are interactions, set up mutex enforcement so users in this test are not also in the others.
+
+If you cannot enforce mutex (sample size constraints), document the overlap and accept the interpretability cost. Do not pretend there is no overlap.
+
+---
+
+## 9. Instrumentation tested with a small canary
+
+Before launching to the full population, expose a small canary group (5 to 10 percent) and confirm:
+- Treatment users actually see the treatment
+- Events fire correctly for both groups
+- The platform reports the right exposure counts
+- Internal traffic is excluded
+- The metric definitions match between the platform and production analytics
+
+Catching instrumentation bugs in canary saves a wasted full test run.
+
+---
+
+## 10. Stakeholders aligned on what each outcome means
+
+The PM, the engineering lead, the design lead, and any other decision-maker have all agreed: if the test wins, we ship; if it loses, we kill; if it is inconclusive, we follow the inconclusive path documented in the decision rule.
+
+If a stakeholder is going to dispute the result regardless of what it shows, the experiment is theater. Resolve the strategic question first; run the experiment only if the result genuinely changes the decision.
+
+---
+
+## Decision
+
+If all ten items are "yes," launch.
+
+If any item is "no":
+- Items 1, 2, 3 (hypothesis, metric, guardrails): blocking. Fix before launch.
+- Items 4, 5, 7 (math, duration, decision rule): blocking. Fix before launch.
+- Items 6, 8, 9 (segments, mutex, canary): worth fixing but launch can proceed if the fix is impractical and the team accepts the risk.
+- Item 10 (stakeholder alignment): blocking. An experiment that cannot change the decision is theater.
+
+The cost of delaying a launch by a day to fix a checklist item is small. The cost of running a test that produces an indefensible result is much higher.

--- a/skills/experiment-design/references/results-interpretation-checklist.md
+++ b/skills/experiment-design/references/results-interpretation-checklist.md
@@ -1,0 +1,112 @@
+# Results interpretation checklist
+
+A step-by-step checklist for reading experiment results and arriving at a defensible decision. Run through it in order. Do not skip steps because the result "looks obvious"; the obvious-looking results are often the ones that fail in production.
+
+---
+
+## Step 1: Did the test run for the pre-committed duration?
+
+**What to look for.** The test ended on the date pre-committed at launch, with the planned analysis happening on that date.
+
+**Red flags.** The test was stopped early because results "looked great." The test was extended past the pre-commitment because results "had not stabilized." The test ran for an arbitrary duration not tied to the pre-commitment.
+
+**When to escalate.** If the duration was changed after launch without documented rationale, the result is compromised. Treat as inconclusive and consider re-running.
+
+---
+
+## Step 2: Did all guardrails stay within tolerance?
+
+**What to look for.** Each pre-defined guardrail (revenue, retention, support tickets, page load time, error rate) within its acceptable range. Confidence intervals around guardrail metrics that exclude the threshold of concern.
+
+**Red flags.** A guardrail moved in the wrong direction even if the change was not "significant." Wide confidence intervals on guardrails (the test was underpowered for the guardrail). A guardrail you did not pre-define being raised post-hoc.
+
+**When to escalate.** A guardrail violation should be treated as binding. The fix is "do not ship," not "the primary metric was good enough to outweigh the guardrail." If the guardrail was poorly chosen, that is a lesson for next time, not a license to ignore it on this test.
+
+---
+
+## Step 3: Did the primary metric move beyond the MDE?
+
+**What to look for.** The point estimate of the primary metric exceeds the pre-committed minimum detectable effect, and the confidence interval excludes zero (or excludes the no-effect threshold for one-sided tests).
+
+**Red flags.** Point estimate is above MDE but the confidence interval crosses zero. The "significance" comes from a peeking artifact (interim analysis that became the headline). The lift comes from a small number of outlier users.
+
+**When to escalate.** If the primary metric is significant but the lift is below MDE, the test was overpowered for the question; the result is technically real but practically too small to matter. Do not ship a 0.3 percent lift just because p equals 0.001.
+
+---
+
+## Step 4: Was the confidence interval clean?
+
+**What to look for.** A confidence interval around the lift estimate that is well-bounded and not crossing zero. Symmetric (or appropriately skewed for the metric type).
+
+**Red flags.** Very wide CI (test was underpowered). Skewed CI hinting at distributional weirdness (a few outliers drove the result). CI computed without ratio-aware variance for ratio metrics.
+
+**When to escalate.** If the CI is wide enough that the practical lift could be anywhere from "not worth shipping" to "amazing," the test does not support a confident ship decision. Run longer or accept inconclusive.
+
+---
+
+## Step 5: Are the results consistent across pre-registered segments?
+
+**What to look for.** The pre-registered segments show effects in the same direction as the overall result. Magnitude can vary; direction should not flip.
+
+**Red flags.** Some segments show effects opposite to the overall result. The overall lift comes from one segment and the rest are flat or negative.
+
+**When to escalate.** If one segment is driving the entire effect and others are negative, the right ship decision is "ship to the segment where it works" only if the targeting infrastructure exists and is worth the maintenance cost. More often the right answer is to redesign the change so it works for the whole population.
+
+Reminder: this step covers PRE-REGISTERED segments only. Post-hoc segments are noise mining; do not re-analyze the data through new segments looking for an interpretation.
+
+---
+
+## Step 6: Did any external events potentially confound the results?
+
+**What to look for.** A timeline of events during the test window: marketing campaigns, product launches, outages, news cycles, holidays, seasonality shifts.
+
+**Red flags.** A campaign launched mid-test that brought a different user mix. A product release mid-test that changed user behavior. An outage during the test that affected one variant differently from the other.
+
+**When to escalate.** If a confounder is identified, isolate it. Stratify the analysis by acquisition source (excludes campaign-driven users), or by date (excludes the outage day), or rerun. Do not handwave the confounder; either fix it or accept that the result is tainted.
+
+---
+
+## Step 7: Is the magnitude practically significant, not just statistically significant?
+
+**What to look for.** The lift is large enough to matter for the business. A 0.3 percent absolute lift on a 30 percent baseline is statistically significant with enough sample but may not justify the engineering cost of maintaining the change.
+
+**Red flags.** "Statistically significant" being used as the only justification. No conversation about whether the lift is large enough to be worth the implementation, maintenance, and complexity cost.
+
+**When to escalate.** If the magnitude is small, ask: "Is this worth the code surface area, the testing surface area, and the cognitive load on the team?" Often the answer is no. Do not ship marginal lifts unless the change is also cheap to maintain.
+
+---
+
+## Step 8: Does the decision match the pre-committed rule?
+
+**What to look for.** The pre-commitment document mapped each possible result to a ship-or-kill decision. The result fits clearly into one of those buckets.
+
+**Red flags.** The result does not fit cleanly. The team is debating which bucket applies. Someone is proposing a new analytical knob to clarify the bucket.
+
+**When to escalate.** If the result is genuinely ambiguous, default to "do not ship" and document why. Inconclusive is a valid outcome; treating it as one is the discipline.
+
+---
+
+## Decision matrix
+
+After running through the checklist, the result fits one of three buckets:
+
+| Bucket | Conditions | Action |
+|---|---|---|
+| Clear win | Primary moved past MDE, CI excludes zero, guardrails clean, segments consistent, no confounders | Ship. File launch. Schedule post-launch monitoring at +30 and +60 days. |
+| Clear loss | Primary moved against expected direction with significance, OR guardrail violated | Kill. Document the learning. Propose follow-up hypothesis if applicable. |
+| Inconclusive | Anything else | Default to do not ship. Run a bigger version, kill, or iterate the hypothesis. |
+
+The inconclusive bucket is the most common and the hardest. The discipline is to recognize it and resist the pull to ship anyway.
+
+---
+
+## Post-launch monitoring (the 30-day rule)
+
+Even shipped experiments need monitoring. The first 30 days after launch are when the production behavior diverges from the test behavior, if it is going to. Schedule a review at day 7, day 14, and day 30.
+
+What to check at each review:
+- Day 7: Production metric matches the experiment lift within reasonable tolerance.
+- Day 14: Lift has not decayed (novelty effect) or amplified (the change interacts with something the test could not capture).
+- Day 30: Long-term metrics (retention, downstream conversion) are not eroding.
+
+If the production behavior diverges materially from the test behavior, the right call is to roll back and investigate, not to "wait and see." Most successful tests behave the same way in production as in the test; the ones that diverge are usually telling you something is wrong.

--- a/skills/experiment-design/references/sample-size-tables.md
+++ b/skills/experiment-design/references/sample-size-tables.md
@@ -1,0 +1,88 @@
+# Sample size tables
+
+Pre-calculated sample size tables for the most common experimentation scenarios. These tables are starting points, not substitutes for running the math against your specific traffic and metric. The math depends on the variance of the metric, the desired power, the alpha threshold, and the test design (one-sided, two-sided, sequential).
+
+Use these tables to:
+- Sanity-check a sample size estimate from your platform's calculator
+- Decide whether the planned test is feasible given your traffic
+- Choose an MDE that is realistic for your traffic level
+
+For exact figures, run the math through your platform's calculator (most experimentation platforms expose one) or use a stats library (`scipy.stats`, R's `pwr` package, or an online calculator).
+
+---
+
+## How to use these tables
+
+Each table assumes:
+- Two-sided test (the standard default for PM experiments)
+- Alpha equals 0.05 (5 percent false positive rate)
+- Power equals 0.80 (80 percent chance of detecting an effect that is really there)
+- Equal group sizes (50/50 split)
+
+Total sample size is the sum across both groups. Per-group sample is half the total.
+
+If you change any of those assumptions, multiply by the indicated factor:
+- Power 0.90 instead of 0.80: multiply sample size by ~1.34
+- Alpha 0.01 instead of 0.05: multiply sample size by ~1.49
+- One-sided test: multiply by ~0.79
+
+Worked example for using Table 1: a product has a baseline conversion rate of 10 percent and wants to detect a 1 percent absolute lift (target 11 percent). Total sample size required is roughly 31,400 users. With 1,000 daily new users in the test population, the test needs about 31 days plus one full weekly cycle. If you can only run it for 14 days, the MDE you can detect at this traffic is closer to 1.5 percent absolute. Pick the change you can detect; do not run an underpowered test.
+
+---
+
+## Table 1: Conversion rate experiments
+
+Total sample size required (across both groups) for a two-sided test, alpha 0.05, power 0.80.
+
+| Baseline rate | MDE 1% abs | MDE 2% abs | MDE 5% abs | MDE 10% abs |
+|---|---|---|---|---|
+| 5% | 14,800 | 4,400 | 1,000 | 360 |
+| 10% | 31,400 | 8,400 | 1,700 | 540 |
+| 20% | 51,800 | 13,400 | 2,500 | 720 |
+| 30% | 65,600 | 16,600 | 3,000 | 800 |
+| 50% | 78,400 | 19,600 | 3,200 | 800 |
+
+**Reading the table.** A product with 30 percent baseline conversion that wants to detect a 2 percent absolute lift (target 32 percent) needs ~16,600 users total, ~8,300 per group. Numbers are approximate and rounded.
+
+**Choosing an MDE that matches traffic.** If you have 5,000 weekly users in the test population:
+- One week of traffic supports detection of ~5 percent absolute lift on a 30 percent baseline (3,000 users, MDE 5 percent matches)
+- Two weeks supports ~3 percent absolute lift
+- Four weeks supports ~2 percent absolute lift
+- Six weeks supports ~1.5 percent absolute lift
+
+Beyond six weeks the test runs into seasonality and product-evolution problems described in SKILL.md. If the change you want to test would only produce a 1 percent absolute lift and your traffic supports 5 percent MDE in a reasonable window, the test is not worth running. Pick a bigger change.
+
+---
+
+## Table 2: Mean comparison experiments (continuous metrics)
+
+For continuous metrics like time-on-task, session length, page views per session, the math depends on the metric's standard deviation, which varies by product. The table below shows sample sizes assuming a coefficient of variation (standard deviation divided by mean) of 1.0, which is typical for engagement metrics.
+
+| Baseline mean | MDE 5% rel | MDE 10% rel | MDE 20% rel |
+|---|---|---|---|
+| Any (CoV ~1.0) | 12,600 | 3,200 | 800 |
+| Any (CoV ~2.0) | 50,400 | 12,600 | 3,200 |
+
+For revenue metrics the CoV is often higher (2.0 to 3.0) because revenue is concentrated in a small fraction of users. Run your variance through the platform calculator before committing to a sample size; the table is illustrative, not authoritative.
+
+---
+
+## Common pitfalls in sample size planning
+
+- **Forgetting to count exposure, not allocation.** If 1,000 users see the experiment per day but only 200 reach the surface where the variant is rendered, your effective sample is 200 per day. Use exposure counts, not bucketing counts.
+- **Treating session-level and user-level differently.** Some metrics are evaluated per session (page views per session), others per user (day-7 retention). Sample size requirements differ. Specify which level the metric is evaluated at and use the matching count.
+- **Forgetting variance reduction.** Methods like CUPED, stratified sampling, and control variates can reduce required sample size by 30 to 50 percent for the same power. If your platform supports them, use them. Sample size tables ignoring variance reduction overstate what you actually need.
+- **Underestimating the weekly cycle requirement.** A test that hits sample size in three days still needs to run a full week to capture cycle effects. Sample size hit is necessary but not sufficient.
+- **Assuming traffic is stable.** If a marketing campaign launches mid-test, the user mix changes and the test may no longer be a clean comparison. Coordinate with marketing before launching tests on user-acquisition-sensitive surfaces.
+
+---
+
+## When the math says "you cannot detect this"
+
+Sometimes the table reads "you need 200,000 users to detect this lift and you have 5,000 a week." Three options:
+
+1. **Accept a larger MDE.** Pick a bigger change worth detecting. A 3 percent absolute lift may be detectable in two weeks; a 0.3 percent lift may take a year. Test the bigger change.
+2. **Find a more sensitive metric.** Sometimes the metric is the constraint, not the change. Switching from "purchases" to "add-to-cart" gives you a higher-frequency event with more sample. The trade-off is that ATC is less directly tied to revenue; pair the more-sensitive primary with a revenue guardrail.
+3. **Skip the test.** If the change is small but cheap and reversible, ship without testing. If it is small and expensive to maintain, do not ship. Running an underpowered test produces noise dressed up as evidence; that is worse than no test.
+
+The discipline is to refuse to run tests that cannot answer the question. An underpowered test is not "better than nothing"; it is worse than nothing because it produces a result that feels meaningful but is not.

--- a/skills/integration-orchestrator/SKILL.md
+++ b/skills/integration-orchestrator/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: integration-orchestrator
+description: "Generate a phased delivery orchestration plan for creative-direction-driven work, mapping which skills run when, what locks at which gate, how handoffs occur between phases, and how the cadence implements in the team's actual tools (Jira, Linear, Notion, Figma, GitHub) with AI agents participating via MCP and CLI. Distinct from `creative-brief` (static project brief) and `creative-direction` (aesthetic direction). This skill produces a temporal map: phase-by-phase cadence, lock points, handoff specs, gate definitions, automation and QA verification gates, and platform-specific implementation. Triggers on integration orchestrator, delivery cadence, project orchestration, when does the brief lock, how to phase creative direction, brand build cadence, rebrand timeline, campaign delivery plan, design-development handoff, brief freeze, identity gate, copy approval phase, QA gate, automated verification, MCP integration for project management, Claude Code workflow setup, agent-driven QA. Triggers when a team is starting a creative-direction project and needs to sequence the work, OR when a project is mid-flight and the cadence has broken (freeze points being unfrozen, parallel work getting out of sync), OR when a team is integrating AI agents into their existing PM workflow. Does NOT fire when the user needs project scoping (use `creative-brief`), aesthetic direction (use `creative-direction`), or general project management without a creative-direction throughline."
+---
+
+# Integration Orchestrator
+
+A brief tells a team what to make. Creative direction tells them what it should feel like. Neither tells them when each decision locks, who reviews what, or what stops the next phase from starting before the prior one is done. That is the gap this skill fills.
+
+The output is a phased orchestration plan the PM can paste into a calendar Monday morning and start running Tuesday. Phases, gates, lock points, handoffs, QA verification rules, and a platform-specific implementation guide for whatever stack the team actually uses (Jira, Linear, Notion, Figma, GitHub, agile sprints).
+
+---
+
+## What this skill is
+
+A creative-direction project has three layers. The brief layer defines scope, audience, deliverables, constraints, success criteria. The direction layer defines tone, aesthetic, relationship, and sensory ambition. Both produce written artifacts. Neither answers the temporal question: when does the brief lock, when does identity lock, when does copy lock, who reviews each, what gets blocked while a gate is open, what happens when a downstream task discovers the brief is wrong, and what makes "Done" mean tested rather than self-reported.
+
+This skill produces that temporal layer. Most teams have briefs and creative direction but no orchestration plan. The result, by week 3, is everyone working in parallel with no shared sense of which decisions are still open and which are locked. Brief drift. Re-work. Identity tokens shifted after copy was already drafted against the old ones. Engineering shipping before design had a chance to review. "Done" tickets that were never actually verified.
+
+The orchestration plan answers all of that. It is not theory. It is a phased timeline with calendar weeks, ticket templates the PM can paste into Jira or Linear, MCP commands for setup, gate definitions with measurable pass criteria, handoff specs with artifact requirements, and QA verification gates with Playwright or Chrome MCP invocations.
+
+---
+
+## When to use
+
+- Starting a new brand build, rebrand, or campaign and the team needs to sequence the work
+- Mid-flight project where the brief is being revisited and downstream work is suffering from constant resets
+- Setting up a new team's agent-driven workflow with MCPs and CLI integration
+- Multi-team work where handoffs between brand, design, and engineering have broken down
+- Establishing QA verification gates so "Done" is measurable, not self-reported
+- Migrating from ad-hoc orchestration to a documented cadence
+- Onboarding a new PM or design lead onto an existing project that has running tickets but no documented sequencing
+- Adding new platforms or tools to an existing workflow and the cadence needs to be re-mapped
+
+---
+
+## When NOT to use
+
+- Use `creative-brief` instead if the deliverable is the project brief itself: scope, audience, deliverables, constraints, success criteria. The orchestrator skill takes the brief as input.
+- Use `creative-direction` if the deliverable is the aesthetic direction: tone, aesthetic, relationship, sensory. The orchestrator schedules the work that answers to the direction; it does not produce the direction.
+- Generic project management software is the platform; this skill produces the plan that runs IN the platform. Do not run this skill if the team needs help picking a tool; it assumes the tool stack is already chosen.
+- Sprint-planning tactics (story-pointing, retros, velocity charts) live downstream of orchestration. The skill produces the cadence; sprint planning fills it in.
+
+---
+
+## Required inputs
+
+- **Project type.** New brand build, rebrand, single landing page, campaign, identity refresh, website refresh, microsite, product launch. The type implies a default phase decomposition that the skill adapts to the specific project.
+- **Team composition.** Total size and role mix. Solo, small (2-3), medium (4-7), large (8+). Whether AI agents (Claude Code, Claude in Chrome, others) participate in production, QA, or both.
+- **Tool stack.** Which of Jira, Linear, Notion, Figma, GitHub the team uses. Plus QA tooling (Playwright, Chrome MCP, Windows MCP, mobile testing harnesses) if known. Plus communication and paging channel (Slack, email, in-tool mention). The output adapts to the actual stack.
+- **Timeline target.** Express (compressed timelines, fewer reviewers, accept higher rework risk), standard (typical cadence at the project type's default duration), or thorough (more reviewers, formal phase reviews, lower rework risk at the cost of slower delivery).
+- **Existing constraints.** What is already locked? Brief approved, identity locked, platform fixed, brand voice already shipped, content management system non-negotiable. The orchestrator plan handles greenfield and mid-flight equally; the existing constraints input is how mid-flight projects are accommodated.
+- **AI agent participation.** Which workflows include agents and at what fidelity. Examples: Claude Code does production tasks against a state file in the repo; Claude in Chrome runs human-readable QA flows on the staging deployment; the agent has access to the Linear MCP and the GitHub MCP but not Jira; the agent can move tickets between Todo, In Progress, Waiting, and Blocked but cannot move to Done (Done requires a human verification step).
+- **Risk profile.** Optional input naming the failure modes the team is most worried about: brief drift, parallel-work conflicts, QA gaps, agent runaway. The orchestration plan front-loads mitigations for the named risks.
+
+---
+
+## The framework: 7 considerations for orchestration
+
+A delivery orchestration plan sits at the intersection of seven considerations. Each filters the choices that follow.
+
+### 1. Phasing
+
+How the project decomposes into phases. The standard shape is discovery, direction, identity, production, QA, and launch. Not every project type uses every phase. A campaign skips identity (it inherits the locked brand identity). A landing page collapses discovery and direction into a single brief phase. A rebrand replaces discovery with audit (positioning is known; the audit assesses what to keep).
+
+The shape of the phases matters less than the explicit answer to two questions per project: which phases run sequentially because the downstream phase cannot start without the prior phase's output, and which phases overlap because their outputs do not depend on each other. Identity must complete before copy starts (copy depends on tone-axis position, which is part of identity). QA must complete before launch. Discovery and audit may overlap with brief drafting, because the brief consumes discovery findings as they emerge.
+
+### 2. Gates
+
+A gate is the approval moment that governs phase transition. The standard gates are brief approval, direction approval, identity approval, voice approval, copy approval, design approval, QA verification, and launch readiness. Each gate has a trigger (the work that opens it), an approver (the person or test suite that passes it), required-to-pass criteria (the measurable thing that says yes or no), what's blocked until the gate passes, and what's already locked from prior gates.
+
+Gates work when the criteria are measurable. "Brief approved" is too vague; "client signed the brief artifact in writing or in a recorded review" is measurable. "QA passed" is too vague; "Playwright critical-flow suite green, console error count at or below baseline, accessibility floor maintained" is measurable. Gates that are not measurable become political; gates that are measurable become structural.
+
+### 3. Lock points
+
+A lock point is the moment an artifact becomes immutable. The brief locks after direction is approved. Identity tokens lock after the identity gate. Voice rules lock after voice approval. Copy locks per page after copy approval. Once locked, the artifact cannot be changed by downstream work; it can only change via a formal change request that triggers re-review of dependent work.
+
+Without explicit lock points, every artifact is conceptually editable forever. That is the source of brief drift. The orchestrator plan names what locks at which gate, where the locked artifact lives, who can request a change, and what gets re-reviewed if a change is approved. Locked is not the same as final; locked means "any further change to this triggers downstream review work, so make changes deliberately."
+
+### 4. Handoffs
+
+A handoff is the moment work transfers between phases or skills. The standard handoffs are discovery to brief, brief to identity, brief to voice, identity plus voice to copy, identity plus copy to design, design to engineering, engineering to launch. Each transfers specific artifacts and decisions. Each leaves some things open and locks others.
+
+There is also a cross-cutting handoff: the adjacent observation handoff. While working on the homepage hero, an agent or person notices the footer copy is inconsistent with the new voice. That observation is not the current task. It is filed as an observation in the project triage queue. The PM or tech lead reviews observations on a regular cadence and triages them into proper tickets. This pattern keeps current work focused while not losing the contextually-relevant findings the team would otherwise either drop or derail current work to address.
+
+### 5. Team-size modulation
+
+A 2-person team and a 12-person team need different orchestration. Solo work is one person playing every role. Small (2-3) means a single reviewer per gate and async handoffs are fine. Medium (4-7) needs multiple reviewers and async sync points. Large (8+) needs formal phase reviews, a dedicated PM for orchestration, and explicit cross-track sync ceremonies because parallel tracks drift apart without them.
+
+The orchestration plan output modulates by scale. Solo gets self-review checklists per phase. Small gets per-gate "review by" assignments. Medium gets reviewer rotation and within-phase mini-gates. Large gets formal phase reviews, cross-track sync, and a brief-owner role. The framework is the same; the cadence's review density and ceremony level change.
+
+### 6. Tool-stack implementation
+
+Phases and gates exist in concept; they implement in tools. The orchestration plan specifies the implementation per platform: in Jira, phases become Epics with custom fields for "Phase", "Locked", "Approver", and "Gate Status"; in Linear, phases become Projects with cycles and label-driven views; in Notion, the brief becomes a database row with relation properties tying to direction docs, identity specs, voice guides, and copy decks; in Figma, phases become library folders with frame-level review status; in GitHub, phases interact with branch protection, PR templates, and CODEOWNERS-driven review routing.
+
+Where MCPs exist (Atlassian, Linear, Notion, GitHub), the plan specifies which orchestration setup operations the MCP can execute and which remain manual UI work. Where MCPs are limited (Figma's Dev Mode MCP is dev-mode-focused; the design library setup remains manual), the plan documents the recommendation without claiming end-to-end automation.
+
+### 7. Automation and QA verification
+
+The single most consequential discipline in the framework. Tasks only move from "QA" to "Done" after automated verification passes. This makes Done a measurable gate, not a self-reported one.
+
+The standard status taxonomy is Todo, In Progress, Waiting, Blocked, Done. Blocked is a first-class status, distinct from Waiting. Waiting means the task is paused for normal handoff or scheduled review; Blocked means the task cannot proceed without human resolution of a specific issue. Agents move tasks to Blocked when they cannot autonomously resolve work; this prevents agents from spinning on un-resolvable problems and burning context.
+
+QA verification gates fire automatically. Playwright MCP runs critical-flow tests; Chrome MCP runs human-readable walkthroughs and captures evidence; Windows MCP handles desktop apps; mobile testing harnesses cover mobile applications. Failure routes to Blocked, files an adjacent observation if the failure surfaced something unrelated, pages the human via the configured channel, and stops. The agent does not retry autonomously.
+
+---
+
+## Common project-type cadences
+
+Seven templates. Each is a skeletal phase map; the cadence-patterns reference file expands each.
+
+- **New brand build.** 6 to 8 weeks across 5 phases: Discovery (1 week), Direction (1 week), Identity (1 to 2 weeks), Production (2 to 3 weeks), Launch (1 week). Gates fire after each phase; identity locks before copy starts.
+- **Rebrand.** 4 to 6 weeks across 4 phases: Audit (1 week, replaces Discovery), Direction (1 week), Identity (1 to 2 weeks), Production (1 to 2 weeks). Audit assumes positioning and audience are known; the work is assessing what to keep, drop, or refresh.
+- **Single landing page.** 1 to 2 weeks across 3 phases: Brief (2 to 3 days), Production (5 to 7 days), QA-Launch (1 to 2 days). Identity is assumed locked. Voice is assumed locked. The work is page-specific copy, design, and engineering.
+- **Campaign.** 2 to 4 weeks across 4 phases: Brief (3 to 5 days), Production (1 to 2 weeks), QA (3 to 5 days), Launch (1 to 2 days). Campaign assumes brand identity and voice exist and are locked.
+- **Identity refresh.** 3 to 4 weeks across 3 phases: Audit (1 week), Identity (1 to 2 weeks), Production (1 week). Skips discovery and positioning. The output is a refreshed identity system that goes into production for application examples.
+- **Website refresh.** 4 to 8 weeks across 4 phases: Audit (1 week), Direction (1 week), Production (2 to 4 weeks), QA-Launch (1 to 2 weeks). Direction may produce a refreshed brief if the audit surfaces positioning gaps.
+- **Microsite or product launch.** 3 to 5 weeks across 4 phases: Brief (3 to 5 days), Production (2 to 3 weeks), QA (3 to 5 days), Launch (2 to 3 days). The microsite or product launch usually has a fixed launch date that drives backward planning.
+
+Each cadence reads as if the PM could paste it into a calendar and start running. Phase boundaries align with calendar weeks where possible, because that is how teams actually plan.
+
+---
+
+## Failure patterns
+
+The orchestration plan exists to prevent these. Each is a real failure mode, observed in the wild on real projects.
+
+- **Brief becomes a write-once doc.** The brief is drafted, signed, then nobody references it again. Downstream work drifts. The fix: lock the brief at a gate and treat any reference to it as a reading, not an edit.
+- **Brief gets unfrozen mid-flight without re-reviewing dependent work.** Someone tweaks the brief's audience or positioning; the change does not propagate to identity, voice, or copy that already depend on the old version. The fix: a formal change-request protocol that triggers re-review of dependent artifacts.
+- **Identity locks before voice.** The typography is finalized before the voice is approved. Result: the type and the voice register conflict (a friendly voice in austere type, or a serious voice in casual type). The fix: voice approval gate fires before or alongside identity lock.
+- **Copy starts before voice locks.** Writers draft against a moving target. Rework is invisible because the original draft never gets compared against the locked voice. The fix: voice approval before copy production.
+- **Multiple parallel design tracks lose brief alignment.** Track A and Track B both interpret the brief slightly differently; by week 3 the two tracks read as different brands. The fix: cross-track sync ceremonies and a brief-owner role.
+- **Engineering starts before design freeze.** Components get built against design that is still moving. Rework downstream when design lands somewhere else. The fix: design approval gate before engineering starts on the affected surface.
+- **Reviews stack at end of phase.** Everyone defers their review to the final day; the gate becomes a 10-hour review marathon and approvers approve under fatigue. The fix: within-phase mini-gates that flatten review demand.
+- **Async handoffs without artifact specification.** "Hand the design over to engineering" without specifying what artifacts (Figma file URL, exported tokens, asset library reference, PR draft template) means engineering opens half a dozen Slack threads to find what they need. The fix: explicit artifact specification per handoff.
+- **QA gate is self-reported.** "Done" tickets get moved to Done without verification. Bugs land in production. The fix: automated verification that fires before status transitions to Done; failure routes to Blocked.
+- **Agents spin on un-resolvable work.** A Claude Code task cannot resolve itself; the agent retries, burns context, runs out of tokens, leaves the work in a worse state than when it started. The fix: Blocked is a first-class status; agents move tasks to Blocked when they cannot autonomously resolve, document the blocker, and stop.
+
+---
+
+## Output format
+
+Default output is a markdown document, typically saved as `ORCHESTRATION.md` at the project root or in a `docs/` subdirectory. The document contains the full plan and is the canonical reference for the team.
+
+Structure:
+
+1. **Project orchestration plan.** Phased timeline with calendar weeks, milestone dates, phase outputs.
+2. **Per-phase gate specs.** What enters, what exits, who approves, the measurable pass criteria for each gate including the QA verification gate.
+3. **Lock-point register.** What becomes immutable when, where the locked artifact lives, who can request a change, and what re-review work a change triggers.
+4. **Tool-stack implementation guide.** Concrete setup for Jira, Linear, Notion, Figma, and GitHub as applicable, with MCP commands or CLI invocations for the parts that automate.
+5. **QA verification gate spec.** Which automated tests must pass, which MCPs run them, where evidence attaches, what happens on failure.
+6. **Handoff specs.** Artifacts transferred per handoff, locked items, change-request protocols, adjacent-observation routing.
+7. **Cross-skill dependency graph.** Which skills run in which phase, what each skill consumes, what each produces.
+8. **Risk register.** Cadence-specific risks with mitigations.
+
+The document is the orchestration plan. The next step after delivery is for the PM to set up the team's tools to match (Jira epics, Linear projects, Notion databases, Figma libraries, GitHub branch protection) and start running the plan.
+
+---
+
+## Reference files
+
+- `references/cadence-patterns.md`. The 7 project-type cadences in detail with phase decomposition, timelines, gate definitions, and tool-stack implementation skeletons.
+- `references/gate-definitions.md`. Each standard gate with trigger, approver, pass criteria, what's blocked, what's already locked, and change-request protocols.
+- `references/handoff-protocols.md`. The standard handoffs between phases and skills, plus the adjacent observation handoff for filing things noticed while working nearby.
+- `references/platform-implementation.md`. How the orchestration maps to Jira, Linear, Notion, Figma, and GitHub, including MCP integration notes per platform and CLI alternatives where MCP is the wrong tool.
+- `references/team-size-modulation.md`. How cadences scale across solo, small, medium, and large teams.
+- `references/automation-and-qa-tooling.md`. The QA verification gate pattern, MCP vs CLI tradeoffs, session memory and momentum patterns, code-to-ticket linkage, and evidence trails.
+- `references/example-orchestration.md`. A complete worked example showing all sections populated for a representative scenario.

--- a/skills/integration-orchestrator/references/automation-and-qa-tooling.md
+++ b/skills/integration-orchestrator/references/automation-and-qa-tooling.md
@@ -1,0 +1,167 @@
+# Automation and QA tooling
+
+The QA verification gate, MCP vs CLI tradeoffs at the strategic level, session memory and momentum patterns, code-to-ticket linkage, evidence trails, and failure routing. This file pairs with platform-implementation.md (which covers per-platform specifics) but stays at strategic-pattern level.
+
+---
+
+## Section 1: The QA verification gate
+
+The single most important pattern in this reference file. Tasks only move from "QA" to "Done" after automated verification passes. This makes Done a measurable gate, not a self-reported one.
+
+The orchestration plan specifies, per project type:
+
+- **Which automated tests must pass.** Defined in writing as part of the orchestration plan output. Different project types have different test suites.
+  - **Web project.** Playwright critical-flow tests covering signup, checkout, contact form, navigation, and any other paths that move money or capture data. Visual regression on key pages (homepage, pricing, top-traffic landing pages). Console error count not exceeding baseline (specify baseline as 0 errors at hero load and during critical flows). Accessibility floor (WCAG AA contrast, keyboard navigation reaching all interactive elements, screen reader landmarks present and labeled). Performance budgets (Lighthouse mobile and desktop scores at or above project target, Core Web Vitals at or above project target).
+  - **Microsite or landing page.** Subset of the above scoped to the page; performance budgets often tighter.
+  - **Campaign.** Cross-deliverable consistency check (do all assets reference the same brand identity? do all touchpoints use the locked voice?) plus per-deliverable QA.
+  - **Identity refresh.** Visual regression on the design library plus an audit of downstream files using deprecated components.
+
+- **Which MCPs run them.**
+  - **Playwright MCP** for browser-driven user-flow tests. The agent invokes the test suite, captures pass/fail per test, and attaches results to the ticket.
+  - **Claude in Chrome / Chrome MCP** for human-readable QA flows with screenshot or GIF evidence trails. Useful when the test isn't a deterministic pass/fail (e.g., "does the checkout flow feel right?" requires a human-readable record). Chrome MCP captures the agent's walkthrough as a GIF or screenshot sequence.
+  - **Windows MCP** for desktop applications. Covers Windows-specific testing scenarios when the project is desktop-app-shaped.
+  - **Mobile testing MCPs** (Detox-based, Appium variants) for mobile apps when applicable.
+
+- **What gets verified in a typical web QA pass.**
+  - Critical user-flow tests (signup, checkout, contact form submission, search if applicable).
+  - Visual regression on key pages (typically 5-10 pages flagged as critical).
+  - Console error count not exceeding baseline.
+  - Accessibility floor (WCAG AA contrast, keyboard navigation, screen reader landmarks).
+  - Performance budgets (Lighthouse, Core Web Vitals).
+
+- **Where the evidence attaches.**
+  - Linked to the ticket as a comment with screenshot or GIF.
+  - Optionally stored in a `.evidence/` folder in the repo (engineering projects) or a designated cloud bucket (S3, GCS).
+
+- **What happens on failure.**
+  - Status moves to Blocked (not back to In Progress).
+  - The blocker reason is documented in the ticket comment.
+  - If the failure surfaced something unrelated to the current task, an adjacent observation gets filed in the project triage queue.
+  - The human is paged via the configured channel.
+  - The agent does NOT keep retrying autonomously; it documents the state and waits.
+
+---
+
+## Section 2: MCP vs CLI tradeoffs at the strategic level
+
+The platform-implementation reference covers per-platform specifics. This section is the strategic frame for choosing between MCP and CLI as the orchestration's primary interface.
+
+### MCP excels at
+
+- Small reads and writes (single ticket update, single comment posting, single page edit).
+- Real-time data (current status of a project, current PRs awaiting review).
+- API-shaped operations that map cleanly to JSON-in / JSON-out.
+- Agent-friendly contracts (structured tool calls with typed responses).
+- Navigation queries ("show me all open tickets in this project", "find the PR that touches this file").
+- Status reads (what's the current gate state, what's locked).
+
+### CLI excels at
+
+- Bulk content updates (large Confluence pages, multi-page Notion exports, repo-wide search-and-replace).
+- File-tree-aware operations (operating on multiple files in a repo, generating a directory of artifacts).
+- Git-like workflows (the gh CLI's strengths around branches, PRs, releases).
+- Lower token cost on heavy operations. MCP roundtrips become expensive at scale; CLI runs locally with no token cost per operation.
+- Scripted automation (CI workflows, deploy pipelines, scheduled jobs).
+
+### Decision pattern
+
+- **For setup and orchestration.** Prefer MCP. PM-friendly, declarative, easy to inspect. The agent can explain what it did via tool-call traces.
+- **For bulk operations.** Prefer CLI. More efficient, lower token cost, better formatting preservation.
+- **For QA verification.** Playwright CLI when the same test runs repeatedly (CI integration, pre-commit hooks). Playwright MCP when verification is ad-hoc and needs to interact with surrounding context (the agent reading a Linear ticket, then running specific tests against the deployed staging site).
+
+### Hybrid pattern
+
+Most production setups use both. MCP for the orchestration plan's setup operations and ongoing navigation; CLI for ongoing bulk work, CI integration, and operations the MCP can't handle efficiently. The orchestration plan specifies which interface fires when.
+
+---
+
+## Section 3: Session memory and momentum
+
+The agent-starts-from-zero problem. Each new Claude Code session re-reads files, re-discovers decisions, re-learns the same gotchas. MCP gives the task list; it doesn't give working momentum.
+
+Patterns to bridge the gap:
+
+### Project state file
+
+Committed alongside code. Typical paths: `CLAUDE.md`, `AGENTS.md`, `.agent/state.md`. Contents:
+
+- **Last completed task** with brief outcome notes ("RAMP-123: homepage hero rewrite. Shipped in PR #456. Worth noting: the existing copy was longer than the new copy, so the design has extra whitespace below the hero now. May need design follow-up.").
+- **Current task in progress** with current status ("RAMP-124: pricing page CTA test. In Progress. Blocking on getting the test variant ID from Mira.").
+- **Open decisions awaiting human input** ("Should we use the new monogram on the favicon, or keep the existing letterform-as-symbol? Pending design lead review.").
+- **Known gotchas the agent should avoid re-discovering** ("The CMS export step takes 8 minutes. Don't kick it off until you're ready to wait. The export contains stale image references; replace with current image URLs from the asset library before publishing.").
+- **Convention reminders specific to the project** ("Branch names use uppercase ticket prefix: feat/RAMP-123-slug. PR descriptions include 'Closes RAMP-123'. Squash merge only.").
+
+### Per-task observation trail
+
+After completing each task, the agent records observations:
+
+- **What was unexpected** ("The CMS API returned a 429 on the first attempt; had to wait 60 seconds before retry succeeded.").
+- **What broke before it worked** ("Initial regex for the slug pattern matched too broadly; tightened to require dash separators.").
+- **What workaround was found** ("The token export script doesn't handle nested groups in Figma; flattened the groups manually before export.").
+- **What pattern might generalize** ("All API endpoints return null when the resource doesn't exist, not 404. Worth refactoring the error handling to assume null rather than 404.").
+
+### Trail-as-next-task generation
+
+When N observations accumulate (typically 5 to 10), hand them back as the brief for the next iteration: "here are 10 observations from this week, turn them into improvements." Keeps the agent's capability pointed at code quality and process refinement, not just task completion.
+
+The orchestrator skill's output bakes these mechanisms into the plan: specifies which state file to use, what content goes in it, when observations get reviewed by the human (typically weekly grooming), how the observation trail informs next-cycle planning.
+
+---
+
+## Section 4: Code-to-ticket linkage
+
+Standard but worth specifying so the orchestration plan can call out exactly which conventions the team uses.
+
+- **Branch naming.** `{type}/{ticket-id}-{slug}`. Type is one of feat / fix / chore / docs / refactor. Examples: `feat/RAMP-123-homepage-hero-rewrite`, `fix/LIN-456-contact-form-validation`. Ticket prefix matches the platform.
+- **PR descriptions.** Include the ticket reference. Closes RAMP-123 for full work; Refs RAMP-123 for partial work. Many platforms auto-link the ticket when this format is used.
+- **Commit messages.** Include the ref where relevant. Squash-merge workflows preserve the ref in the squash commit, which means the merged commit on main has the ticket trail.
+- **CODEOWNERS.** When set up, PR review routing happens automatically and the orchestration plan's review-by assignments align with platform-native routing.
+
+The orchestration plan specifies the convention per platform combination (Jira+GitHub uses RAMP-123 prefix style; Linear+GitHub uses LIN-456 or the team's chosen prefix). Without that specification, branch names drift across team members and the auto-linking breaks.
+
+---
+
+## Section 5: Evidence trails and recording
+
+Some pattern, some practical advice.
+
+### Recording tools
+
+- **Claude in Chrome auto-records GIFs** of QA flows. Useful for evidence attached to tickets. Limitations: GIF format is large and not video-quality; for longer flows, prefer MP4 or WebP if the recording tool supports it.
+- **Screenshot evidence** is sufficient for most ticket-level QA artifacts. Tools like Playwright auto-capture on test failure; Chrome MCP can take ad-hoc screenshots during human-readable QA.
+- **Loom or similar** for human-narrated walkthroughs when the audience needs context (client review of the staging site, stakeholder review of a complex flow).
+
+### Where evidence lives
+
+Three options, each with tradeoffs:
+
+- **Attached directly to the ticket as a comment.** Most discoverable but bloats the ticket. Best for evidence that pairs tightly with a specific ticket.
+- **In a designated cloud bucket** (S3, GCS) with a link in the ticket. Ticket stays clean, evidence has a stable URL. Best for projects with high evidence volume.
+- **In a `.evidence/` folder in the repo.** Works for engineering-heavy projects but cumbersome for design or copy work. Pairs well with the project state file pattern; evidence and state co-locate.
+
+### Retention
+
+Most projects don't need permanent evidence retention beyond the ticket. Specify a retention policy in the orchestration plan:
+
+- 30 days for QA evidence (passing tests don't need long retention).
+- 90 days for bug-related evidence (bug reproduction often resurfaces within 90 days).
+- Indefinite for design final approvals (the audit trail matters for years).
+
+---
+
+## Section 6: Failure routing
+
+When automated verification fails OR an agent hits something it cannot autonomously resolve, the failure follows a defined routing.
+
+1. **Status moves to Blocked.** Not back to In Progress, not to Waiting. Blocked is a first-class status that means "human action required to unblock".
+2. **The blocker reason is documented** in the ticket comment with specifics: which test failed, which file was the locus, which assertion didn't pass, what the agent already tried.
+3. **If the failure surfaced something unrelated to the current task,** an adjacent observation gets filed in the project triage queue.
+4. **The human is paged via the configured channel.**
+   - Slack (preferred for in-team work, fastest response).
+   - Email (for cross-team or external-stakeholder blockers).
+   - Linear or Jira mention (for in-tool routing when the team prefers a single channel).
+5. **The agent does NOT continue retrying.** It documents the state and waits. Retrying is the path that turns a single failure into a context-burning loop.
+
+This routing is itself part of the orchestration plan output: the skill specifies which channels are configured, who's on the escalation tree, and what response time is expected per blocker severity (typically: P0 blockers paged immediately; P1 paged within a working hour; P2 surfaced at next standup; P3 added to the triage queue without a page).
+
+The discipline of Blocked-as-first-class-status is what makes agent participation safe at scale. Without it, agents either burn context retrying or silently abandon work; with it, the agent has a clear "I'm stuck" signal that keeps the work visible to the human team.

--- a/skills/integration-orchestrator/references/cadence-patterns.md
+++ b/skills/integration-orchestrator/references/cadence-patterns.md
@@ -1,0 +1,245 @@
+# Cadence patterns
+
+The 7 project-type cadences in working detail. Each cadence covers phase decomposition, calendar timelines, gate definitions, lock-point map, and tool-stack implementation skeleton.
+
+## The 5-status taxonomy
+
+Every cadence in this file uses the same 5-status taxonomy:
+
+- **Todo.** Work scoped, not yet started.
+- **In Progress.** Work being actively done.
+- **Waiting.** Work paused for normal handoff or scheduled review. Examples: a ticket waiting for the next standup, a PR waiting for its assigned reviewer, a design awaiting client review at the next scheduled session.
+- **Blocked.** Work cannot proceed without human resolution of a specific issue. Distinct from Waiting. An agent moves a task to Blocked when it cannot autonomously resolve and documents the blocker. The agent then stops; it does not retry.
+- **Done.** Work complete AND verified. The QA verification gate must pass before transition to Done. Self-reported "I think this works" does not transition to Done; the automated test gate (or, in non-engineering contexts, the explicit reviewer signoff) does.
+
+Status transitions are restricted at the gate level. The QA gate prevents transition to Done. The approval gates prevent forward progress until the gate passes. Blocked tickets generate a paging signal to the configured channel.
+
+---
+
+## 1. New brand build (6 to 8 weeks)
+
+The full lifecycle. Greenfield brand or a brand whose existing assets are being replaced wholesale.
+
+### Phase decomposition
+
+| Phase | Duration | Output |
+|---|---|---|
+| Discovery | 1 week | Audience, positioning, competitive landscape, references |
+| Direction | 1 week | Creative direction brief (axes locked) |
+| Identity | 1 to 2 weeks | Logo system, color, typography, imagery direction, motion |
+| Production | 2 to 3 weeks | Voice guide, copy, design system, page builds |
+| Launch | 1 week | QA, soft launch, full launch |
+
+### Gates
+
+- **End of Discovery.** Brief approval. Required: client signed brief artifact (in writing or recorded review).
+- **End of Direction.** Direction approval. Required: axis positions locked, references curated.
+- **End of Identity.** Identity approval. Required: logo system, color tokens, typography, imagery direction documented.
+- **Mid-Production.** Voice approval. Required: voice guide signed.
+- **End of Production.** Copy approval and design approval. Required: per-page copy and design signed.
+- **Pre-Launch.** QA verification. Required: Playwright critical-flow suite green, console error count at or below baseline, accessibility floor maintained.
+- **Launch readiness.** Final go/no-go. Required: deployment checklist complete, rollback plan documented.
+
+### Lock points
+
+Brief locks at end of Direction. Identity tokens lock at end of Identity. Voice locks mid-Production. Copy locks per page at end of Production. Design tokens lock with identity; design final lock at end of Production.
+
+### Tool-stack implementation
+
+- **Jira:** 1 Epic per phase, Stories per work item, custom fields for Phase / Locked / Approver / Gate Status. Workflow scheme with the 5-status taxonomy.
+- **Linear:** 1 Project per phase, Cycles per week, Labels per skill (`brand-identity`, `brand-voice`, `landing-page-copy`, etc.).
+- **Notion:** Brief database with one row, related databases for direction docs, identity specs, voice guides, copy decks. Phase dashboard views.
+- **Figma:** Library structure: Discovery moodboards, Direction tokens, Identity components, Production frames. Frame-level review status.
+- **GitHub:** Branch protection on `main`. PRs from `phase/{phase-name}/*` branches.
+
+### Example ticket titles
+
+- Discovery: "Audience: 5 archetypes interviewed", "Positioning: locate the brand against 3 competitors"
+- Direction: "Direction: confirm tone-axis position", "Direction: rejection list signed off"
+- Identity: "Identity: logo lockup variants for review", "Identity: color tokens locked"
+- Production: "Voice guide: tone-shift table approved", "Copy: homepage hero v3 reviewed"
+- Launch: "QA: Playwright critical flow regression green", "Launch: deploy to production"
+
+---
+
+## 2. Rebrand (4 to 6 weeks)
+
+Existing brand. Audience and positioning known. Audit replaces discovery.
+
+### Phase decomposition
+
+| Phase | Duration | Output |
+|---|---|---|
+| Audit | 1 week | What to keep, drop, refresh; positioning gaps |
+| Direction | 1 week | Creative direction brief |
+| Identity | 1 to 2 weeks | Refreshed logo, color, type, imagery |
+| Production | 1 to 2 weeks | Updated voice guide, copy, design library, page builds |
+
+### Gates
+
+Audit approval, direction approval, identity approval, voice approval, copy approval, design approval, QA verification, launch readiness. Same gates as new brand build minus the Launch phase (rebrand often launches with the production push rather than a separate phase).
+
+### Lock points
+
+Audit findings lock at end of Audit (decisions about what to keep stay in scope; revisiting requires change request). All other lock points match new brand build.
+
+### Tool-stack implementation
+
+Same as new brand build. The Audit phase typically uses a Notion database with rows for "Existing asset / Decision (keep/drop/refresh)/Owner / Status".
+
+---
+
+## 3. Single landing page (1 to 2 weeks)
+
+The brand identity and voice are locked. The work is page-specific copy, design, and engineering.
+
+### Phase decomposition
+
+| Phase | Duration | Output |
+|---|---|---|
+| Brief | 2 to 3 days | Page brief, success criteria |
+| Production | 5 to 7 days | Copy, design, build |
+| QA-Launch | 1 to 2 days | QA, deploy |
+
+### Gates
+
+- **End of Brief.** Page brief approval. Required: success metric defined.
+- **Mid-Production.** Copy approval. Required: signed against existing voice guide.
+- **End of Production.** Design approval and engineering review. Required: design final, build complete.
+- **End of QA-Launch.** QA verification and launch readiness combined. Required: Playwright run green, console errors at baseline, deploy executed.
+
+### Lock points
+
+Page brief locks at end of Brief. Copy locks mid-Production. Design tokens are inherited from the brand identity (already locked). Design final locks at end of Production.
+
+### Tool-stack implementation
+
+- **Jira / Linear:** Single Epic for the page, 5 to 8 Stories.
+- **Notion:** Single brief row, one direction artifact (the page brief).
+- **Figma:** Working file referencing the brand library; one set of frames.
+- **GitHub:** Single feature branch, PR template, branch protection on `main`.
+
+---
+
+## 4. Campaign (2 to 4 weeks)
+
+Brand identity and voice locked. Multiple deliverables under one campaign theme.
+
+### Phase decomposition
+
+| Phase | Duration | Output |
+|---|---|---|
+| Brief | 3 to 5 days | Campaign brief, deliverable list |
+| Production | 1 to 2 weeks | Per-deliverable copy, design, build |
+| QA | 3 to 5 days | Cross-deliverable QA |
+| Launch | 1 to 2 days | Coordinated launch |
+
+### Gates
+
+Campaign brief approval, per-deliverable copy approval, per-deliverable design approval, cross-deliverable QA verification, launch readiness.
+
+### Lock points
+
+Campaign brief locks at end of Brief. Per-deliverable copy locks at copy approval. Per-deliverable design locks at design approval. Cross-deliverable consistency checked at QA gate (a single change request on the campaign brief triggers re-review across all deliverables).
+
+### Tool-stack implementation
+
+- **Jira / Linear:** 1 Epic for campaign, 1 Story per deliverable plus per-deliverable subtasks.
+- **Notion:** Campaign brief row plus deliverable rows in a related database.
+- **Figma:** Library file plus one frame per deliverable.
+- **GitHub:** Multiple feature branches off a campaign branch, single PR per deliverable.
+
+---
+
+## 5. Identity refresh (3 to 4 weeks)
+
+Existing brand. Voice and positioning stay. Identity gets refreshed.
+
+### Phase decomposition
+
+| Phase | Duration | Output |
+|---|---|---|
+| Audit | 1 week | What stays, what changes |
+| Identity | 1 to 2 weeks | Refreshed logo, color, type, imagery |
+| Production | 1 week | Application examples (web, signage, social) |
+
+### Gates
+
+Audit approval, identity approval, production review. Voice and copy gates skipped (voice stays locked; copy gets light updates if any).
+
+### Lock points
+
+Audit findings lock at end of Audit. Identity tokens lock at end of Identity. Application examples lock at end of Production but tokens remain canonical.
+
+### Tool-stack implementation
+
+- **Figma:** Refresh of existing library; new component versions; old components deprecated rather than deleted (downstream files still reference them).
+- **Notion:** Identity spec row with relations to before/after asset databases.
+- **Jira / Linear:** Smaller scope than rebrand; 1 Epic, 8 to 15 Stories.
+- **GitHub:** Library updates land via versioned PR; downstream consumers update on their own cadence.
+
+---
+
+## 6. Website refresh (4 to 8 weeks)
+
+Existing site. Either a partial refresh (specific sections) or a full overhaul.
+
+### Phase decomposition
+
+| Phase | Duration | Output |
+|---|---|---|
+| Audit | 1 week | Current site assessment, gaps, priorities |
+| Direction | 1 week | Refreshed brief if positioning has shifted |
+| Production | 2 to 4 weeks | Voice updates, copy, design, build |
+| QA-Launch | 1 to 2 weeks | Cross-page QA, soft launch, full launch |
+
+### Gates
+
+Audit approval, direction approval (if direction phase happens; some refreshes skip), per-section copy approval, per-section design approval, QA verification, launch readiness.
+
+### Lock points
+
+Audit findings lock at end of Audit. Direction (if produced) locks at end of Direction. Per-section copy locks at copy approval per section. Design tokens lock with the design library; design final per section locks at design approval.
+
+### Tool-stack implementation
+
+- **Jira / Linear:** 1 Epic per phase, sub-Epics per section if the site is large.
+- **Notion:** Brief plus per-section page in a database.
+- **Figma:** Library refresh plus per-section design files.
+- **GitHub:** Per-section feature branches, branch protection, CI gates per section.
+
+---
+
+## 7. Microsite or product launch (3 to 5 weeks)
+
+Fixed launch date. Plan backward from the launch.
+
+### Phase decomposition
+
+| Phase | Duration | Output |
+|---|---|---|
+| Brief | 3 to 5 days | Launch brief, microsite scope |
+| Production | 2 to 3 weeks | Copy, design, build, integrations |
+| QA | 3 to 5 days | Cross-flow QA |
+| Launch | 2 to 3 days | Coordinated launch sequence |
+
+### Gates
+
+Launch brief approval, copy approval, design approval, QA verification, launch readiness.
+
+### Lock points
+
+Launch brief locks at end of Brief. Copy locks at copy approval. Design locks at design approval. The launch date is the hardest lock; if QA fails, the launch slips rather than launching with bugs.
+
+### Tool-stack implementation
+
+- **Jira / Linear:** 1 Epic, multiple Stories per surface (microsite, supporting pages, integrations).
+- **Notion:** Launch brief plus dependency table (assets, integrations, third parties).
+- **Figma:** Microsite design file referencing brand library.
+- **GitHub:** Microsite feature branch plus per-surface sub-branches; branch protection plus pre-launch CI gate.
+
+---
+
+## How to use this file
+
+Pick the cadence whose project type matches yours. Follow the phase decomposition for your team size (use the team-size-modulation reference for adjustments). Implement in your tool stack using the platform-implementation reference for per-platform setup. Configure the QA verification gate using the automation-and-qa-tooling reference. The pieces compose; this file is the cadence skeleton.

--- a/skills/integration-orchestrator/references/example-orchestration.md
+++ b/skills/integration-orchestrator/references/example-orchestration.md
@@ -1,0 +1,267 @@
+# Example orchestration
+
+A complete worked example showing all sections of the orchestration plan populated for a representative scenario. The PM should be able to read this Monday morning and start setting up tools Tuesday.
+
+## Scenario
+
+A 4-person team is doing a rebrand for a 15-year-old hospitality brand. The existing brand has a loyal customer base and recognizable identity assets, but the visual register has aged poorly and the digital surfaces haven't been updated since 2019.
+
+- **Team.** PM (Mira), design lead (Karim), copy lead (Jess), senior engineer (Dax).
+- **Timeline.** 6 weeks.
+- **Tool stack.** Jira (existing, the team's main work tracker) + Figma + GitHub. Notion is not used by this team. Slack for communication. Loom for client review walkthroughs.
+- **AI agent participation.** Claude Code participates in production phase tasks (component library updates, page builds). Claude in Chrome runs QA gates on the staging deployment. Agents have access to the Atlassian MCP and GitHub MCP. Agents move tickets between Todo, In Progress, Waiting, and Blocked but do NOT move to Done; Done requires human verification.
+- **Client.** Hospitality brand owner is non-technical. Reviews happen via Loom-recorded walkthroughs scheduled at end of each phase.
+
+---
+
+## 1. Project orchestration plan
+
+### Phased timeline
+
+- **Week 1 (Audit).** Existing brand assessment. Audience already known; the audit assesses what to keep, drop, refresh. Output: audit findings document.
+- **Week 2 (Direction).** Refreshed creative direction brief. Tone, aesthetic, relationship, sensory positions confirmed. Output: direction artifact.
+- **Weeks 3-4 (Identity).** Refreshed logo lockup, color tokens, typography selections, imagery direction. Output: locked identity tokens published to Figma library, identity spec document.
+- **Weeks 5-6 (Production).** Voice guide refresh, copy update for top 8 pages, design final per page, engineering implementation, QA verification, launch.
+
+### Calendar boundaries
+
+Week 1: Mon-Fri Audit, Friday phase review with brand owner via Loom walkthrough.
+Week 2: Mon-Fri Direction, Friday phase review.
+Weeks 3-4: Mon-Fri Identity, mid-Week 4 voice approval gate, Friday Week 4 identity approval gate plus Loom walkthrough.
+Weeks 5-6: Mon-Tue Week 5 copy approval per page, Wed-Fri Week 5 design final per page (rolling), Mon-Wed Week 6 engineering implementation (rolling), Thu Week 6 QA verification, Fri Week 6 launch.
+
+---
+
+## 2. Per-phase gate specs
+
+### Audit approval gate (end of Week 1)
+
+- **Trigger.** All Audit tasks transitioned to Done. Audit findings document complete.
+- **Approver.** Brand owner (via Loom walkthrough plus email signoff). Mira reviews internally first.
+- **Required to pass.** Audit findings document complete (existing assets categorized as keep / drop / refresh, gaps identified). Brand owner signed off in writing.
+- **Blocks until passed.** Direction phase work.
+
+### Direction approval gate (end of Week 2)
+
+- **Trigger.** Tone, aesthetic, relationship, sensory positions selected. References curated. Rejection list documented.
+- **Approver.** Brand owner plus Karim (design lead).
+- **Required to pass.** All four axis positions confirmed in writing. Reference brand list documented. Rejection list signed off.
+- **Blocks until passed.** Identity phase production work.
+
+### Voice approval gate (mid Week 4)
+
+- **Trigger.** Refreshed voice guide drafted by Jess against locked direction.
+- **Approver.** Brand owner plus Jess (copy lead).
+- **Required to pass.** Voice guide complete (attributes, tone shifts, vocabulary, paired examples). At least 3 paired examples per major content type.
+- **Blocks until passed.** Copy production for shipping pages.
+
+### Identity approval gate (end of Week 4)
+
+- **Trigger.** Refreshed logo, color tokens, typography, imagery direction documented and rendered.
+- **Approver.** Brand owner plus Karim.
+- **Required to pass.** Logo lockup variants reviewed. Selected variants documented. Color tokens specified as hex codes. Typography selections specified as named typefaces with weights. Imagery direction documented.
+- **Blocks until passed.** Design production at scale.
+
+### Copy approval gate (per page, Week 5)
+
+- **Trigger.** Per-page copy drafted against locked voice guide.
+- **Approver.** Brand owner (via Loom walkthrough for top 3 pages; email approval for the other 5) plus Jess.
+- **Required to pass.** Copy matches voice guide. Calls-to-action consistent with success criteria.
+- **Blocks until passed.** Design final for that page.
+
+### Design approval gate (per page, Week 5-6)
+
+- **Trigger.** Design final rendered against locked copy and locked identity tokens.
+- **Approver.** Karim plus Mira.
+- **Required to pass.** Design references locked identity tokens. Copy reflected exactly as approved. Responsive states designed. Empty/loading/error states accounted for.
+- **Blocks until passed.** Engineering of that page.
+
+### QA verification gate (Thu Week 6)
+
+- **Trigger.** Engineering signaled complete; ticket transitioned to QA status.
+- **Approver.** Automated test suite (Playwright via MCP) plus Claude in Chrome walkthrough; human review on test failure.
+- **Required to pass.** Playwright critical-flow suite green. Console error count at 0 for hero load and during critical flows. Accessibility floor maintained (WCAG AA contrast, keyboard navigation, screen reader landmarks). Lighthouse mobile score at or above 85, desktop at or above 95. Visual regression on top 8 pages within tolerance.
+- **Blocks until passed.** Status transition to Done. Launch readiness for the affected page.
+
+### Launch readiness gate (Fri Week 6)
+
+- **Trigger.** All 8 affected pages have passed QA verification.
+- **Approver.** Mira (project owner) plus Dax (launch coordinator).
+- **Required to pass.** Deployment checklist complete. Rollback plan documented. On-call coverage assigned for the launch window. Brand owner notified.
+
+---
+
+## 3. Lock-point map
+
+- **Audit findings lock at end of Week 1.** Existing-asset decisions cannot be revisited without change request triggering re-review of Direction work.
+- **Direction locks at end of Week 2.** Axis positions cannot be revisited without change request triggering re-review of Identity, Voice, and Copy work.
+- **Identity tokens lock at end of Week 4.** Color tokens, typography selections, logo lockup committed to Figma library v2.0. Downstream design and engineering work references the locked library version.
+- **Voice rules lock mid Week 4.** Voice guide v2.0 committed to canonical Confluence page. Downstream copy production references the locked voice guide.
+- **Per-page copy locks at copy approval gate (Week 5).** Each page's copy locks individually as it passes its approval gate; design final for that page can begin.
+- **Per-page design locks at design approval gate (Week 5-6).** Each page's design locks individually; engineering for that page can begin.
+- **Code merges to main (Week 5-6, rolling).** Branch protection prevents direct pushes; PRs merge after CODEOWNERS review and CI gates pass.
+
+---
+
+## 4. Handoff specs
+
+- **Audit to Direction (Friday Week 1).** Audit findings document URL, summary of gaps and opportunities. Filed in Jira as a Confluence page link in the Direction phase Epic description.
+- **Direction to Identity (Friday Week 2).** Direction artifact URL, axis positions documented, reference brand list, rejection list. Filed in Jira as Confluence page links in the Identity phase Epic description.
+- **Direction to Voice (Friday Week 2, parallel to Direction-to-Identity).** Same artifacts; Voice phase work begins in parallel with Identity.
+- **Identity plus Voice to Copy (Mid-Week 5).** Locked identity tokens (Figma library v2.0 URL), locked voice guide (Confluence URL), per-page scope (Jira tickets). Filed in Jira as Story descriptions per page.
+- **Identity plus Copy to Design (Per page, Week 5).** Locked copy (Confluence URL with "approved" marker), locked identity tokens (Figma library v2.0 URL). Filed in Jira as the design-phase Story description per page.
+- **Design to Engineering (Per page, Week 5-6).** Final design (Figma frame URL), exported asset library (cloud bucket URL), responsive notes (Figma annotations), motion specifications. Filed in Jira as the engineering-phase Story description per page.
+- **Engineering to QA (Per page, Week 6).** Verified deployed-to-staging surface, QA evidence (Playwright run results URL, accessibility audit URL), deployment checklist URL.
+
+### Adjacent observation routing
+
+The team's triage queue is a Jira project labeled "Project triage". Filed observations route there without an assignee. Mira triages every Monday and Thursday at standup. Observation content includes: what was observed, why it might matter, link to the work that was happening when noticed, suggested triage priority. The agent uses the Atlassian MCP to file observations.
+
+---
+
+## 5. Tool-stack implementation
+
+### Jira
+
+Issue type scheme:
+- **Epic:** one per phase (Audit, Direction, Identity, Production-Voice, Production-Copy, Production-Design, Production-Engineering, Production-QA, Launch).
+- **Story:** one per work item within a phase.
+- **Task:** subtasks under stories.
+- **Bug:** for issues filed during QA.
+
+Custom fields:
+- Phase (single-select with the 8 phase names).
+- Locked (checkbox).
+- Approver (user picker).
+- Gate Status (single-select with the 8 standard gates).
+
+Workflow scheme: 5-status taxonomy (Todo / In Progress / Waiting / Blocked / Done) with workflow validators preventing premature transitions to Done without QA verification.
+
+Confluence space:
+- Brief page (rebrand brief).
+- Direction page (creative direction artifact).
+- Audit findings page.
+- Identity spec page (logo, color, typography, imagery).
+- Voice guide page.
+- Copy doc per page (top 8 pages).
+- Orchestration plan page (this document, committed to the project space).
+
+MCP setup:
+- Atlassian MCP configured with OAuth credentials (admin one-time setup).
+- Initial Epic creation: 8 epics, one per phase, populated by the agent on Day 1.
+- Initial Story creation per phase: agent populates from the orchestration plan.
+
+### Figma
+
+Library file structure:
+- "Tokens" page: color, typography, spacing, motion.
+- "Components" page: identity components (logo, badges, branded UI elements).
+- "Patterns" page: page-level patterns (hero variants, card patterns, footer).
+- "Page templates" page: top 8 page templates for the rebrand.
+- "Working files" page: per-page design working files.
+
+Library publish discipline:
+- v1.0 published at start of Week 3 (existing identity, used as baseline).
+- v2.0 published at end of Week 4 (refreshed identity, locks at identity gate).
+- Per-page working files reference v2.0 starting Week 5.
+
+### GitHub
+
+Repository: existing repo for the brand's website.
+
+Branch protection on main:
+- Require PR reviews (1 reviewer minimum).
+- Require status checks (lint, type-check, build, accessibility audit, Playwright run).
+- Require linear history (squash merges only).
+
+CODEOWNERS:
+- Frontend code: Dax.
+- Design tokens: Karim.
+- Copy markdown: Jess.
+
+PR template:
+- Ticket reference (Closes RAMP-XXX or Refs RAMP-XXX).
+- Summary.
+- Test plan.
+- Screenshots/GIFs for UI changes.
+- QA evidence URL.
+
+GitHub MCP setup:
+- GitHub MCP configured with the repo's PAT.
+- Initial PR template committed via MCP.
+- CODEOWNERS file committed via MCP.
+
+---
+
+## 6. Automation and QA verification
+
+### Playwright test suite spec
+
+Critical flows to test:
+- Homepage hero loads and renders.
+- Reservation flow (the brand's primary conversion path) end-to-end through booking confirmation.
+- Contact form submission (validation, submission, success state).
+- Newsletter signup.
+- Top-traffic landing pages render without console errors.
+
+Visual regression on top 8 pages:
+- Homepage, About, Reservations, Locations, Menu, Press, Contact, Loyalty.
+
+Accessibility audit per page using axe-core or equivalent:
+- WCAG AA contrast.
+- Keyboard navigation reaching all interactive elements.
+- Screen reader landmarks present and labeled.
+
+### Chrome MCP walkthrough scenarios
+
+For Loom-recorded brand owner reviews and ad-hoc human-readable QA:
+- Reservation flow walkthrough with screenshots at each step.
+- Brand consistency walkthrough (top 8 pages, evaluating typography and color consistency).
+- Mobile responsive walkthrough (the brand's audience is heavily mobile).
+
+### Evidence trail policy
+
+- QA evidence (test results, screenshots, GIFs) attached to each ticket as comments.
+- 90-day retention for engineering-related evidence.
+- Indefinite retention for design final approvals (committed to Confluence with the design spec page).
+
+### Failure routing
+
+- Slack channel #project-rebrand-launch is the team's coordination channel. Blockers page Mira via Slack mention.
+- P0 blockers (broken reservation flow): page Dax immediately via direct Slack mention.
+- P1 blockers (broken page render): surface at next standup.
+- P2-P3 blockers: file as adjacent observation in the triage queue.
+
+---
+
+## 7. Risk register
+
+Cadence-specific risks and mitigations.
+
+### Risk 1: Brand owner availability for Loom reviews
+
+The brand owner is busy and may delay phase reviews, slipping the timeline. Mitigation: Mira schedules Loom reviews 1 week in advance with calendar holds. Backup reviewer for direction approval gate is the head of marketing on the brand owner's team (Mira identified this person at project kickoff).
+
+### Risk 2: Identity refresh expectations vs reality
+
+The brand owner may expect a more dramatic refresh than the audit recommends, OR may reject the refresh as too dramatic. Mitigation: Karim shares 3 directional moodboards at end of Week 1 to align expectations BEFORE Direction phase locks in. The moodboards are not the final identity; they're directional samples to confirm the team and the brand owner are pointing in the same direction.
+
+### Risk 3: Engineering surface area
+
+The website has 8 pages but also a custom CMS, a reservation integration, and an email pipeline. The 6-week timeline assumes only the page surface gets touched. Mitigation: Mira confirmed at project kickoff that CMS, reservations, and email pipeline are out of scope. Documented in the brief. If the brand owner requests adding any of these mid-flight, formal change request triggers timeline review.
+
+### Risk 4: Agent coordination overhead
+
+Claude Code participates in production tasks; Claude in Chrome runs QA gates. The agents access the Atlassian and GitHub MCPs. Risk: agent action and human action collide on the same ticket; human commits something the agent had also drafted. Mitigation: agents are not assigned tickets; they take tickets from the "Available for agent" queue (a Jira label). Humans take tickets from the "Available for human" queue. Mira moves tickets between queues at standup.
+
+### Risk 5: QA verification baseline drift
+
+Console error baseline is set at start of project. If a third-party script (analytics, heatmap, customer support chat) lands during the project and adds console errors, the baseline shifts. Mitigation: console error baseline is reset weekly during standup. Any new errors that appear get triaged immediately as either an accepted change to baseline (third-party expected) or a regression that needs fixing.
+
+---
+
+## How to use this example
+
+This example is the format the orchestration plan output takes. Real outputs differ in specifics (different team, different timeline, different stack, different risks) but the structure is the same. The PM reads through, sets up the tools to match, and starts running the plan Tuesday.
+
+The discipline that makes this work: every section is specific. Generic plans fail. "QA gate must pass" is not a plan; "Playwright critical flows pass, console errors at baseline 0, accessibility floor WCAG AA, Lighthouse mobile at or above 85, visual regression on top 8 pages within tolerance" is a plan.

--- a/skills/integration-orchestrator/references/gate-definitions.md
+++ b/skills/integration-orchestrator/references/gate-definitions.md
@@ -1,0 +1,119 @@
+# Gate definitions
+
+The 8 standard gates. Each gate includes its trigger, approver, pass criteria, what's blocked until passing, what's already locked from prior gates, and the change-request protocol if the gate is failed or reopened later.
+
+A gate is the moment a phase transition gets approved. Gates work when their pass criteria are measurable. "Approved" is too vague; "client signed the artifact in writing or in a recorded review" is measurable. The orchestration plan specifies measurable criteria per gate.
+
+---
+
+## 1. Brief approval gate
+
+Closes the Discovery phase (or Audit phase, on rebrand projects) and opens Direction.
+
+- **Trigger.** All Discovery tasks transition to Done. The brief artifact is drafted.
+- **Approver.** Project owner (typically the client or the founder). For internal work, the senior stakeholder.
+- **Required to pass.** The brief artifact is complete (audience, positioning, deliverables, constraints, success criteria all populated). Approver signed in writing OR a recorded review session captured agreement. The brief artifact is committed to its canonical location (Notion brief database row, Confluence page, or repo file).
+- **Blocks until passed.** Direction phase work, identity phase work, voice phase work, copy work.
+- **Already locked.** Nothing yet; this is the first gate.
+- **Change-request protocol.** If the brief is reopened after this gate, the project re-enters Discovery briefly to assess what changed, then re-runs Direction starting from the updated brief. Identity, voice, copy, and design work that depends on the changed brief sections gets re-reviewed.
+
+---
+
+## 2. Direction approval gate
+
+Closes Direction phase and opens Identity.
+
+- **Trigger.** Axis positions selected (tone, aesthetic, relationship, sensory). References curated. Rejection list documented.
+- **Approver.** Project owner plus the design lead.
+- **Required to pass.** All four axis positions confirmed in writing. Reference brands documented with one-line rationale each. Rejection list signed off (what the brief explicitly says no to).
+- **Blocks until passed.** Identity phase production work. Voice production work. Any copy production.
+- **Already locked.** The brief.
+- **Change-request protocol.** If a direction axis is changed after this gate, identity work and voice work that depend on the changed axis get re-reviewed. Tone changes ripple to voice; aesthetic changes ripple to identity; relationship changes ripple to copy register; sensory changes ripple to motion and rhythm decisions.
+
+---
+
+## 3. Identity approval gate
+
+Closes Identity phase. Opens production at full volume.
+
+- **Trigger.** Logo system, color tokens, typography selections, imagery direction documented and rendered.
+- **Approver.** Project owner plus design lead.
+- **Required to pass.** Logo lockup variants reviewed (typically 6 to 12). Selected variants documented with rationale. Color tokens specified as hex codes. Typography selections specified as named typefaces with weights. Imagery direction documented (style, palette, treatment).
+- **Blocks until passed.** Design production at scale (component library, page designs). Engineering work that depends on design tokens.
+- **Already locked.** Brief, direction.
+- **Change-request protocol.** If identity tokens change after this gate, design files that reference the tokens get re-rendered. Engineering work that consumed the old tokens gets reviewed. Voice work is typically unaffected unless typography selection changes the implied tone register.
+
+---
+
+## 4. Voice approval gate
+
+Closes voice production. Opens copy production at scale.
+
+- **Trigger.** Voice guide drafted. Tone-shift table populated. Vocabulary list compiled. Paired examples written.
+- **Approver.** Project owner plus copy lead.
+- **Required to pass.** Voice guide complete (attributes, tone shifts, vocabulary, grammar, paired examples). At least 3 paired examples per major content type (hero copy, body, microcopy). Voice signed off in writing.
+- **Blocks until passed.** Copy production for shipping pages.
+- **Already locked.** Brief, direction, identity (or identity in progress; voice can lock alongside identity if both phases overlap).
+- **Change-request protocol.** If voice rules change after this gate, all copy that has been drafted against the old rules gets re-reviewed. The copy rework varies by scope: a vocabulary substitution is light; a tone-shift table change can mean rewriting from scratch.
+
+---
+
+## 5. Copy approval gate
+
+Per-page or per-deliverable. Closes copy production for that page or deliverable.
+
+- **Trigger.** Copy drafted against the locked voice guide. Internal review complete.
+- **Approver.** Project owner plus copy lead. For per-page copy, the page owner if different.
+- **Required to pass.** Copy matches the voice guide (verifiable by running the voice-guide checklist). All sections complete. Microcopy populated. Calls-to-action consistent with the brief's success criteria.
+- **Blocks until passed.** Design final for that page or deliverable. Engineering of the copy-dependent surface.
+- **Already locked.** Brief, direction, identity, voice.
+- **Change-request protocol.** Per-page copy changes after this gate trigger re-review of the design final for that page (because design length, hierarchy, and rhythm depend on copy length). Engineering work for that page may need to be revisited if the copy change affects layout.
+
+---
+
+## 6. Design approval gate
+
+Per-page or per-deliverable. Closes design production for that page or deliverable.
+
+- **Trigger.** Design final rendered against locked copy and locked identity tokens.
+- **Approver.** Design lead plus project owner.
+- **Required to pass.** Design references the locked identity tokens (no off-token color, type, or spacing values). Copy is reflected exactly as approved (no copy edits hidden in the design). Responsive states designed. Empty states, loading states, error states accounted for.
+- **Blocks until passed.** Engineering of the design-dependent surface.
+- **Already locked.** Brief, direction, identity, voice, copy.
+- **Change-request protocol.** Design changes after this gate trigger engineering re-review for the affected surface. The change-request protocol routes through the design lead to assess scope (token-level changes are light; component or layout changes are heavy).
+
+---
+
+## 7. QA verification gate
+
+Per-surface. Closes engineering and verification, opens launch readiness for that surface.
+
+- **Trigger.** Ticket transitions to "QA" status (developer signaled engineering complete).
+- **Approver.** Automated test suite, with human review on test failure or ambiguous result.
+- **Required to pass.** Defined Playwright critical-flow test suite green. Console error count at or below baseline (specify the baseline per project; for a typical web app, 0 errors at hero load, 0 errors during critical flows). Accessibility floor maintained: WCAG AA contrast ratios on all text, keyboard navigation reaching all interactive elements, screen reader landmarks present and labeled. Performance budgets met (Lighthouse mobile score at or above project target, Core Web Vitals at or above project target). Visual regression on key pages within tolerance.
+- **Blocks until passed.** Status transition to Done. Launch readiness for the affected surface.
+- **Already locked.** Code merged to main, design tokens, copy, identity, voice, direction, brief.
+- **Change-request protocol.** Failure routes the ticket to Blocked status (not back to In Progress). The blocker reason is documented in the ticket comment. If the failure surfaced something unrelated to the ticket's scope (e.g., a regression in a sibling page), an adjacent observation is filed in the project triage queue. The human is paged via the configured channel. The agent does NOT continue retrying autonomously.
+
+---
+
+## 8. Launch readiness gate
+
+Closes the project (or the launch phase of a multi-phase project).
+
+- **Trigger.** All affected surfaces have passed the QA verification gate.
+- **Approver.** Project owner plus the launch coordinator (typically the PM or the senior engineer on rotation).
+- **Required to pass.** Deployment checklist complete (environment variables set, secrets rotated, third-party integrations live, monitoring active, alerting configured). Rollback plan documented (which command, who runs it, where logs go). Launch communications drafted (internal: who knows the launch is happening; external: any customer-facing announcement). On-call coverage assigned for the launch window.
+- **Blocks until passed.** The actual production deploy.
+- **Already locked.** Everything: brief, direction, identity, voice, copy, design, code, QA evidence.
+- **Change-request protocol.** Launch readiness failure typically delays the launch rather than reopening upstream gates. If the failure is severe (a critical bug found in pre-launch QA), the affected surface returns to In Progress for fix, then re-runs through Engineering and QA verification before launch can proceed.
+
+---
+
+## How gates compose
+
+Gates are not isolated. Each gate locks artifacts that downstream gates assume are stable. A QA verification failure that traces to a copy bug means the copy approval gate produced bad output, which traces back to either a voice rule that wasn't applied or a brief that wasn't reflected. The gate chain is the audit trail.
+
+When a gate is reopened, the change-request protocol cascades downstream. The orchestration plan specifies the protocol per gate so the team knows in advance what re-review work a change triggers. The cost of a change is visible at the moment it's requested, not discovered after the fact.
+
+The QA verification gate is the gate that does the most work for the team. It is the gate that prevents "Done" from being self-reported. Configure it carefully; trust it once configured.

--- a/skills/integration-orchestrator/references/handoff-protocols.md
+++ b/skills/integration-orchestrator/references/handoff-protocols.md
@@ -1,0 +1,143 @@
+# Handoff protocols
+
+A handoff is the moment work transfers between phases or skills. Without explicit handoff specs, the receiving phase opens a half-dozen Slack threads to find what they need. With them, the work moves cleanly because the receiving phase knows exactly what artifacts to expect, what's locked, and what's still open.
+
+This file covers the 7 standard handoffs plus an 8th cross-cutting handoff: the adjacent-observation routing.
+
+---
+
+## 1. Discovery to Brief
+
+The first handoff. Discovery findings transfer to brief drafting.
+
+- **What's transferred.** Audience research notes (interview summaries, persona documents, audience-side observations). Positioning notes (competitive landscape, differentiation hypotheses). Reference materials gathered during discovery (brands, articles, examples that surfaced).
+- **What's locked.** Nothing yet. Everything is still open.
+- **What stays open.** All of it. Discovery is input, not decision.
+- **Common breakdown.** Discovery findings get summarized too aggressively; the brief drafter loses the nuance. Mitigation: hand off the full notes plus a synthesis, not just the synthesis.
+- **Artifact specification.** Discovery findings live in a Notion database, a Google Doc, or a folder of markdown files. The handoff includes a link plus a one-paragraph synthesis.
+- **Platform support.** Notion: relation property from brief row to discovery findings. Jira: linked issue. Linear: project relationship.
+
+---
+
+## 2. Brief to Identity
+
+After brief approval. The identity work begins against the locked brief.
+
+- **What's transferred.** Approved brief (audience, positioning, deliverables, constraints). Direction artifact (axis positions). Reference brand list. Rejection list.
+- **What's locked.** Brief is locked. Direction is locked. Audience and positioning cannot be revisited without change request.
+- **What stays open.** Everything inside the identity scope: logo system, color, typography, imagery direction, motion. The identity team picks within the constraints the brief and direction set.
+- **Common breakdown.** The identity team interprets the rejection list loosely. A "no laurel mark" rejection becomes "well, our laurel is different". Mitigation: rejection-list adherence is a gate criterion at identity approval.
+- **Artifact specification.** Brief lives in its canonical location (Notion brief row, Confluence page, or repo file). Direction artifact is a sibling document. Both URLs go in the identity-phase Epic or Project description.
+- **Platform support.** Jira: Epic description with links. Linear: Project description with attached docs. Notion: relation properties.
+
+---
+
+## 3. Brief to Voice
+
+In parallel with Brief-to-Identity. Voice work begins against the locked brief and direction.
+
+- **What's transferred.** Approved brief. Direction artifact (specifically the tone-axis position). Reference voice samples (other brands the team likes for their voice).
+- **What's locked.** Brief, direction.
+- **What stays open.** Voice attributes, tone-shift rules, vocabulary choices, grammar rules, paired examples.
+- **Common breakdown.** Voice gets started without referencing the locked tone-axis position; the writer drafts in their natural voice rather than the project's. Mitigation: voice production opens with a tone-axis check ("the brief says Provocative; here is what Provocative implies for vocabulary, sentence shape, and rejection list").
+- **Artifact specification.** Tone-axis position from direction artifact. Reference voice samples as a Notion subpage or a markdown file with quoted samples.
+- **Platform support.** Same as Brief-to-Identity.
+
+---
+
+## 4. Identity plus Voice to Copy
+
+After identity approval and voice approval. Copy production begins.
+
+- **What's transferred.** Identity tokens (typography selections, color tokens, spacing). Voice guide (attributes, tone shifts, vocabulary, paired examples). Page or deliverable scope (which pages, which sections, what each section needs).
+- **What's locked.** Brief, direction, identity tokens, voice rules.
+- **What stays open.** Per-page copy choices within the locked voice. Calls-to-action language. Section ordering decisions where the design has not yet been finalized.
+- **Common breakdown.** Copy is drafted for length without the typography in mind, and lands in design as either too long or too short for the rendered hero. Mitigation: copy production references the typography selection from the start; the writer drafts knowing which weight and size the copy will live in.
+- **Artifact specification.** Identity tokens published in Figma library or in a tokens markdown file. Voice guide as a Notion page or markdown file. Page scope as a Jira/Linear ticket per page.
+- **Platform support.** Figma library is the canonical token source. Jira/Linear ticket per page or section.
+
+---
+
+## 5. Identity plus Copy to Design
+
+After copy approval per page. Design final begins for that page.
+
+- **What's transferred.** Locked copy (final approved text). Identity tokens (typography, color, spacing). Voice guide (for microcopy and any error or empty states the design generates).
+- **What's locked.** Brief, direction, identity, voice, copy for the affected page.
+- **What stays open.** Design layout decisions, responsive breakpoint behavior, motion design, empty/loading/error states.
+- **Common breakdown.** Design starts before copy locks. Length, rhythm, and hierarchy get designed against placeholder text; when copy lands, the design has to be reworked. Mitigation: copy locks per page before design final starts. If parallel work is needed, design produces a wireframe with placeholder copy AND a flag noting "real copy pending; layout subject to revision".
+- **Artifact specification.** Locked copy in the canonical copy doc with an explicit "approved" marker. Identity tokens in Figma library. Page scope from copy-phase ticket.
+- **Platform support.** Figma frame per page, linked to ticket in Jira/Linear.
+
+---
+
+## 6. Design to Engineering
+
+After design approval per page. Engineering builds the page.
+
+- **What's transferred.** Final design (Figma file URL). Tokens (referenced from Figma library). Asset library (images, icons, illustrations exported and named per convention). Component specifications (any new components designed). Responsive behavior notes. Motion specifications (entry, exit, hover, loading states).
+- **What's locked.** Brief, direction, identity, voice, copy, design final.
+- **What stays open.** Implementation choices (state management, framework patterns, accessibility implementation, performance optimization). Component naming if new components.
+- **Common breakdown.** Asset exports happen ad-hoc as engineering needs them, leading to inconsistent file names, missing variants, and back-and-forth Slack messages. Mitigation: design phase exports a complete asset library (using the team's naming convention) before handoff. Engineering pulls from the library, does not request new exports during build unless missing.
+- **Artifact specification.** Figma URL, exported asset folder (cloud bucket or repo path), responsive notes as Figma annotations or a sibling markdown doc.
+- **Platform support.** Figma URL in the engineering ticket. Asset folder URL or path in the ticket. PR template references the design ticket.
+
+---
+
+## 7. Engineering to Launch
+
+After QA verification per surface. The surface goes to launch.
+
+- **What's transferred.** Verified surface (deployed to staging, tested). QA evidence (Playwright run results, accessibility audit results, performance audit results, console error counts). Deployment checklist for this surface. Rollback plan.
+- **What's locked.** Everything: brief, direction, identity, voice, copy, design, code merged to main, QA evidence.
+- **What stays open.** Launch coordination (which surface launches first, monitoring during launch window, on-call coverage).
+- **Common breakdown.** Launch happens before all surfaces have passed QA verification. Result: one surface launches with bugs, recoverable with rollback if monitoring catches it. Mitigation: launch readiness gate requires ALL surfaces to have passed QA verification, not just the most-prominent surface.
+- **Artifact specification.** QA evidence linked to ticket (screenshots, GIFs, test result logs). Deployment checklist as a runbook document. Rollback plan as a sibling runbook document.
+- **Platform support.** GitHub PR with QA artifact attachments or evidence URL. Linear or Jira ticket with the runbook URL.
+
+---
+
+## 8. Adjacent observation handoff (cross-cutting)
+
+The handoff that fires when an agent or person, while working on Task X, notices something about Task Y or Surface Z that is not the current task but is contextually adjacent.
+
+### Examples
+
+- Working on copy for the homepage hero, the writer notices the footer copy is inconsistent with the new voice. Filing the footer inconsistency as an observation, not stopping the homepage work.
+- Running QA on the pricing page, an agent notices the contact form on the about page has a console error. Filing the contact form error as an observation, not pausing the pricing-page QA.
+- Updating the Figma design library, the designer notices a deprecated component is still being used in the dashboard mockups. Filing a usage-cleanup observation, not modifying the dashboard mockup.
+- Reviewing a PR, an engineer notices a typo in a docstring in an unrelated file. Filing a typo observation, not blocking the PR review on it.
+
+### Why this handoff matters
+
+Without it, the team has two bad options. Option one: stop the current work and address the observation, derailing focus. Option two: ignore it, lose the context, never come back to it. The adjacent-observation handoff lets the current work proceed while preserving the finding for triage.
+
+### Routing
+
+The observation gets filed in a project triage queue, NOT directly assigned to anyone. The triage queue is reviewed on a regular cadence (typically daily standup or weekly grooming). The PM or tech lead triages the observation: discard if it's not relevant, file as a normal ticket if it is, attach to an existing ticket if it's a fragment of larger work.
+
+### Content of the observation
+
+Each filed observation includes:
+
+- **What was observed.** A specific factual statement (the footer says "Get in Touch" while the new voice would say "Reach out").
+- **Why it might matter.** A brief rationale (voice consistency, user-facing inconsistency, latent bug).
+- **Where it was noticed.** A link to the work that was happening when the observation surfaced (the PR, the Figma frame, the Notion page).
+- **Suggested triage priority.** The reporter's gut call (low / medium / high). The triager makes the actual call; the suggestion is just signal.
+
+### Platform support
+
+- **Jira.** A separate "triage" project or a labeled queue inside the main project. Observations get filed without an assignee; the triager assigns at triage time.
+- **Linear.** A "Triage" inbox is built into Linear and works exactly for this purpose.
+- **Notion.** A triage database; the assignee field stays empty until triage.
+- **GitHub.** Observations filed as issues without an assignee; CODEOWNERS may auto-route the issue to the relevant team for triage.
+
+The orchestration plan specifies which platform's triage queue is the canonical one for the project (typically the same platform as the main work) and the triage cadence (daily standup or weekly grooming). Without those specifics, observations either pile up untriaged or scatter across channels and get lost.
+
+---
+
+## How handoffs compose with gates
+
+A gate closes a phase. A handoff opens the next phase's work against the gate's locked output. The two patterns reinforce each other: gates make sure nothing premature ships; handoffs make sure the receiving work has what it needs to start.
+
+A failed gate triggers a handoff backward (rework the prior phase). A failed handoff (artifact missing, scope unclear) is itself often the symptom of a gate that didn't enforce its pass criteria. When a handoff goes wrong, audit the prior gate's criteria.

--- a/skills/integration-orchestrator/references/platform-implementation.md
+++ b/skills/integration-orchestrator/references/platform-implementation.md
@@ -1,0 +1,174 @@
+# Platform implementation
+
+How the orchestration plan implements in each platform. Per platform: workflow representation (how phases, gates, lock points, and handoffs map), MCP integration notes (what AI agents can do via the platform's MCP), and CLI alternatives (where the CLI is the better tool than MCP).
+
+This file pairs with the rampstack.co integrations content (`/integrations/jira`, `/integrations/linear`, `/integrations/notion`, `/integrations/figma`, `/integrations/github`, `/integrations/agile-creative-direction`). Cross-reference those pages for setup screenshots and additional team patterns.
+
+---
+
+## Jira / Atlassian
+
+### Workflow representation
+
+- **Phase representation.** Each phase becomes an Epic. Stories or Tasks live within the Epic. Custom fields tag the Phase explicitly.
+- **Gate representation.** Workflow status. The 5-status taxonomy (Todo / In Progress / Waiting / Blocked / Done) maps to Jira's workflow statuses, with workflow validators or transitions enforcing gate rules. A custom "Gate Status" field tracks gate state separately from issue status.
+- **Lock-point representation.** Custom field "Locked" (boolean) on the parent artifact (Epic for phase locks, Story for per-page locks). Locked issues display a visible label so reviewers know not to make untracked changes.
+- **Handoff representation.** Issue link types ("Blocks", "Is blocked by", "Relates to"). Linked Confluence page for the artifact (brief, direction, voice guide, copy doc).
+- **Concrete setup snippet.** Issue type scheme: Epic, Story, Task, Subtask, Bug. Custom fields: Phase (single-select with phase names), Locked (checkbox), Approver (user picker), Gate Status (single-select with the 8 standard gates). Workflow scheme: 5-status taxonomy with validators preventing premature transitions.
+
+### MCP integration notes
+
+- **Availability.** Official remote MCP server, launched 2025.
+- **References.** [Atlassian's Remote MCP Server announcement](https://www.atlassian.com/blog/announcements/remote-mcp-server) and [github.com/atlassian/atlassian-mcp-server](https://github.com/atlassian/atlassian-mcp-server).
+- **Capabilities.** Jira issue CRUD, status transitions, comment posting, JQL queries, Confluence page operations (read, write, update). Authentication via OAuth or API token.
+- **What the orchestrator skill can populate via MCP.** Initial epic structure from the orchestration plan (one epic per phase). Initial issue tree (stories per work item). Custom field values from the orchestration plan (Phase, Approver, Gate Status). Comments documenting handoffs and gate transitions. Confluence pages for the brief, direction artifact, voice guide, and orchestration plan itself.
+- **Practical limits.** Workflow scheme creation typically requires admin-level UI setup; MCP is better at populating against an existing scheme than at configuring the scheme from scratch. Heavy Confluence content edits lose Atlassian Document Format (ADF) details through MCP roundtrips when the content is rich (tables, callouts, complex code blocks). For simple page content, MCP roundtrips work; for heavily-formatted content, edit in the UI or use the CLI.
+
+### CLI alternatives and when to use them
+
+- **Atlassian official CLI (acli)** plus community alternatives (jira-cli, etc.).
+- **When CLI is the better choice.**
+  - Bulk operations across many tickets (200+ issues). MCP roundtrips become token-expensive at scale; CLI is more efficient.
+  - Heavy Confluence content edits where ADF formatting matters. CLI tools that parse and write ADF directly preserve formatting better than MCP roundtrips.
+  - Scripted reporting (export issues to CSV, generate burndown reports, run JQL across multiple projects).
+  - CI integration (running JQL in a CI step to validate that all blockers are resolved before deploy).
+- **Pattern note.** Some teams mirror Jira and Confluence content as local markdown files in a `.atlassian/` folder, syncing periodically via CLI. This pattern trades simplicity for power. Document it as one viable approach for engineering-heavy teams; PMs will rarely need it.
+
+---
+
+## Linear
+
+### Workflow representation
+
+- **Phase representation.** Each phase becomes a Project. Cycles (Linear's time-boxed sprints) sit within the project for week-by-week granularity.
+- **Gate representation.** Project status workflow plus issue status workflow. Linear's status workflow customizes to the 5-status taxonomy. Labels mark gate state per issue (e.g., "gate:identity-approved", "gate:qa-pending").
+- **Lock-point representation.** Labels (e.g., "locked:identity-tokens", "locked:voice"). Locked issues stay visible in their project but cannot be reopened without an explicit label removal.
+- **Handoff representation.** Project relationships (predecessor / successor projects), issue dependencies, and Linear's automatic mention parsing for cross-references.
+- **Concrete setup snippet.** Project template per project type (new brand build, rebrand, etc.) with phases pre-populated as projects, cycles configured, label taxonomy defined. Status workflow customized to include Blocked as a first-class status (Linear ships with Backlog, Todo, In Progress, Done, Cancelled by default; add Waiting and Blocked).
+
+### MCP integration notes
+
+- **Availability.** Official, well-supported.
+- **Reference.** [linear.app/docs/mcp](https://linear.app/docs/mcp).
+- **Capabilities.** Issues, projects, cycles, teams, labels, comments, attachments. Full CRUD on most entities; webhooks for event-driven workflows.
+- **What the orchestrator skill can populate via MCP.** Project setup with cycles. Label taxonomy from the orchestration plan. Initial issue population per phase. Project description and milestones. Status workflow customization. Initial assignee and reviewer assignments per the orchestration plan's review-by routing.
+- **Coverage note.** Linear's MCP coverage is the most complete of the 5 platforms. For teams running a Linear-based stack with AI agents, this MCP is the recommended starting point. The agent can do almost everything programmatically.
+
+### CLI alternatives and when to use them
+
+- **CLI status.** No widely-adopted Linear CLI. The MCP coverage is sufficient that CLI is rarely needed.
+- **API direct calls** remain an option for scripted setup if MCP isn't available in the runtime context.
+- **When the API is the better choice.** Bulk import scripts when migrating from another platform. Scheduled reports run from CI. Webhook handlers for event-driven external integrations.
+
+---
+
+## Notion
+
+### Workflow representation
+
+- **Phase representation.** Brief database with one row per project. Related databases for direction docs, identity specs, voice guides, copy decks. Each related database has its own rows; relation properties tie everything to the canonical brief.
+- **Gate representation.** Status property on each artifact row. Phase view filters the database by status to surface what's open vs locked.
+- **Lock-point representation.** A "Locked" checkbox or status property on each artifact row. Filtered views surface locked vs unlocked artifacts.
+- **Handoff representation.** Relation properties between databases. The brief row relates to the direction row, which relates to the identity spec row, which relates to the voice guide row, etc.
+- **Concrete setup snippet.** Brief database schema: Title, Status, Phase, Locked, Approver, Owner, Notes. Related databases: Direction, Identity, Voice, Copy, Design, QA Evidence. Relation properties tie each related row back to the brief. Dashboard view per phase.
+
+### MCP integration notes
+
+- **Availability.** Official.
+- **Reference.** [developers.notion.com/guides/mcp/overview](https://developers.notion.com/guides/mcp/overview).
+- **Capabilities.** Database queries, page CRUD, property updates, block-level reads, search.
+- **What the orchestrator skill can populate via MCP.** Brief-as-database-row schema creation (with the property set from the orchestration plan). Relation property setup between briefs and project artifacts. Initial brief content population from the orchestration plan. Dashboard view configuration where the view config supports it (with caveats; some view configurations remain UI-only).
+- **Practical limits.** Workspace-level permissions and team membership remain UI-driven; MCP is most useful AFTER initial workspace setup. Some view types (calendar views, certain board views with custom grouping) cannot be created via MCP and must be set up in the UI.
+
+### CLI alternatives and when to use them
+
+- **Community CLIs.** notion-cli and similar tools exist but are less mature than the MCP.
+- **When the CLI is the better choice.** Exporting databases for backup. Bulk content migration from another tool. Scripted database schema changes (adding properties across hundreds of rows).
+- **For most teams.** The MCP is sufficient. CLI tools become useful only for specialized operations the MCP can't handle.
+
+---
+
+## Figma
+
+### Workflow representation
+
+- **Phase representation.** Library file with frame folders per phase: Discovery moodboards, Direction tokens, Identity components, Production frames. Frame-level review status surfaces in the Figma comments and frame metadata.
+- **Gate representation.** Frame status (Ready for review / In review / Approved). Components versioned in the library; outdated components marked as deprecated rather than deleted (downstream files still reference them).
+- **Lock-point representation.** Library publish state. Once a library version is published, dependent files reference that version. Token changes ship as a new library version, which downstream files explicitly opt into.
+- **Handoff representation.** Frame URL plus exported assets. Engineering handoff uses Dev Mode for token export and component spec.
+- **Concrete setup snippet.** Library file structure: top-level pages for "Tokens", "Components", "Patterns", "Page templates", "Working files". Within each, frame folders per phase. Frame-level review status set via Figma's standard comment-and-status workflow. Library publish discipline: identity tokens publish at the identity gate; the library version is the lock point.
+
+### MCP integration notes
+
+- **Availability.** Figma Dev Mode MCP exists but is dev-mode-focused (component inspection, code generation, design token export).
+- **Reference.** Figma's [Dev Mode documentation](https://www.figma.com/dev-mode/).
+- **Capabilities (Dev Mode MCP).** Component property reads. Design token export (color, typography, spacing). Frame inspection (layer tree, properties, constraints). Component variant queries.
+- **What the orchestrator skill can populate via MCP.** Limited. Library structure recommendations and frame organization remain primarily manual setup. The MCP is more useful for downstream developer handoff than upstream design ops.
+- **Practical limits.** Design library creation, frame organization, library-level permissions, and team membership are UI-driven. Treat the orchestrator skill's Figma recommendations as documentation for the design lead, not as automation targets.
+
+### CLI alternatives and when to use them
+
+- **Figma API.** Can be invoked via custom scripts for token export, asset download, and metadata queries. No first-party CLI for design ops.
+- **When the API is the better choice.** Token export scripts that run in CI to update a design system repository. Asset download automation for engineering handoffs. Metadata reporting (audit how many frames are in review status across the library).
+- **For most cases.** The design lead implements Figma orchestration manually following the skill's recommendations. Automation is layered in only when the project is large enough to warrant the engineering investment.
+
+---
+
+## GitHub
+
+### Workflow representation
+
+- **Phase representation.** Issues for non-engineering tracking (when GitHub is the canonical platform; otherwise Jira/Linear lead). Branches per feature with naming convention `{type}/{ticket}-{slug}`. PRs for design and engineering review.
+- **Gate representation.** Branch protection on `main`. PR review requirements. CODEOWNERS for review routing. GitHub Actions for CI gates (lint, test, build, deploy preview).
+- **Lock-point representation.** Branch state. Once code is merged to main, it's locked unless a follow-up PR amends it. Tags mark release lock points.
+- **Handoff representation.** PR description references the originating ticket. PR review by CODEOWNERS routes to the right reviewer. PR merge triggers ticket auto-transition (configured per platform combination).
+- **Concrete setup snippet.** Branch protection: require PR reviews before merge, require status checks (CI), require linear history (rebase or squash, no merge commits). CODEOWNERS file routes PRs to the relevant team. PR template requires ticket reference, summary, test plan, screenshots/GIFs for UI changes. GitHub Actions workflow runs CI gates on every PR.
+
+### MCP integration notes
+
+- **Availability.** Official.
+- **Reference.** [github.com/github/github-mcp-server](https://github.com/github/github-mcp-server).
+- **Capabilities.** PR ops (create, comment, review, merge). Issue ops (create, comment, close, label). File content (read, write). Branch protection (read; configuration is mostly UI/API-driven). Repository search. Code search. Workflow runs (read).
+- **What the orchestrator skill can populate via MCP.** PR template files. Issue templates. CONTRIBUTING.md and review-protocol docs. Initial issue tree from the orchestration plan when GitHub is the canonical work tracker. CODEOWNERS file. GitHub Actions workflow files committed to `.github/workflows/`.
+- **Practical limits.** Branch protection rulesets are typically configured via GitHub UI or repository settings API (not MCP); the orchestrator skill's branch protection recommendations remain documentation rather than automation. Repository creation, team membership, and organization-level settings are UI-driven.
+
+### CLI alternatives and when to use them
+
+- **gh CLI.** The dominant tool for GitHub operations. Officially maintained, broadly adopted.
+- **When to prefer gh CLI over MCP.**
+  - Bulk PR operations (merging 20 dependabot PRs in a single sweep).
+  - Scripted workflows (a deploy script that creates a release, tags, and updates a changelog).
+  - Repository setup automation (create a new repo, push initial commits, set up labels and branch protection).
+  - When token cost matters on heavy operations. The CLI is more efficient than MCP roundtrips for repetitive tasks.
+- **Hybrid pattern.** Most production setups use both. MCP for navigation and orchestration ("show me open PRs assigned to me", "comment on PR #123 with this summary"); gh CLI for transactional and bulk operations ("create a PR from this branch with these reviewers", "merge these 10 dependabot PRs"). The two tools complement each other.
+
+---
+
+## Cross-platform patterns
+
+### Code-to-ticket linkage
+
+The standard convention for linking PRs and commits back to tickets:
+
+- **Branch naming.** `{type}/{ticket}-{slug}`. Type is one of feat / fix / chore / docs / refactor. Examples: `feat/RAMP-123-homepage-hero-rewrite`, `fix/LIN-456-contact-form-validation`. Ticket prefix matches the platform (RAMP for the team's main project in Jira, LIN for Linear, etc.).
+- **PR descriptions.** Include the ticket reference. Closes RAMP-123 for full work; Refs RAMP-123 for partial work. Many platforms auto-link the ticket when this format is used.
+- **Commit messages.** Include the ref where relevant. Squash-merge workflows preserve the ref in the squash commit, which means the merged commit on main has the ticket trail.
+
+### Status synchronization
+
+When a PR merges, the linked ticket auto-transitions. Configure via the linked platform's automation:
+
+- **Jira automation.** "When PR merged, transition issue to Done" (with QA verification gate enforced upstream so this is safe).
+- **Linear's auto-transition.** Linear-GitHub integration auto-moves issues based on PR state.
+- **GitHub Actions.** A workflow that runs on PR merge and posts a comment to the linked Linear/Jira issue. Useful when the platform's native integration doesn't cover the team's exact transition rules.
+
+### Multi-platform stacks
+
+Common combinations:
+
+- **Linear + GitHub.** Most common for tech teams. Linear's MCP is mature; GitHub's MCP is mature. The two integrate well via Linear's GitHub integration plus PR/branch naming conventions.
+- **Jira + GitHub.** Most common for enterprise. Atlassian remote MCP plus GitHub MCP cover the orchestration; workflow setup is more involved than Linear because Jira's workflow flexibility means more setup decisions.
+- **Notion + Linear + GitHub.** PM-led with engineering sub-tracking. Notion holds the brief and creative artifacts; Linear holds the engineering work; GitHub holds the code. Notion-Linear linking is via relation property pointing to the Linear issue URL; Linear-GitHub linking is via Linear's native integration.
+- **Notion + Figma + GitHub.** Creative-led with engineering handoff. Notion holds the brief; Figma holds the design; GitHub holds the code. This combination has the lightest engineering tooling and works for design-led projects with simple production paths.
+
+The orchestration plan specifies the canonical platform for each work type and the linkage convention between platforms. Without that specification, work scatters across platforms and links break.

--- a/skills/integration-orchestrator/references/team-size-modulation.md
+++ b/skills/integration-orchestrator/references/team-size-modulation.md
@@ -1,0 +1,65 @@
+# Team-size modulation
+
+A 2-person team and a 12-person team need different orchestration. The framework (phases, gates, lock points, handoffs) is the same; the cadence's review density, sync ceremony, and tool-stack adjustments scale with team size.
+
+This file covers four scales: solo, small (2-3), medium (4-7), large (8+). For each: review density, sync cadence, handoff formality, risk profile, tool-stack adjustments, and AI agent participation pattern.
+
+---
+
+## Solo (1 person)
+
+Everything is the same person playing every role. The brief author, identity designer, voice writer, copy writer, design lead, and engineer are all you.
+
+- **Review density.** Self-review only. Per-phase self-review checklists replace formal gates. The risk is that nothing actually catches mistakes; the discipline is to step away from the work between drafting and reviewing (overnight is best, an afternoon walk is the minimum).
+- **Sync cadence.** Daily plan, weekly review against the orchestration plan. Document the daily plan and the weekly review in a project state file (CLAUDE.md, AGENTS.md, or .agent/state.md).
+- **Handoff formality.** Inline. Self-handoffs document themselves in the project state file rather than as separate artifacts.
+- **Risk profile.** Phases blur together. Lock points get unfrozen without ceremony. The brief that was approved last week becomes "well, I had a better idea, let me just edit it" and downstream work drifts.
+- **Tool-stack adjustments.** Skip Jira workflow validators, Linear cycle ceremony, formal review routing. Use the simplest tool the project needs (often Notion or markdown files in a repo). Resist setting up tooling beyond what's actually used; solo projects fail more often from over-tooling than from under-tooling.
+- **AI agent participation pattern.** Heavy. Solo work benefits most from agent participation because the agent is the second pair of eyes that solo work otherwise lacks. The agent runs QA verification gates, reviews copy against the locked voice, runs accessibility audits, and surfaces patterns the solo person might miss. The orchestration plan output specifies which agent runs at which gate.
+
+---
+
+## Small (2-3 people)
+
+Single reviewer per gate. Async handoffs are fine. Daily standup is sufficient for sync.
+
+- **Review density.** One reviewer per gate. The team picks a primary reviewer per phase based on expertise (design lead reviews identity gates, copy lead reviews voice and copy gates, the senior engineer reviews QA verification and launch readiness).
+- **Sync cadence.** Daily 15-minute standup. Weekly 60-minute phase review. Async messaging in between.
+- **Handoff formality.** Documented but inline (a Notion page comment, a Linear issue description, a Slack message in the project channel). The small team can rely on shared context that larger teams cannot.
+- **Risk profile.** The single reviewer becomes a bottleneck. When the design lead is the only person who can pass the identity approval gate and they're on PTO, the project blocks. Mitigation: the orchestration plan specifies a backup reviewer per gate.
+- **Tool-stack adjustments.** Light tool setup. Linear's default workflow is fine; Jira can run with a basic workflow scheme; Notion runs with basic database schemas. Don't set up complex automations until the team feels the lack of them.
+- **AI agent participation pattern.** Moderate. Agents handle production tasks, QA verification, and adjacent observation filing. Humans handle reviews, gate approvals, and decisions that require taste or political judgment. The orchestration plan specifies which roles agents fill and which stay human.
+
+---
+
+## Medium (4-7 people)
+
+Multiple reviewers, async sync points, weekly phase reviews. The team is large enough that shared context erodes; documentation matters more.
+
+- **Review density.** Two reviewers per gate (one primary, one secondary for cross-check). Reviewer rotation across phases prevents one person from becoming the bottleneck.
+- **Sync cadence.** Daily standup. Weekly phase review. Bi-weekly cross-track sync if there are parallel tracks. Async messaging in between with explicit channels per phase.
+- **Handoff formality.** Documented in the canonical platform (Jira issue, Linear project, Notion database row). Slack threads are fine for discussion but the canonical record lives in the work-tracking platform.
+- **Risk profile.** Review density becomes the gating factor. Reviewers stack up at end of phase, leading to fatigue reviews and rubber-stamped approvals. Mitigation: within-phase mini-gates that flatten review demand. Instead of reviewing 8 deliverables on phase-end Friday, review 2 mid-week and 6 at phase-end.
+- **Tool-stack adjustments.** Custom fields, labels, and automation start to matter. Set up workflow validators that prevent premature transitions. Set up custom views per role (designer view, engineer view, PM view) so each person sees only what's relevant to them.
+- **AI agent participation pattern.** Agents handle QA verification gates, surface adjacent observations, and run reports (which tickets are stuck, which gates are open, which assignees are overloaded). Humans handle reviews and approvals. The agent's role expands from "do production work" to "monitor the orchestration plan and surface drift".
+
+---
+
+## Large (8+ people)
+
+Formal phase reviews, dedicated PM for orchestration, multiple parallel tracks. Cross-track drift is the dominant risk.
+
+- **Review density.** Three or more reviewers per gate. Phase reviews become formal meetings with prepared agendas. Reviewer rotation is mandatory; the project cannot rely on any one person.
+- **Sync cadence.** Daily standup per track. Weekly cross-track sync. Bi-weekly project-wide review. Monthly stakeholder review for projects spanning multiple months.
+- **Handoff formality.** Strict. Every handoff specifies artifacts, locked items, and change-request protocols in writing. Async handoffs without artifact specification break large teams; the receiving track wastes a week trying to figure out what was actually handed off.
+- **Risk profile.** Cross-track drift. Track A and Track B both interpret the brief differently; by week 3 the two tracks read as different brands. Mitigation: a dedicated brief-owner role whose job is to maintain the brief as canonical reference, plus cross-track sync ceremonies and explicit change-request protocols. Brief drift is a leading indicator; the brief-owner role exists to catch it before it becomes track drift.
+- **Tool-stack adjustments.** Full workflow scheme with validators. Custom fields tracking phase, gate status, approver, locked status. Multiple boards or views per track. Automation rules for status synchronization across linked platforms (Jira-GitHub, Linear-GitHub). Reporting dashboards.
+- **AI agent participation pattern.** Agents become orchestration monitors. The agent's role is to track phase status across tracks, surface drift, run cross-track sync prep (which tracks are on schedule, which are slipping), file adjacent observations across track boundaries, and run QA verification gates. The agent is most valuable at the cross-track surface where humans cannot easily hold all the context.
+
+---
+
+## How to choose your scale's pattern
+
+Match the cadence to actual team size. The most common mistake is to use a small-team cadence on a medium-team project, which leads to the single-reviewer bottleneck, OR to use a large-team cadence on a small-team project, which leads to ceremony overhead that nothing earns.
+
+When the team scales mid-project (a 2-person small team grows to 5 people during production phase, for example), the orchestration plan should specify the transition: at what point does the cadence shift, what new reviewers come online, what additional ceremonies start. The plan's risk register should flag scaling moments as a known risk because cadence transitions are themselves a source of drift.


### PR DESCRIPTION
Flagship of the new PM-experimentation skill suite. Pairs with the experimentation platforms documented in `/integrations` (Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon).

## What's in it

- **SKILL.md** (252 lines, 14 substantive sections plus a framework summary and a reference-files index). Covers hypothesis discipline (cause + effect + magnitude + mechanism), sample size and MDE, duration, what NOT to A/B test, segments, interactions, ratio metrics and the delta method, network effects, sequential testing, pre-commitment vs p-hacking, decision-making, common failures.
- **7 reference files**:
  - `hypothesis-templates.md`: 5 templates with worked examples across conversion, engagement, revenue, retention, funnel-step.
  - `sample-size-tables.md`: pre-calculated tables, how-to-use guidance, common pitfalls.
  - `common-failures.md`: 15 anti-patterns with symptom / root cause / fix / prevention.
  - `results-interpretation-checklist.md`: 8-step checklist, three-bucket decision matrix, 30-day post-launch monitoring rule.
  - `platform-comparison.md`: profiles of all 7 platforms with strengths, gotchas, and a decision matrix.
  - `pre-experiment-readiness-checklist.md`: 10-item go/no-go.
  - `post-experiment-decision-framework.md`: mechanical application of pre-commitment, ship/kill/inconclusive routing.

## Voice

Senior-PM-to-junior-PM. Mentor tone. Concrete over abstract. Anti-marketing — the kind of doc a PM would actually print and reference, not a vendor pitch surface.

## README

Count bumped 62 → 63. Product section grows from 3 to 4 entries. Rows 34 through 62 renumbered to 35 through 63 via descending-order sed.

## Quality gates

- `python .github/scripts/lint_skills.py`: PASSED. 63 skills validated, 28 warnings (all pre-existing line-length warnings on other skills; experiment-design SKILL.md is at 252 lines, just over the 250 soft target but well under the 500 hard cap).
- Em-dash audit: zero hits across `skills/experiment-design/`.
- Forbidden-phrase audit: zero hits (in this guide / let's dive in / let's explore / game-changer / cutting-edge / robust / seamless / streamlined / leverage / empower / etc.).
- Real-firm scrub for 'illumine': zero hits.

## What's next

- Companion landing page at `/skills/experiment-design` ships in a follow-up `rampstackco-app` PR (next in this dispatch).
- `feature-flagging` and `experimentation-analytics` skills follow in subsequent dispatches.
- Optional `experimentation-platform-orchestrator` skill after the three foundational PM-experimentation skills land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)