### PR TITLE
refactor(readme): generate catalog from skill metadata

### DIFF
--- a/.github/scripts/lint_skills.py
+++ b/.github/scripts/lint_skills.py
@@ -353,6 +353,37 @@ def check_line_lengths(result: LintResult) -> None:
                     result.warn(f"{rel}: {n} lines (target is under {REFERENCE_LINE_LIMIT})")
 
 
+def check_readme_catalog_generated(result: LintResult) -> None:
+    """README catalog content must match the output of the generator script.
+
+    Runs `scripts/generate_readme_catalog.py --check` and surfaces its diff
+    on failure. This is the strict version of `check_readme_catalog_count`,
+    which is kept as a sanity check for badge and header counts.
+    """
+    import subprocess
+
+    generator = REPO_ROOT / "scripts" / "generate_readme_catalog.py"
+    if not generator.exists():
+        result.fail(
+            f"generator script not found at {generator.relative_to(REPO_ROOT)}"
+        )
+        return
+    proc = subprocess.run(
+        [sys.executable, str(generator), "--check"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return
+    detail = (proc.stdout or proc.stderr or "").strip()
+    result.fail(
+        "README catalog out of sync with skill metadata. "
+        "Run: python scripts/generate_readme_catalog.py --write"
+        + (f"\n{detail}" if detail else "")
+    )
+
+
 def check_readme_catalog_count(result: LintResult) -> None:
     """README badge and catalog claims must match the actual SKILL.md count."""
     if not README.exists():
@@ -404,6 +435,7 @@ CHECKS: list[Callable[[LintResult], None]] = [
     check_cross_skill_references,
     check_line_lengths,
     check_readme_catalog_count,
+    check_readme_catalog_generated,
 ]
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,26 @@ If you have not read [SKILL_AUTHORING.md](SKILL_AUTHORING.md), start there. It i
 
 ---
 
+## Adding a new skill
+
+The README catalog section is generated from skill folder metadata. Do not hand-edit it.
+
+1. Create the skill folder at `skills/your-skill-name/`.
+2. Author `SKILL.md` with these YAML frontmatter fields:
+   - `name` (string, must match folder name)
+   - `description` (string, 2 to 4 sentences with triggers)
+   - `category` (one of: `strategy-and-discovery`, `brand`, `design`, `content`, `seo-foundation`, `seo-audit-suite`, `product`, `development`, `qa`, `operations`, `growth`, `research`, `cross-cutting`, `process-and-team`)
+   - `catalog_summary` (string, one-line description for the catalog table)
+   - `display_order` (integer, controls position within the category; omit for alphabetical-by-slug)
+3. Add at least one reference file under `skills/your-skill-name/references/`.
+4. Run `python scripts/generate_readme_catalog.py --write`. The generator updates the badge, subtitle, "What you get" counts, table-of-contents anchor, catalog header, and the catalog table.
+5. Verify with `python .github/scripts/lint_skills.py`.
+6. Open the PR.
+
+The catalog content between `<!-- CATALOG:START -->` and `<!-- CATALOG:END -->` (and the six smaller marker pairs) is owned by the generator. Hand edits inside markers are overwritten on the next run. The generator is the source of truth.
+
+---
+
 ## Skill structure (the short version)
 
 ```
@@ -94,7 +114,7 @@ Before opening a PR, verify all of the following:
 - [ ] `SKILL.md` is under 250 lines (hard cap 500)
 - [ ] Each reference file is under 400 lines
 - [ ] You have read at least one existing skill in a similar category and matched its style
-- [ ] You added an entry to the catalog in `README.md` if your contribution is a new skill
+- [ ] If you added a new skill, the new SKILL.md frontmatter has `category`, `catalog_summary`, and `display_order` fields, and `python scripts/generate_readme_catalog.py --write` was run to update the README catalog
 - [ ] If you added a new skill, you ran a quick local search for trigger collisions with existing skills
 
 ---
@@ -118,7 +138,7 @@ Before opening a PR, verify all of the following:
 1. A maintainer reviews the PR for structural compliance, voice match, and substance.
 2. Comments may be left for clarification or required changes.
 3. Once approved, the PR is merged.
-4. The catalog count in README.md and the skill folder structure are kept consistent.
+4. CI runs the lint suite on every PR, including the generator-sync check. Stale README catalog blocks the merge.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+<!-- COUNT_BADGE:START -->
 [![Skills](https://img.shields.io/badge/Skills-65-blue.svg)](#the-65-skill-catalog)
+<!-- COUNT_BADGE:END -->
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -18,7 +20,9 @@
 
 </div>
 
+<!-- COUNT_INTRO:START -->
 > 65 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+<!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
 
@@ -32,7 +36,9 @@
 - [Getting started](#getting-started)
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
+<!-- COUNT_TOC:START -->
 - [The 65-skill catalog](#the-65-skill-catalog)
+<!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
 - [Repository structure](#repository-structure)
@@ -58,8 +64,10 @@ This is not a curated list of other people's skills. It is a single, opinionated
 
 What you get:
 
+<!-- COUNT_WHATYOUGET:START -->
 - **65 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
-- **119 reference files** (templates, checklists, decision matrices, worked examples)
+- **132 reference files** (templates, checklists, decision matrices, worked examples)
+<!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
 - **Uniform structure.** Every skill uses the same section order, the same tone, and the same authoring conventions. Predictable in, predictable out.
@@ -246,10 +254,16 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 
 ---
 
+<!-- COUNT_CATALOG_HEADER:START -->
 ## The 65-skill catalog
+<!-- COUNT_CATALOG_HEADER:END -->
 
+<!-- COUNT_CATALOG_INTRO:START -->
 All 65 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+<!-- COUNT_CATALOG_INTRO:END -->
 
+<!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
+<!-- CATALOG:START -->
 ### Strategy and discovery (5)
 
 | # | Skill | What it does |
@@ -388,6 +402,7 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 63 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
 | 64 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
 | 65 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+<!-- CATALOG:END -->
 
 ---
 

--- a/SKILL_AUTHORING.md
+++ b/SKILL_AUTHORING.md
@@ -35,6 +35,9 @@ The eight required headers are: `## When to use`, `## When NOT to use`, `## Requ
 ---
 name: skill-name
 description: "A pushy, trigger-rich description. Two to four sentences. See description rules below."
+category: category-id
+catalog_summary: "One-line description for the README catalog table"
+display_order: 1
 ---
 
 # Skill Name
@@ -94,6 +97,22 @@ description: "A pushy, trigger-rich description. Two to four sentences. See desc
 - `references/file.md` - [What it is and when to read it]
 - `references/file.md` - [What it is and when to read it]
 ```
+
+---
+
+## Frontmatter fields
+
+Every SKILL.md frontmatter has five required fields. The first two are the trigger surface; the last three drive the README catalog generator.
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Must match the folder name. Used by Claude when loading the skill. |
+| `description` | string | 2 to 4 sentences. See description rules below. |
+| `category` | string | One of: `strategy-and-discovery`, `brand`, `design`, `content`, `seo-foundation`, `seo-audit-suite`, `product`, `development`, `qa`, `operations`, `growth`, `research`, `cross-cutting`, `process-and-team`. Determines the catalog section the skill renders into. |
+| `catalog_summary` | string | One-line description used as the third column of the catalog table. Aim for under 140 characters. No trailing punctuation. |
+| `display_order` | integer | Position within the category. Smallest first. Skills with no `display_order` render after the ordered ones, alphabetically by slug. |
+
+After editing any of these fields, run `python scripts/generate_readme_catalog.py --write` to regenerate the README catalog content. CI runs `--check` and fails the build if the README is out of sync.
 
 ---
 

--- a/scripts/generate_readme_catalog.py
+++ b/scripts/generate_readme_catalog.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Generate README.md catalog content from skill folder metadata.
+
+Walks ``skills/`` and parses each ``SKILL.md`` frontmatter for the fields
+``name``, ``description``, ``category``, ``catalog_summary``, and
+``display_order``. Produces the README catalog section, the skill count
+badge, the subtitle blockquote, the "What you get" counts, the catalog
+header, the table-of-contents anchor, and the catalog intro line.
+
+Two operating modes:
+
+    --check  Exit 0 if README is in sync with skill metadata. Exit 2 with
+             a unified diff if README is stale.
+    --write  Update README.md in place between marker comments. Print a
+             one-line summary on success.
+
+Run from the repo root: ``python scripts/generate_readme_catalog.py --check``.
+
+Markers in README.md:
+
+    <!-- COUNT_BADGE:START -->          ... <!-- COUNT_BADGE:END -->
+    <!-- COUNT_INTRO:START -->          ... <!-- COUNT_INTRO:END -->
+    <!-- COUNT_WHATYOUGET:START -->     ... <!-- COUNT_WHATYOUGET:END -->
+    <!-- COUNT_TOC:START -->            ... <!-- COUNT_TOC:END -->
+    <!-- COUNT_CATALOG_HEADER:START --> ... <!-- COUNT_CATALOG_HEADER:END -->
+    <!-- COUNT_CATALOG_INTRO:START -->  ... <!-- COUNT_CATALOG_INTRO:END -->
+    <!-- CATALOG:START -->              ... <!-- CATALOG:END -->
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from difflib import unified_diff
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+README = REPO_ROOT / "README.md"
+
+
+# Canonical category order. Drives the README catalog section order and the
+# allowed values for the ``category`` frontmatter field. Each tuple is
+# (category_id, display_title, optional_intro_paragraph).
+CATEGORIES: list[tuple[str, str, str | None]] = [
+    ("strategy-and-discovery", "Strategy and discovery", None),
+    ("brand", "Brand", None),
+    ("design", "Design", None),
+    ("content", "Content", None),
+    (
+        "seo-foundation",
+        "SEO foundation",
+        "Tool-agnostic SEO skills. These define the conceptual frameworks. "
+        "The SEO audit suite below adds the Ahrefs MCP-powered execution layer.",
+    ),
+    (
+        "seo-audit-suite",
+        "SEO audit suite (Ahrefs MCP-powered)",
+        "End-to-end SEO audit workflows that pull data from the Ahrefs MCP "
+        "and produce concrete deliverables. These skills assume the Ahrefs "
+        "MCP is connected.",
+    ),
+    ("product", "Product", None),
+    ("development", "Development", None),
+    ("qa", "Quality assurance", None),
+    ("operations", "Operations", None),
+    ("growth", "Growth", None),
+    ("research", "Research", None),
+    ("cross-cutting", "Cross-cutting workflows", None),
+    ("process-and-team", "Process and team", None),
+]
+CATEGORY_IDS = {cid for cid, _, _ in CATEGORIES}
+
+
+MARKERS = [
+    "COUNT_BADGE",
+    "COUNT_INTRO",
+    "COUNT_WHATYOUGET",
+    "COUNT_TOC",
+    "COUNT_CATALOG_HEADER",
+    "COUNT_CATALOG_INTRO",
+    "CATALOG",
+]
+
+
+@dataclass(frozen=True)
+class Skill:
+    slug: str
+    name: str
+    description: str
+    category: str
+    catalog_summary: str
+    display_order: int | None
+
+
+def parse_frontmatter(skill_md: Path) -> dict:
+    """Read SKILL.md and return its YAML frontmatter as a dict."""
+    text = skill_md.read_text(encoding="utf-8")
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)$", text, re.DOTALL)
+    if not match:
+        raise ValueError(f"{skill_md}: no YAML frontmatter delimited by --- markers")
+    data = yaml.safe_load(match.group(1))
+    if not isinstance(data, dict):
+        raise ValueError(f"{skill_md}: frontmatter is not a YAML dict")
+    return data
+
+
+def load_skills() -> list[Skill]:
+    """Walk SKILLS_DIR and return validated Skill records.
+
+    Raises SystemExit with a list of validation errors if any skill is
+    missing required fields or has an unknown category.
+    """
+    skills: list[Skill] = []
+    errors: list[str] = []
+    for entry in sorted(SKILLS_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+        skill_md = entry / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        try:
+            fm = parse_frontmatter(skill_md)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        name = fm.get("name")
+        description = fm.get("description")
+        category = fm.get("category")
+        catalog_summary = fm.get("catalog_summary")
+        display_order = fm.get("display_order")
+        missing = [
+            label
+            for label, value in (
+                ("name", name),
+                ("description", description),
+                ("category", category),
+                ("catalog_summary", catalog_summary),
+            )
+            if not value
+        ]
+        if missing:
+            errors.append(
+                f"{entry.name}: missing frontmatter fields: {', '.join(missing)}"
+            )
+            continue
+        if category not in CATEGORY_IDS:
+            allowed = ", ".join(sorted(CATEGORY_IDS))
+            errors.append(
+                f"{entry.name}: unknown category '{category}'. "
+                f"Allowed values: {allowed}"
+            )
+            continue
+        skills.append(
+            Skill(
+                slug=entry.name,
+                name=str(name),
+                description=str(description),
+                category=str(category),
+                catalog_summary=str(catalog_summary),
+                display_order=int(display_order) if display_order is not None else None,
+            )
+        )
+    if errors:
+        raise SystemExit("Skill frontmatter validation failed:\n  " + "\n  ".join(errors))
+    return skills
+
+
+def group_by_category(skills: list[Skill]) -> dict[str, list[Skill]]:
+    """Bucket skills by category id and sort within each bucket.
+
+    Sort key: (display_order ascending, slug ascending). Skills without a
+    display_order sort to the end alphabetically.
+    """
+    grouped: dict[str, list[Skill]] = {cid: [] for cid, _, _ in CATEGORIES}
+    for skill in skills:
+        grouped[skill.category].append(skill)
+    sentinel = 10_000
+    for items in grouped.values():
+        items.sort(
+            key=lambda s: (s.display_order if s.display_order is not None else sentinel, s.slug)
+        )
+    return grouped
+
+
+def count_reference_files() -> int:
+    """Count files under any skills/*/references/ directory."""
+    total = 0
+    for entry in sorted(SKILLS_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+        ref_dir = entry / "references"
+        if not ref_dir.exists():
+            continue
+        for ref in ref_dir.iterdir():
+            if ref.is_file():
+                total += 1
+    return total
+
+
+def generate_catalog(grouped: dict[str, list[Skill]]) -> str:
+    """Build the full catalog markdown block: section headers and tables."""
+    lines: list[str] = []
+    counter = 0
+    for index, (cid, title, intro) in enumerate(CATEGORIES):
+        items = grouped.get(cid, [])
+        lines.append(f"### {title} ({len(items)})")
+        lines.append("")
+        if intro:
+            lines.append(intro)
+            lines.append("")
+        lines.append("| # | Skill | What it does |")
+        lines.append("|---|---|---|")
+        for skill in items:
+            counter += 1
+            lines.append(
+                f"| {counter} | [`{skill.slug}`](skills/{skill.slug}/SKILL.md) | "
+                f"{skill.catalog_summary} |"
+            )
+        if index < len(CATEGORIES) - 1:
+            lines.append("")
+    return "\n".join(lines)
+
+
+def generate_badge(total: int) -> str:
+    return f"[![Skills](https://img.shields.io/badge/Skills-{total}-blue.svg)](#the-{total}-skill-catalog)"
+
+
+def generate_intro_blockquote(total: int) -> str:
+    return (
+        f"> {total} stack-agnostic skills covering brand, design, content, "
+        "SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered "
+        "SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, "
+        "plain HTML, or anything else."
+    )
+
+
+def generate_whatyouget(total: int, ref_total: int, cat_total: int) -> str:
+    return (
+        f"- **{total} skills** across {cat_total} categories, every one "
+        "with a complete `SKILL.md` and at least one reference file\n"
+        f"- **{ref_total} reference files** (templates, checklists, decision "
+        "matrices, worked examples)"
+    )
+
+
+def generate_toc_link(total: int) -> str:
+    return f"- [The {total}-skill catalog](#the-{total}-skill-catalog)"
+
+
+def generate_catalog_header(total: int) -> str:
+    return f"## The {total}-skill catalog"
+
+
+def generate_catalog_intro(total: int) -> str:
+    return (
+        f"All {total} skills are shipped. Each has a complete SKILL.md "
+        "plus at least one reference file (template, checklist, or playbook)."
+    )
+
+
+def replace_block(text: str, marker: str, new_content: str) -> str:
+    """Replace the body between a START/END marker pair.
+
+    The replacement body is sandwiched by single newlines, producing:
+
+        <!-- MARKER:START -->
+        {new_content}
+        <!-- MARKER:END -->
+    """
+    pattern = re.compile(
+        rf"(<!-- {re.escape(marker)}:START -->)(.*?)(<!-- {re.escape(marker)}:END -->)",
+        re.DOTALL,
+    )
+    matches = list(pattern.finditer(text))
+    if not matches:
+        raise ValueError(f"Marker pair '{marker}' not found in README.md")
+    if len(matches) > 1:
+        raise ValueError(f"Marker pair '{marker}' appears more than once in README.md")
+    replacement = f"\\1\n{new_content}\n\\3"
+    return pattern.sub(replacement, text, count=1)
+
+
+def render_readme(text: str, skills: list[Skill]) -> str:
+    """Apply all marker replacements and return the updated README content."""
+    grouped = group_by_category(skills)
+    total = len(skills)
+    ref_total = count_reference_files()
+    cat_total = len(CATEGORIES)
+    text = replace_block(text, "COUNT_BADGE", generate_badge(total))
+    text = replace_block(text, "COUNT_INTRO", generate_intro_blockquote(total))
+    text = replace_block(
+        text, "COUNT_WHATYOUGET", generate_whatyouget(total, ref_total, cat_total)
+    )
+    text = replace_block(text, "COUNT_TOC", generate_toc_link(total))
+    text = replace_block(text, "COUNT_CATALOG_HEADER", generate_catalog_header(total))
+    text = replace_block(text, "COUNT_CATALOG_INTRO", generate_catalog_intro(total))
+    text = replace_block(text, "CATALOG", generate_catalog(grouped))
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate README catalog content from skill folder metadata."
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero with a diff if README is stale.",
+    )
+    mode.add_argument(
+        "--write",
+        action="store_true",
+        help="Update README.md in place between marker comments.",
+    )
+    args = parser.parse_args()
+
+    if not SKILLS_DIR.exists():
+        print(f"ERROR: skills/ directory not found at {SKILLS_DIR}", file=sys.stderr)
+        return 1
+
+    try:
+        skills = load_skills()
+    except SystemExit as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    current = README.read_text(encoding="utf-8")
+    try:
+        updated = render_readme(current, skills)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        if current == updated:
+            return 0
+        diff = unified_diff(
+            current.splitlines(keepends=True),
+            updated.splitlines(keepends=True),
+            fromfile="README.md (current)",
+            tofile="README.md (generated)",
+        )
+        sys.stdout.writelines(diff)
+        print(
+            "\nREADME catalog is stale. "
+            "Run: python scripts/generate_readme_catalog.py --write"
+        )
+        return 2
+
+    README.write_text(updated, encoding="utf-8")
+    ref_total = count_reference_files()
+    print(
+        f"Updated {len(MARKERS)} sections in README.md, "
+        f"{len(skills)} skills, {ref_total} reference files"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/accessibility-audit/SKILL.md
+++ b/skills/accessibility-audit/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: accessibility-audit
 description: "Run a comprehensive WCAG accessibility audit covering perceivable, operable, understandable, and robust principles. Use this skill whenever the user wants to audit accessibility, review WCAG compliance, fix accessibility issues, prepare for accessibility certification, address an accessibility lawsuit risk, or systematically improve a site's accessibility. Triggers on accessibility audit, WCAG audit, a11y audit, accessibility compliance, ADA compliance, screen reader test, keyboard navigation, accessibility report, fix accessibility, axe scan. Also triggers when accessibility issues have been reported and need systematic remediation."
+category: development
+catalog_summary: "WCAG compliance audit with remediation plan"
+display_order: 3
 ---
 
 # Accessibility Audit

--- a/skills/after-action-report/SKILL.md
+++ b/skills/after-action-report/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: after-action-report
 description: "Run a structured after-action review (postmortem, retrospective) on a launch, incident, or completed project to capture timeline, root cause analysis, contributing factors, and actionable lessons. Use this skill whenever the user wants to run a postmortem, retrospective, AAR, or after-action review on any past event. Triggers on after-action report, AAR, postmortem, retrospective, retro, post-incident review, what went well what didn't, lessons learned, blameless postmortem, root cause analysis, RCA, five whys. Also triggers when the user has just shipped something or just resolved an incident and wants to capture learnings."
+category: operations
+catalog_summary: "Post-mortems, retros, learnings documentation"
+display_order: 3
 ---
 
 # After-Action Report

--- a/skills/analytics-strategy/SKILL.md
+++ b/skills/analytics-strategy/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: analytics-strategy
 description: "Design measurement frameworks including event taxonomy, KPI hierarchy, dashboard architecture, attribution models, and analytics implementation strategy. Use this skill whenever the user wants to plan analytics, design dashboards, build event taxonomies, define KPIs, set up tracking, or audit existing measurement. Triggers on analytics strategy, measurement plan, event taxonomy, tracking plan, KPI framework, dashboard design, north star metric, attribution model, conversion tracking, GA4 setup, Mixpanel setup, analytics audit. Also triggers when the user has data but no clear way to use it, or wants to make decisions but doesn't know what to track."
+category: growth
+catalog_summary: "Measurement frameworks, dashboard design, event taxonomy"
+display_order: 1
 ---
 
 # Analytics Strategy

--- a/skills/art-direction/SKILL.md
+++ b/skills/art-direction/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: art-direction
 description: "Direct visual and creative work for campaigns, photography, illustration, video, and branded experiences. Use this skill whenever the user wants to brief a photographer, direct illustrators, plan a creative campaign, develop visual concepts, write a creative direction document, or evaluate creative work for fit. Triggers on art direction, photo brief, photography brief, illustration brief, campaign concept, creative concept, visual direction, mood board, look and feel, visual treatment, video direction. Also triggers when the user has approved brand identity but needs to extend it into specific creative deliverables."
+category: design
+catalog_summary: "Photography, illustration, and visual direction for campaigns"
+display_order: 3
 ---
 
 # Art Direction

--- a/skills/backup-and-disaster-recovery/SKILL.md
+++ b/skills/backup-and-disaster-recovery/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: backup-and-disaster-recovery
 description: "Plan and run backups, set recovery objectives, and run disaster recovery drills. Use this skill when defining RPO/RTO targets, designing backup architecture, deciding what to back up and how often, planning for full-region or platform outages, or running a restoration drill. Triggers on backup, restore, RPO, RTO, disaster recovery, DR, business continuity, what if the database is gone, what if our hosting goes down, recovery drill, ransomware planning. Also triggers when an incident reveals a gap in restoration capability."
+category: operations
+catalog_summary: "RPO/RTO targets, backup strategy, restoration drills"
+display_order: 6
 ---
 
 # Backup and Disaster Recovery

--- a/skills/brand-discovery/SKILL.md
+++ b/skills/brand-discovery/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: brand-discovery
 description: "Run upstream brand discovery covering audience research, competitive landscape, category dynamics, problem space, and positioning territory exploration. Use this skill at the very start of a brand or website project when the user needs to understand who they're for, who they compete with, what the audience actually needs, and where the brand could plausibly stand. Triggers on brand discovery, audience research, market research, competitive scan, category research, customer research, who is this for, who are we, positioning research, intake, kickoff. Also triggers when a creative brief is requested but the upstream inputs (audience, competitors, problem space) are not yet clear."
+category: strategy-and-discovery
+catalog_summary: "Audience research, competitive scan, positioning territory exploration"
+display_order: 1
 ---
 
 # Brand Discovery

--- a/skills/brand-ideation/SKILL.md
+++ b/skills/brand-ideation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: brand-ideation
 description: "Generate, evaluate, and narrow brand concepts during early ideation including positioning territories, naming candidates, mood directions, and narrative angles. Use this skill whenever the user is in the early phase of brand creation, exploring brand directions, brainstorming names, building moodboards, generating positioning options, or trying to choose between multiple brand directions. Triggers on brand ideation, brand concept, naming, brand name, name candidates, positioning, brand positioning, mood board, brand directions, exploring brands, early brand work, brand exploration, brand brainstorm, brand options. Also triggers when the user has multiple half-formed brand ideas and needs help converging on one, even if they do not say 'ideation' explicitly."
+category: brand
+catalog_summary: "Naming, positioning territories, mood directions, narrative angles"
+display_order: 1
 ---
 
 # Brand Ideation

--- a/skills/brand-identity/SKILL.md
+++ b/skills/brand-identity/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: brand-identity
 description: "Design or evaluate a brand visual identity system covering logo, color, typography, imagery direction, iconography, and motion principles. Use this skill whenever the user wants to design a logo, build a visual identity, define brand colors, choose brand typography, develop iconography, plan brand imagery, or evaluate an existing identity for cohesion. Triggers on logo design, brand identity, visual identity, brand mark, wordmark, monogram, color palette, brand colors, brand typography, type system, iconography, brand imagery, motion design, brand system, identity system. Also triggers when the user has a brand direction approved and now needs the visual artifacts that express it."
+category: brand
+catalog_summary: "Logo system, color, typography, imagery, iconography, motion"
+display_order: 2
 ---
 
 # Brand Identity

--- a/skills/brand-style-guide/SKILL.md
+++ b/skills/brand-style-guide/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: brand-style-guide
 description: "Build or audit a comprehensive brand style guide that documents the full brand system including story, logo system, color, typography, imagery, voice, applications, and dos/don'ts. Use this skill whenever the user wants to create brand guidelines, document an existing brand, build a brand book, audit an existing style guide for completeness, or produce the artifact that other teams will reference for years. Triggers on style guide, brand guidelines, brand book, brand standards, brand manual, style sheet, brand documentation, brand reference. Also triggers when the brand identity is finished and needs to be documented for handoff to designers, developers, vendors, or future team members."
+category: brand
+catalog_summary: "The canonical reference document for the full brand system"
+display_order: 3
 ---
 
 # Brand Style Guide

--- a/skills/brand-voice/SKILL.md
+++ b/skills/brand-voice/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: brand-voice
 description: "Develop or document a complete brand voice and tone system covering voice attributes, tone shifts by context, vocabulary preferences, grammar rules, and copy examples. Use this skill whenever the user wants to define how a brand sounds, write a voice and tone document, audit existing copy for voice consistency, train a team or AI assistant on brand voice, or refine the personality of brand writing. Triggers on brand voice, voice and tone, tone of voice, writing voice, brand personality, copy voice, voice document, voice guidelines, how should we write, voice training, voice audit. Also triggers when the user has copy that 'feels off' and the underlying issue is voice, even if not stated explicitly."
+category: brand
+catalog_summary: "Voice attributes, tone shifts, vocabulary, paired-example library"
+display_order: 4
 ---
 
 # Brand Voice

--- a/skills/code-review-web/SKILL.md
+++ b/skills/code-review-web/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: code-review-web
 description: "Review web application code for bugs, security issues, performance problems, and stack-specific anti-patterns. Use this skill whenever the user wants to review code, debug a production issue, investigate a build failure, audit security, or check a PR before merging. Triggers on code review, review my code, debug, build error, broken, not working, why is X failing, check this code, security check, PR review, audit code, refactor. Also triggers when investigating 4xx or 5xx errors, deploy failures, environment variable issues, and CMS integration problems."
+category: development
+catalog_summary: "PR review, build error diagnosis, security and quality checks"
+display_order: 1
 ---
 
 # Code Review for Web

--- a/skills/content-and-copy/SKILL.md
+++ b/skills/content-and-copy/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: content-and-copy
 description: "Write or edit website copy, blog content, and editorial pieces with attention to voice, structure, and goal. Use this skill whenever the user wants to write an article, draft website copy, edit existing content for clarity or voice, write a blog post, or produce general editorial content. Triggers on write a blog post, draft an article, write copy for, edit this, rewrite this, write content, write a guide, draft a how-to, write web copy. Also triggers when content has been outlined and now needs to be written, or when existing content needs voice or clarity edits."
+category: content
+catalog_summary: "Website copy, blog content, content production frameworks"
+display_order: 1
 ---
 
 # Content and Copy

--- a/skills/content-migration/SKILL.md
+++ b/skills/content-migration/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: content-migration
 description: "Move content between platforms, domains, or URL structures while preserving SEO equity, user bookmarks, and integrations. Use this skill when planning a CMS migration, replatforming, consolidating sites, changing URL structures, or merging content from multiple sources. Triggers on content migration, replatform, CMS migration, domain migration, URL restructure, redirect map, site merge, content consolidation, migration plan, post-migration drop. Also triggers when planning a launch that involves moving existing content."
+category: cross-cutting
+catalog_summary: "Platform migrations with SEO equity preservation"
+display_order: 2
 ---
 
 # Content Migration

--- a/skills/content-strategy/SKILL.md
+++ b/skills/content-strategy/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: content-strategy
 description: "Develop a content strategy covering editorial positioning, content pillars, formats, calendar, governance, and topical authority planning. Use this skill whenever the user wants to plan a content program, define content pillars, build an editorial calendar, structure topic clusters, set up content governance, or align content production with broader brand and SEO goals. Triggers on content strategy, content plan, editorial strategy, content pillars, content calendar, editorial calendar, topical authority, topic clusters, content governance, content roadmap, content production. Also triggers when the user is about to start producing content without a strategic plan."
+category: strategy-and-discovery
+catalog_summary: "Editorial strategy, content calendar, topical authority planning"
+display_order: 5
 ---
 
 # Content Strategy

--- a/skills/cost-optimization/SKILL.md
+++ b/skills/cost-optimization/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: cost-optimization
 description: "Audit and reduce infrastructure and tooling costs without sacrificing reliability or velocity. Use this skill when reviewing monthly cloud or SaaS spend, finding unused resources, rightsizing infrastructure, negotiating vendor contracts, deciding what to consolidate, or planning for budget cuts. Triggers on cost optimization, cloud spend, SaaS spend, rightsizing, unused resources, FinOps, infrastructure audit, vendor consolidation, budget cut, cost review. Also triggers when finance flags rising costs or when a contract renewal is up."
+category: cross-cutting
+catalog_summary: "Infrastructure spend audits, rightsizing, contract negotiation"
+display_order: 5
 ---
 
 # Cost Optimization

--- a/skills/creative-brief/SKILL.md
+++ b/skills/creative-brief/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: creative-brief
 description: "Create or refine a creative brief that bridges discovery and execution. Use this skill whenever the user is starting a new project, kicking off a website, beginning a brand build or redesign, briefing a designer or developer or AI agent, or trying to align a team before building. Triggers on creative brief, design brief, brand brief, project kickoff, kicking off, briefing the team, project intake, design direction, brief the designer, brief the dev, where do we start, how do we start, write a brief, project overview, scope this project, align on direction. Also triggers when the user has a vague idea and needs to make it concrete enough to hand off, even if they do not say 'brief' explicitly."
+category: strategy-and-discovery
+catalog_summary: "Project briefs that align stakeholders before work starts"
+display_order: 2
 ---
 
 # Creative Brief

--- a/skills/creative-direction/SKILL.md
+++ b/skills/creative-direction/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: creative-direction
 description: "Walk the user through four directional axes (tone register, aesthetic philosophy, audience relationship, sensory ambition) and produce a structured aesthetic brief that downstream skills consume as required input. This is the aesthetic depth layer, distinct from `creative-brief` which covers the operational kickoff (scope, audience, deliverables, constraints). Use this skill when a project needs aesthetic coherence across many small decisions and the user has not yet articulated direction beyond a vague feeling. The brief becomes a reference that content, copy, design, and art-direction skills check against when producing output. Triggers on creative direction, aesthetic direction, set the aesthetic, define the visual direction, what's the vibe, what's the tone, the four axes, tone register, aesthetic philosophy, audience relationship, sensory ambition, our visual register. Also triggers when multiple downstream aesthetic-producing skills are about to run and need a shared brief to maintain coherence. Does NOT fire when the user needs a general kickoff brief covering scope and constraints (use `creative-brief` instead), for tactical single-piece work, when the user already has complete aesthetic direction documented, for purely functional output, or for production-stage work where direction is locked."
+category: strategy-and-discovery
+catalog_summary: "Four-axis aesthetic brief (tone, aesthetic, audience, sensory ambition) for cross-skill coherence"
+display_order: 3
 ---
 
 # Creative Direction

--- a/skills/cro-optimization/SKILL.md
+++ b/skills/cro-optimization/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: cro-optimization
 description: "Run conversion rate optimization through hypothesis-driven testing including audit, hypothesis generation, test design, statistical analysis, and rollout decisions. Use this skill whenever the user wants to optimize conversion, run A/B tests, audit a funnel, generate test hypotheses, design experiments, or analyze test results. Triggers on conversion optimization, CRO, A/B test, split test, multivariate test, hypothesis, conversion funnel, funnel audit, experiment design, statistical significance, lift, optimization. Also triggers when the user has a conversion problem and isn't sure where to start, or when test results are ambiguous and need interpretation."
+category: growth
+catalog_summary: "Hypothesis-driven testing, conversion optimization"
+display_order: 2
 ---
 
 # CRO Optimization

--- a/skills/dependency-management/SKILL.md
+++ b/skills/dependency-management/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dependency-management
 description: "Manage third-party libraries, runtimes, and SaaS dependencies. Use this skill when setting an update cadence, responding to security advisories, dealing with deprecated dependencies, evaluating new dependencies, auditing what's installed, or unblocking a dependency upgrade. Triggers on dependency, package update, security patch, lockfile, deprecated, breaking change, supply chain, dependency audit, npm audit, dependabot, renovate. Also triggers when a build breaks after an update or when an advisory is published for a used package."
+category: cross-cutting
+catalog_summary: "Package updates, security patches, lockfile hygiene"
+display_order: 4
 ---
 
 # Dependency Management

--- a/skills/design-standards/SKILL.md
+++ b/skills/design-standards/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: design-standards
 description: "Apply production-grade design standards when building or reviewing pages, components, or UI. Use this skill whenever the user asks to build a page, design a component, lay out a section, review the UI, fix the layout, or check design quality. Triggers on build a page, create a component, design a section, hero, card, CTA, layout, review the UI, fix the design, design system, design tokens, spacing, typography scale, button standards, mobile design. Also triggers for any production design decision where contrast, accessibility, spacing, or visual hierarchy matters."
+category: design
+catalog_summary: "Production-grade page and component design standards"
+display_order: 2
 ---
 
 # Design Standards

--- a/skills/design-system/SKILL.md
+++ b/skills/design-system/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: design-system
 description: "Build or audit a design system including component library, design tokens, naming conventions, contribution model, and documentation. Use this skill whenever the user wants to build a design system, audit an existing system, define design tokens at the system level, structure a component library, or set up design system governance. Triggers on design system, component library, design tokens, atomic design, atoms, molecules, organisms, design system documentation, Storybook, Figma library, system governance, design contribution model. Also triggers when teams are inconsistent across products and a system is the answer."
+category: design
+catalog_summary: "Component library, design tokens, design system documentation"
+display_order: 1
 ---
 
 # Design System

--- a/skills/documentation-strategy/SKILL.md
+++ b/skills/documentation-strategy/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: documentation-strategy
 description: "Design and run a documentation system for a team or product. Use this skill when planning what to document, choosing a documentation tool, organizing existing docs, fixing stale documentation, designing a maintenance cadence, or scoping technical writing work. Triggers on documentation, docs, tech writing, knowledge base, wiki, runbook, README, internal docs, doc audit, doc maintenance, stale docs, where do we document. Also triggers when the team is repeatedly answering the same questions or when onboarding takes too long."
+category: process-and-team
+catalog_summary: "Documentation systems, what to document, maintenance cadence"
+display_order: 2
 ---
 
 # Documentation Strategy

--- a/skills/domain-strategy/SKILL.md
+++ b/skills/domain-strategy/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: domain-strategy
 description: "Plan, manage, and optimize a domain portfolio. Use this skill for DNS architecture decisions, redirect strategies, registrar choice, parking unused domains, multi-site setups, and domain consolidation or split planning. Triggers on DNS, domain, registrar, redirect, parking, subdomain, apex, www vs non-www, multi-site, portfolio, hreflang setup, domain migration. Also triggers when planning a new site that needs domain decisions made before launch."
+category: operations
+catalog_summary: "DNS architecture, redirects, registrars, multi-domain portfolios"
+display_order: 4
 ---
 
 # Domain Strategy

--- a/skills/email-deliverability/SKILL.md
+++ b/skills/email-deliverability/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: email-deliverability
 description: "Make sure email actually reaches inboxes. Use this skill when setting up email authentication (SPF, DKIM, DMARC), diagnosing emails landing in spam, planning a domain reputation strategy, monitoring sender reputation, or hardening against email spoofing. Triggers on email deliverability, SPF, DKIM, DMARC, spam folder, sender reputation, mailbox provider, soft bounces, bounce rate, BIMI, MTA-STS, deliverability audit. Also triggers when a marketing or transactional email isn't reaching users."
+category: operations
+catalog_summary: "DMARC, SPF, DKIM, sender reputation, deliverability monitoring"
+display_order: 8
 ---
 
 # Email Deliverability

--- a/skills/email-sequences/SKILL.md
+++ b/skills/email-sequences/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: email-sequences
 description: "Design and write email campaigns and sequences including onboarding flows, lifecycle campaigns, transactional emails, newsletters, and broadcast sends. Use this skill whenever the user wants to write email copy, plan an email sequence, design an onboarding drip, or set up lifecycle email campaigns. Triggers on email sequence, drip campaign, onboarding email, lifecycle email, welcome email, transactional email, newsletter, email broadcast, nurture sequence, abandoned cart, re-engagement, win-back. Also triggers when planning email automation flows or writing email subject lines for campaigns."
+category: content
+catalog_summary: "Onboarding flows, lifecycle campaigns, transactional copy"
+display_order: 3
 ---
 
 # Email Sequences

--- a/skills/experiment-design/SKILL.md
+++ b/skills/experiment-design/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: experiment-design
 description: A discipline for designing experiments (A/B tests, multivariate, holdouts) so the results actually answer the question you asked. Hypothesis writing, sample size, duration, segment analysis, interpretation, decision-making, and the common failure modes that produce confidently wrong shipping decisions.
+category: product
+catalog_summary: "Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls"
+display_order: 4
 ---
 
 # Experiment Design

--- a/skills/experimentation-analytics/SKILL.md
+++ b/skills/experimentation-analytics/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: experimentation-analytics
 description: How to read experiment results without fooling yourself. Confidence intervals, p-values, multiple testing, sequential testing, CUPED, heterogeneous treatment effects, ratio metrics, network effects, dashboard reconciliation, and the interpretation failures that produce confidently wrong shipping decisions.
+category: product
+catalog_summary: "Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation"
+display_order: 6
 ---
 
 # Experimentation Analytics

--- a/skills/feature-flagging/SKILL.md
+++ b/skills/feature-flagging/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: feature-flagging
 description: Operational discipline for feature flags as production infrastructure. Flag types, naming, targeting rules, rollout strategy, lifecycle, governance, stale flag management, and the technical debt patterns that bite teams who weren't deliberate about it.
+category: product
+catalog_summary: "Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance"
+display_order: 5
 ---
 
 # Feature Flagging

--- a/skills/form-strategy/SKILL.md
+++ b/skills/form-strategy/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: form-strategy
 description: "Design forms that convert, validate well, resist spam, and integrate cleanly with downstream systems. Use this skill when designing or auditing any form (contact, signup, checkout, multi-step, embedded), planning validation logic, fighting spam, choosing form tooling, or improving form conversion. Triggers on form design, form validation, form conversion, multi-step form, form spam, captcha, honeypot, form abandonment, signup form, contact form. Also triggers when form completion rates are low or spam is overwhelming."
+category: cross-cutting
+catalog_summary: "Form design, validation patterns, spam prevention, conversion tuning"
+display_order: 1
 ---
 
 # Form Strategy

--- a/skills/frontend-component-build/SKILL.md
+++ b/skills/frontend-component-build/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: frontend-component-build
 description: "Build production-ready frontend components with accessible markup, sensible props, defined states, and tested behavior. Use this skill whenever the user wants to build a component from scratch, refactor an existing one, design a component API, or implement a UI element with proper states and accessibility. Triggers on build a component, create a button, create a modal, create a form input, component API, props design, component states, refactor component, accessible component. Also triggers when implementing UI from a design that needs to be reusable."
+category: development
+catalog_summary: "Component architecture, props design, accessibility from the start"
+display_order: 2
 ---
 
 # Frontend Component Build

--- a/skills/incident-response/SKILL.md
+++ b/skills/incident-response/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: incident-response
 description: "Manage active production incidents through detection, triage, mitigation, communication, and resolution with structured roles and decision-making. Use this skill whenever the user has an active incident, a production issue, a service outage, a security incident, or needs to plan incident response procedures. Triggers on incident response, production incident, outage, service down, site down, P0, P1, severity, downtime, on-call, incident commander, status page, postmortem prep. Also triggers when something is actively broken in production and the user is figuring out what to do."
+category: operations
+catalog_summary: "Incident triage, comms, mitigation, escalation"
+display_order: 2
 ---
 
 # Incident Response

--- a/skills/information-architecture/SKILL.md
+++ b/skills/information-architecture/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: information-architecture
 description: "Design the structure of a website or product including sitemap, navigation, URL structure, content types, taxonomy, and labeling. Use this skill whenever the user asks to plan a sitemap, design navigation, structure URLs, define content types, build taxonomies, design site search, or organize content at the system level. Triggers on sitemap, site structure, navigation, IA, information architecture, URL structure, content types, taxonomy, categorization, breadcrumbs, hub pages, faceted navigation, site search, labeling. Also triggers when content is being created without a structural plan, or when an existing site's structure is being audited or restructured."
+category: strategy-and-discovery
+catalog_summary: "Sitemap, navigation, URL structure, content types, taxonomy"
+display_order: 4
 ---
 
 # Information Architecture

--- a/skills/integration-orchestrator/SKILL.md
+++ b/skills/integration-orchestrator/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: integration-orchestrator
 description: "Generate a phased delivery orchestration plan for creative-direction-driven work, mapping which skills run when, what locks at which gate, how handoffs occur between phases, and how the cadence implements in the team's actual tools (Jira, Linear, Notion, Figma, GitHub) with AI agents participating via MCP and CLI. Distinct from `creative-brief` (static project brief) and `creative-direction` (aesthetic direction). This skill produces a temporal map: phase-by-phase cadence, lock points, handoff specs, gate definitions, automation and QA verification gates, and platform-specific implementation. Triggers on integration orchestrator, delivery cadence, project orchestration, when does the brief lock, how to phase creative direction, brand build cadence, rebrand timeline, campaign delivery plan, design-development handoff, brief freeze, identity gate, copy approval phase, QA gate, automated verification, MCP integration for project management, Claude Code workflow setup, agent-driven QA. Triggers when a team is starting a creative-direction project and needs to sequence the work, OR when a project is mid-flight and the cadence has broken (freeze points being unfrozen, parallel work getting out of sync), OR when a team is integrating AI agents into their existing PM workflow. Does NOT fire when the user needs project scoping (use `creative-brief`), aesthetic direction (use `creative-direction`), or general project management without a creative-direction throughline."
+category: product
+catalog_summary: "Sequence creative-direction work across phases, gates, handoffs, and QA verification"
+display_order: 3
 ---
 
 # Integration Orchestrator

--- a/skills/internationalization/SKILL.md
+++ b/skills/internationalization/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: internationalization
 description: "Plan and run a multi-language or multi-region site. Use this skill when adding new locales, choosing URL structure for languages (subfolders vs subdomains vs ccTLDs), implementing hreflang, planning translation workflow, handling currency and date formats, designing for RTL languages, or auditing a stalled internationalization rollout. Triggers on internationalization, i18n, localization, l10n, hreflang, multi-language, translation workflow, RTL, locale, ccTLD, subfolder vs subdomain, language switcher. Also triggers when international audiences underperform or translations are stale."
+category: cross-cutting
+catalog_summary: "Locale strategy, hreflang, translation workflow, RTL design"
+display_order: 3
 ---
 
 # Internationalization

--- a/skills/journey-mapping/SKILL.md
+++ b/skills/journey-mapping/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: journey-mapping
 description: "Build customer journey maps and service blueprints that visualize the end-to-end user experience including touchpoints, emotions, friction, and underlying systems. Use this skill whenever the user wants to map a customer journey, build a service blueprint, identify friction across an experience, align teams on the user experience, or visualize touchpoints and pain points. Triggers on customer journey, journey map, service blueprint, user journey, experience map, touchpoint analysis, friction map, journey audit, end-to-end experience, customer experience map. Also triggers when the team has departmental views of users but no shared map of what the experience actually feels like."
+category: research
+catalog_summary: "Customer journey maps, service blueprints, friction analysis"
+display_order: 3
 ---
 
 # Journey Mapping

--- a/skills/landing-page-copy/SKILL.md
+++ b/skills/landing-page-copy/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: landing-page-copy
 description: "Write landing page copy with attention to the hero, value proposition, social proof, objection handling, and conversion-focused CTAs. Use this skill whenever the user wants to write a landing page, sales page, hero section, or any conversion-focused web copy. Triggers on landing page, sales page, hero copy, value proposition, headline, subheadline, hero section, CTA copy, conversion copy, opt-in page, squeeze page. Also triggers when the user has a marketing campaign or product launch needing dedicated conversion copy."
+category: content
+catalog_summary: "Landing pages, sales pages, hero-to-CTA flow"
+display_order: 2
 ---
 
 # Landing Page Copy

--- a/skills/launch-runbook/SKILL.md
+++ b/skills/launch-runbook/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: launch-runbook
 description: "Plan and execute a launch runbook covering pre-launch verification, go-live procedures, DNS cutover, post-launch monitoring, and rollback procedures. Use this skill whenever the user is preparing to launch a website or product, planning a DNS cutover, building a go-live checklist, or executing a launch day. Triggers on launch runbook, go-live, launch day, DNS cutover, deploy to production, site launch, product launch, cutover plan, launch checklist, deployment procedure. Also triggers when a launch is approaching and the team needs structured coordination, even if 'runbook' is not explicitly stated."
+category: operations
+catalog_summary: "Go-live runbook, DNS cutover, deploy day procedures"
+display_order: 1
 ---
 
 # Launch Runbook

--- a/skills/logo-design/SKILL.md
+++ b/skills/logo-design/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: logo-design
 description: "Generate logo variants for a brand or organization, producing multiple production-grade marks across different architectures (wordmark, lockup, symbol-only, letterform-as-symbol, monogram) with rationale, application specs, and decision-ready presentation. Distinct from `brand-identity`, which produces a complete identity system covering logo plus color plus type plus voice plus applications. This skill goes deep on the logo specifically: typographic register selection, symbol approach taxonomy, application context discipline (16px favicon, embroidery, signage, motion), production specs (SVG-ready, single-color reproducibility, reverse versions). Triggers on logo design, design a logo, logo for X, brand mark, wordmark, logotype, monogram, lockup, mark variants, logo iterations, redesign the logo, refine the logo, logo refresh, letterform-as-symbol. Also triggers when the user has an established brand and wants to explore mark variants or when iterating on existing logo work for production. Does NOT fire when the user needs full brand identity (use `brand-identity`), brand positioning or strategy (use `brand-discovery`), project-wide creative direction (use `creative-direction`), or one-off illustration."
+category: brand
+catalog_summary: "Logo variants across architectures (wordmark, lockup, monogram, letterform-as-symbol), with rationale and application specs"
+display_order: 5
 ---
 
 # Logo Design

--- a/skills/media-asset-management/SKILL.md
+++ b/skills/media-asset-management/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: media-asset-management
 description: "Plan and run a media pipeline for images, video, and downloadable assets. Use this skill when designing image storage and delivery, choosing formats (WebP, AVIF), setting up responsive images, picking a video host, organizing a brand asset library, or auditing a slow image pipeline. Triggers on image pipeline, asset library, DAM, image optimization, WebP, AVIF, responsive images, video hosting, image CDN, asset workflow, media management. Also triggers when images are slow, broken, or scattered across systems."
+category: operations
+catalog_summary: "Image pipelines, video hosting, asset libraries, format selection"
+display_order: 9
 ---
 
 # Media Asset Management

--- a/skills/monitoring-and-alerting/SKILL.md
+++ b/skills/monitoring-and-alerting/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: monitoring-and-alerting
 description: "Design and run a monitoring system for a website or web app. Use this skill when setting up uptime checks, defining SLOs, configuring error tracking, choosing what to alert on, designing on-call rotations, or fixing alert fatigue. Triggers on monitoring, alerts, uptime, SLO, SLA, error rate, on-call, pager, alert fatigue, observability, dashboards, what should we monitor. Also triggers when an incident reveals a gap in monitoring."
+category: operations
+catalog_summary: "SLO design, uptime checks, alert routing, on-call rotations"
+display_order: 5
 ---
 
 # Monitoring and Alerting

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: performance-optimization
 description: "Diagnose and fix web performance issues including Core Web Vitals (LCP, INP, CLS), bundle size, asset optimization, render performance, and runtime efficiency. Use this skill whenever the user wants to improve page speed, fix Core Web Vitals, optimize assets, reduce bundle size, debug slow renders, or systematically improve a site's performance. Triggers on performance, page speed, Core Web Vitals, LCP, INP, CLS, FID, TTFB, bundle size, code splitting, image optimization, lazy loading, render blocking, slow page, performance audit, Lighthouse score. Also triggers when traffic or conversion is dropping due to perceived slowness."
+category: development
+catalog_summary: "Core Web Vitals, asset optimization, render performance"
+display_order: 4
 ---
 
 # Performance Optimization

--- a/skills/pm-spec-writing/SKILL.md
+++ b/skills/pm-spec-writing/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: pm-spec-writing
 description: "Translate ideas, feature requests, or vague concepts into specific, actionable dev briefs. Use this skill whenever the user has an idea they want to build, a feature to spec out, a bug to file, a project to scope, or needs to convert a half-formed idea into a clear implementation brief. Triggers on I want to add, we should build, can we make, what is the plan for, how do we implement, dev brief, feature spec, PRD, user story, acceptance criteria, scope this, prioritize. Also triggers when the user has a list of things they want to build and needs help converting them into well-formed tasks."
+category: product
+catalog_summary: "PRDs, user stories, acceptance criteria, dev briefs"
+display_order: 1
 ---
 
 # PM Spec Writing

--- a/skills/qa-testing/SKILL.md
+++ b/skills/qa-testing/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: qa-testing
 description: "Run QA testing on a page, feature, or full site at one of three depth tiers (smoke, standard, full). Use this skill whenever the user asks to test a page, audit a site, check for bugs, verify a deploy, run a QA sweep, or review accessibility, performance, or SEO basics. Triggers on test, QA, audit, verify, check, is it working, does it look right, broken, 404, image not loading, post-deploy check, regression test. Also triggers proactively after any significant code change or new page launch where verification matters."
+category: qa
+catalog_summary: "Pre-launch QA, regression testing, cross-browser checks"
+display_order: 1
 ---
 
 # QA Testing

--- a/skills/roadmap-planning/SKILL.md
+++ b/skills/roadmap-planning/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: roadmap-planning
 description: "Build a multi-quarter roadmap from a backlog of ideas, requests, and ongoing initiatives. Use this skill when planning the next quarter, sequencing dependent work, balancing build vs improve vs maintain, or making the case for what NOT to do. Triggers on roadmap, quarterly planning, what should we build next, sequencing, prioritization, OKR planning, capacity planning, what's on the roadmap, plan the year, what to ship next quarter. Also triggers when stakeholders are pulling in different directions and the team needs a defensible plan."
+category: product
+catalog_summary: "Quarterly planning, prioritization, dependency mapping"
+display_order: 2
 ---
 
 # Roadmap Planning

--- a/skills/security-baseline/SKILL.md
+++ b/skills/security-baseline/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: security-baseline
 description: "Establish a security baseline for a website or web app. Use this skill when configuring HTTPS and TLS, setting security headers, planning secrets management, evaluating CSP policies, doing a basic security audit, or hardening a site before launch. Triggers on security headers, HTTPS, TLS, CSP, content security policy, HSTS, secrets management, vulnerability scan, security audit, harden, OWASP, security baseline. Also triggers when a security review is required for compliance or before going live."
+category: operations
+catalog_summary: "HTTPS, security headers, CSP, secrets management, vulnerability scans"
+display_order: 7
 ---
 
 # Security Baseline

--- a/skills/seo-aeo-geo/SKILL.md
+++ b/skills/seo-aeo-geo/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-aeo-geo
 description: "Optimize content and site structure for AI-driven search experiences including AI overviews, large language model citations, generative answer engines, and AI assistants. Use this skill whenever the user wants to optimize for AI search, get cited by language models, appear in AI overviews, build llms.txt, structure content for AI extraction, or future-proof their SEO for the shift from blue links to AI answers. Triggers on AEO, GEO, AI search, AI SEO, AI overview, generative search, LLM optimization, llms.txt, AI citation, ChatGPT search, Perplexity, Gemini, Claude search, AI assistant optimization, answer engine. Also triggers when the user expresses concern about AI eating their organic traffic or wants to understand how to remain visible as search shifts."
+category: seo-foundation
+catalog_summary: "AI search optimization, llms.txt, extraction-friendly content"
+display_order: 7
 ---
 
 # AEO and GEO

--- a/skills/seo-audit-orchestration/SKILL.md
+++ b/skills/seo-audit-orchestration/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-audit-orchestration
 description: "Master orchestrator for a full SEO audit suite powered by the Ahrefs MCP. Use this skill when running a comprehensive SEO audit, scoping a quarterly health check, doing pre-acquisition SEO due diligence, or post-migration verification. Triggers on full SEO audit, comprehensive SEO review, SEO health check, audit my site, SEO due diligence, audit suite, comprehensive audit, end-to-end SEO. Also triggers when a stakeholder wants the complete picture rather than a single-dimension audit."
+category: seo-audit-suite
+catalog_summary: "Master orchestrator: sequences the suite, produces a rollup report"
+display_order: 1
 ---
 
 # SEO Audit Orchestration

--- a/skills/seo-backlink-audit/SKILL.md
+++ b/skills/seo-backlink-audit/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-backlink-audit
 description: "Audit a backlink profile using Ahrefs MCP data: profile health, anchor text distribution, toxic link identification, lost link reclamation, and gap analysis against competitors. Use this skill when reviewing backlink health, scoping a disavow project, recovering from a manual action, planning link building, or doing M&A due diligence on a property's link equity. Triggers on backlink audit, link profile, toxic links, disavow, anchor text analysis, lost links, link reclamation, referring domains, link gap. Also triggers when traffic decline correlates with link loss or when an unnatural link warning appears in Search Console."
+category: seo-audit-suite
+catalog_summary: "Profile health, anchor mix, toxic links, reclamation, gap analysis"
+display_order: 2
 ---
 
 # SEO Backlink Audit

--- a/skills/seo-competitor/SKILL.md
+++ b/skills/seo-competitor/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-competitor
 description: "Run a competitive SEO analysis comparing the user's site to chosen competitors across SERP overlap, content depth, backlink profiles, technical posture, and brand presence. Use this skill whenever the user wants to analyze competitors, find content gaps, identify backlink opportunities, understand why competitors outrank them, or benchmark against the rest of their category. Triggers on competitor analysis, competitive analysis, SERP analysis, content gap, backlink gap, why is X ranking, who is winning the SERP, beat my competitor, benchmark, market positioning. Also triggers when planning a content strategy and the question 'what are competitors doing' is implicit."
+category: seo-foundation
+catalog_summary: "SERP overlap, content gaps, backlink gaps, technical comparison"
+display_order: 4
 ---
 
 # SEO Competitor Analysis

--- a/skills/seo-content-audit/SKILL.md
+++ b/skills/seo-content-audit/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-content-audit
 description: "Audit existing content across a site to decide what to keep, update, merge, redirect, or delete. Use this skill whenever the user wants to audit existing content, fix content decay, resolve keyword cannibalization, prune underperforming pages, prioritize content updates, or apply a keep/update/merge/redirect/delete framework to a content library. Triggers on content audit, content decay, content refresh, cannibalization, keyword cannibalization, prune content, delete pages, redirect old pages, content inventory, what to keep, what to update, content scorecard, evergreen refresh. Also triggers when traffic is dropping site-wide and the cause might be content quality, even if 'audit' is not said explicitly."
+category: seo-foundation
+catalog_summary: "Keep/update/merge/redirect/delete decisions across a site"
+display_order: 6
 ---
 
 # Content Audit

--- a/skills/seo-content-gap-audit/SKILL.md
+++ b/skills/seo-content-gap-audit/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-content-gap-audit
 description: "Audit content gaps and decay using Ahrefs MCP data: missing topics, thin coverage, outdated content, and decaying pages. Use this skill when planning a content roadmap, refreshing a stale catalog, building topical authority, or identifying which existing pages need update versus replacement. Triggers on content gap, content audit, content refresh, content roadmap, decaying content, content decay, topical authority, what topics should we cover, where is competitor content stronger. Also triggers when organic traffic is flat despite consistent publishing."
+category: seo-audit-suite
+catalog_summary: "Missing topics, thin coverage, outdated content, decay diagnosis"
+display_order: 4
 ---
 
 # SEO Content Gap Audit

--- a/skills/seo-keyword-gap-audit/SKILL.md
+++ b/skills/seo-keyword-gap-audit/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-keyword-gap-audit
 description: "Find keywords competitors rank for that the target property does not, and prioritize them by opportunity. Uses Ahrefs MCP for keyword and competitor data. Use this skill when planning content investment, identifying quick wins, building a content calendar against a competitor set, or scoping a market entry. Triggers on keyword gap, content gap, competitor keywords, opportunity keywords, what should we target, where are competitors winning, keyword opportunity. Also triggers when planning content for a new market or after losing organic share to a specific competitor."
+category: seo-audit-suite
+catalog_summary: "Competitor keyword gaps with opportunity scoring and clustering"
+display_order: 3
 ---
 
 # SEO Keyword Gap Audit

--- a/skills/seo-keyword/SKILL.md
+++ b/skills/seo-keyword/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-keyword
 description: "Run keyword research, classify by search intent, cluster into topical groups, and prioritize for content production. Use this skill whenever the user asks to do keyword research, find target keywords, identify ranking opportunities, classify search intent, build a topical map, or plan a content strategy around what people search for. Triggers on keyword research, keyword strategy, search intent, keyword clustering, topic clusters, keyword difficulty, search volume, ranking opportunity, content gap, what should I write about, target keyword, primary keyword, secondary keyword, long-tail. Also triggers when planning a content calendar or new site without keywords yet defined."
+category: seo-foundation
+catalog_summary: "Discovery, intent classification, clustering, prioritization"
+display_order: 3
 ---
 
 # Keyword Research

--- a/skills/seo-offpage/SKILL.md
+++ b/skills/seo-offpage/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-offpage
 description: "Plan and execute off-page SEO including link building, digital PR, brand mentions, citation building, and external authority signals. Use this skill whenever the user wants to build backlinks, plan a digital PR campaign, list local citations, run guest post outreach, develop linkable assets, recover lost links, or audit a backlink profile for risk. Triggers on link building, backlinks, digital PR, brand mentions, citation building, guest post, outreach, linkable asset, broken link building, HARO, podcast outreach, off-page SEO, anchor text, link velocity, toxic backlinks, disavow. Also triggers when the user is trying to grow domain authority or earn coverage."
+category: seo-foundation
+catalog_summary: "Link building, digital PR, citations, linkable assets"
+display_order: 5
 ---
 
 # Off-Page SEO

--- a/skills/seo-onpage/SKILL.md
+++ b/skills/seo-onpage/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-onpage
 description: "Run a comprehensive on-page SEO audit or optimization pass covering title tags, meta descriptions, header structure, content quality, internal links, image optimization, URL hygiene, and on-page schema. Use this skill whenever the user asks to optimize a page, audit on-page SEO, fix titles or meta tags, review header structure, check internal linking, improve a single URL's search performance, or write SEO-friendly copy. Triggers on on-page SEO, page audit, title tag, meta description, H1, header structure, internal links, image alt, URL slug, page optimization, optimize this page, SEO this page. Also triggers for any single-page review where ranking, click-through, or relevance signal quality is the goal, even if the user does not say 'SEO' explicitly."
+category: seo-foundation
+catalog_summary: "Single-page audits and optimization across 8 dimensions"
+display_order: 1
 ---
 
 # On-Page SEO

--- a/skills/seo-rank-tracking/SKILL.md
+++ b/skills/seo-rank-tracking/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-rank-tracking
 description: "Set up and run rank tracking using Ahrefs MCP: pick the right keywords to track, segment them by purpose, set baselines, and define alert thresholds. Use this skill when starting a new tracking project, baselining for a campaign, choosing what to monitor, or building a rank reporting cadence. Triggers on rank tracking, keyword tracking, monitor rankings, track positions, what should we track, ranking dashboard, baseline rankings, alert thresholds. Also triggers when a stakeholder wants weekly or monthly ranking visibility."
+category: seo-audit-suite
+catalog_summary: "Setup, baseline, segmentation, alerting, dashboarding"
+display_order: 7
 ---
 
 # SEO Rank Tracking

--- a/skills/seo-site-health-audit/SKILL.md
+++ b/skills/seo-site-health-audit/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-site-health-audit
 description: "Triage technical SEO findings from Ahrefs Site Audit (and similar crawlers) by SEO impact, not just severity. Use this skill when reviewing crawl results, prioritizing technical fixes, scoping a technical SEO sprint, or after running any site-wide crawl. Triggers on site audit results, technical fix list, crawl errors, technical SEO triage, prioritize technical issues, what should we fix first, broken links, redirect chains. Also triggers when a long list of crawler issues is creating decision paralysis."
+category: seo-audit-suite
+catalog_summary: "Triage Ahrefs Site Audit findings by SEO impact, not severity"
+display_order: 6
 ---
 
 # SEO Site Health Audit

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-technical
 description: "Run a comprehensive technical SEO audit covering crawlability, indexability, rendering, site architecture, structured data, page experience, security, and internationalization. Use this skill whenever the user asks about technical SEO, crawl issues, indexing problems, sitemaps, robots.txt, canonical tags, schema markup, page speed, Core Web Vitals, hreflang, redirects, or site-wide search performance. Triggers on technical SEO, site audit, crawlability, indexability, sitemap, robots.txt, canonical, redirect chain, schema, JSON-LD, Core Web Vitals, page speed, hreflang, mobile usability, HTTPS, security headers, render-blocking, JavaScript SEO. Also triggers when a site has indexing problems, traffic drops, or migration concerns, even if 'technical SEO' is not said explicitly."
+category: seo-foundation
+catalog_summary: "Crawlability, indexability, rendering, schema, page experience"
+display_order: 2
 ---
 
 # Technical SEO

--- a/skills/seo-traffic-diagnosis/SKILL.md
+++ b/skills/seo-traffic-diagnosis/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: seo-traffic-diagnosis
 description: "Diagnose organic traffic changes (drops, stalls, or unexpected wins) using Ahrefs MCP plus Search Console data. Use this skill when traffic suddenly dropped, has been flat despite investment, after an algorithm update, after a migration or deploy, or when a competitor seems to be taking share. Triggers on traffic dropped, traffic decline, traffic stalled, organic decline, lost rankings, why is traffic down, algorithm update, post-migration traffic loss, traffic diagnosis. Also triggers when stakeholders are panicking about analytics."
+category: seo-audit-suite
+catalog_summary: "Diagnose drops, stalls, or wins via 5-layer root cause analysis"
+display_order: 5
 ---
 
 # SEO Traffic Diagnosis

--- a/skills/skill-creation-walkthrough/SKILL.md
+++ b/skills/skill-creation-walkthrough/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: skill-creation-walkthrough
 description: Step-by-step guide for creating your own Claude Skills, from deciding whether a skill is the right tool to writing the SKILL.md file, structuring reference material, and making it trigger reliably. Use when you want to package a workflow, framework, or repeated task into a reusable Skill, when an existing skill is not triggering or not loading the right context, when you are auditing a skill that is underperforming, or when you want to publish a skill for others. Also triggers when someone asks "how do I make a skill" or "what makes a good skill". Useful for individuals, teams, and anyone publishing skills publicly.
+category: process-and-team
+catalog_summary: "The meta-skill: how to write your own custom skills"
+display_order: 5
 ---
 
 A walkthrough for designing, writing, and maintaining your own Claude Skills. Covers when a skill is the right shape for your problem, how to write a description that actually triggers, how to structure SKILL.md and references, and how to test and iterate.

--- a/skills/stakeholder-communication/SKILL.md
+++ b/skills/stakeholder-communication/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: stakeholder-communication
 description: "Communicate effectively with stakeholders across functions and seniority levels. Use this skill when writing status updates, preparing executive reviews, sharing technical decisions with non-technical audiences, managing up, communicating bad news, or designing the communication cadence for a project. Triggers on stakeholder update, status report, executive summary, exec review, manage up, communicate bad news, project comms, status meeting, weekly update. Also triggers when a project is going off track and the team needs to communicate it."
+category: process-and-team
+catalog_summary: "Status updates, exec readouts, project communications"
+display_order: 1
 ---
 
 # Stakeholder Communication

--- a/skills/team-onboarding-playbook/SKILL.md
+++ b/skills/team-onboarding-playbook/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: team-onboarding-playbook
 description: Design a structured onboarding experience that gets new team members productive in 30, 60, and 90 days. Use when a new hire is joining, when contractors or agency partners need to ramp up, when an existing team is restructuring and members are switching focus, or when current onboarding feels chaotic and slow. Also triggers when one person owns all the tribal knowledge and you need to capture it, when you keep losing people in their first 90 days, or when a new project has many fresh members joining at once. Useful for engineering, design, product, marketing, and operations roles.
+category: process-and-team
+catalog_summary: "30-60-90 onboarding plans for new hires and contractors"
+display_order: 4
 ---
 
 A repeatable framework for building an onboarding playbook that ramps new team members predictably without burning out the people training them.

--- a/skills/usability-testing/SKILL.md
+++ b/skills/usability-testing/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: usability-testing
 description: "Plan and run usability tests on existing or prototype designs including test design, task scripts, moderation, observation, and findings synthesis. Use this skill whenever the user wants to test usability, run a moderated test, run an unmoderated test, validate a design, find usability issues, or improve task completion. Triggers on usability test, usability testing, moderated test, unmoderated test, task script, think aloud, prototype testing, user testing, design validation, task completion. Also triggers when the user has built something and wants to know if real users can use it before shipping."
+category: research
+catalog_summary: "Test design, moderation, findings reports"
+display_order: 2
 ---
 
 # Usability Testing

--- a/skills/ux-research/SKILL.md
+++ b/skills/ux-research/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: ux-research
 description: "Plan and execute user research including research planning, recruiting, interview design, qualitative synthesis, and translating findings into product decisions. Use this skill whenever the user wants to plan user research, design interviews, recruit participants, conduct discovery, run formative research, or synthesize qualitative findings. Triggers on user research, UX research, user interviews, discovery research, generative research, formative research, qualitative research, user insights, research synthesis, recruitment, interview guide, jobs to be done. Also triggers when product decisions are being made without user input and the user wants to fix that."
+category: research
+catalog_summary: "Research planning, user interviews, qualitative synthesis"
+display_order: 1
 ---
 
 # UX Research

--- a/skills/vendor-evaluation/SKILL.md
+++ b/skills/vendor-evaluation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: vendor-evaluation
 description: "Evaluate, select, and contract with vendors and SaaS tools. Use this skill when comparing alternatives, running an RFP, scoring vendors against criteria, negotiating contracts, planning a switch, or assessing a vendor's risk. Triggers on vendor evaluation, RFP, vendor selection, build vs buy, SaaS evaluation, vendor scorecard, vendor comparison, contract negotiation, vendor switch, procurement. Also triggers when a renewal is coming up or when a tool isn't meeting expectations."
+category: process-and-team
+catalog_summary: "Tool and vendor selection using a structured rubric"
+display_order: 3
 ---
 
 # Vendor Evaluation


### PR DESCRIPTION
## Summary

Replaces the hand-edited README catalog with build-time generation from SKILL.md frontmatter.

- New script: `scripts/generate_readme_catalog.py` (walks `skills/`, parses frontmatter, produces the catalog markdown plus count strings)
- New lint rule: `check_readme_catalog_generated` (runs the generator in `--check` mode; CI fails on stale README)
- New SKILL.md frontmatter fields: `category`, `catalog_summary`, `display_order`
- All 65 existing SKILL.md files retrofitted
- `CONTRIBUTING.md` and `SKILL_AUTHORING.md` updated for the new flow

Eliminates the parallel-PR conflict class on `README.md` that caused PR #9 (stale-base duplicate) and PR #12 (bad rebase that dropped feature-flagging) friction. Future skill PRs only touch the skill folder; the generator handles README updates.

## Marker pairs in README.md

The generator owns content between these pairs:

- `<!-- COUNT_BADGE:START -->` / `<!-- COUNT_BADGE:END -->`
- `<!-- COUNT_INTRO:START -->` / `<!-- COUNT_INTRO:END -->`
- `<!-- COUNT_WHATYOUGET:START -->` / `<!-- COUNT_WHATYOUGET:END -->`
- `<!-- COUNT_TOC:START -->` / `<!-- COUNT_TOC:END -->`
- `<!-- COUNT_CATALOG_HEADER:START -->` / `<!-- COUNT_CATALOG_HEADER:END -->`
- `<!-- COUNT_CATALOG_INTRO:START -->` / `<!-- COUNT_CATALOG_INTRO:END -->`
- `<!-- CATALOG:START -->` / `<!-- CATALOG:END -->`

## Quality gates

- Lint passes 65 skills with the new rule
- Generator is idempotent (running `--write` twice produces no diff)
- Em-dash and forbidden-phrase audit zero on new content
- Real-firm scrub clean

## Test plan

- [ ] CI lint job passes (includes the new `check_readme_catalog_generated` rule)
- [ ] `python scripts/generate_readme_catalog.py --check` exits 0 on the merged main
- [ ] `python scripts/generate_readme_catalog.py --write` is idempotent on the merged main
- [ ] Catalog renders correctly in the GitHub "Files changed" view