### PR TITLE
feat(skills): add experimentation-analytics (9th flagship, PM-experimentation suite skill 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-64-blue.svg)](#the-64-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-65-blue.svg)](#the-65-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -18,7 +18,7 @@
 
 </div>
 
-> 64 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 65 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
 
@@ -32,7 +32,7 @@
 - [Getting started](#getting-started)
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
-- [The 64-skill catalog](#the-64-skill-catalog)
+- [The 65-skill catalog](#the-65-skill-catalog)
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
 - [Repository structure](#repository-structure)
@@ -58,8 +58,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 
 What you get:
 
-- **64 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
-- **112 reference files** (templates, checklists, decision matrices, worked examples)
+- **65 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
+- **119 reference files** (templates, checklists, decision matrices, worked examples)
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
 - **Uniform structure.** Every skill uses the same section order, the same tone, and the same authoring conventions. Predictable in, predictable out.
@@ -246,9 +246,9 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 
 ---
 
-## The 64-skill catalog
+## The 65-skill catalog
 
-All 64 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 65 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 
 ### Strategy and discovery (5)
 
@@ -314,7 +314,7 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 29 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
 | 30 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
-### Product (5)
+### Product (6)
 
 | # | Skill | What it does |
 |---|---|---|
@@ -323,70 +323,71 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 33 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
 | 34 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
 | 35 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
+| 36 | [`experimentation-analytics`](skills/experimentation-analytics/SKILL.md) | Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 36 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 37 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 38 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 39 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 37 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 38 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 39 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 40 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 40 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 41 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 41 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 42 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 43 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 44 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 45 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 46 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 47 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 48 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 49 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 42 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 43 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 44 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 45 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 46 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 47 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 48 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 49 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 50 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 50 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 51 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 51 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 52 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 52 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 53 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 54 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 53 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 54 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 55 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 55 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 56 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 57 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 58 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 59 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 56 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 57 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 58 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 59 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 60 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 60 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 61 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 62 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 63 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 64 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 61 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 62 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 63 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 64 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 65 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 
 ---
 

--- a/skills/experimentation-analytics/SKILL.md
+++ b/skills/experimentation-analytics/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: experimentation-analytics
+description: How to read experiment results without fooling yourself. Confidence intervals, p-values, multiple testing, sequential testing, CUPED, heterogeneous treatment effects, ratio metrics, network effects, dashboard reconciliation, and the interpretation failures that produce confidently wrong shipping decisions.
+---
+
+# Experimentation Analytics
+
+A data-team-mentor's playbook for interpreting experiment results without fooling yourself.
+
+The result panel is the moment-of-truth for an experiment. The numbers on it determine whether you ship, kill, or iterate. They also expose every shortcut taken in the design phase: an underpowered test produces wide confidence intervals; a peeked test produces a too-narrow p-value; a ratio metric without delta-method correction produces overconfident lift estimates. Most ship-the-wrong-thing decisions trace back to misreading the result panel.
+
+This skill is the discipline that prevents misreading. It assumes the experiment was designed well (see the `experiment-design` skill). It assumes the platform's results panel is technically correct (most modern platforms are; some older ones are not). It assumes you can read a number off a screen. The hard part is knowing what each number actually means and what it does not, and that is what is here.
+
+When to use this skill: any time you are reading an experiment result panel and about to make a ship, kill, or iterate decision.
+
+---
+
+## What this skill is for
+
+This skill covers result interpretation, the statistical concepts that make the numbers trustworthy, and the dashboard reconciliation work that prevents executive-level confusion when the experiment number does not match the BI number. The audience is product managers and data analysts who read experiment results together and need a shared vocabulary that does not paper over the dangerous parts of statistics.
+
+Companion skills cover the adjacent territory. The `experiment-design` skill covers pre-experiment thinking: hypothesis, sample size, MDE, segments, what NOT to test. Read it before designing the test; read this skill when reading the result. The `feature-flagging` skill covers the operational mechanics of flag management, environment promotion, and stale-flag cleanup. Together the three skills span the experimentation lifecycle from intent through interpretation. Pair this skill with the relevant `/integrations/{platform}` microsite for platform-specific MCP commands; Statsig, PostHog, Optimizely, GrowthBook, Eppo, Amplitude, and Kameleoon all expose rich analytics surfaces that this skill informs how to read.
+
+---
+
+## The result panel: what every modern platform should expose
+
+A result panel that omits any of the following is a black box. Treat results from black-box platforms with extra skepticism, and consider exporting raw assignment and event data into a notebook where you can compute the missing pieces yourself.
+
+What a competent platform exposes:
+
+- Variants and traffic allocation (e.g., 50/50, 33/33/33). Allocation drift across the test window indicates assignment bugs.
+- Per-variant primary metric: point estimate, confidence interval (or credible interval for Bayesian), sample size at the variant level.
+- Lift: variant minus control, expressed as both absolute change and relative percent. Both numbers matter; relative is intuitive, absolute is what shows up in revenue calculations.
+- Statistical significance: p-value (frequentist) or probability of being best (Bayesian). The methodology should be labeled clearly so you know which interpretation rules apply.
+- Variance reduction technique applied: CUPED, post-stratification, regression adjustment. If the platform applies these silently, ask which.
+- Guardrail metric statuses: each guardrail labeled green, amber, or red against its tolerance. The tolerance was set at design time; the panel just enforces it.
+- Per-segment results for pre-registered segments only. Post-hoc segment slicers are tempting and dangerous.
+- Test status: running, ended, decision filed.
+- A time series of the lift across the test window. This is where novelty effects, primacy effects, and assignment bugs become visible.
+
+If you are looking at a result panel that hides any of these, the first move is to surface them, not to ship.
+
+---
+
+## Confidence intervals: the most important number
+
+The single most important number on the result panel is the confidence interval (CI) on the lift. More important than the point estimate. More important than the p-value. The CI tells you what you actually know.
+
+What a 95% CI of [+2%, +6%] means: under repeated sampling, the true effect would fall in this range 95% of the time. The true effect is most likely somewhere near the middle, but the extremes are entirely consistent with the data.
+
+What it does not mean: it does not literally mean "there is a 95% chance the true effect is between +2% and +6%." That is the Bayesian credible interval, which often gives similar numerical answers but is conceptually different. PMs can usually live with the loose intuition; analysts should know the precise version when defending a number to a skeptic.
+
+The width of the CI matters more than the center for most ship decisions. A wide CI means you do not know much yet. A narrow CI means you know with precision. The point estimate is your best guess; the width is your humility.
+
+Practical decision rules, in order of importance:
+
+1. If the CI includes zero AND a meaningful positive number (say [-1%, +5%]), you do not have enough data to ship. Period. The point estimate may look favorable, but the data is consistent with no effect and consistent with a meaningful win. You cannot tell which.
+2. If the CI is all-positive (lower bound greater than zero, e.g., [+1%, +4%]), there is a real effect. Now evaluate magnitude: is the lower bound large enough to be worth the implementation cost?
+3. If the CI is all-negative (upper bound less than zero, e.g., [-5%, -1%]), there is real harm. Kill the test.
+4. If the CI straddles zero but is narrow (e.g., [-0.5%, +0.5%]), this is a real null result. The effect is small enough to call essentially zero. Useful information; do not ship the change for "lift" reasons (you found none) but do not panic about harm either.
+5. If the CI straddles zero and is wide (e.g., [-5%, +8%]), the test is inconclusive. The data is consistent with a moderate win, no effect, or a moderate loss. Run longer, run bigger, or accept that the question cannot be answered at the available traffic.
+
+For a worked-example cheatsheet, see `references/confidence-interval-cheatsheet.md`.
+
+---
+
+## P-values: what they mean and what they do not
+
+The p-value is the probability of observing the lift you saw (or a larger one) IF the true effect were zero. A p-value of 0.04 means: under the null hypothesis of no effect, you would see this much lift purely by chance about 4% of the time.
+
+What the p-value does not mean, despite frequent abuse:
+
+- It does not mean "there is a 96% chance the treatment works." That sentence has no defensible interpretation; the p-value is computed under the assumption that the treatment does NOT work, so it cannot tell you the probability that it does.
+- It does not mean "the effect is large." A tiny effect tested against a huge sample can produce a vanishingly small p-value. The p-value is about the strength of evidence against the null, not the size of the effect.
+- It does not mean "the result will replicate." A p-value of 0.04 is associated with replication rates well below 50% in most published research; statistical significance is not reproducibility.
+
+The 0.05 cutoff is convention, not law. If you pre-committed to alpha equals 0.05, follow it; the discipline of pre-commitment is more valuable than the specific threshold. If you did not pre-commit, p equals 0.06 is not categorically different from p equals 0.04, and treating it as such is theater.
+
+Always read the CI alongside the p-value. The p-value tells you about the null hypothesis; the CI tells you about the magnitude. Both matter; neither is sufficient alone. A p-value of 0.001 with a CI of [+0.1%, +0.3%] is a real but practically tiny effect; a p-value of 0.08 with a CI of [-1%, +12%] is a noisy estimate that could be huge or zero. The former is technically significant and not worth shipping; the latter is technically not significant and you might still want to dig deeper.
+
+The peeking problem applies to p-values directly. Standard p-values assume one analysis at the end of the test. Multiple analyses inflate the false positive rate. Modern platforms with sequential testing report "always-valid" or "anytime-valid" p-values that survive peeking; older platforms do not. Know which you are looking at. See `references/p-value-interpretation-guide.md` for deeper coverage.
+
+---
+
+## Multiple testing corrections
+
+The problem in one sentence: with twenty independent comparisons at alpha equals 0.05, you expect one false positive purely by chance. With fifty comparisons, two or three. With a hundred, five.
+
+Where multiple testing creeps in unintentionally:
+
+- Multiple variants: A vs B vs C vs D is three pairwise comparisons against control, not one.
+- Multiple metrics: tracking primary plus six guardrails plus three secondary metrics is ten chances to find significance somewhere.
+- Multiple segments: ten segments times three metrics is thirty chances.
+- Multiple time windows: looking at week 1, week 2, week 3, and the full test is four chances per metric per segment.
+
+Two correction methods you should know:
+
+- Bonferroni correction. Divide alpha by the number of comparisons. Conservative; controls the family-wise error rate (the probability of even one false positive across the family of tests). Use when false positives are catastrophic.
+- Benjamini-Hochberg (BH) correction. Less conservative; controls the false discovery rate (the expected proportion of false positives among the things called significant). Better for exploratory analysis.
+
+Most modern platforms support these natively as a configuration option. Configure them, or know which the platform applies by default. Some platforms apply corrections silently to the displayed p-values; others report uncorrected numbers and expect you to do the math.
+
+The PM-friendly heuristic: pre-register your primary metric and primary segment. Treat everything else as exploratory. Findings in non-primary metrics or non-primary segments require larger effects, replication in a follow-up test, or both before they justify shipping. The discipline of designating primary up front protects you from the multiple-testing trap better than any correction formula.
+
+---
+
+## Sequential testing math
+
+The peeking problem revisited from the analytics side. Classical t-tests, z-tests, and proportion tests assume one analysis at the end of a test. If you analyze the data five times during the test and stop the moment you see significance, your false positive rate is much higher than the nominal 5%. With daily peeking on a four-week test, false positive rate can climb above 30%.
+
+Sequential testing methods adjust the math to allow continuous monitoring without inflating false positives. The names you will encounter:
+
+- mSPRT (mixture sequential probability ratio test). Produces "always-valid" p-values: you can look any time, and the false positive rate stays at the nominal alpha. Common in modern platforms.
+- Group sequential designs. Plan a fixed set of interim analyses (say, three) with adjusted significance thresholds at each. Less flexible than mSPRT but well-understood.
+- Anytime-valid confidence intervals. The CI version of always-valid p-values. Wider than fixed-horizon CIs by design; the cost of peek-safety is some statistical efficiency.
+
+Modern platforms with sequential testing built in: Statsig (always-valid by default), Eppo (sequential CIs as a configuration), parts of PostHog (depending on the experiment type), GrowthBook (mSPRT supported). If your panel says "always-valid p-value" or "anytime-valid CI," that is sequential. If it says "p-value" with no qualifier, it is probably fixed-horizon and peeking inflates false positives.
+
+If your platform does not support sequential testing, the discipline is: pre-commit to a single analysis date at launch, do not peek, and if you must peek, do not make decisions based on the peek. Save the decision-making for the pre-committed date. This is hard. Sequential testing makes it easier.
+
+The trade-off: sequential tests have wider CIs and less aggressive p-values than fixed-horizon tests at the same sample size. The cost is real but usually worth it for PM contexts where the discipline of not peeking is impractical.
+
+---
+
+## CUPED variance reduction
+
+CUPED (Controlled-experiment Using Pre-Experiment Data) uses pre-experiment behavior of the same users to subtract out their baseline, leaving a cleaner signal of the treatment effect. The result is the same point estimate with a much narrower confidence interval, often 30% to 50% narrower, which is equivalent to roughly doubling your effective sample size for free.
+
+When CUPED helps:
+
+- Metrics with high pre-experiment baseline variance: revenue per user, sessions per user, engagement minutes, content consumption.
+- Tests where users have meaningful history (logged-in users, users from before a certain date).
+- Long-running products where pre-experiment behavior strongly predicts in-experiment behavior.
+
+When CUPED does not help:
+
+- Brand-new users with no pre-experiment data.
+- One-time conversion metrics with no pre-experiment baseline (a user either signs up or does not; there is nothing to subtract).
+- Tests where pre-experiment behavior is essentially uncorrelated with the metric being moved.
+
+How to read CUPED-adjusted results: the point estimate is roughly the same as the unadjusted estimate; the CI is narrower. If a result switched from "significant with CUPED" to "not significant without CUPED," that is normal and the CUPED-adjusted version is the more powerful test. If a result went the other way (significant without CUPED, not significant with), the unadjusted result was probably noise that CUPED correctly removed.
+
+A common confusion: "CUPED made our lift smaller, so we should ship the unadjusted version." This is wrong. CUPED reduces variance, not point estimates. If the lift looks smaller after CUPED, the unadjusted lift was probably inflated by chance correlation with pre-experiment behavior; the CUPED estimate is closer to the true effect. Trust the adjusted version.
+
+Platform support: Statsig, Eppo, GrowthBook, parts of PostHog, Amplitude (Experiment product). Optimizely has equivalent variance reduction. If your platform offers CUPED, turn it on for any metric where pre-experiment data exists.
+
+For deeper coverage of CUPED, the delta method, and other statistical methods, see `references/statistical-method-reference.md`.
+
+---
+
+## Heterogeneous treatment effects (HTE) and segments
+
+A heterogeneous treatment effect is when the treatment works differently for different segments. New users see +5%, power users see -2%, average is +1%. This is common, often interesting, and easy to over-read.
+
+Why HTE is tempting: "let us just ship to new users." Why it is dangerous: post-hoc segment discovery is often noise; targeting infrastructure costs are real; UI complexity from per-segment behavior compounds over time.
+
+The right way to handle HTE:
+
+- Pre-register the segments you care about before launching. Two or three is plenty; ten is overfitting waiting to happen.
+- If a pre-registered segment shows a meaningfully different effect, treat it as evidence worth following up. Not as a green light to ship to that segment alone.
+- Before shipping segment-only behavior, ask: is the segment large enough to matter, is the effect large enough to justify the targeting work, and can we build the targeting cleanly in production?
+- If the segment was discovered post-hoc by slicing the data many ways, treat the finding as a hypothesis for a follow-up test. Do not ship based on one observation.
+
+HTE versus simple averaging: when segments have meaningfully different effects, the average underrepresents both. A treatment that is +10% for half the population and -5% for the other half averages to +2.5%, which understates the win for half and ignores the loss for the other. The average is still the right number for "ship to everyone" decisions; per-segment numbers are the right inputs for "should we invest in segment-specific targeting" decisions.
+
+Practical heuristic: if pre-registered segments show meaningfully different effects, write a follow-up hypothesis. Run a follow-up test that confirms the segment behavior with appropriate power. Then decide on segment-specific shipping. The cost of the follow-up test is much smaller than the cost of shipping segment-targeted behavior that does not actually work.
+
+---
+
+## Ratio metrics and the delta method
+
+Most "rate" metrics are ratios. Conversion rate equals conversions divided by users. Click-through rate equals clicks divided by impressions. Revenue per user equals revenue divided by users. Average order value equals revenue divided by orders.
+
+Why this matters for analytics: standard variance estimation for sums does not apply directly to ratios. Naive variance estimation on ratios produces incorrectly narrow confidence intervals and inflated false positive rates. You ship things that look significant but are not, because the math under the hood was wrong.
+
+Two correct approaches:
+
+- Delta method. A calculus-based correction (Taylor expansion linearization) that produces correct CIs and p-values for ratio metrics. Fast, well-understood, what most modern platforms use.
+- Bootstrap. A simulation-based alternative: resample users with replacement many times, compute the ratio each time, and read off the empirical distribution. Distribution-free and intuitive; slower than delta method.
+
+How to verify your platform: ask "what variance estimator do you use for ratio metrics?" If the answer is "standard t-test on proportions," that is wrong for any ratio that is not a simple binary conversion (one row per user, converted yes or no). If the answer is "delta method," "linearization," or "bootstrap," correct.
+
+Most modern platforms (Statsig, Eppo, PostHog, Optimizely, GrowthBook) handle this correctly. Older or homegrown platforms often do not. The risk is silent: the panel shows confidence intervals that look reasonable but are too narrow, and you ship changes that do not produce the claimed effect.
+
+Worked example. Revenue per user is a ratio: total revenue divided by total users. Suppose treatment shows a 5% lift with a CI that excludes zero under the wrong (naive) variance estimator. Under the correct delta-method estimator, the same point estimate has a CI that includes zero. The wrong math says "significant, ship." The correct math says "inconclusive, run longer or accept noise." Shipping based on the wrong math means shipping changes that do not produce the claimed effect in production, then puzzling over why the launch did not move the dashboard.
+
+---
+
+## Bayesian vs frequentist results panels
+
+Frequentist panels (most older platforms, parts of most modern ones) show p-values, confidence intervals, and "statistically significant" labels. Bayesian panels (Eppo by default, Statsig as an option, parts of PostHog) show probability of being best, credible intervals, and posterior distributions.
+
+For most PM contexts, both approaches produce similar ship-or-kill decisions when the experiment was designed correctly. The vocabulary differs; the underlying judgment is similar.
+
+Bayesian advantages:
+
+- Natural multi-variant comparison: "variant B has 87% probability of being best" reads more naturally than the equivalent Bonferroni-corrected p-value soup.
+- Peek-safe by construction: posterior probabilities are valid at any time without sequential corrections.
+- More intuitive for stakeholders unfamiliar with hypothesis testing.
+- Allows informative priors when you have prior knowledge (rare in practice for shipping decisions).
+
+Frequentist advantages:
+
+- Better-understood: most analytics teams have stronger frequentist training.
+- Clearer pre-registration semantics: "alpha equals 0.05, MDE equals 5%, decision rule X" is unambiguous.
+- Longer track record in regulated contexts.
+
+Mixing them within a single experiment is fine. Most platforms (Eppo, Statsig) let you toggle. Pick one per experiment and stick with it; do not switch mid-flight to chase a more favorable interpretation. That is the Bayesian-frequentist version of p-hacking and corrodes the discipline.
+
+---
+
+## Network effects and SUTVA violation
+
+SUTVA (Stable Unit Treatment Value Assumption) is the technical name for "one user's treatment does not affect another user's outcome." When SUTVA holds, standard A/B test math works. When it is violated, the math systematically understates or overstates the true effect.
+
+When SUTVA is violated:
+
+- Two-sided marketplaces. Changes to buyers shift seller behavior, which affects control buyers competing for the same supply. Treatment buyers' actions leak into the control group's experience.
+- Social products. A treatment user's changed behavior affects the experience of users they interact with, regardless of which group those friends are in.
+- Supply-constrained features. When supply is limited, treatment users compete with control users for the same scarce resource, and the test cannot cleanly separate treatment effect from substitution.
+- Notification systems. A treatment that increases notification volume changes user behavior across the whole platform, not just in the treatment cell.
+
+The "interference dampens lift" pattern is the most common version. In marketplace experiments, if your treatment looks small, the true effect (in the absence of interference) may be 2x to 3x larger than what the standard A/B test reports. Killing a winning test because the leaked-into-control lift looked small is a common mistake.
+
+Detection methods:
+
+- Switchback experiments. Toggle the entire population between treatment and control across time windows (week 1 treatment, week 2 control, etc.). Eliminates cross-user interference within each window; requires careful temporal modeling.
+- Cluster randomization. Assign whole units (cities, markets, friend groups) rather than individual users. Eliminates within-cluster interference at the cost of effective sample size.
+- Geographic experiments. Launch in some regions, hold others. Slow and expensive but interference-clean.
+
+When in doubt about whether interference is present, run a small cluster-randomized version as a check. If the cluster-randomized lift is much larger than the user-randomized lift, you have evidence of interference and should rerun the main test as cluster-randomized.
+
+---
+
+## Dashboard metric vs experiment metric reconciliation
+
+The scenario: your business intelligence dashboard shows revenue grew 8% last week. Your experiment platform shows the treatment lifted revenue 2%. How can both be true?
+
+Likely answers, ranked by frequency:
+
+- Different denominators. The dashboard shows all users; the experiment shows just enrolled users. Most experiments enroll a subset; the lift only applies to that subset.
+- Different time windows. The dashboard is rolling 7 days; the experiment is fixed start to end. The two windows can move independently.
+- External effects. Marketing campaigns, seasonality, competitor activity, news cycles. The experiment correctly excludes these by random assignment; the dashboard reflects them.
+- Selection effects. Who gets enrolled in the experiment matters. New users only? Logged-in users only? Users who passed a feature flag check? Each filter changes the population the lift applies to.
+- Different metric definitions. "Revenue" might be gross in one place and net of refunds in another. "Conversions" might count differently across systems.
+
+Reconciliation discipline: never report experiment results as "the feature drove $X in revenue this week." Always report as "the feature lifted enrolled-user revenue Y% during the test period." The first phrasing implies a company-wide impact that the experiment cannot measure; the second phrasing is precise about what the experiment actually showed.
+
+The "blended attribution" trap is the most common reconciliation failure. PM takes the experiment lift (say +2% revenue per user) and multiplies by the total user base for a company-wide impact estimate ("$10M in incremental revenue"). This is wrong twice over. The lift only applies to enrolled users (typically 10% to 50% of the base). Even within the enrolled group, the lift was measured during the test conditions; long-term and at full scale, the effect can be different. The right phrasing is "during the four-week test, enrolled users (about 30% of the active base) showed a 2% revenue-per-user lift relative to control." Then leadership can do the careful arithmetic of how that translates at full launch.
+
+For deeper reconciliation patterns and stakeholder-facing language, see `references/dashboard-vs-experiment-reconciliation.md`.
+
+---
+
+## Long-term effect estimation
+
+Most A/B tests run for two to four weeks. Many feature decisions need a thirty- to ninety-day understanding because behavior changes over longer windows: novelty fades, primacy fades, retention impacts emerge, network effects compound.
+
+Three patterns for long-term measurement:
+
+- Holdout groups. Keep a percentage of users (often 5% to 10%) on the control treatment for thirty or more days post-launch. Compare their long-term behavior to the launched-to users. The comparison measures the long-term effect cleanly because the holdout was randomized at the same time as the original test.
+- Geo experiments. Launch the change in some markets and hold others. Measure long-term differences across market pairs. Slow, expensive, and the markets need to be comparable, but interference-clean and capable of measuring effects that user-randomization cannot.
+- Difference-in-differences (diff-in-diff). Pre-launch versus post-launch measurement in a treated market versus a control market. Useful when you cannot randomize at all (regulatory rollouts, partner-specific changes). Weaker than randomized methods but defensible when randomization is impossible.
+
+Practical heuristic: any feature with novelty risk (new UI, new mechanic, new pricing, new notification cadence) deserves a thirty-day holdout. Set it up at launch, not later; setting it up later requires unwinding the launch and is rarely done in practice. The cost of the holdout is small (a small percentage of users on the old experience for a month); the value is the ability to detect long-term degradation before it compounds.
+
+---
+
+## Common interpretation failures
+
+Rapid-fire reference. Each pattern is described in more detail in `references/common-interpretation-failures.md`.
+
+- "P equals 0.04, ship it." No consideration of CI width, magnitude, or guardrails. Significance is a necessary condition, not a sufficient one.
+- "We saw +5% on day 3, ending early." Peeking, novelty effect, or both. Day-3 lifts are routinely larger than day-14 lifts; ending early ships noise.
+- "The new flow worked for power users (post-hoc segment)." Noise mining. The segment was found by slicing the data multiple ways; the apparent lift will not replicate.
+- "Our experiment said +2%, but launch only delivered +0.5%." Often the experiment was correct: the lift applied to enrolled users in test conditions, and at full launch the effect is diluted by non-enrolled users, novelty fade, or interference effects the test could not capture.
+- "Revenue went up but the CI for retention straddled zero so we ignored it." A guardrail violation that was reframed as "no signal." If retention is a guardrail, the guardrail is binding; "we did not see a clear signal" is not the same as "we have evidence of safety."
+- "We CUPED-adjusted away a real treatment effect." CUPED reduces variance, not the point estimate. If the lift looked smaller after CUPED, the unadjusted lift was probably noise that CUPED correctly removed. Trust the adjusted version.
+- "Two segments showed opposite effects; we shipped to the better segment." Likely overfitting unless both segments were pre-registered and the targeting infrastructure exists. Re-test before shipping.
+- "We ran the test, it was inconclusive, but the trend was directional so we shipped." Inconclusive is inconclusive. Directional patterns are not evidence; they are wishful reading of noise.
+
+---
+
+## The framework: 14 considerations for trustworthy experiment interpretation
+
+Trustworthy interpretation sits at the intersection of fourteen considerations. Each is covered in detail in its own section above.
+
+1. **Result panel completeness.** The panel exposes variants, allocation, per-variant metrics, lifts, significance, variance reduction, guardrails, segments, time series, and status. Missing pieces are red flags.
+2. **Confidence interval reading.** Width matters more than center. Five practical decision rules cover the cases where CI excludes zero, includes zero narrowly, and includes zero widely.
+3. **P-value semantics.** The probability of seeing the lift if the null is true. Not the probability that the treatment works. Always read alongside the CI.
+4. **Multiple testing corrections.** Bonferroni for family-wise control, BH for false discovery rate. Pre-register primary metrics and segments; treat the rest as exploratory.
+5. **Sequential testing math.** Always-valid p-values and anytime-valid CIs survive peeking. Fixed-horizon p-values inflate false positives under daily monitoring.
+6. **CUPED variance reduction.** Same point estimate, narrower CI. Use whenever pre-experiment data is available and informative.
+7. **Heterogeneous treatment effects.** Pre-register segments. Treat post-hoc segment effects as hypotheses for follow-up tests, not as ship signals.
+8. **Ratio metrics.** Use delta method or bootstrap. Naive proportion estimators understate variance and inflate false positives.
+9. **Bayesian vs frequentist.** Pick one per experiment and stick with it. Both produce similar ship decisions when the experiment was designed correctly.
+10. **Network effects and SUTVA.** Marketplace and social products often violate SUTVA. Cluster randomization, switchback, or geographic experiments when interference is suspected.
+11. **Dashboard reconciliation.** Different denominators, time windows, external effects, and metric definitions explain most disagreements between BI dashboards and experiment panels.
+12. **Long-term effect estimation.** Holdouts, geo experiments, and diff-in-diff for effects that emerge over thirty to ninety days.
+13. **Common interpretation failures.** A pattern catalog of the most frequent ways smart teams ship wrong things.
+14. **The discipline of inconclusive.** The hardest call is "we do not have enough signal to ship." It is often the right call.
+
+The sections above expand each consideration in turn. Read the relevant section before making the decision, not after.
+
+---
+
+## Reference files
+
+- [`references/confidence-interval-cheatsheet.md`](references/confidence-interval-cheatsheet.md). How to read a CI, what to ignore, the five decision rules with worked examples for each.
+- [`references/p-value-interpretation-guide.md`](references/p-value-interpretation-guide.md). What it means, what people pretend it means, the 0.05 convention, the peeking problem, and the multiple-testing context.
+- [`references/statistical-method-reference.md`](references/statistical-method-reference.md). CUPED, the delta method, sequential testing methods (mSPRT, group sequential, anytime-valid), HTE handling, multiple testing corrections, cluster randomization. The technical reference for analysts.
+- [`references/dashboard-vs-experiment-reconciliation.md`](references/dashboard-vs-experiment-reconciliation.md). Why the BI number does not match the experiment number, the blended-attribution trap, and how to communicate the difference to non-statistical stakeholders.
+- [`references/result-presentation-templates.md`](references/result-presentation-templates.md). Five templates for stakeholder communication: clear win, clear loss, inconclusive (the most common, hardest), mixed (positive primary with ambiguous guardrail), and long-term holdout report.
+- [`references/analytics-platform-comparison.md`](references/analytics-platform-comparison.md). Profiles of seven major platforms (Statsig, PostHog, Optimizely, GrowthBook, Eppo, Amplitude, Kameleoon) covering what each exposes, what each hides, and the gotchas in each.
+- [`references/common-interpretation-failures.md`](references/common-interpretation-failures.md). Fifteen-plus failure patterns: name, symptom, root cause, fix, prevention.
+
+---
+
+## Closing: the courage to call it inconclusive
+
+Most experiment results are not clear ship-or-kill. They are inconclusive: lift exists but the CI straddles zero; lift is real but does not justify the implementation cost; lift is significant but a guardrail is concerning; lift looks great in one segment but the segment is small or the targeting infrastructure does not exist.
+
+The hardest decision a PM makes in a given week is often "we do not have enough signal to ship." The temptation to lower the bar after seeing the result is enormous. The discipline of saying "inconclusive" is the discipline of caring about being right more than being decisive.
+
+The same discipline applies to analysts. The temptation to slice the data one more way until something looks significant, to apply one more variance reduction technique, to switch from frequentist to Bayesian mid-test, is constant. Each individual move feels like a small judgment call. Cumulatively they destroy the integrity of the analysis. The result is not "we found a real effect"; the result is "we ran enough analytical knobs that something looked significant."
+
+Inconclusive is a valid outcome. The lesson, if there is one, is for the next hypothesis: the effect is smaller than expected, the segment matters, the test was underpowered, the metric was the wrong one. Use the inconclusive result to design a better next test. Do not retrofit a story onto the current one.
+
+For pre-experiment design discipline, see the `experiment-design` skill. For the operational mechanics of feature flags that deliver the variants, see the `feature-flagging` skill. For platform-specific MCP commands and example prompts, pair this skill with the matching `/integrations/{platform}` microsite for your stack.

--- a/skills/experimentation-analytics/references/analytics-platform-comparison.md
+++ b/skills/experimentation-analytics/references/analytics-platform-comparison.md
@@ -1,0 +1,147 @@
+# Analytics platform comparison
+
+Profiles of seven major experimentation platforms covering what each exposes, what each hides, and the gotchas in each. Pair with the matching `/integrations/{platform}` microsite on rampstack.co for MCP setup, auth, and example prompts.
+
+The categorization below is for analytics surface area specifically. All seven platforms are competent at running experiments; the difference is what they expose on the result panel and how the math under the hood handles edge cases.
+
+---
+
+## Statsig
+
+**Statistical defaults.** Among the most rigorous in the category. Always-valid p-values (sequential testing) by default. CUPED variance reduction available and easy to enable. Delta method for ratio metrics. Comprehensive HTE analysis with pre-registered and exploratory modes.
+
+**What is exposed.** Per-variant metrics with CIs, lift point estimate, always-valid p-value, sample size, variance reduction technique applied, guardrail status, segment results for pre-registered segments, time series of the lift across the test window.
+
+**What can be hidden by default.** Some advanced configuration is buried in the UI; defaults are sensible but worth confirming. The "topline metrics" view simplifies away the CI in some contexts.
+
+**Gotchas.**
+
+- Always-valid p-values are wider than fixed-horizon by design. Teams new to sequential testing sometimes interpret "less significant" as "weaker effect" rather than "peek-safe math."
+- The auto-generated guardrail metrics catch some categories well (latency, error rate) and miss others (business-critical metrics specific to your product). Augment with custom guardrails.
+- The "experiment hub" view groups results across multiple experiments and can mask single-experiment subtlety.
+
+**Where it shines.** Mid-stage to late-stage product teams running many concurrent experiments where peek-safety and variance reduction matter. The default rigor saves teams from common mistakes without requiring statistical expertise.
+
+---
+
+## PostHog
+
+**Statistical defaults.** Solid for the open-source experimentation category. Frequentist by default; Bayesian available. Variance reduction via "stats engine" configuration. Sequential testing in some experiment types.
+
+**What is exposed.** Per-variant metrics, CIs, p-values, sample size, time series, segment results.
+
+**What can be hidden.** The newer "stats engine" updates change defaults across versions; what you see depends on the deployment version. Older deployments may use less-rigorous defaults.
+
+**Gotchas.**
+
+- Self-hosted vs cloud can differ in stats engine version. Confirm the version when interpreting numbers.
+- The "winner" badge can appear on results that are technically significant but practically tiny. Always read the CI.
+- Bayesian and frequentist views can coexist for the same experiment; use one consistently per experiment.
+
+**Where it shines.** Teams that want experimentation embedded in their analytics platform rather than separate. PostHog's strength is the integration of feature flags, experiments, session recording, and product analytics in one place.
+
+---
+
+## Optimizely
+
+**Statistical defaults.** Enterprise-grade rigor. Stats Engine includes sequential testing, ratio-aware variance estimation, and configurable significance thresholds. Long track record in the category.
+
+**What is exposed.** Comprehensive per-variant statistics, configurable significance thresholds, sequential testing labels, sample size, segment analysis with pre-registration.
+
+**What can be hidden.** Configuration depth means defaults vary by account setup. Confirm with the platform admin which defaults are in play for your project.
+
+**Gotchas.**
+
+- The classic Optimizely product (Web Experimentation) and the newer products (Feature Experimentation, Personalization) have different stats engines. Know which product your team is on.
+- Enterprise pricing can mean limited license seats; non-statistician PMs sometimes work from screenshots taken by analysts, which loses interactive panel context.
+- The "lift" display can default to relative percent without the absolute number; both matter.
+
+**Where it shines.** Larger organizations with established experimentation practices, regulated contexts where the rigorous track record matters, and teams that need extensive personalization alongside experimentation.
+
+---
+
+## GrowthBook
+
+**Statistical defaults.** Open-source-first, warehouse-native. Explicit choice between Bayesian and frequentist. Sequential testing via mSPRT. CUPED supported.
+
+**What is exposed.** Per-variant metrics with CIs, lift, significance, variance reduction, guardrails, segment results.
+
+**What can be hidden.** Because GrowthBook runs on top of your data warehouse, the metric definitions live in your SQL; verify them when reading results. A subtle metric query change can shift results without anyone noticing.
+
+**Gotchas.**
+
+- Warehouse latency affects how fresh the result panel is. A daily batch is common; treat panel data as up to one day stale.
+- Custom metrics defined in SQL can drift from dashboard definitions of the same metric. Reconcile carefully.
+- The "experiment health checks" surface assignment imbalance and other quality issues; pay attention when they fire.
+
+**Where it shines.** Engineering-led teams that want experimentation tied directly to the warehouse and version-controlled metric definitions. The open-source core means full transparency on the math.
+
+---
+
+## Eppo
+
+**Statistical defaults.** Best-in-class statistical defaults among the platforms. Bayesian and frequentist supported, with Bayesian as the default for most use cases. Sequential CIs available. CUPED supported. Delta method for ratio metrics. Strong HTE analysis.
+
+**What is exposed.** Per-variant metrics with credible intervals (Bayesian) or CIs (frequentist), probability of being best, posterior distributions, lift, guardrails, segments.
+
+**What can be hidden.** The Bayesian default produces "probability variant B is best" rather than a p-value, which can confuse stakeholders trained on frequentist conventions. Switch to frequentist if your team's vocabulary is p-value-based; do not switch mid-experiment.
+
+**Gotchas.**
+
+- Bayesian probabilities and frequentist p-values answer different questions; do not translate one into the other naively.
+- Eppo's "decision support" feature recommends actions based on the result; treat the recommendation as input, not as the decision.
+- Warehouse-native like GrowthBook; same caveats about metric definition drift.
+
+**Where it shines.** Data-team-led organizations that want statistical rigor as a default. Eppo's design philosophy is "make it hard to do the wrong thing"; the defaults reflect that.
+
+---
+
+## Amplitude (Experiment)
+
+**Statistical defaults.** Behavioral analytics first, experimentation second. Frequentist defaults; sequential testing available. Variance reduction supported.
+
+**What is exposed.** Per-variant metrics with CIs, p-values, sample size, segment analysis, guardrails. Tightly integrated with Amplitude's behavioral analytics surface.
+
+**What can be hidden.** Some statistical configuration options are less prominent than in Statsig or Eppo; defaults are reasonable but worth confirming.
+
+**Gotchas.**
+
+- Strength is the integration with behavioral analytics, not the rigor of the experimentation engine. For teams that prioritize statistical sophistication, the engine is competent but not the strongest.
+- Amplitude's "insights" auto-generate from event data; the same flexibility that makes them useful makes it easy to slice into noise.
+- Experiment results can be viewed alongside cohort and funnel analyses; this is powerful and risky (post-hoc cohort definitions are noise mining).
+
+**Where it shines.** Product teams already invested in Amplitude for behavioral analytics. The integration of experiment results with the broader product analytics is the differentiator.
+
+---
+
+## Kameleoon
+
+**Statistical defaults.** Frequentist with Bayesian options. CUPED and sequential testing supported. Strong personalization and AI-driven optimization features.
+
+**What is exposed.** Per-variant metrics with CIs, p-values, lift, segments, guardrails.
+
+**What can be hidden.** The personalization and AI optimization features can take experiment results and apply them automatically; verify which of your "experiments" are actually fully randomized A/B tests vs personalization rollouts.
+
+**Gotchas.**
+
+- The boundary between experiment and personalization can blur. Personalization decisions made by an AI engine are not the same as ship decisions made from a randomized A/B test.
+- Less common in the US than the European market; documentation and community resources are more limited than for Statsig, PostHog, or Optimizely.
+- Some advanced statistical features require specific subscription tiers.
+
+**Where it shines.** Teams running heavy personalization alongside experimentation, particularly in the European market. The personalization features are differentiated; the experimentation engine is competent.
+
+---
+
+## Quick comparison
+
+| Platform | Sequential testing | CUPED | Delta method | Bayesian option | Strongest for |
+|---|---|---|---|---|---|
+| Statsig | Default | Yes | Yes | Yes | Multi-team experimentation rigor |
+| PostHog | Some types | Configurable | Yes | Yes | Embedded analytics + experiments |
+| Optimizely | Yes | Yes | Yes | No (frequentist Stats Engine) | Enterprise + personalization |
+| GrowthBook | Yes (mSPRT) | Yes | Yes | Yes | Warehouse-native, open source |
+| Eppo | Yes | Yes | Yes | Default | Statistical rigor by default |
+| Amplitude | Yes | Yes | Yes | Yes | Behavioral analytics integration |
+| Kameleoon | Yes | Yes | Yes | Yes | Personalization-heavy contexts |
+
+The platform choice is rarely the bottleneck on getting experimentation right. All seven are competent. The bottleneck is the design discipline (covered in the `experiment-design` skill), the interpretation discipline (covered in this skill), and the operational discipline of the flag layer (covered in the `feature-flagging` skill). Pick the platform that fits the team's existing stack and skill mix; spend the effort on the disciplines.

--- a/skills/experimentation-analytics/references/common-interpretation-failures.md
+++ b/skills/experimentation-analytics/references/common-interpretation-failures.md
@@ -1,0 +1,203 @@
+# Common interpretation failures
+
+Fifteen-plus failure patterns that produce confidently wrong shipping decisions. Each pattern is described as: name, symptom (what it looks like in the panel or the discussion), root cause (why it happens), fix (what to do this time), prevention (how to avoid it next time).
+
+---
+
+## Pattern 1: P-value worship
+
+**Symptom.** "P equals 0.04, ship it." No discussion of CI width, magnitude, or guardrails.
+
+**Root cause.** Treating statistical significance as a binary truth. The p-value answers one specific question (how surprising is this data under the null) and people use it to answer all questions.
+
+**Fix.** Always pair the p-value with the CI on the lift and the guardrail status. A significant p-value with a wide CI that includes practically tiny effects is not a ship signal.
+
+**Prevention.** Pre-commitment includes the MDE, not just the alpha. The decision rule should reference the lift magnitude relative to the MDE, not just the p-value.
+
+---
+
+## Pattern 2: Early stop on a peek
+
+**Symptom.** Test ended on day 3 or day 5 because the result "looked great." Headline lift is 5% to 10%; later analysis shows the effect was much smaller.
+
+**Root cause.** Standard p-values inflate under peeking. Early-test lifts are systematically larger than late-test lifts due to regression to the mean and novelty effects.
+
+**Fix.** Re-run the test to the pre-committed end date. Treat the early result as suggestive only. If the platform supports always-valid p-values, those are peek-safe; otherwise, do not stop early.
+
+**Prevention.** Pre-commit the analysis date at launch. If the platform offers sequential testing, enable it. If not, do not look at intermediate results.
+
+---
+
+## Pattern 3: Post-hoc segment mining
+
+**Symptom.** "The new flow worked for power users on Android in the EU on weekends." The segment was discovered by slicing the data many ways looking for an effect.
+
+**Root cause.** Multiple comparisons. With enough segments, some will show a "significant" effect purely by chance. The pattern is real for the test data; it does not replicate.
+
+**Fix.** Treat the post-hoc segment finding as a hypothesis for a follow-up test, not as a ship signal. Pre-register the segment in the new test and run it cleanly.
+
+**Prevention.** Pre-register segments at design time. Two or three is plenty; ten is overfitting waiting to happen. Treat any segment not in the pre-registration list as exploratory.
+
+---
+
+## Pattern 4: Launch dilution misread
+
+**Symptom.** "Our experiment said +2%, but launch only delivered +0.5%. The experiment was wrong."
+
+**Root cause.** The experiment lift applied to enrolled users in test conditions. Launch dilution from non-enrolled users, novelty fade, and interference effects routinely produce smaller production effects than test effects. The experiment was usually correct; the production measurement is correctly capturing the diluted effect.
+
+**Fix.** Compare apples to apples: the launch effect on the same enrolled-user population, in the same conditions. If the launch effect on enrolled users matches the test, the experiment was right; the dashboard sees a smaller number because the dashboard includes everyone.
+
+**Prevention.** Communicate experiment results in enrolled-user terms, not extrapolated to the full base. The blended-attribution trap is the source of most "experiment wrong" complaints.
+
+---
+
+## Pattern 5: Guardrail reframing
+
+**Symptom.** "Revenue went up but the CI for retention straddled zero so we ignored it." A guardrail movement that was reframed as "no signal" rather than treated as binding.
+
+**Root cause.** The guardrail was pre-committed but the team did not pre-commit a clear rule for "what counts as a guardrail violation." A wide CI on the guardrail leaves room for interpretation; the interpretation usually favors shipping.
+
+**Fix.** If retention is a guardrail, the guardrail binds. "We did not see a clear signal" is not the same as "we have evidence of safety." A wide guardrail CI means the test was underpowered for the guardrail; the right answer is more sample, not "ship anyway."
+
+**Prevention.** At pre-commitment, define guardrail rules as: "ship only if the CI on the guardrail clearly excludes a [X percent] degradation." Then apply the rule mechanically when results come in.
+
+---
+
+## Pattern 6: CUPED misinterpretation
+
+**Symptom.** "We CUPED-adjusted away a real treatment effect. Let us report the unadjusted version." OR "The unadjusted lift is bigger; CUPED is hiding our win."
+
+**Root cause.** Misunderstanding what CUPED does. CUPED reduces variance, not the point estimate. If the lift looks smaller after CUPED, the unadjusted lift was probably inflated by chance correlation with pre-experiment behavior.
+
+**Fix.** Trust the CUPED-adjusted estimate. If the estimate is smaller and the CI is narrower, the CUPED estimate is closer to the true effect.
+
+**Prevention.** Educate the team on what CUPED does before enabling it. The first time the unadjusted and adjusted numbers diverge, walk through why.
+
+---
+
+## Pattern 7: Opposite-segment shipping
+
+**Symptom.** "Two segments showed opposite effects; we shipped to the better segment." Often without re-testing or without infrastructure to support segment-specific behavior.
+
+**Root cause.** Post-hoc segment discovery (most common) or pre-registered segments where the targeting infrastructure does not exist. Either way, segment-only shipping is a significant commitment that requires more evidence than a single observation.
+
+**Fix.** Treat the segment finding as a hypothesis for a follow-up test. Confirm the effect with an appropriately powered re-test. Build the targeting infrastructure with eyes open about ongoing maintenance cost.
+
+**Prevention.** Pre-register segments. Build the targeting infrastructure separately, before any segment-specific shipping decision; do not let the decision force the infrastructure into existence under deadline pressure.
+
+---
+
+## Pattern 8: Directional ship
+
+**Symptom.** "The result was technically inconclusive, but the trend was directional so we shipped."
+
+**Root cause.** Inconclusive is hard to communicate; directional language sounds more decisive. The team substitutes the appearance of evidence for actual evidence.
+
+**Fix.** Inconclusive is inconclusive. The directional pattern is wishful reading of noise. Do not ship; either run a bigger test or kill the hypothesis.
+
+**Prevention.** Pre-commit decision rules that map each possible result to a ship-or-kill decision. The inconclusive case should map to "do not ship" by default. Discussions of "directional" outcomes are a sign that pre-commitment was incomplete or is being ignored.
+
+---
+
+## Pattern 9: Mid-test methodology switch
+
+**Symptom.** Test was running with frequentist analysis; results were ambiguous; team switched to Bayesian (or vice versa) and the new view "shows we should ship."
+
+**Root cause.** Different methodologies can produce different ship recommendations on the same data, particularly near the significance threshold. Switching mid-flight to find the more favorable interpretation is the Bayesian-frequentist version of p-hacking.
+
+**Fix.** Stick with the methodology pre-committed at launch. If the result is ambiguous under the pre-committed method, that is the result.
+
+**Prevention.** Pre-commit the methodology along with the metric and the alpha. Document the choice in the experiment configuration so the change is visible if anyone tries.
+
+---
+
+## Pattern 10: Ratio metric without delta method
+
+**Symptom.** Conversion rate or revenue per user with a CI that looks suspiciously narrow. The result panel shows significance that does not replicate at launch.
+
+**Root cause.** Naive variance estimation on ratio metrics produces incorrectly narrow CIs and inflated false positive rates. The platform did not use delta method, bootstrap, or another ratio-aware estimator.
+
+**Fix.** Re-analyze with a ratio-aware estimator. If the platform does not support one, export raw data and compute correctly in a notebook.
+
+**Prevention.** Verify your platform's variance estimator for ratio metrics during onboarding. If the answer is "standard t-test on proportions," consider migrating or implementing the correction yourself.
+
+---
+
+## Pattern 11: Marketplace interference undercount
+
+**Symptom.** Marketplace experiment shows a small lift; team kills the test as not worth the effort. Later, a feature implemented for other reasons shows a much larger effect on the same metric.
+
+**Root cause.** SUTVA violation. In two-sided marketplaces, treatment users compete with control users for the same supply; the lift "leaks" into control. The standard A/B test undercounts the true effect, often by a factor of 2x to 3x.
+
+**Fix.** Re-run as cluster randomized (whole markets to treatment or control) or switchback. Compare the results to the user-randomized version to estimate the interference factor.
+
+**Prevention.** Identify SUTVA violation risk at design time. For marketplace, social, and supply-constrained features, default to cluster randomization or switchback unless interference is demonstrably negligible.
+
+---
+
+## Pattern 12: Definition drift between systems
+
+**Symptom.** Experiment result shows +X% on conversion. Dashboard shows the launch having no effect on conversion. Investigation reveals the two systems define "conversion" differently.
+
+**Root cause.** Metric definitions live in different places (experiment platform, BI dashboard, data warehouse) and drift over time. Each definition individually makes sense; the comparison is meaningless.
+
+**Fix.** Reconcile the definitions before the next post-launch report. Pick one canonical definition and align both systems.
+
+**Prevention.** Centralize metric definitions (semantic layer, dbt model, shared SQL library). Audit all "the same metric" usages quarterly.
+
+---
+
+## Pattern 13: Confounded test window
+
+**Symptom.** Test ran during a marketing campaign, a product launch, an outage, or a holiday. The result is reported without acknowledging the external event.
+
+**Root cause.** Random assignment usually handles external events (treatment and control are equally affected). But if the external event affects the metric definition (campaign brings different user mix), the populations stop being comparable.
+
+**Fix.** Stratify the analysis by the relevant covariate (acquisition source for campaigns, date for outages). If the stratified analysis differs meaningfully from the pooled analysis, report the stratified version and explain.
+
+**Prevention.** Maintain a calendar of marketing campaigns, product launches, and known external events. Avoid scheduling sensitive tests during these windows. If unavoidable, plan the stratification at design time.
+
+---
+
+## Pattern 14: Long-tail metric overweighted by outliers
+
+**Symptom.** Revenue per user shows a large lift driven by a few high-value users. The lift is "significant" but unstable across re-samples.
+
+**Root cause.** Long-tailed distributions (revenue, session length, content engagement) have a few users contributing disproportionately. Random assignment of those users to treatment or control can drive large apparent effects that do not represent the underlying treatment effect.
+
+**Fix.** Winsorize the metric (cap extreme values at the 99th percentile, for example) and re-analyze. If the winsorized result is materially different from the raw result, the outliers were driving the effect.
+
+**Prevention.** Pre-commit to a winsorization threshold for long-tailed metrics. Apply the same threshold across treatment and control. Document the choice.
+
+---
+
+## Pattern 15: Significance from sample size, not effect
+
+**Symptom.** "P equals 0.001, very significant." CI on the lift is [+0.1%, +0.3%]. Magnitude is tiny.
+
+**Root cause.** With enough sample, even tiny effects produce small p-values. Significance is not the same as magnitude. Shipping a 0.2% lift because "p was tiny" is a misuse of the framework.
+
+**Fix.** Read the CI alongside the p-value. If the practical lift is too small to matter, do not ship regardless of significance.
+
+**Prevention.** Pre-commit to an MDE (minimum detectable effect) as part of the design. If the observed lift is below the MDE, the test was overpowered and the result, while real, is not actionable.
+
+---
+
+## Pattern 16: Overcorrection panic
+
+**Symptom.** Result shows a clean lift on the primary metric. Team adds five new metrics post-hoc and applies Bonferroni correction across all of them. Now the primary metric is "not significant."
+
+**Root cause.** Multiple testing corrections apply to pre-registered comparisons, not to post-hoc analyses meant to "stress-test" the result. Adding metrics after seeing the result and then correcting is statistically incoherent.
+
+**Fix.** Apply corrections only to the pre-registered comparison set. Post-hoc metrics are exploratory and should be reported as such, without claiming to update the primary inference.
+
+**Prevention.** Pre-register the metric set at design time. Treat any metric not on the list as exploratory.
+
+---
+
+## The pattern behind the patterns
+
+Most of these failures share a common shape: the team had a hypothesis they wanted to confirm, the result was less clean than hoped, and the team applied an analytical knob (slice, switch methodology, drop outliers, reframe the guardrail, peek early) to make the result look cleaner. Each individual move feels like a small judgment call. Cumulatively they destroy the integrity of the analysis.
+
+The defense against this pattern is pre-commitment. The defense against pre-commitment being weakened over time is documenting the pre-commitment somewhere immutable (PR description, signed Slack message, pinned ticket) and applying it mechanically when results come in. The pre-commitment is not the team's enemy; it is the team's protection from its own future motivated reasoning.

--- a/skills/experimentation-analytics/references/confidence-interval-cheatsheet.md
+++ b/skills/experimentation-analytics/references/confidence-interval-cheatsheet.md
@@ -1,0 +1,107 @@
+# Confidence interval cheatsheet
+
+The CI on the lift is the single most important number on the result panel. This cheatsheet covers what it means, what to ignore, and the five decision rules that map a CI to a ship, kill, or wait decision.
+
+---
+
+## What the CI is
+
+A 95% confidence interval (CI) on a lift estimate is a range of values that, under repeated sampling of the experiment, would contain the true effect 95% of the time. The point estimate (the center) is your best single guess at the true effect. The width is your humility about how much you actually know.
+
+Three common CI shapes you will see on result panels:
+
+- Symmetric. Lift estimate +3% with CI [+1%, +5%]. The middle is the best guess; the bounds are equidistant.
+- Skewed. Lift estimate +3% with CI [-0.5%, +8%]. Common with small samples or distributions with long tails. The point estimate is still the best guess; the asymmetry tells you the data is consistent with a wider range on the upside than the downside.
+- Always-valid (sequential). Same shape as a normal CI but wider by design. Survives daily peeking. If your panel says "anytime-valid CI," that is what you are looking at.
+
+---
+
+## What to read first
+
+Width before center. A narrow CI tells you a lot about the true effect; a wide CI tells you very little, regardless of where it is centered. A point estimate of +5% with CI [+4.5%, +5.5%] is a precise estimate of a real lift. A point estimate of +5% with CI [-3%, +13%] is essentially "we have no idea, somewhere between a meaningful loss and a huge win."
+
+The position of zero relative to the CI. If zero is well outside the CI on the positive side, you have a real positive effect. If zero is well outside on the negative side, you have a real harm. If zero is inside the CI, you cannot rule out "no effect."
+
+---
+
+## What to ignore
+
+The point estimate alone. Without the CI, the point estimate is a single number with no honesty about how much it could move under different sampling. Reading "lift was +3%" without the CI is reading half the result.
+
+The p-value alone. P-values tell you about the strength of evidence against the null; CIs tell you about the magnitude of the effect. Both matter. A tiny lift with p equals 0.001 is technically significant and not worth shipping. A big lift with p equals 0.10 is technically inconclusive and worth a follow-up test.
+
+The "statistically significant" label as a binary. Most platforms color-code significance as a green check or a red X. The label is fine as a heuristic; the underlying CI is what you should defend the decision on.
+
+---
+
+## The five decision rules
+
+### Rule 1: CI all-positive, lift above MDE. Ship.
+
+**Example.** MDE was 2%; CI is [+3%, +6%].
+
+The lower bound of the CI exceeds the MDE you committed to detect. The data is inconsistent with no effect AND inconsistent with a trivial effect. Confidence is high, magnitude is meaningful. Ship.
+
+Confirm guardrails are clean before filing the launch.
+
+### Rule 2: CI all-positive, lift below MDE. Probably do not ship.
+
+**Example.** MDE was 5%; CI is [+0.5%, +1.2%].
+
+The lift is real (CI excludes zero) but small (entire CI is below the MDE). The test was overpowered for the question, or the effect is smaller than expected. Real but tiny lifts are rarely worth shipping; the engineering, testing, and cognitive surface area exceeds the gain.
+
+The exception: changes that are essentially free to ship and maintain. A copy tweak with a +0.5% lift might be worth shipping; a feature requiring ongoing infrastructure with the same lift is not.
+
+### Rule 3: CI all-negative. Kill.
+
+**Example.** CI is [-4%, -1%].
+
+The data is inconsistent with no effect and inconsistent with a positive effect. The change made things worse with high confidence. Kill the test. Document the lesson if the result is surprising; sometimes the lesson is "users wanted what we already had."
+
+### Rule 4: CI straddles zero, narrow. Real null result.
+
+**Example.** CI is [-0.5%, +0.8%].
+
+Zero is inside the CI, but so is everything else within a small range. The data is consistent with no effect and inconsistent with any meaningful positive or negative effect. This is a real "we tested and it does not move the metric" result. Useful information; do not ship for "lift" reasons (you found none) but do not panic about harm either.
+
+The product question becomes: does the change have value beyond the metric we measured (brand consistency, code maintainability, accessibility)? If yes, ship for those reasons. If no, do not ship.
+
+### Rule 5: CI straddles zero, wide. Inconclusive.
+
+**Example.** CI is [-5%, +8%].
+
+Zero is inside the CI and so is a wide range of meaningful effects in both directions. The data does not distinguish "moderate win" from "no effect" from "moderate loss." The test was underpowered for the question.
+
+Three follow-up paths:
+
+- Run longer or run bigger to narrow the CI.
+- Make the treatment bolder so the expected effect is larger and detectable at the available traffic.
+- Accept that the question cannot be answered cleanly and move on.
+
+The temptation is to ship anyway because "the point estimate was favorable." The point estimate is not evidence when the CI is this wide. Resist.
+
+---
+
+## Pairing the CI with guardrails
+
+The CI on the primary metric is where the ship decision lives. The CI on each guardrail is where the safety check lives. Read both.
+
+A guardrail CI that excludes the threshold of concern is clean. For example, if retention is a guardrail and you require it to not drop more than 1%, a guardrail CI of [-0.3%, +0.4%] is clean. A CI of [-2%, +0.5%] is not clean even though it includes zero, because the lower bound exceeds the threshold.
+
+Wide guardrail CIs mean the test was underpowered for the guardrail. That is a real problem: you cannot claim safety on a metric you did not measure precisely. The fix is more sample, not "the point estimate looked fine."
+
+---
+
+## Worked example: the "looks great" trap
+
+**Setup.** PM running a checkout redesign. Pre-committed primary: revenue per visitor. MDE: 3%. Guardrail: refund rate not increasing by more than 0.5%.
+
+**Day 5.** Result panel shows revenue per visitor +6%, p equals 0.03, CI [+0.5%, +11.5%]. Refund rate +0.3%, CI [-0.4%, +1.0%].
+
+**The temptation.** Both metrics moved favorably; the headline is significant. PM proposes ending the test early.
+
+**The CI read.** Revenue CI [+0.5%, +11.5%] has a lower bound (+0.5%) below the MDE (+3%). The data is consistent with a real but tiny lift, not just the headline +6%. The guardrail CI [-0.4%, +1.0%] has an upper bound (+1.0%) that exceeds the threshold (+0.5%); the test cannot rule out a guardrail violation.
+
+**The right call.** Do not ship yet. Run to the pre-committed end date. Both CIs need to narrow before the ship case is defensible. The day-5 read is suggestive but not decisive; it is exactly the case the pre-commitment discipline was designed to handle.
+
+**Common variant.** PM ships anyway because "the trend is positive." Three weeks later the launch shows a refund rate increase that wipes out the revenue gain. The day-5 CI was warning of this exact possibility; the team did not read the width.

--- a/skills/experimentation-analytics/references/dashboard-vs-experiment-reconciliation.md
+++ b/skills/experimentation-analytics/references/dashboard-vs-experiment-reconciliation.md
@@ -1,0 +1,87 @@
+# Dashboard vs experiment reconciliation
+
+The scenario: the BI dashboard shows revenue grew 8% last week, the experiment platform shows the treatment lifted revenue 2%, and an executive asks how both can be true. This reference covers the common reasons numbers disagree, the blended-attribution trap, and how to communicate the difference.
+
+---
+
+## Why numbers disagree (in order of frequency)
+
+**Different denominators.** The dashboard is computed across all users (or all sessions, or all transactions). The experiment is computed across enrolled users only. If 30% of users are enrolled in the experiment, the experiment lift applies to roughly 30% of the metric base; the dashboard sees the entire base. A 2% lift on the enrolled 30% looks like roughly 0.6% on the dashboard, even if everything is working perfectly.
+
+**Different time windows.** The dashboard shows rolling seven days; the experiment shows fixed start to end. Comparing a moving window to a fixed window is comparing two different summaries of overlapping but distinct data.
+
+**External effects.** Marketing campaigns, seasonality, news cycles, competitor moves, weather. The experiment correctly excludes these by random assignment (treatment and control see the same external effects, so they cancel in the lift estimate). The dashboard reflects them in full. The dashboard moving up has nothing to do with the experiment moving up.
+
+**Selection effects in enrollment.** Who is enrolled matters. New users only? Logged-in only? Users who passed a feature flag check? Each filter changes the population the experiment lift applies to, and changes how that population's behavior compares to the dashboard total.
+
+**Different metric definitions.** "Revenue" might be gross in the dashboard and net of refunds in the experiment. "Conversions" might count differently across systems (does a re-purchase count? a subscription renewal? a free trial activation?). Definitional drift between systems is common and almost always under-investigated.
+
+**Pipeline lag.** The dashboard is real-time or near-real-time. The experiment is computed on a daily batch with attribution windows that delay the metric by hours or days. Comparing a real-time number to a batched-and-attributed number is comparing two different versions of the truth.
+
+**Different attribution models.** First-touch vs last-touch vs multi-touch attribution can produce wildly different "revenue" numbers from the same underlying events. The dashboard and the experiment might use different models without anyone realizing.
+
+---
+
+## The blended attribution trap
+
+The most common reconciliation failure: take the experiment lift and multiply by the total user base for company-wide impact.
+
+**The wrong calculation.** Experiment shows +2% revenue per user. Total active users: 5 million. "The feature drove $X million in incremental revenue."
+
+**Why it is wrong, twice over.**
+
+- The lift only applies to enrolled users, not the total base. If 30% of users are enrolled, the in-test impact is roughly 30% of what the multiplication suggests.
+- Even within enrolled users, the lift was measured during the test conditions. Long-term and at full scale, the effect can be smaller (novelty fade, interference effects, market saturation) or sometimes larger (network effects that compound, learning effects).
+
+**The right framing.** "During the four-week test, enrolled users (about 30% of the active base) showed a 2% revenue-per-user lift relative to control. Extrapolating to a full launch requires assumptions about how the effect translates at scale; the simple multiplication ignores those assumptions."
+
+The right framing is longer. Stakeholders sometimes push back on the precision. The precision is the point: the simple version is wrong, and shipping based on the simple version produces forecasts that do not materialize.
+
+---
+
+## How to communicate to non-statistical stakeholders
+
+The temptation is to translate the experiment result into a single number that sounds like the dashboard. The translation is usually wrong because the two numbers are answering different questions.
+
+**Better framings:**
+
+- "The experiment is asking 'does this change move the metric for users who see it?' The dashboard is asking 'how is the metric trending overall?' Both can move independently and both can be true at the same time."
+- "The experiment lift applies to enrolled users, in test conditions, during the test window. Translating to a launch forecast requires assumptions about scale, novelty, and interference."
+- "If we ship to everyone, we expect the dashboard to move by roughly [X percent of the lift], plus or minus [a wide range], because of [specific assumptions]."
+
+**Worse framings to avoid:**
+
+- "The feature drove $X million in revenue this week." (Conflates the experiment lift with the dashboard movement.)
+- "We hit our target." (When the target was set against the dashboard but the result is from the experiment.)
+- "The lift was bigger in production than in the test." (Usually a sign of confounding, not vindication.)
+
+---
+
+## When to dig into discrepancies vs accept them
+
+**Dig in when:**
+
+- The experiment shows a big effect and the dashboard shows nothing. The experiment is making a claim that the launch did not deliver. Either the experiment was wrong (selection effect, pipeline bug, confounder) or the launch is being measured wrong.
+- The experiment shows nothing and the dashboard shows a big effect. The experiment is missing a real movement. Either the test was underpowered, the wrong population was enrolled, or the dashboard movement is from external factors.
+- The directions disagree (experiment positive, dashboard negative). Almost always indicates a definitional drift or pipeline issue that needs investigation.
+
+**Accept the discrepancy when:**
+
+- The magnitudes are different but the directions agree. Usually a denominator or selection issue; document the explanation and move on.
+- The dashboard is volatile and the experiment is stable. The dashboard reflects external noise the experiment correctly excludes.
+- The dashboard is stable and the experiment showed a small effect. The launch effect is too small to detect in the dashboard's noise.
+
+---
+
+## A reconciliation checklist for the moment of confusion
+
+When a stakeholder asks "why do these numbers not match?", run through this:
+
+1. **Same metric definition?** Confirm the experiment and dashboard are computing the metric the same way. Check the definitional doc for both. Ask the data team if there is no doc.
+2. **Same denominator?** Confirm the experiment population and the dashboard population. Often they differ.
+3. **Same time window?** Confirm the experiment window and the dashboard window are aligned (or explain why they are not).
+4. **Any external events?** List campaigns, launches, outages, holidays during the test window. The dashboard reflects them; the experiment cancels them.
+5. **Any pipeline lag?** Confirm both numbers are using the same attribution and the same data freshness.
+6. **Any selection effects?** Who got enrolled and how? If enrollment was non-random (by feature flag check, by cohort), the experiment population is not representative of the dashboard population.
+
+If all six check out and the numbers still disagree by a meaningful amount, escalate to data engineering. There is probably a pipeline bug in one of the two systems.

--- a/skills/experimentation-analytics/references/p-value-interpretation-guide.md
+++ b/skills/experimentation-analytics/references/p-value-interpretation-guide.md
@@ -1,0 +1,118 @@
+# P-value interpretation guide
+
+The p-value is the most-mentioned and most-misunderstood number on the result panel. This guide covers what it actually means, what people pretend it means, when the 0.05 cutoff binds and when it does not, and how to read p-values alongside the CI.
+
+---
+
+## What the p-value is
+
+The p-value is the probability of observing the lift you saw (or one larger in magnitude), IF the true effect were zero. It is computed under the assumption that the treatment had no effect; the value tells you how surprised you should be by the observed data under that assumption.
+
+A p-value of 0.04 means: under the null hypothesis of no effect, you would see this much lift purely by chance about 4% of the time. A p-value of 0.001 means it would happen 0.1% of the time. Smaller p-values are stronger evidence against the null; larger p-values are weaker evidence.
+
+That is the whole technical definition. Everything else is interpretation, and most of it is wrong.
+
+---
+
+## What the p-value is not
+
+These are the most common misinterpretations. Each one is wrong for a specific reason.
+
+**"P equals 0.04 means 96% chance the treatment works."** No. The p-value is computed under the assumption that the treatment does NOT work; it cannot tell you the probability that it does. The Bayesian probability of the alternative depends on the prior, which the p-value does not contain.
+
+**"P equals 0.001 means the effect is huge."** No. P-values are about the strength of evidence against the null, not the size of the effect. A tiny effect tested against a very large sample produces a tiny p-value. The CI tells you the size; the p-value tells you the certainty.
+
+**"A significant result will replicate."** Not necessarily. A p-value of 0.05 is associated with replication rates well below 50% in most published research. Statistical significance is one piece of evidence; reproducibility requires confirmation.
+
+**"P greater than 0.05 means there is no effect."** No. P-values cannot prove the null. A non-significant result means "we do not have enough evidence to reject no-effect," which is weaker than "no-effect is true." The CI tells you the practical conclusion: a wide CI straddling zero is "we do not know," while a narrow CI around zero is "the effect is small enough to call zero."
+
+**"P equals 0.06 is much worse than p equals 0.04."** No. The 0.05 cutoff is convention; the underlying evidence is roughly the same. Treating 0.06 as categorically different from 0.04 is theater unless you pre-committed to the cutoff.
+
+---
+
+## The 0.05 convention
+
+Alpha equals 0.05 is the standard significance threshold by historical convention, not because the math says 0.05 is special. The convention is useful because it provides a shared reference point, and pre-committing to a threshold prevents post-hoc rationalization.
+
+Two valid uses of the threshold:
+
+- **Pre-committed alpha.** You declared at design time that you would ship if p was less than 0.05 and the CI excluded zero. Now apply the rule mechanically. If the result hit 0.04, follow the pre-commitment.
+- **Convention reference point.** When communicating with stakeholders, "significant at the conventional 5% threshold" is a familiar phrasing. Use it as long as the underlying CI is also reported.
+
+Two invalid uses:
+
+- **Post-hoc threshold games.** Result is p equals 0.06; you decide that 0.10 is "good enough this time." This is p-hacking.
+- **Treating the threshold as a binary truth.** Result is p equals 0.04; you ship without reading the CI. The threshold is necessary but not sufficient evidence to ship.
+
+---
+
+## Always read the CI alongside the p-value
+
+The p-value tells you about the null hypothesis. The CI tells you about the magnitude. They answer different questions, and decisions need both answers.
+
+| Scenario | P-value | CI on lift | Decision |
+|---|---|---|---|
+| Real, meaningful effect | 0.001 | [+3%, +6%] | Ship if guardrails clean |
+| Real but tiny effect | 0.001 | [+0.2%, +0.4%] | Probably do not ship; magnitude too small |
+| Suggestive but uncertain | 0.08 | [-0.5%, +12%] | Inconclusive; run longer or kill |
+| Inconclusive null | 0.30 | [-1%, +1%] | Real null result; do not ship for lift reasons |
+| Inconclusive wide | 0.30 | [-7%, +9%] | Underpowered; not enough information |
+
+Reading just the p-value loses the magnitude. Reading just the CI loses the certainty calibration. Both are routine on every result panel; both deserve attention.
+
+---
+
+## The peeking problem
+
+Standard p-values assume one analysis at the end of the test. Multiple analyses inflate the false positive rate.
+
+The math: at one analysis, alpha equals 5% means 5% false positive rate. At three analyses, it climbs toward 14%. At daily peeking on a four-week test, it can exceed 30%. The "significant" results you find by peeking are disproportionately false positives that will not replicate.
+
+Two fixes:
+
+- **Sequential testing methods.** Modern platforms (Statsig, Eppo, GrowthBook with mSPRT, parts of PostHog) report "always-valid" or "anytime-valid" p-values that survive peeking. The math is wider by design; the cost of peek-safety is some statistical efficiency.
+- **Pre-commitment.** If your platform does not support sequential testing, declare the analysis date at launch and do not peek. If you must peek (some platforms make it hard not to), do not make decisions on intermediate peeks.
+
+If your panel says "p-value" without a qualifier, assume fixed-horizon. Treat early-peek results as suggestive only.
+
+---
+
+## Multiple testing context
+
+A p-value of 0.05 means a 5% false positive rate per comparison. With twenty comparisons, you expect one false positive purely by chance.
+
+Where this matters:
+
+- Multiple variants (A vs B vs C vs D is three pairwise tests).
+- Multiple metrics (primary plus six guardrails plus three secondary is ten chances).
+- Multiple segments (ten segments times three metrics is thirty chances).
+
+Pre-register the primary metric and primary segment. Treat the rest as exploratory. A "significant" finding in a non-primary metric or non-primary segment requires either a larger effect, a follow-up test, or both before it justifies shipping. The discipline of pre-registration protects you from the multiple-testing trap better than any correction formula.
+
+When the platform applies a correction (Bonferroni, Benjamini-Hochberg) silently, the p-values you see have already been adjusted. Know which the platform applies by default; otherwise you may double-correct in your interpretation.
+
+---
+
+## Bayesian alternatives
+
+Some platforms (Eppo by default, Statsig as a configuration option) report Bayesian probabilities rather than frequentist p-values. The vocabulary differs:
+
+- "Probability variant B is best": the Bayesian equivalent of multi-variant frequentist comparison.
+- "Probability of beating control by at least X%": directly answers the magnitude question that frequentist p-values dance around.
+- "Posterior credible interval": the Bayesian analogue of the confidence interval, with an interpretation closer to lay intuition ("there is a 95% chance the true effect is in this range").
+
+For most PM contexts, both approaches produce similar ship decisions when the experiment was designed correctly. Pick one per experiment and stick with it. Switching mid-flight to chase a more favorable interpretation is the Bayesian-frequentist version of p-hacking.
+
+---
+
+## Communicating p-values to non-technical stakeholders
+
+Stakeholders often want a one-sentence summary. The temptation is "p equals 0.04, so we should ship." The temptation is wrong because it loses the magnitude.
+
+Better one-liners:
+
+- "We saw a 4% lift in revenue per visitor; the data rules out no-effect and is consistent with a 2% to 6% true lift."
+- "The test was inconclusive: the lift could be anywhere from a small loss to a moderate win."
+- "We measured a small but real effect: about 0.5% lift, which is statistically detectable but probably not worth shipping."
+
+Each names the magnitude, the uncertainty, and the decision implication. None reduces the question to a p-value threshold check.

--- a/skills/experimentation-analytics/references/result-presentation-templates.md
+++ b/skills/experimentation-analytics/references/result-presentation-templates.md
@@ -1,0 +1,123 @@
+# Result presentation templates
+
+Five templates for stakeholder communication on experiment results. Each names the structure, the vocabulary, what to emphasize, and what to omit. Use the right template for the result you have, not the one that flatters the team.
+
+---
+
+## Template 1: Clear win
+
+**When to use.** Primary metric moved past MDE, CI on lift excludes zero, all guardrails clean, pre-registered segments consistent.
+
+**Structure.**
+
+1. **Headline.** "We are shipping [feature]. The test showed a [X percent] lift in [primary metric] with [Y percent] confidence. Guardrails are clean."
+2. **The number.** Point estimate of the lift, with the CI in parentheses. "Revenue per visitor lifted 4.2% (CI [+2.8%, +5.6%])."
+3. **Magnitude in business terms.** "At our enrolled traffic, that is roughly [$Z] in incremental [period] revenue from this cohort. Full-launch impact depends on rollout assumptions."
+4. **Guardrails.** One line per guardrail confirming it stayed within tolerance.
+5. **Decision and timing.** "Filing the launch this week. Post-launch monitoring at days 7, 14, and 30."
+
+**Vocabulary to use.** "Real lift," "high confidence," "exceeds the threshold we committed to," "shipping."
+
+**Vocabulary to avoid.** Superlatives ("dramatic," "unprecedented," "transformative"). The number speaks; superlatives do not add to it.
+
+**What to omit.** Long discussion of why the test worked, deep statistical detail, exhaustive caveats. The headline result is clean; the writeup should be too.
+
+---
+
+## Template 2: Clear loss
+
+**When to use.** Primary metric moved against expected direction with significance, OR a guardrail was violated.
+
+**Structure.**
+
+1. **Headline.** "We are not shipping [feature]. The test showed [a negative effect / a guardrail violation]."
+2. **The number.** Point estimate and CI. Be precise about which metric showed the issue.
+3. **Likely cause, if known.** Brief diagnosis: "Conversion dropped because users did not understand the new flow. Session recordings confirm confusion at step three."
+4. **What we learned.** One or two sentences naming the lesson for the next hypothesis.
+5. **Decision and follow-up.** "Killing the test. Filing the learning in the team retrospective. Considering [follow-up direction] as a next test."
+
+**Vocabulary to use.** "The test showed," "killing," "the change made things worse on [metric]," "we learned."
+
+**Vocabulary to avoid.** "Failed" applied to the team. "Setback." Defensive language. The test produced a clear answer; the team did its job.
+
+**What to omit.** Speculation about what would have happened with a different design. Excessive postmortem detail. The kill is the right decision; do not over-justify it.
+
+---
+
+## Template 3: Inconclusive (the most common, hardest)
+
+**When to use.** Primary metric did not clearly move past MDE, CI is wide, OR guardrails are clean but signal is weak. The most frequent real outcome and the hardest to communicate without slipping into "we should ship anyway."
+
+**Structure.**
+
+1. **Headline.** "The test was inconclusive. We do not have enough signal to ship and we do not have enough signal to kill."
+2. **The number.** Point estimate and the wide CI. Name the width: "Lift was +1.8%, but the CI is [-2.1%, +5.7%]; the data is consistent with a moderate win, no effect, or a moderate loss."
+3. **What we know vs what we do not.** "We can rule out a large negative effect. We cannot distinguish a small positive effect from no effect. We cannot say whether shipping would help or hurt."
+4. **The three resolution paths.**
+
+   - Run bigger or longer: extend the test to narrow the CI. Cost: [time and traffic]. Benefit: a clearer answer.
+   - Make the treatment bolder: redesign with a larger expected effect, then re-test. Cost: design and engineering effort. Benefit: addresses the underlying mechanism rather than the measurement.
+   - Kill the idea: accept that the change does not produce a meaningfully detectable effect at our traffic. Cost: closing the hypothesis. Benefit: team time freed for higher-signal work.
+5. **Recommendation.** Pick one path and explain why.
+6. **Decision.** "Going with [path]. Re-evaluating in [timeframe]."
+
+**Vocabulary to use.** "Inconclusive," "the data does not distinguish," "we cannot confidently say," "the right call is to [chosen path]."
+
+**Vocabulary to avoid.** "Trending positive," "directional improvement," "looks promising." These are the phrases that get teams to ship inconclusive tests; they are wishful reading of noise.
+
+**What to omit.** Pleas to ship "since we are already here." Optimistic projections of what the lift "would be" with more sample. Alternative analyses that conveniently show significance.
+
+The hardest version of this template is the case where the team has invested in the hypothesis and the result is inconclusive. The temptation is to find a way to justify shipping. The discipline is to use the structure above and let the inconclusive result be inconclusive.
+
+---
+
+## Template 4: Mixed result (positive primary, ambiguous guardrail)
+
+**When to use.** Primary metric moved past MDE with clean significance, but a guardrail metric showed concerning movement that did not clearly violate tolerance.
+
+**Structure.**
+
+1. **Headline.** "The primary metric moved as expected. A guardrail showed concerning movement; we are [shipping with monitoring / holding for further investigation]."
+2. **Primary metric result.** Point estimate and CI. "Conversion lifted 5.1% (CI [+3.4%, +6.8%])."
+3. **Guardrail concern.** Specific. "Refund rate point estimate moved +0.4%, with CI [-0.1%, +0.9%]. Pre-committed tolerance was no more than +0.5%. The CI does not clearly violate tolerance, but the upper bound is right at the threshold."
+4. **The interpretation question.** "Pre-committed decision rule was 'do not ship if the guardrail CI excludes safe behavior.' The CI does not exclude safe behavior, but it does not exclude a violation either."
+5. **Recommendation with reasoning.** Two valid paths:
+
+   - Ship with extra monitoring: production behavior at +1, +2, +4 weeks specifically watching the guardrail. Roll back if it crosses tolerance in production. Acceptable when the primary lift is large and the guardrail risk is reversible.
+   - Hold and re-test: extend the test to narrow the guardrail CI. Acceptable when the primary lift is marginal or the guardrail is hard to monitor in production.
+6. **Decision.** Pick the path. Document the guardrail-specific monitoring or the re-test plan.
+
+**Vocabulary to use.** "The guardrail CI does not clearly exclude tolerance," "shipping with intensified monitoring," "the pre-committed rule was."
+
+**Vocabulary to avoid.** "The guardrail did not move significantly" (when the CI does not exclude movement, do not pretend it did). "The primary lift outweighs the guardrail concern" (the guardrail was set as binding for a reason).
+
+**What to omit.** Reframing the guardrail as a "secondary metric" that does not need to bind. The guardrail was set during pre-commitment; it binds.
+
+---
+
+## Template 5: Long-term holdout report (30 / 60 / 90 days post-launch)
+
+**When to use.** Reporting back on a feature that shipped with a holdout group, after the holdout period has elapsed.
+
+**Structure.**
+
+1. **Headline.** "[Feature] post-launch holdout report at [day count]. Long-term effect [confirms / diverges from / disconfirms] the test result."
+2. **Test result reminder.** What the test showed at launch. "At launch, the test measured a +4% lift in [metric]."
+3. **Long-term result.** What the holdout shows now. "At day 30, the launched cohort shows a +3.2% lift over the holdout (CI [+1.8%, +4.6%])."
+4. **Comparison.** Direct: "The long-term effect is [in line with / smaller than / larger than] the test estimate. [If smaller: the difference is consistent with novelty fade / interference / dilution. If larger: the difference is consistent with network effects / learning effects.]"
+5. **Decision implications.** "[Continue the launch as is / revisit the design / consider rollback]."
+6. **Holdout disposition.** "[Releasing the holdout into the launched cohort / extending the holdout for another 30 days]."
+
+**Vocabulary to use.** "Long-term effect," "confirms / diverges from," "novelty fade," "we observe."
+
+**Vocabulary to avoid.** "Vindication" or "we were right." Long-term reports are about updating the prior, not declaring victory.
+
+**What to omit.** Excessive celebration of a confirmed lift. Excessive panic about a divergent lift. The report is information for the next decision; let the information drive it.
+
+---
+
+## A note on the "we should report this differently" temptation
+
+When a result is inconclusive or mixed, there is always a way to slice the data, frame the writeup, or pick the chart that makes the result look more decisive. Resist.
+
+The cost of overstating an inconclusive result is shipping changes that do not work, eroding trust in the experimentation discipline, and accumulating production complexity for no gain. The cost of accurately reporting an inconclusive result is one round of disappointment from stakeholders who wanted a cleaner answer. The first cost compounds; the second does not. Use the right template for the actual result.

--- a/skills/experimentation-analytics/references/statistical-method-reference.md
+++ b/skills/experimentation-analytics/references/statistical-method-reference.md
@@ -1,0 +1,150 @@
+# Statistical method reference
+
+The technical reference for analysts. Covers the methods named in the SKILL.md with enough depth to verify a platform's implementation, recognize when a method is needed, and explain the choice to a skeptical reviewer.
+
+---
+
+## CUPED (Controlled-experiment Using Pre-Experiment Data)
+
+**What it does.** Uses pre-experiment behavior of the same users to subtract out their baseline, leaving a cleaner signal of the treatment effect. Same point estimate as the unadjusted analysis; narrower CI.
+
+**The math, in one paragraph.** For each user, take their in-experiment metric value Y and their pre-experiment metric value X. Compute the regression coefficient theta that relates X to Y in the control group. Replace Y with Y minus theta times (X minus X-bar) for every user. Run the analysis on the adjusted Y. The variance of the adjusted Y is lower than the variance of Y by a factor proportional to the squared correlation between X and Y, which directly narrows the CI.
+
+**Variance reduction in practice.** Typical reduction is 30% to 50% for engagement metrics, 20% to 40% for revenue metrics, near zero for one-time conversions. Effective sample size roughly doubles when variance halves.
+
+**When to use.**
+
+- Metrics with high pre-experiment baseline variance (revenue per user, sessions per user, engagement minutes).
+- Tests where users have meaningful history (logged-in users, users from before a certain date).
+- Long-running products where pre-experiment behavior strongly predicts in-experiment behavior.
+
+**When NOT to use.**
+
+- Brand-new users with no pre-experiment data.
+- One-time conversion metrics with no pre-experiment baseline.
+- Tests where pre-experiment behavior is uncorrelated with the metric being moved (a notification redesign rarely correlates with prior revenue, for example).
+
+**How to verify your platform implements it correctly.** Ask: "Do you compute theta on control only, or on the pooled population?" Pooled is technically wrong (induces bias). Control-only is correct. "What pre-experiment window do you use?" Common defaults are 14 to 28 days; the choice should be documented.
+
+**Common confusion.** "CUPED made our lift smaller, so we should report the unadjusted version." Wrong. CUPED reduces variance, not the point estimate. If the lift looks smaller after CUPED, the unadjusted lift was probably inflated by chance correlation with pre-experiment behavior; the CUPED estimate is closer to the true effect.
+
+---
+
+## The delta method
+
+**What it does.** Provides correct variance estimation for ratio metrics. Naive variance estimation on ratios produces incorrectly narrow CIs and inflated false positive rates.
+
+**Why ratios are special.** Standard variance formulas assume sums of independent observations. Ratios are functions of two correlated sums (numerator and denominator). The variance of a ratio depends on the variance of the numerator, the variance of the denominator, AND the covariance between them. Naive estimators ignore the denominator variance and the covariance.
+
+**The math, in one paragraph.** For a ratio R equals N divided by D, the delta method approximates the variance of R using a first-order Taylor expansion around the means of N and D. The result expresses Var(R) as a function of Var(N), Var(D), Cov(N, D), and the means. The approximation is excellent when the sample size is moderate to large, which it is for almost any A/B test.
+
+**When to use.**
+
+- Conversion rate (conversions per user, when users can have multiple events).
+- Click-through rate (clicks per impression).
+- Revenue per user.
+- Average order value.
+- Any metric expressible as numerator divided by denominator where users can contribute multiple values.
+
+**When the simple formula is fine.**
+
+- Per-user binary conversion (one row per user, converted yes or no). The standard proportion variance formula is correct here.
+
+**Bootstrap as an alternative.** Resample users with replacement many times, compute the ratio each time, read off the empirical CI. Distribution-free; slower than delta method. Both produce similar CIs for typical A/B test sizes.
+
+**How to verify your platform.** Ask "what variance estimator do you use for ratio metrics?" Acceptable answers: delta method, linearization, bootstrap with user-level resampling. Unacceptable: standard t-test on proportions (wrong for non-binary ratios), bootstrap with row-level resampling (ignores within-user correlation).
+
+---
+
+## Sequential testing methods
+
+**The peeking problem.** Standard p-values assume one analysis at the end of the test. Multiple analyses inflate the false positive rate. Daily peeking on a four-week test can push false positive rate above 30%.
+
+**Group sequential designs (GSD).** Plan a fixed set of interim analyses (often three) with adjusted significance thresholds at each. The thresholds are computed so the overall false positive rate stays at the nominal alpha. Well-understood; less flexible than always-valid methods.
+
+**Mixture sequential probability ratio test (mSPRT).** Produces "always-valid" p-values: the false positive rate stays at nominal alpha regardless of how many times you analyze. Common in modern platforms. The math: define a likelihood ratio between the alternative and null hypotheses, integrated over a prior on the effect size. The test rejects when the ratio exceeds 1/alpha.
+
+**Anytime-valid confidence intervals.** The CI version of always-valid p-values. Produced by taking the inverse of the always-valid test family. Wider than fixed-horizon CIs; the cost of peek-safety is some statistical efficiency, typically 10% to 30% wider.
+
+**Implementation across platforms.**
+
+- Statsig: always-valid by default for sequential metrics.
+- Eppo: sequential CIs available as a configuration.
+- GrowthBook: mSPRT supported.
+- PostHog: depends on the experiment type and configuration.
+- Optimizely: supports sequential via Stats Engine.
+- Amplitude (Experiment): supports sequential testing.
+
+**How to read the panel.** "Always-valid p-value" or "anytime-valid CI" labels indicate sequential. "P-value" with no qualifier is fixed-horizon; treat early peeks as suggestive only.
+
+---
+
+## Heterogeneous treatment effects (HTE)
+
+**What HTE is.** The treatment works differently for different segments. New users see +5%, power users see -2%, average is +1%.
+
+**Pre-registered vs post-hoc.** Pre-registered HTE analysis is one of the segment definitions you committed to at design time, with sample size budgeted for the segment. Post-hoc HTE discovery is finding a segment whose effect is large by mining the data; this is noise mining and the apparent lift will not replicate.
+
+**When to ship segment-only.** Three conditions must all hold:
+
+- The segment was pre-registered.
+- The effect within the segment is large enough to justify shipping.
+- The targeting infrastructure exists (or is cheap to build) and the maintenance cost is acceptable.
+
+If any condition fails, do not ship segment-only. Either ship to everyone (taking the average effect) or do not ship.
+
+**Methods for principled HTE detection.**
+
+- Causal forests: machine learning method for estimating heterogeneous treatment effects across many features.
+- Conditional average treatment effects (CATE) with regression: model the effect as a function of covariates.
+- Pre-registered segment analysis: simpler, more defensible, and sufficient for most PM contexts.
+
+For most A/B tests, pre-registered segment analysis is the right level of sophistication. Causal forests are useful for marketplace and personalization research where the effect is genuinely expected to vary across many dimensions.
+
+---
+
+## Multiple testing corrections
+
+**The problem.** With twenty independent comparisons at alpha equals 0.05, you expect one false positive purely by chance. With fifty, two or three.
+
+**Bonferroni correction.** Divide alpha by the number of comparisons. With 20 comparisons, use alpha equals 0.0025 per comparison. Conservative; controls the family-wise error rate (probability of any false positive across the family).
+
+**Benjamini-Hochberg (BH) correction.** Less conservative; controls the false discovery rate (expected proportion of false positives among the things called significant). Better for exploratory analysis where some false positives are tolerable.
+
+**When to use which.**
+
+- Small number of pre-registered comparisons with high stakes: Bonferroni.
+- Larger exploratory analysis where some false positives are acceptable: BH.
+- Single pre-registered primary metric: no correction needed (one comparison).
+
+**How platforms apply corrections.** Some platforms apply corrections silently to displayed p-values; others report uncorrected numbers. Know which your platform does. The "5 of 12 metrics significant" headline means very different things depending on whether the p-values were corrected.
+
+---
+
+## Cluster randomization
+
+**When SUTVA is violated.** SUTVA (Stable Unit Treatment Value Assumption) says one user's treatment does not affect another user's outcome. Violated in two-sided marketplaces, social products, supply-constrained features, and notification systems.
+
+**Cluster randomization as a fix.** Assign whole units (cities, markets, friend groups, sessions) to treatment or control rather than individual users. Eliminates within-cluster interference at the cost of effective sample size.
+
+**Trade-off.** A cluster of 1000 users behaves more like one observation than 1000 independent observations. Effective sample size is roughly the number of clusters times the within-cluster correlation factor. Cluster randomization with 50 clusters has roughly the power of a user-randomized test with 200 to 500 users, even if the clusters contain millions of users total.
+
+**Designing for cluster randomization.** Choose the cluster boundary so that interference happens within clusters but not across them. Cities work for marketplace experiments. Friend groups work for social products. Sessions work for some notification studies.
+
+**Switchback experiments as an alternative.** Toggle the entire population between treatment and control across time windows (week 1 treatment, week 2 control). Eliminates cross-user interference within each window. Requires careful temporal modeling because the windows are not independent (carryover effects, day-of-week effects).
+
+**Detection of SUTVA violation without redesign.** Compare a small cluster-randomized version to the user-randomized version. If the cluster-randomized lift is much larger than the user-randomized lift, the user-randomized test is leaking treatment into control via interference. The user-randomized test is undercounting the effect.
+
+---
+
+## Variance reduction beyond CUPED
+
+**Stratified sampling.** Pre-stratify users by a known covariate (geography, segment, signup cohort) and randomize within strata. Reduces variance from imbalanced randomization at the cost of slightly more complex analysis.
+
+**Post-stratification.** Run normal randomization, then adjust the analysis for known covariates after the fact. Similar variance reduction to CUPED for the right covariates.
+
+**Regression adjustment.** Include covariates as controls in the regression that estimates the treatment effect. Equivalent to post-stratification for one covariate; generalizes to multiple.
+
+**Doubly robust estimation.** Combines regression adjustment with inverse-probability weighting. Robust to misspecification of either the outcome model or the propensity model. Overkill for most A/B tests; useful for observational analysis and some quasi-experiments.
+
+For most PM contexts, CUPED plus pre-registered segment analysis covers the variance reduction needs. The methods above are the next step up when the standard tools are insufficient.


### PR DESCRIPTION
Skill 3 of 3 in the PM-experimentation suite. Pairs with experiment-result-rich platforms in /integrations (Statsig, PostHog, Optimizely, GrowthBook, Eppo, Amplitude, Kameleoon).

17-section SKILL.md plus 7 reference files. Voice: data-team-mentor-to-PM.

## What it covers

The skill codifies how to interpret experiment dashboards without fooling yourself: confidence intervals (the most important number), p-values (what they do and do not mean), multiple testing corrections, sequential testing, CUPED variance reduction, heterogeneous treatment effects, ratio metrics with the delta method, Bayesian vs frequentist panels, SUTVA violation detection, dashboard vs experiment reconciliation, long-term effect estimation, and the common interpretation failures that produce confidently wrong shipping decisions.

## Files

- skills/experimentation-analytics/SKILL.md (17 sections)
- 7 reference files in skills/experimentation-analytics/references/
- README.md catalog count bumped 63 to 64; references 105 to 112

## Voice / discipline gates

- Zero em-dashes (verified)
- Zero forbidden phrases (verified against the dispatch list)
- Zero references to "illumine"
- Lint passes (python .github/scripts/lint_skills.py): all 8 checks OK, 64 skills validated

## Note on the parallel feature-flagging dispatch

A parallel skill (feature-flagging) is being authored simultaneously by another agent. If that PR merges first, this one will need a rebase to resolve catalog count + table numbering on README.md.