### PR TITLE
feat(skills): add feature-flagging (8th flagship, PM-experimentation suite skill 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-63-blue.svg)](#the-63-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-64-blue.svg)](#the-64-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -18,7 +18,7 @@
 
 </div>
 
-> 63 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 64 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
 
@@ -32,7 +32,7 @@
 - [Getting started](#getting-started)
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
-- [The 63-skill catalog](#the-63-skill-catalog)
+- [The 64-skill catalog](#the-64-skill-catalog)
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
 - [Repository structure](#repository-structure)
@@ -58,8 +58,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 
 What you get:
 
-- **63 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
-- **105 reference files** (templates, checklists, decision matrices, worked examples)
+- **64 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
+- **112 reference files** (templates, checklists, decision matrices, worked examples)
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
 - **Uniform structure.** Every skill uses the same section order, the same tone, and the same authoring conventions. Predictable in, predictable out.
@@ -246,9 +246,9 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 
 ---
 
-## The 63-skill catalog
+## The 64-skill catalog
 
-All 63 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 64 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 
 ### Strategy and discovery (5)
 
@@ -314,7 +314,7 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 29 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
 | 30 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
-### Product (4)
+### Product (5)
 
 | # | Skill | What it does |
 |---|---|---|
@@ -322,70 +322,71 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 32 | [`roadmap-planning`](skills/roadmap-planning/SKILL.md) | Quarterly planning, prioritization, dependency mapping |
 | 33 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
 | 34 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
+| 35 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 35 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 36 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 37 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 38 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 36 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 37 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 38 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 39 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 39 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 40 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 40 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 41 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 42 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 43 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 44 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 45 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 46 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 47 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 48 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 41 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 42 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 43 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 44 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 45 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 46 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 47 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 48 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 49 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 49 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 50 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 50 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 51 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 51 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 52 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 53 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 52 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 53 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 54 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 54 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 55 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 56 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 57 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 58 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 55 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 56 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 57 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 58 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 59 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 59 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 60 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 61 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 62 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 63 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 60 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 61 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 62 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 63 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 64 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 
 ---
 

--- a/skills/feature-flagging/SKILL.md
+++ b/skills/feature-flagging/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: feature-flagging
+description: Operational discipline for feature flags as production infrastructure. Flag types, naming, targeting rules, rollout strategy, lifecycle, governance, stale flag management, and the technical debt patterns that bite teams who weren't deliberate about it.
+---
+
+# Feature Flagging
+
+A senior engineer's playbook for using feature flags well, not just frequently.
+
+Feature flags are infrastructure. Treated as such, they enable kill switches, gradual rollouts, A/B experiments, permission gates, and operational toggles without redeploys. Treated casually, they become the largest accumulating technical debt in your codebase: thousands of dead flags, conflicting evaluation logic, brittle targeting, and a permission surface no one fully understands.
+
+This skill is the discipline that prevents the second outcome. It assumes you have a feature flag platform (LaunchDarkly, Flagsmith, Split.io, VWO FME, GrowthBook, Statsig, PostHog, Optimizely; the platform does not matter for the principles). It assumes your engineering team can implement targeting rules and SDK integration. The hard part is the operational discipline, and that is what is here.
+
+When to use this skill: any time you are about to introduce a flag, modify a flag, audit existing flags, or design a flag-related governance policy.
+
+---
+
+## What this skill is for
+
+The skill spans the operational lifecycle of a flag from creation through retirement. Flag types and the discipline of not mixing them. Naming conventions that survive code review. Lifecycle expectations baked in at creation, not bolted on later. Targeting rules that compose without fragility. Rollout strategies that match the risk profile of the launch. Stale flag management on a quarterly cadence. Governance and permissions that balance access with audit. Performance considerations so flags do not become a latency tax. Testing patterns that cover both branches. Rollback discipline. Observability across rollouts.
+
+The skill does not cover experiment design; for hypothesis writing, sample size, MDE, and the discipline of arriving at a defensible decision, see the `experiment-design` skill. It does not cover statistical analysis or variance reduction; those live in the `experimentation-analytics` skill. It does not cover platform-specific tooling; for that, pair with the matching `/integrations/{platform}` microsite for your stack. The microsite shows the MCP commands, auth, and example prompts for the specific platform; this skill produces the operational shape that the platform implements.
+
+---
+
+## The five flag types
+
+Mixing flag types is the root cause of most flag mess. A flag is one of five things; commit at creation and do not let it drift.
+
+**Release flag.** Code is in production but disabled. The new feature ships dark, gets toggled on for a percentage, then ramps to 100. Lifetime: short, days to weeks. Lifecycle: clean removal after launch. Common name prefix: `release_`.
+
+**Experiment flag.** Users are randomly assigned to variants; conversion is measured. The flag controls which variant a user sees. Lifetime: medium, one to six weeks. Lifecycle: variant chosen, code paths consolidated, flag removed. Common name prefix: `exp_`.
+
+**Operational flag.** A kill switch or circuit breaker that lets ops disable a misbehaving feature without a redeploy. Lifetime: long-lived, often years. Lifecycle: usually never removed; remains as standby. Common name prefix: `ops_`.
+
+**Permission flag.** Controls feature access by plan tier, customer cohort, or region. The free tier sees one set of features; the enterprise tier sees another. Lifetime: long-lived. Lifecycle: managed alongside billing and access infrastructure. Common name prefix: `perm_`.
+
+**Configuration flag.** Lets some customers see different behavior based on contractual configuration. White-label tenants, regulated regions, custom rollout schedules per account. Lifetime: long-lived. Lifecycle: governed by sales and product agreements. Common name prefix: `cfg_`.
+
+Each type has different lifecycle, governance, and removal expectations. Mixing them in one flag (the flag is both a kill switch AND a permission gate AND now we are using it for an experiment) is the most common source of flag mess. When the flag's purpose changes, create a new flag and migrate. Do not overload an existing one.
+
+---
+
+## Flag naming conventions
+
+A flag name encodes type, owner, and purpose. Without that encoding, a flag list at month nine is unreadable and the cleanup playbook from `references/stale-flag-cleanup-playbook.md` cannot tell what is safe to remove.
+
+The convention this skill recommends is `<type>_<owner>_<semantic_name>_<version_or_date>`:
+
+- `release_checkout_redesign_2026q2`
+- `exp_billing_pricing_v2`
+- `ops_search_circuit_breaker`
+- `perm_enterprise_audit_log`
+- `cfg_tenant_acme_custom_dashboard`
+
+Pick snake_case or kebab-case once, organization-wide, and stick with it. Mixing both in the same platform produces typo-driven bugs that bite at 3 AM. Vague names die a slow death: `new_feature`, `temp_toggle`, `test_flag`, `pricing_update_v3`. Within months, no one knows which `pricing_update` shipped and which is dead.
+
+For deeper coverage including the table of typed prefixes, owner conventions, and the migration plan for existing badly-named flags, see `references/flag-naming-conventions.md`.
+
+---
+
+## The flag lifecycle
+
+Every flag has five life phases. Each phase has explicit entry and exit criteria. Skipping phases is how flag mess accumulates.
+
+**Birth.** Flag created with explicit metadata: owner, type, target removal date (for release and experiment flags), rollout plan, monitoring approach. The metadata is not optional; without it the flag has no end-of-life.
+
+**Adolescence.** The feature behind the flag is being built. Code paths exist for both the disabled (current production) branch and the enabled (new) branch. Both are tested. The flag remains off in production.
+
+**Launch.** Production rollout begins. Percentage starts low (1 or 5 percent), monitored at each step, ramps if metrics hold. Ramp gates documented in `references/flag-rollout-strategies.md`.
+
+**Maturity.** The flag is at 100 percent rollout. The new code path is the production path. Monitoring continues for at least 30 days to catch issues that did not show up during the ramp.
+
+**Death.** The flag is removed from code (PR that deletes the gating logic) and removed from the platform. The audit trail records the removal.
+
+The asymmetry: birth is fast (one PR creates the flag and gates the new code), death requires intentional cleanup. Most flag mess is unfinished death. Birth-and-death have to be planned together; the death plan is part of the birth metadata.
+
+For the per-phase checklist, see `references/flag-lifecycle-checklist.md`.
+
+---
+
+## Targeting rules and segmentation
+
+A targeting rule is the boolean expression that determines whether a user, account, or request gets the treatment branch. There are four useful target dimensions:
+
+- **User attributes.** `user.email_domain == "acme.com"`, `user.signup_date > "2026-01-01"`, `user.plan == "enterprise"`.
+- **Account attributes.** `account.tier == "enterprise"`, `account.region == "EU"`, `account.feature_x_enabled == true`.
+- **Request attributes.** `request.country == "US"`, `request.device_type == "mobile"`, `request.api_version >= 3`.
+- **Time-based.** `time > "2026-06-01T00:00:00Z"`, `time < "2026-12-31T23:59:59Z"`.
+
+Compose with AND, OR, and NOT. Keep the expressions simple. If your rule needs three nested clauses, your taxonomy is wrong. Either define a segment (a named group of users with shared attributes) and target the segment, or split into multiple flags.
+
+The most common pitfall: targeting on attributes that change frequently. If the rule is `user.last_login_date > "2026-04-01"`, a user who logs in on May 1 sees the treatment, then their value changes the next day, and they see the control again. The user experience whiplashes. Volatile attributes belong in segments computed off snapshots, not in live targeting rules.
+
+For pattern catalog and anti-patterns, see `references/targeting-rule-patterns.md`.
+
+---
+
+## Rollout strategies
+
+Different launches deserve different rollout strategies. Match the strategy to the risk profile.
+
+**Percentage rollout.** The default for release flags. Start at 1 or 5 percent. Watch error rates, latency, and the primary success metric for at least one peak hour. If clean, ramp to 10. Watch. Ramp to 25, then 50, then 100. Total elapsed time depends on traffic, but a typical pattern is 1 percent for one day, then 10 percent for two days, then 50 for two days, then 100. Production rollouts that complete in under four hours are usually rolling too fast.
+
+**Cohort rollout.** Internal employees first, then beta customers, then free tier, then paid. Each cohort is a named segment; the flag advances through them in sequence. Use this for risky launches where the blast radius matters more than rollout speed.
+
+**Geo-staged rollout.** One region at a time. The default for compliance-sensitive features (data residency, regulatory disclosures, region-specific UX). Pair with the platform's region targeting capability so the rule does not have to be hand-written.
+
+**Time-based rollout.** Scheduled flips at known times. Useful for marketing-coordinated launches where the toggle has to fire at a specific moment. Watch the timezone; midnight Eastern is not midnight UTC. Avoid time-based rollouts on holidays unless you have weekend on-call coverage.
+
+The "ramp and watch" rule: at each percentage step, monitor the system for at least one peak hour before advancing. The peak hour is when the rate of any new failure mode is highest; if the system holds at peak for an hour, the next step is safe. If you ramp during off-peak and immediately advance, you have not actually tested the change.
+
+For full strategy detail and a worked example for a checkout redesign, see `references/flag-rollout-strategies.md`.
+
+---
+
+## Stale flag management
+
+Every live flag adds runtime cost: evaluation overhead, two code paths to maintain, mental overhead for engineers who read the code. One flag is fine. Two hundred dead flags is a productivity tax that compounds.
+
+Most platforms support stale flag reporting: flags that have not been evaluated in N days. Threshold defaults: 30 days for release flags and experiment flags, 90 days for operational and permission flags. A flag that has not been evaluated in 30 days is either retired in production (no users in the targeting rule) or completely dead in code (the gating call has been removed but the flag itself was never deleted).
+
+The cleanup playbook is mechanical:
+
+1. Generate the stale flag report from the platform.
+2. For each flag: identify owner, last evaluation, type, recommended action.
+3. Triage in a quarterly meeting: keep, remove, or investigate.
+4. Open one PR per flag for code-side removal. One per PR is reviewable; bundling ten is not.
+5. Delete from the platform after the PR merges.
+
+The reason cleanup does not happen by default: removing a flag is a code change PR with review, testing, and deploy overhead. PMs do not reward it (the feature already shipped). SREs eventually get fed up with the noise. The fix is to make removal part of the launch checklist, not a separate effort. When a flag is created, the removal date is in the metadata. The launch ticket has a follow-up sub-ticket scheduled 30 days out that says "remove flag X." If the launch goes well, the sub-ticket gets done.
+
+For the full quarterly cadence including ownership rotation for orphan flags, see `references/stale-flag-cleanup-playbook.md`.
+
+---
+
+## Governance and permissions
+
+Different roles need different access. Engineering can create flags broadly. Product can author targeting rules in dev and staging. Production targeting changes deserve a smaller set of approvers.
+
+Recommended permission tiers:
+
+- **Viewer.** Read-only across all environments. Includes most of engineering, product, support.
+- **Editor.** Can create and modify flags in dev and staging. Includes the team that owns the flag.
+- **Approver.** Can promote flag changes from staging to production. Smaller group; usually the team lead and the on-call engineer.
+- **Admin.** Full control including deleting flags, modifying permissions, and accessing audit logs. Smallest group; platform team plus a backup.
+
+Production-impacting flag changes go through review like deploys, not chat. The change request describes the rule diff, the rollout plan, and the abort criteria. An approver applies the change after review; the rule does not silently appear in production because someone clicked a button.
+
+Audit trail: every flag change logged with actor, timestamp, before/after rule, reason. Most platforms expose this; configure it to write to the central log aggregator alongside other infrastructure events.
+
+Environment promotion: rules tested in dev, promoted to staging, promoted to production. Authoring a production rule directly in production skips both staging tests and the review gate. Treat it as a deploy: dev → staging → production, with the same review and approval at each stage.
+
+Emergency override: who can flip the kill switch at 3 AM? Document, test in incident drills, and confirm the override path actually works. A kill switch nobody can find is not a kill switch.
+
+---
+
+## Flag dependencies and conflicts
+
+Two failure modes that come from flags interacting:
+
+**Dependency.** Flag B's code path requires flag A to be on. Hard to model in most platforms; the SDK does not know about the inter-flag relationship. Avoid where possible; if you need to express it, document in the flag description and add a unit test that fails if A is off and B is on.
+
+**Conflict.** Two flags target the same surface, last-write-wins. The result depends on evaluation order, which depends on SDK implementation, which depends on platform internals. Detect via shared-key audit: any two flags whose targeting rules overlap on the same code path is a conflict candidate. The platform usually does not flag this; the team has to audit.
+
+Cross-team conflict is the dangerous version: team Alpha's release flag for the checkout redesign interacts with team Bravo's experiment on the pricing page. The interaction is invisible until production users see broken UI because both flags fired. The fix is up-front coordination via the experiment registry described in `experiment-design`. Discover before launch via planning, not via a 2 AM incident.
+
+For mutually exclusive experiment groups (where the platform enforces that a user is in either test A or test B but never both), see the experiment-design skill's coverage of mutex enforcement.
+
+---
+
+## Performance considerations
+
+A flag evaluation is a function call (cheap) plus possibly a network call to the platform (expensive). The performance question is how much you spend in the latter.
+
+Cache aggressively. Most server-side SDKs cache flag values per request, per session, or per user; configure the cache so the network call happens once per relevant scope, not on every flag check. A request that evaluates fifty flags should hit the platform once at request start, not fifty times.
+
+Bulk evaluation: most platforms support evaluating all flags for a user or context in one call. Use it. The latency cost of "fifty individual flag checks" is fifty times the per-check overhead; the latency cost of "one bulk evaluation that returns all fifty" is one round trip plus a fast lookup per check.
+
+SDK selection: server-side SDKs are usually preferable to client-side for sensitive logic where latency, security, and freshness matter. Client-side SDKs are appropriate for UI-only behavior where the user can see the flag value in DevTools anyway. Mixing the two creates inconsistencies; if a user gets a different flag value on the server than the client, the UI breaks.
+
+Latency budget: evaluating fifty flags per request should add no more than 5 ms in the typical case. If it adds more, the SDK is misconfigured (no caching, no bulk evaluation, evaluating in a hot loop). Audit before scaling.
+
+---
+
+## Testing flag-gated code
+
+Both branches need tests. The disabled branch is the existing production behavior; the enabled branch is the new code. Unit tests cover both with explicit flag overrides at test setup.
+
+Test the transition. What happens to a user mid-session when their flag value changes? In most well-behaved systems, the user finishes their current request with the value they had at request start, then sees the new value on the next request. Document the assumption explicitly. If your system mid-flips a user inside a session, that is usually a bug.
+
+Integration tests with flag overrides: most platforms support test-only flag overrides that do not affect production. Use them for end-to-end tests that exercise both branches. Without test overrides, integration tests have to share the production flag config, which means you cannot test new features that are still gated off in production.
+
+Common failure: shipping a "wins" experiment but only the test environment had the right targeting rules. The test environment let in 100 percent of test users via a permissive rule; production rules are stricter and let in only 20 percent. The lift you measured does not translate. Catch via staged rollout: the first 1 percent in production should match the test result before you ramp further.
+
+---
+
+## Rollback discipline
+
+Flags are useful for instant rollback of the gated change. They are not a substitute for code rollback. If a bug ships in code that is not flag-gated (a fix to the existing path, an unrelated change in the same deploy), flipping the flag does nothing. Treat flag rollback as one tool among several, not as the only tool.
+
+If flipping the flag does work, document the rollback. If it does not work, the bug is in non-flag-gated code or in flag dependencies. Diagnose accordingly; do not assume the flag failed.
+
+Speed matters. How fast can you flip a flag in production? The target is under 60 seconds via UI or MCP, under 5 minutes via API plus auth. If your platform takes 15 minutes to propagate a flag change, that is a real incident-response constraint and the team should know.
+
+Practice. Include flag rollback in incident drills. The first time you flip a kill switch should not be at 3 AM with revenue dropping; it should be in a drill with everyone calm.
+
+---
+
+## Observability on flags
+
+Log flag evaluations alongside other request data. The flag value at evaluation time goes on the request log as a contextual field. When you investigate a slow request or an error, the log shows which flag values were active.
+
+Alert on flag evaluation rate changes. If a flag's evaluation rate suddenly drops, the rule is misconfigured (no users matching) or the SDK is broken. Either way, the team should know within minutes.
+
+Build dashboards for production rollouts. What percentage of users see treatment versus control, broken down by region, plan, device, etc. Without the dashboard, the rollout is a black box; with it, the team can answer "are we actually rolling out evenly across segments?" without writing a SQL query.
+
+Connect to error tracking. When errors spike during a rollout, the dashboard should show whether errors correlate with the flag value. Spike on treatment branch = roll back the flag. Spike on both branches = the issue is unrelated and the flag rollback will not help.
+
+---
+
+## Common failures (rapid-fire)
+
+A short pattern catalog. Detail in `references/`.
+
+- "We launched but 90 percent of users still see the old version" means the rollout rule is wrong. Audit the rule against actual user attributes.
+- "We disabled the flag but the bug is still happening" means the affected code path is not flag-gated, or there is a cached value, or a dependent flag is still on.
+- "We have 400 dead flags and removing them is too risky" means cleanup never happened. Start the quarterly cadence now; one PR per flag.
+- "Two flags target the same code path and we don't know which wins" means a conflict. Audit shared keys, decide one of them is canonical, retire the other.
+- "Our flag evaluator is causing latency spikes" means bulk evaluation or caching is missing. Audit the SDK config.
+- "We need to give finance access to feature toggles but they shouldn't change production rules" means permission tiering. Viewer for finance, editor for the owning team, approver for the team lead.
+
+---
+
+## The framework: 14 considerations for sustainable feature flagging
+
+When designing or auditing feature flags, walk these 14 considerations:
+
+1. **Type clarity.** Release, experiment, operational, permission, or configuration. Pick one at creation; do not let it drift.
+2. **Naming.** Typed prefix, owner prefix, semantic name. Avoid vague.
+3. **Lifecycle planning.** Birth and death committed at creation. Removal date in metadata.
+4. **Targeting taxonomy.** User, account, request, or time-based. Avoid volatile attributes.
+5. **Rule simplicity.** AND, OR, NOT only. Three nested clauses means the taxonomy is wrong.
+6. **Rollout match.** Strategy matches the risk profile. Percentage for low risk, cohort for medium, geo for compliance, time-based for coordinated launches.
+7. **Ramp discipline.** One peak hour at each percentage step. No four-hour rollouts.
+8. **Stale flag cadence.** Quarterly cleanup. One PR per removal. Make removal part of the launch checklist.
+9. **Permission tiering.** Viewer / editor / approver / admin. Fewer admins than approvers, fewer approvers than editors.
+10. **Environment promotion.** Dev to staging to production with review gates. Production rules are not authored in production.
+11. **Conflict audit.** Two flags on the same surface = conflict. Detect via shared-key audit; coordinate cross-team via the experiment registry.
+12. **Performance budget.** Bulk evaluation, caching, server-side SDKs for sensitive logic. 5 ms total budget for fifty flag checks.
+13. **Branch testing.** Both code paths covered by tests. Transition behavior documented.
+14. **Observability.** Every flag evaluation logged. Every rollout dashboarded. Errors correlated with flag value during incidents.
+
+---
+
+## Reference files
+
+The following reference files extend this skill:
+
+- [`references/flag-naming-conventions.md`](references/flag-naming-conventions.md): typed prefixes, owner prefixes, semantic naming patterns, and the migration plan for existing badly-named flags.
+- [`references/flag-lifecycle-checklist.md`](references/flag-lifecycle-checklist.md): birth-to-death checklist organized by lifecycle phase.
+- [`references/flag-types-reference.md`](references/flag-types-reference.md): the five flag types in detail with worked examples and common pitfalls.
+- [`references/stale-flag-cleanup-playbook.md`](references/stale-flag-cleanup-playbook.md): quarterly cleanup process and the orphan-ownership pattern.
+- [`references/targeting-rule-patterns.md`](references/targeting-rule-patterns.md): common patterns and anti-patterns for targeting rules.
+- [`references/flag-rollout-strategies.md`](references/flag-rollout-strategies.md): percentage, cohort, geo, time-based, and combination strategies with a worked example.
+- [`references/governance-and-permissions.md`](references/governance-and-permissions.md): permission tiers, environment promotion, approval workflows, and emergency override.
+
+---
+
+## Closing: when to remove a flag
+
+The default disposition for any flag should be removal. Flags that earn permanent residence in the codebase (operational kill switches, permission flags tied to billing, configuration flags tied to contracts) are exceptions, not norms. Most release and experiment flags should be removed within 30 days of the launch decision.
+
+The cost of leaving them is real: every dead flag is two code paths to maintain, two test suites to keep green, and one more line of mental overhead for the engineer who reads the file next quarter. The cost compounds across hundreds of flags.
+
+The discipline of removing them is the discipline of caring about the codebase you will work in next quarter. It is the same discipline behind cleaning up after a deploy, removing dead imports, and writing a post-mortem within a week of the incident. None of it ships features today. All of it makes shipping features tomorrow easier.
+
+For platform-specific patterns (which platform handles which flag type best, what the MCP commands look like, where the gotchas live), pair this skill with the matching `/integrations/{platform}` microsite for your stack. For the experiment-design layer above this skill (hypothesis discipline, sample size, decision-making), see the `experiment-design` skill. For the analytical layer below this skill (variance reduction, sequential testing math, Bayesian alternatives), see the `experimentation-analytics` skill when it ships.

--- a/skills/feature-flagging/references/flag-lifecycle-checklist.md
+++ b/skills/feature-flagging/references/flag-lifecycle-checklist.md
@@ -1,0 +1,119 @@
+# Flag lifecycle checklist
+
+A phase-by-phase checklist for the operational discipline of a flag from creation through removal. Run through the phase the flag is currently in; do not skip ahead.
+
+---
+
+## Phase 1: Birth (creation)
+
+Before merging the PR that introduces a new flag:
+
+- [ ] Type committed. Release, experiment, operational, permission, or configuration. Pick one.
+- [ ] Name follows the convention from `flag-naming-conventions.md`.
+- [ ] Owner assigned. The team or person responsible for the flag's lifecycle.
+- [ ] Target removal date set in metadata (release flags: 30-60 days; experiment flags: end of test plus 14 days; operational/permission/configuration flags: "long-lived, review annually").
+- [ ] Rollout plan attached. Percentage, cohort, geo, or time-based; abort criteria defined.
+- [ ] Monitoring approach attached. What metric is being watched? What alert fires if the rollout breaks something?
+- [ ] Both code branches tested. The disabled branch (existing production) and the enabled branch (new code).
+- [ ] Default value confirmed off in production.
+- [ ] Removal sub-ticket created and scheduled (release/experiment flags only).
+
+If any item is no, do not merge.
+
+---
+
+## Phase 2: Adolescence (pre-launch)
+
+The feature behind the flag is being built in dev and staging. The flag remains off in production.
+
+- [ ] Feature complete in code, both branches tested.
+- [ ] QA sign-off on enabled branch.
+- [ ] Staging rule mirrors planned production rule (does not have to match exactly; should be representative).
+- [ ] Telemetry confirmed. Logs include flag value as a contextual field. Dashboards exist for the metrics the rollout will watch.
+- [ ] Rollout plan reviewed by approver.
+
+---
+
+## Phase 3: Launch (rollout)
+
+Production rollout begins. Each percentage step has its own gate.
+
+For each step (typical: 1% → 10% → 50% → 100%):
+
+- [ ] Apply rule change via platform UI, MCP, or API.
+- [ ] Confirm rule applied. Flag evaluation rate matches expected percentage.
+- [ ] Watch primary success metric, error rate, latency p95 for at least one peak hour.
+- [ ] If clean, advance to next step.
+- [ ] If degraded, hold or roll back. Document what was observed.
+
+At 100%:
+
+- [ ] Hold for 7 days at 100% before declaring launch complete.
+- [ ] Confirm metrics stable across the full holding period.
+- [ ] Schedule the 30-day review (calendar reminder for the owner).
+
+---
+
+## Phase 4: Maturity (post-launch)
+
+Flag is at 100% rollout. Both code paths still exist. The new path is production.
+
+- [ ] 30-day review: any regressions detected? Any rollbacks needed?
+- [ ] Confirm the removal sub-ticket created at birth still exists and is scheduled.
+- [ ] Confirm no unexpected dependencies on the flag from other code paths.
+
+If the flag is operational, permission, or configuration, the lifecycle ends here. The flag is permanent.
+
+If the flag is release or experiment, proceed to Phase 5.
+
+---
+
+## Phase 5: Death (removal)
+
+The flag has reached its target removal date or its purpose is complete.
+
+Code-side:
+
+- [ ] Open a single PR that removes the flag's gating logic. One flag per PR.
+- [ ] Delete the disabled branch (the old code path). Keep only the enabled branch.
+- [ ] Delete tests that targeted the disabled branch.
+- [ ] Update any documentation that referenced the flag.
+- [ ] Confirm CI passes; tests still cover the new (now permanent) code path.
+- [ ] Merge the PR.
+
+Platform-side (after PR merges):
+
+- [ ] Confirm the flag has zero evaluations in the platform's dashboard for at least 24 hours.
+- [ ] Archive or delete the flag from the platform.
+- [ ] Audit log entry confirms deletion with actor, timestamp, reason.
+
+Documentation:
+
+- [ ] Close the original removal sub-ticket created at birth.
+- [ ] Update any team-level flag inventory the team maintains.
+
+---
+
+## Phase 6: Audit (quarterly)
+
+Even with the discipline above, some flags will slip through. The quarterly audit catches them.
+
+- [ ] Generate stale flag report from the platform (>30 days unevaluated for release/experiment, >90 days for operational).
+- [ ] Triage in a meeting: keep, remove, or investigate per flag.
+- [ ] Open removal PRs (one per flag) for the "remove" pile.
+- [ ] Investigate the "investigate" pile; usually the answer is remove or rename.
+
+For the full audit pattern, see `stale-flag-cleanup-playbook.md`.
+
+---
+
+## Common slips
+
+The phases above describe the disciplined path. Common slips:
+
+- Birth without removal date. Fix: require the removal date as part of the flag-creation form or PR template.
+- Launch without monitoring. Fix: the rollout plan review at end of Phase 2 catches this.
+- Maturity skipped (rolled to 100%, never reviewed). Fix: the 30-day review reminder is in the launch ticket.
+- Death skipped (flag forgotten). Fix: the quarterly audit catches it.
+
+The slips compound. A skipped death today is one more flag to clean up at quarter end. A hundred skipped deaths over a year is the productivity tax described in `stale-flag-cleanup-playbook.md`.

--- a/skills/feature-flagging/references/flag-naming-conventions.md
+++ b/skills/feature-flagging/references/flag-naming-conventions.md
@@ -1,0 +1,128 @@
+# Flag naming conventions
+
+A flag name encodes type, owner, and purpose. Encoding makes flag lists readable at month nine and lets the cleanup playbook tell what is safe to remove. This reference documents the conventions, shows worked examples, and provides the migration plan for existing badly-named flags.
+
+---
+
+## The format
+
+`<type>_<owner>_<semantic_name>_<version_or_date>`
+
+Each segment is mandatory for new flags except the version/date suffix, which is recommended but optional for short-lived release flags.
+
+---
+
+## Typed prefixes
+
+| Prefix | Type | Lifetime | Example |
+|---|---|---|---|
+| `release_` | Release flag | Days to weeks | `release_checkout_redesign_2026q2` |
+| `exp_` | Experiment flag | 1-6 weeks | `exp_billing_pricing_v2` |
+| `ops_` | Operational flag | Long-lived | `ops_search_circuit_breaker` |
+| `perm_` | Permission flag | Long-lived | `perm_enterprise_audit_log` |
+| `cfg_` | Configuration flag | Long-lived | `cfg_tenant_acme_custom_dashboard` |
+
+Pick one prefix style organization-wide. Mixing `release_` with `release-` produces typo bugs that bite during 3 AM rollbacks.
+
+---
+
+## Owner prefix
+
+The owner segment is the team or component that owns the code behind the flag. It does not have to be the team that created the flag.
+
+Examples:
+- `checkout` for the checkout team
+- `billing` for the billing team
+- `search` for the search team
+- `growth` for the growth team
+- `infra` for platform/SRE work
+
+Organizations with many small teams may use a two-segment owner like `growth_signup` or `infra_db_failover`. Organizations with a single product team may use a component-level owner like `pricing`, `dashboard`, `api`.
+
+---
+
+## Semantic name
+
+The semantic name describes what the flag controls. It should read naturally to someone who has not seen the flag before.
+
+Good semantic names:
+- `redesign` (the team is redesigning a surface)
+- `ml_recommendations` (the feature is ML-driven recommendations)
+- `circuit_breaker` (the flag is a circuit breaker, an operational kill switch)
+- `audit_log` (the feature behind the flag is an audit log)
+- `single_step_billing` (a specific UX pattern the flag controls)
+
+Bad semantic names:
+- `new_feature` (which feature?)
+- `temp_toggle` (temporary for what?)
+- `test_flag` (for testing what?)
+- `pricing_update_v3` (which version was v3? was there a v2?)
+
+---
+
+## Version or date suffix
+
+For experiment flags and release flags that may iterate, include a version or date suffix so old and new variants are distinguishable.
+
+- `release_checkout_redesign_2026q2`: quarter-stamped release
+- `exp_pricing_test_v2`: second iteration of a pricing test
+- `release_signup_form_v3_2026_05`: third iteration, May 2026
+
+Operational, permission, and configuration flags usually do not need a version suffix; they are stable infrastructure.
+
+---
+
+## Worked examples (good)
+
+```
+release_checkout_redesign_2026q2
+release_signup_passwordless_2026_06
+exp_billing_pricing_v2
+exp_homepage_hero_copy_test_v1
+ops_search_circuit_breaker
+ops_db_failover_manual_override
+perm_enterprise_audit_log
+perm_eu_data_residency
+cfg_tenant_acme_custom_dashboard
+cfg_white_label_partner_xyz
+```
+
+Each name says: what type of flag, who owns it, what it controls, and (where applicable) which iteration.
+
+---
+
+## Worked examples (bad)
+
+```
+new_pricing                  // bad: no type, no owner, no version
+temp_homepage_test           // bad: "temp" promises removal that never happens
+billing_flag_2               // bad: vague semantic, what does flag_2 do?
+killswitch                   // bad: which feature does this kill?
+enterprise_features          // bad: ambiguous, is this permission or configuration?
+beta_users_only              // bad: targeting concept in the flag name; rule should target, not name
+```
+
+---
+
+## Migration plan for badly-named flags
+
+If the existing platform has hundreds of badly-named flags, do not rename them all at once. The pattern is to rename on touch:
+
+1. Establish the convention. Document it; share with the team.
+2. New flags follow the convention. No exceptions.
+3. Existing flags get renamed when touched: when the rule changes, when the rollout advances, when ownership transfers, when removal is scheduled.
+4. Quarterly cleanup includes a "rename batch" of the 5-10 worst-named flags, especially ones that are confusing during the cleanup itself.
+5. After 6-12 months, the platform stabilizes on the convention.
+
+Bulk renames can be scripted via the platform's API, but renaming forces a code change in every place the flag key is referenced. Bundle renames with refactors, not as standalone PRs.
+
+---
+
+## Anti-pattern: targeting in the name
+
+Do not put targeting concepts in the flag name. The flag name describes what the flag controls; the targeting rule describes who sees it.
+
+Bad: `enterprise_users_audit_log` (the "enterprise_users" is targeting)
+Better: `perm_audit_log` (the flag is a permission flag for the audit log; the rule targets enterprise users)
+
+If the targeting rule changes (audit log opens up to all paid customers), the flag does not need to be renamed. The rule does the work.

--- a/skills/feature-flagging/references/flag-rollout-strategies.md
+++ b/skills/feature-flagging/references/flag-rollout-strategies.md
@@ -1,0 +1,150 @@
+# Flag rollout strategies
+
+Different launches deserve different rollout strategies. Match the strategy to the risk profile of the change. The five patterns below cover most cases; combine them when needed.
+
+---
+
+## Percentage rollout
+
+The default for release flags. The flag advances through fixed percentage steps with a monitoring gate at each step.
+
+Typical sequence:
+
+| Step | Percentage | Hold time |
+|---|---|---|
+| 1 | 1% | At least one peak hour |
+| 2 | 10% | At least 24 hours |
+| 3 | 50% | At least 48 hours |
+| 4 | 100% | Hold for 7 days before declaring complete |
+
+Hold times are minimums. If the metric being watched takes longer than 24 hours to stabilize (retention, downstream conversion), extend the holds accordingly.
+
+Abort criteria at each step:
+- Error rate exceeds baseline by 10 percent.
+- Latency p95 exceeds baseline by 20 percent.
+- Primary success metric trends materially negative.
+- Any P1 alert fires that traces back to the flag.
+
+If any abort criterion fires, hold or roll back. Do not advance.
+
+---
+
+## Cohort rollout
+
+For risky launches where the blast radius matters. Each cohort is a named segment; the flag advances through cohorts in sequence.
+
+Typical sequence:
+
+1. Internal employees only. Bugs surface from the team that can fix them quickly.
+2. Beta customers (opt-in). Engaged users who tolerate roughness in exchange for early access.
+3. Free-tier customers. Larger population; risk to revenue is bounded because they are unpaid.
+4. Paid customers, smaller plans first. Tier-by-tier escalation.
+5. Paid customers, enterprise. Last; highest revenue impact, lowest tolerance for issues.
+
+Each cohort hold is at least one full business cycle (5-7 days). Compress only with strong upstream confidence (the change has already shipped through internal and beta with zero issues).
+
+Abort criteria same as percentage rollout, plus: support ticket volume from the cohort exceeds baseline.
+
+---
+
+## Geo-staged rollout
+
+Default for compliance-sensitive features (data residency, region-specific regulations, locale-specific UX). One region at a time.
+
+Typical sequence:
+
+1. Single test region (often the team's home region; US-East or EU-West for most products).
+2. English-speaking regions (US, CA, UK, AU, NZ).
+3. Western Europe (DE, FR, ES, IT, NL, etc.).
+4. APAC (JP, SG, AU, etc.).
+5. LATAM and remaining regions.
+
+Hold per region depends on the product. For compliance features, hold long enough to detect any regulatory complaint or support escalation; for UX features, one full business cycle suffices.
+
+Abort criteria same as cohort, plus: any region-specific regulatory escalation. Compliance issues are non-negotiable rollback triggers.
+
+---
+
+## Time-based rollout
+
+Scheduled flips at known times. Useful for marketing-coordinated launches where the toggle has to fire at a specific moment (a press release, a partner co-launch, a planned downtime window).
+
+Pattern:
+
+1. The flag has a `time > $LAUNCH_TIMESTAMP` condition.
+2. Internal QA confirms the timestamp is correct in the platform UI.
+3. The launch hour arrives; the flag flips automatically.
+4. The team monitors the same metrics as a percentage rollout but at the full population from minute one.
+
+Watch the timezone. Coordinate the timestamp explicitly: midnight Eastern is not midnight UTC; "Friday at 9 AM" is ambiguous across timezones. Use UTC in the rule and let the platform UI display in the user's local time.
+
+Avoid time-based rollouts:
+- On weekends, unless weekend on-call exists.
+- On major holidays, unless the launch is the holiday itself (rare).
+- Overlapping with other major launches or known marketing campaigns; the metrics get confounded.
+
+---
+
+## Combination strategies
+
+The strategies above compose. Common combinations:
+
+**Percentage within cohort.** "Roll out to 50 percent of beta customers, then ramp to 100 percent of beta, then start the cohort rollout to free tier." Useful when the blast radius matters even within a single cohort.
+
+**Geo within percentage.** "Roll out to 1 percent of users in US-East only, then 10 percent of US-East, then expand to other regions." Useful when geo isolation is important for incident containment.
+
+**Time-based gated by cohort.** "At time T, the flag turns on, but only for the beta cohort. The rollout to other cohorts happens later." Useful when the public announcement matters but the broader rollout should still be cautious.
+
+---
+
+## Worked example: checkout redesign launch
+
+A team is launching a redesigned checkout flow. The change is high-risk (revenue surface, complex code, third-party payment integrations).
+
+Rollout plan:
+
+| Day | Stage | Rule | Hold | Watch |
+|---|---|---|---|---|
+| 1 | Internal | `user.email_domain == "yourcompany.com"` | 24 hours | Bug reports from team |
+| 2-4 | Internal extended | Same | 72 hours | Conversion, error rate |
+| 5 | Beta | `user.beta_opted_in == true` | 24 hours | Conversion, error rate, support |
+| 6-8 | Beta extended | Same | 72 hours | Conversion, primary funnel metrics |
+| 9 | Production 1% | `rollout 1% of all users` | 24 hours (must include peak) | Full alerting |
+| 10 | Production 10% | `rollout 10%` | 24 hours | Full alerting |
+| 11 | Production 50% | `rollout 50%` | 48 hours | Full alerting |
+| 13 | Production 100% | `rollout 100%` | 7 days | Full alerting |
+| 20 | Launch declared complete | Same rule | n/a | 30-day review scheduled |
+| 50 | 30-day review | Same rule | n/a | Decide on flag removal |
+| 60-80 | Flag removal PR | Code path consolidated | n/a | n/a |
+
+Abort criteria at every stage:
+- Checkout completion rate drops more than 1 percent absolute.
+- Payment failure rate increases at all.
+- Error rate (any 5xx) increases by more than 10 percent.
+- Support ticket volume on checkout increases.
+
+Total time from launch to flag-removed: about 80 days. The work to remove the flag at day 60-80 is part of the launch plan, not an afterthought.
+
+---
+
+## When to compress
+
+The cadences above are conservative defaults. Compress only with strong upstream confidence:
+
+- The change has already shipped behind a feature flag for an extended period (release-as-experiment-as-release).
+- The blast radius is genuinely small (an internal admin tool, a low-traffic settings page).
+- A previous similar launch went through the full cadence with zero issues, and the new launch is structurally analogous.
+
+Even with strong confidence, do not skip the production 1 percent stage. The first 1 percent in production is the only stage where production-specific issues (real user agents, real network conditions, real account distributions) surface.
+
+---
+
+## When to extend
+
+Extend the cadence when:
+
+- The metric being watched is slow (retention measured at day-7 or day-30 cannot be observed at a 24-hour hold).
+- The change involves a third party (payment processor, email provider, analytics vendor) whose behavior under load is unknown.
+- The team is new to flag rollouts and benefits from the slower pace as a learning exercise.
+
+Extension is cheaper than incident response. Conservative defaults are correct defaults.

--- a/skills/feature-flagging/references/flag-types-reference.md
+++ b/skills/feature-flagging/references/flag-types-reference.md
@@ -1,0 +1,83 @@
+# Flag types reference
+
+The five flag types in detail. Mixing them in one flag is the most common source of flag mess; commit at creation and do not let the type drift.
+
+---
+
+## Release flag
+
+**Definition.** A flag that gates a new feature so the code can ship to production while disabled. The team toggles it on for a percentage, ramps to 100, then removes the flag.
+
+**Lifetime.** Days to weeks. Most release flags should be removed within 30 days of reaching 100 percent rollout.
+
+**Lifecycle pattern.** Birth (PR adds gated code), adolescence (testing in dev/staging), launch (gradual percentage ramp in production), maturity (100 percent, monitor for 30 days), death (removal PR consolidates code paths).
+
+**Worked example.** `release_checkout_redesign_2026q2` gates a new checkout flow. Created when the new flow PR merges. Toggled on for 1 percent of users on day 1; ramps to 10 percent on day 2, 50 percent on day 4, 100 percent on day 6. Removed on day 36 after the 30-day review confirms no regressions.
+
+**Common pitfalls.** Skipping the removal step (the most common). Conflating with an experiment flag (the team wants to A/B test the rollout instead of just ramping it; that is a different type). Leaving the flag at 50 percent forever because the team is "watching" it (either ramp to 100 or roll back; do not park).
+
+---
+
+## Experiment flag
+
+**Definition.** A flag that randomly assigns users to variants for an A/B or multivariate test. The platform tracks conversion per variant; the team decides which variant wins, then ships the winner.
+
+**Lifetime.** One to six weeks. Tied to the duration of the test.
+
+**Lifecycle pattern.** Birth (PR adds the variants behind the flag), adolescence (canary in dev/staging), launch (test runs at the full target audience), maturity (test ends, decision made), death (winning variant code consolidated; flag removed).
+
+**Worked example.** `exp_billing_pricing_v2` tests two pricing page layouts. 50/50 split. Test runs for 21 days, hits the pre-committed sample size. Variant B wins. The PR removes the flag and the variant A code path; only variant B remains in production.
+
+**Common pitfalls.** Letting the experiment flag persist after the decision (the most common). Treating an inconclusive result as "let's keep the test running" instead of "kill or redesign." Mixing experiment with release: the team uses an experiment flag to gradually ramp a feature; if it is a ramp, it is a release flag.
+
+---
+
+## Operational flag
+
+**Definition.** A kill switch or circuit breaker. Lets ops disable a misbehaving feature without a code redeploy. The flag is on by default in production; flipped off only during incidents.
+
+**Lifetime.** Long-lived. Often years. Removed only when the underlying feature is removed.
+
+**Lifecycle pattern.** Birth (PR adds the kill switch around a risk surface), maturity (the flag sits at "on" indefinitely), occasional use during incidents.
+
+**Worked example.** `ops_search_circuit_breaker` wraps the search service. If the search service starts returning errors at high rates during a 3 AM incident, on-call flips the flag off, and the search bar shows a graceful fallback message until the underlying issue is fixed.
+
+**Common pitfalls.** No incident drill (the first time the kill switch is used should not be at 3 AM). Wrapping logic that does not need a kill switch (every feature does not need one; pick the high-risk surfaces). Conflating with a release flag (the team uses the kill switch as a rollout control; if it is a ramp, the new code path needs its own release flag, and the kill switch wraps the larger feature).
+
+---
+
+## Permission flag
+
+**Definition.** Controls feature access by plan tier, customer cohort, or region. The free tier sees one set of features; the enterprise tier sees another. The flag is the access control mechanism.
+
+**Lifetime.** Long-lived. Tied to the business model.
+
+**Lifecycle pattern.** Birth (PR adds the gate around a paid feature), maturity (the flag stays in production indefinitely), evolution (the rule changes as plans evolve, but the flag remains).
+
+**Worked example.** `perm_enterprise_audit_log` controls access to the audit log feature. Only accounts on the enterprise plan see it. When the plan structure changes (audit log opens up to the team plan too), the rule changes; the flag remains.
+
+**Common pitfalls.** Putting permission logic in code instead of in the flag (so the team has to deploy when plans change). Conflating with configuration: permission flags govern access by plan/role; configuration flags govern behavior per tenant contract. Permission flags use the same evaluation surface as release flags but the lifecycle is fundamentally different.
+
+---
+
+## Configuration flag
+
+**Definition.** Lets some customers see different behavior based on contractual configuration. White-label tenants, regulated regions, custom rollout schedules per account, partner integrations.
+
+**Lifetime.** Long-lived. Tied to the contract or regulatory requirement.
+
+**Lifecycle pattern.** Birth (PR adds the configuration switch for a specific tenant or partner), maturity (the flag remains as long as the contract is active), evolution (the rule changes as new tenants come on or existing ones renegotiate).
+
+**Worked example.** `cfg_tenant_acme_custom_dashboard` enables a custom dashboard for Acme Corp because their contract specifies it. The flag's targeting rule is `account.tenant_id == "acme"`. The flag remains in production as long as Acme is a customer.
+
+**Common pitfalls.** Configuration sprawl: every tenant request becomes a new flag, the platform has hundreds, no one can audit. Mitigation: use segments and tenant-attribute targeting on a smaller set of feature flags rather than per-tenant flags. Conflating with permission: configuration governs custom behavior per tenant contract; permission governs access by plan tier.
+
+---
+
+## Anti-pattern: type drift
+
+A flag created as a release flag gets repurposed as an experiment, then later as a permission gate. The name still says `release_`. The targeting rule is now multi-purpose. The lifecycle expectation is unclear. Removing the flag breaks something somewhere.
+
+The fix is to refuse type drift. When the purpose changes, create a new flag of the new type and migrate the rule. The original flag is removed once nothing depends on it. This is more work than just changing the rule on the existing flag, but it preserves the type-clarity discipline.
+
+The recovery for an existing type-drifted flag: rename to one of the five types, document the current actual purpose, and treat the flag as that type from now on. The original mixed history is grandfathered; the going-forward behavior is single-typed.

--- a/skills/feature-flagging/references/governance-and-permissions.md
+++ b/skills/feature-flagging/references/governance-and-permissions.md
@@ -1,0 +1,115 @@
+# Governance and permissions
+
+Different roles need different access to the flag system. Engineering needs broad ability to create flags. Product needs to author targeting rules in dev and staging. Production targeting changes deserve a smaller approver pool. The pattern below balances access with audit.
+
+---
+
+## Permission tiers
+
+Four tiers cover most cases. Not every organization needs all four.
+
+| Tier | Scope | Typical members |
+|---|---|---|
+| Viewer | Read-only across all environments | Most of engineering, product, support, finance, executive |
+| Editor | Create and modify flags in dev and staging | The team that owns the flag's surface |
+| Approver | Promote flag changes from staging to production | Team lead, on-call engineer, designated approvers |
+| Admin | Delete flags, modify permissions, access audit logs | Platform team plus a backup |
+
+Smaller organizations may collapse Editor and Approver into a single "Engineer" tier. Larger organizations may add a fifth tier ("Owner") for cross-cutting governance.
+
+---
+
+## Environment-based permissions
+
+Permissions vary by environment. The same person can have Editor in dev/staging and Viewer in production. The environment-based scope is the second axis after role.
+
+| Environment | Default access | Notes |
+|---|---|---|
+| Dev | Editor for engineering, Viewer for everyone else | Sandbox; mistakes are cheap |
+| Staging | Editor for the owning team, Viewer for everyone else | Pre-production; mistakes are detectable |
+| Production | Approver for the owning team, Viewer for everyone else | Live; mistakes are expensive |
+
+Production changes go through review like deploys. The change request describes the rule diff, the rollout plan, and the abort criteria. An approver applies the change after review. The rule does not silently appear in production because someone clicked a button.
+
+---
+
+## Approval workflow
+
+For production-impacting changes:
+
+1. Editor authors the change in staging.
+2. Editor tests the change in staging (the rule applies, the metric moves as expected).
+3. Editor opens a change request in the platform (most platforms have a built-in change-request workflow; if not, a Slack channel with a bot suffices).
+4. The request includes: rule diff, rollout plan, abort criteria, link to relevant ticket/PR, link to staging test results.
+5. An approver reviews. If clean, applies. If not, comments and the editor revises.
+6. The change applies in production with the audit trail attached.
+
+For low-risk operational changes (a kill switch flip during an incident), the workflow can be compressed: the approver applies directly without a separate change request, and the audit trail captures the change with the incident reference. Document this exception explicitly so emergencies do not produce unexplained audit entries.
+
+---
+
+## Audit trail
+
+Every flag change must be logged with:
+
+- Actor (who applied it, by user identity).
+- Timestamp.
+- Before-state and after-state (the rule diff).
+- Reason (free-text or linked ticket).
+
+Most platforms do this automatically. Configure the audit log to also write to the central log aggregator (Datadog, Splunk, ELK, the team's choice). The platform's audit log is fine for routine inspection; the centralized log is where investigation happens during incidents.
+
+Audit retention: at least one year. Two years for organizations with regulatory obligations.
+
+---
+
+## Emergency override
+
+An emergency override is the path that lets on-call flip a kill switch at 3 AM without going through the standard approval workflow.
+
+The pattern:
+
+1. A small group has Approver permission on the operational kill switches specifically.
+2. The group includes the on-call rotation; on-call inherits Approver for the duration of their shift.
+3. Emergency overrides apply with the standard audit trail; the reason field includes the incident reference.
+4. After the incident, the override is reviewed in the post-mortem.
+
+Test the override in incident drills. The first time on-call flips a kill switch should not be at 3 AM with revenue dropping; it should be in a drill with everyone calm. If the drill reveals the override path is broken (the on-call's account does not have the right permission, the platform's UI is confusing, the mobile app does not let you change rules), fix it immediately.
+
+---
+
+## Service accounts
+
+Automation needs flag access too. CI/CD pipelines may flip flags as part of deploys; monitoring systems may flip kill switches based on alerts; orchestration agents may modify flags via MCP.
+
+Service accounts:
+
+- Each automation has its own service account with a clearly named identity (`ci_pipeline`, `monitoring_alert_bot`, `agent_orchestrator`).
+- Service accounts have the minimum permission needed for their scope. The CI account that flips release flags after deploy does not need permission to delete flags.
+- Service account credentials rotate on a schedule (90 days for production access).
+- Audit log entries from service accounts are clearly marked so they can be filtered separately from human changes.
+
+Mixing human and service-account credentials in the same identity is the most common audit-trail mistake. The investigation question "who changed this flag at 2 AM" should not have the answer "an automation, but we are not sure which one because it was authenticated as a human admin."
+
+---
+
+## The "production console freeze" anti-pattern
+
+Some organizations respond to a production flag incident by tightening access so much that every flag change requires a ticket, a meeting, and a 24-hour delay. The result is over-correction: routine flag changes get queued, the team starts authoring rules in code instead of in the platform, and the platform stops being load-bearing.
+
+The fix is not to freeze access. The fix is to:
+
+- Tighten the approval workflow (require change requests for production).
+- Tighten the audit log (capture every change with reason).
+- Tighten the emergency override (drill it).
+- Loosen the day-to-day workflow so editors can do their jobs without paperwork.
+
+Bureaucracy substitutes for trust. Trust is built via the audit log and the approval workflow. Once the audit log is solid, day-to-day editing can stay fast.
+
+---
+
+## Cross-team coordination
+
+When a flag's surface overlaps with another team's work, coordinate before the change. The experiment registry pattern from the `experiment-design` skill applies here too: maintain a shared list (in the platform, in a wiki, in a shared doc) of flags currently being modified or rolled out per surface. Before launching a flag rollout, check the registry for conflicts.
+
+Cross-team coordination does not have to be heavy. A 5-minute Slack check ("we're rolling out flag X on the checkout flow tomorrow at 1 PM, anyone working on adjacent flags?") is enough for most cases. The cost of skipping the check is the cross-team conflict scenario from the SKILL.md, where two flags interact and produce broken UI.

--- a/skills/feature-flagging/references/stale-flag-cleanup-playbook.md
+++ b/skills/feature-flagging/references/stale-flag-cleanup-playbook.md
@@ -1,0 +1,116 @@
+# Stale flag cleanup playbook
+
+A quarterly cadence for keeping the flag inventory healthy. Without it, dead flags compound: every quarter adds 20-50 release/experiment flags that never got removed, and after two years the platform has hundreds of dead entries that nobody can confidently delete.
+
+The playbook is mechanical. Run it every quarter, the same way. Resist the urge to skip a quarter because the platform "looks fine."
+
+---
+
+## What counts as stale
+
+| Flag type | Stale threshold |
+|---|---|
+| Release | 30 days without evaluation |
+| Experiment | 30 days without evaluation |
+| Operational | 90 days without evaluation |
+| Permission | Annual review; not "stale" by evaluation count |
+| Configuration | Annual review; tied to contract status |
+
+Most platforms expose a "stale flag" report or a "last evaluated" timestamp per flag. If yours does not, the SDK can be configured to emit evaluation events to an analytics destination, and the analytics database becomes the source of truth.
+
+---
+
+## Quarterly process
+
+### Step 1: Generate the report
+
+Pull the stale flag list from the platform. Filter by type-specific threshold above. Output: a list of flags with last-evaluation timestamp, owner, type, current rule.
+
+### Step 2: Owner triage
+
+For each flag in the list, route to the owner. The owner has three options per flag:
+
+- **Remove.** The flag is dead. Open a code-side removal PR.
+- **Keep.** The flag is still load-bearing for a real reason (operational kill switch that has not fired in 90 days but should remain; permission flag for a feature whose rule is being audited annually). Document the reason; remove from this quarter's list.
+- **Investigate.** The owner does not know why the flag exists or what it controls. Spawn a sub-task to investigate; the flag stays in next quarter's list.
+
+If a flag has no owner (the original owner left, ownership was never assigned, the flag predates the convention), rotate to the platform/SRE team for a forced decision in step 3.
+
+### Step 3: Triage meeting
+
+A 30-minute meeting per quarter. Attendees: representative from each team that owns flags, the platform/SRE team, the engineering lead.
+
+Walk the list. For each flag:
+
+- Confirm the owner's recommendation.
+- For "investigate" flags, decide a deadline: investigation completes by next month or the flag is force-removed.
+- For orphan flags (no owner, force-routed to platform), the platform team makes the call: remove if there is no evidence of active use, keep with documentation if there is.
+
+The meeting produces three artifacts: a remove list, a keep list with reasons, an investigate list with deadlines.
+
+### Step 4: Removal PRs
+
+One PR per flag. Bundle is tempting; resist it. One-flag-per-PR has three advantages:
+
+1. The reviewer can confirm the flag is genuinely dead by inspecting only the removed code paths.
+2. If a flag was not actually dead (a code path uses it that the search missed), the rollback is a single revert.
+3. The PR title and description reference the specific flag, which produces a clean audit trail.
+
+Each PR:
+
+- Removes the flag's evaluation calls from code.
+- Consolidates the gated branches: usually keeps the "on" branch as permanent code and deletes the "off" branch.
+- Removes any tests that targeted only the removed branch.
+- Updates documentation that referenced the flag.
+
+### Step 5: Platform deletion
+
+After the removal PR merges and ships:
+
+- Wait 24 hours for the new code to fully roll out.
+- Confirm the platform shows zero evaluations of the flag for the full 24-hour window.
+- Archive or delete the flag from the platform.
+- Audit log entry confirms deletion with actor, timestamp, reason ("quarterly cleanup, removal PR #NNNN").
+
+### Step 6: Verification
+
+A week after platform deletion:
+
+- Spot-check the codebase for any remaining references to the flag's key (string-grep). Should be zero.
+- Spot-check the platform for the flag's reappearance (sometimes platforms restore archived flags via API automation; rare but worth checking).
+
+---
+
+## Orphan flags
+
+Orphan flags (no owner) are the hardest case. The original owner left the company, the team that owned the area dissolved, the flag predates the ownership convention.
+
+The pattern:
+
+1. Default ownership routes to the platform/SRE team.
+2. The platform team asks: "Is this flag's targeting rule consistent with documented product behavior? Would removing it change observable behavior for any user?"
+3. If no observable change, remove. If yes, escalate to the team most plausibly impacted.
+4. If no team can be identified and no observable change is detectable, the flag is a candidate for removal in the next quarterly meeting; document the orphan status and remove on a 60-day delay so any silent dependency can be discovered.
+
+The 60-day delay is a hedge against unknown dependencies. In most cases, no one notices and the flag is safely removed. In the rare cases where a forgotten cron job or a downstream service was depending on the flag, the issue surfaces during the delay window.
+
+---
+
+## Tooling
+
+Most platforms provide some automation:
+
+- LaunchDarkly: Code References finds usages in the codebase, flags candidates for removal.
+- Statsig: Stale Gates report.
+- GrowthBook: stale flag dashboard.
+- Flagsmith: change request workflow integrates removal with governance.
+
+The automation reduces manual work but does not replace the triage meeting. The meeting is where humans make the keep/remove decision, which is the part automation cannot do.
+
+---
+
+## Make removal part of the launch checklist
+
+The most important pattern is upstream: make flag removal part of the launch checklist, not a separate quarterly effort. When a release flag is created, the launch ticket has a sub-ticket scheduled 30 days out: "Remove flag X." When the launch goes well and the flag reaches 100 percent, the sub-ticket gets done as part of post-launch hygiene.
+
+Quarterly cleanup is the safety net for everything that slips past the upstream discipline. The discipline reduces the safety-net workload from "300 dead flags" to "5 dead flags," which is the difference between a 30-minute triage meeting and a multi-day project.

--- a/skills/feature-flagging/references/targeting-rule-patterns.md
+++ b/skills/feature-flagging/references/targeting-rule-patterns.md
@@ -1,0 +1,183 @@
+# Targeting rule patterns
+
+Common patterns and anti-patterns for flag targeting rules. The patterns work; the anti-patterns produce flag mess that takes quarters to unwind.
+
+---
+
+## Pattern: percentage rollout
+
+Default: flag off (0 percent). Override: flag on for a percentage of the user population.
+
+```
+Default rule: off
+Override: rollout 10% of all users
+```
+
+The platform handles the bucketing (usually a stable hash on user ID, so the same user gets the same value across requests). Use this for release flags during ramps.
+
+Variation: percentage within a segment. `Default off; rollout 50% of users where account.tier == "enterprise"`. Useful when the rollout should reach only a subset of the population.
+
+---
+
+## Pattern: internal-only
+
+Restrict the flag to internal employees first. The flag is on for `@yourcompany.com` emails; everyone else sees the disabled state.
+
+```
+Default rule: off
+Override: on if user.email_domain == "yourcompany.com"
+```
+
+Use this for the first stage of a sensitive release. Internal users find bugs without external exposure.
+
+---
+
+## Pattern: opt-in beta
+
+Users who have opted into beta features see the flag on. Implementation requires an opt-in mechanism somewhere in the product (settings page, signup flow, support request).
+
+```
+Default rule: off
+Override: on if user.beta_opted_in == true
+```
+
+Use this for risky features that need engaged-user feedback. The opt-in is the consent mechanism; the flag is the access mechanism.
+
+---
+
+## Pattern: cohort-based
+
+Target a named segment defined elsewhere in the platform. The segment captures the cohort logic so the flag rule stays simple.
+
+```
+Default rule: off
+Override: on if user IN segment "early_access_2026q2"
+```
+
+Use this when the cohort is shared across multiple flags (the same set of "early access" users sees several features). The segment is the single source of truth; flags reference it.
+
+---
+
+## Pattern: geo-staged
+
+Target users by region. The country or region attribute usually comes from the request (IP-based geolocation) or the account profile.
+
+```
+Default rule: off
+Override: on if request.country IN ("US", "CA")
+```
+
+Use this for compliance launches (data residency regulations, region-specific UX). Stage the rollout: US first, then EU, then APAC.
+
+---
+
+## Pattern: time-based scheduled flip
+
+The flag turns on at a specific time. Useful for marketing-coordinated launches.
+
+```
+Default rule: off
+Override: on if time > "2026-06-01T12:00:00Z"
+```
+
+Watch the timezone. Avoid scheduling on weekends or holidays unless on-call coverage exists for the rollout window.
+
+---
+
+## Pattern: composition (cohort within percentage)
+
+A percentage of a cohort. Useful when the rollout should be slow even within an opt-in group.
+
+```
+Default rule: off
+Override: on if user.beta_opted_in == true AND rollout 25% of those users
+```
+
+Order matters: the percentage applies to the cohort, not the full population. The platform's rule editor usually makes this clear.
+
+---
+
+## Anti-pattern: volatile-attribute targeting
+
+Targeting on attributes that change frequently produces user-experience whiplash.
+
+Bad:
+```
+Override: on if user.last_login_date > "2026-04-01"
+```
+
+A user's last_login_date changes every time they log in. They see the treatment one day, the control the next. The experience flickers; conversion data is noise.
+
+Fix: target on stable attributes. Or, snapshot the attribute at a fixed point (`user.first_login_date_was_after_2026_04_01`) and use the snapshot.
+
+---
+
+## Anti-pattern: deeply nested AND/OR
+
+If your rule has three levels of nesting, the taxonomy is wrong.
+
+Bad:
+```
+Override: on if (
+  (user.country == "US" AND user.signup_date > "2026-01-01")
+  OR
+  (account.tier == "enterprise" AND NOT user.churned)
+  OR
+  (user.beta_opted_in == true AND request.device == "mobile")
+)
+```
+
+The intent is unclear, the rule is fragile, and reviewing it during incidents is slow.
+
+Fix: define a segment that captures the intent (e.g., "eligible_for_new_dashboard") and use the segment in the flag rule. Or split into multiple flags (one for the US/recent-signup case, one for the enterprise case, one for the mobile-beta case) and let the calling code combine them.
+
+---
+
+## Anti-pattern: production rules drift from staging
+
+The team tests the flag in staging with rule X. The rule that ships in production is rule Y, written directly in the production console without re-testing in staging.
+
+Result: the staging tests do not predict production behavior. The first 1 percent rollout in production reveals the gap, and the team scrambles to align.
+
+Fix: rules go through environment promotion. Author in staging, test in staging, promote to production via the platform's promotion workflow. If the platform does not have promotion, copy the rule from staging to production via a documented process and confirm the rule is identical in both before flipping production on.
+
+---
+
+## Anti-pattern: targeting in the flag name
+
+Bad: `flag_name = "enterprise_audit_log"` with rule `account.tier == "enterprise"`.
+
+When the rule changes (audit log opens up to team-tier accounts), the flag name lies.
+
+Fix: name the flag for what it controls (`perm_audit_log`), let the rule do the targeting work. The rule can change without renaming the flag.
+
+---
+
+## Anti-pattern: kill switch with a complex rule
+
+A kill switch (operational flag) should have a simple rule: `on for everyone` or `off for everyone`. If your kill switch's rule is `on for everyone except a specific cohort with these conditions`, you are using an operational flag as a permission gate.
+
+Fix: use a permission flag for the per-cohort access; use a separate operational flag (`ops_feature_x_killswitch`) for the universal kill. The operational flag wraps the entire feature; the permission flag wraps the access to the feature.
+
+---
+
+## Pattern: explicit ramp gate
+
+Some platforms let you tag a flag's rule with explicit "stages." The flag advances through stages on a button press, with each stage having its own rule.
+
+```
+Stage 1: rollout 1%
+Stage 2: rollout 10% (advance from stage 1 manually)
+Stage 3: rollout 50% (advance from stage 2 manually)
+Stage 4: rollout 100% (advance from stage 3 manually)
+```
+
+Use this when the platform supports it. The explicit stages make rollout history readable: you can see when each stage advanced, by whom, with what observed metrics.
+
+---
+
+## Composition rule of thumb
+
+If a flag's rule reads naturally to a non-engineer ("on for enterprise customers in the US"), the rule is simple enough. If the rule requires a five-minute explanation, it is too complex; refactor into segments or split into multiple flags.
+
+The rule is read more times than it is written. Optimize for readability.


### PR DESCRIPTION
Skill 2 of 3 in the PM-experimentation suite. Pairs with feature-flag platforms in \`/integrations\` (LaunchDarkly, Flagsmith, Split.io, VWO FME, GrowthBook, Statsig, PostHog, Optimizely).

## What's in it

- **SKILL.md** (278 lines, 14 substantive sections plus framework summary and reference-files index). Covers the five flag types (release, experiment, operational, permission, configuration; do not mix), naming conventions, lifecycle, targeting rules, rollout strategies, stale flag management, governance and permissions, dependencies and conflicts, performance, branch testing, rollback discipline, observability.
- **7 reference files**:
  - \`flag-naming-conventions.md\`: typed prefixes, owner prefixes, semantic naming, migration plan for badly-named flags.
  - \`flag-lifecycle-checklist.md\`: per-phase checklist (birth, adolescence, launch, maturity, death, audit).
  - \`flag-types-reference.md\`: the five flag types in detail, worked examples, common pitfalls.
  - \`stale-flag-cleanup-playbook.md\`: quarterly cadence, orphan-ownership pattern.
  - \`targeting-rule-patterns.md\`: patterns and anti-patterns including volatile-attribute targeting and deeply-nested rules.
  - \`flag-rollout-strategies.md\`: percentage, cohort, geo, time-based, combination strategies; worked checkout-redesign example with full timeline.
  - \`governance-and-permissions.md\`: permission tiers, environment promotion, approval workflow, emergency override, service accounts.

## Voice

Senior-engineer-to-team-lead. More tactical than experiment-design's mentor voice. Concrete patterns over abstract framing.

## README

Count bumped 63 → 64. Product section grows from 4 to 5 entries. Rows 35 through 63 renumbered to 36 through 64 via descending-order sed. Reference files count bumped 105 → 112.

## Quality gates

- \`python .github/scripts/lint_skills.py\`: PASSED. 64 skills validated, 29 warnings (all pre-existing line-length warnings on other skills; feature-flagging SKILL.md at 278 lines is over the 250 soft target but well under the 500 hard cap).
- Em-dash audit on \`skills/feature-flagging/\` and \`README.md\`: zero hits (the seven em-dashes I introduced as separators were converted to colons before commit).
- Forbidden-phrase audit: zero hits.
- Real-firm scrub for 'illumine': zero hits.
- Cross-skill backtick references: \`experiment-design\` (real, on main), plus forward-pointers to \`experimentation-analytics\` (parallel agent) and \`/integrations/{platform}\` paths (microsites on main).

## Parallel work note

A parallel skill (\`experimentation-analytics\`) is being authored simultaneously in a different working directory. If that PR merges first, this one will need a rebase to resolve catalog count and table numbering on \`README.md\`.

## What's next

- Companion landing page at \`/skills/feature-flagging\` ships in a follow-up rampstackco-app PR (next in this dispatch).
- \`experimentation-analytics\` skill follows in parallel (Agent B).
- Optional \`experimentation-platform-orchestrator\` skill after the three foundational PM-experimentation skills land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)