### PR TITLE
feat(skills): add experimentation-platform-orchestrator (10th flagship, completes PM-experimentation suite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 <!-- COUNT_BADGE:START -->
-[![Skills](https://img.shields.io/badge/Skills-65-blue.svg)](#the-65-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-66-blue.svg)](#the-66-skill-catalog)
 <!-- COUNT_BADGE:END -->
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
@@ -21,7 +21,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 65 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 66 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -37,7 +37,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 65-skill catalog](#the-65-skill-catalog)
+- [The 66-skill catalog](#the-66-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -65,8 +65,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **65 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
-- **132 reference files** (templates, checklists, decision matrices, worked examples)
+- **66 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
+- **139 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -255,11 +255,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 65-skill catalog
+## The 66-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 65 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 66 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -328,7 +328,7 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 29 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
 | 30 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
-### Product (6)
+### Product (7)
 
 | # | Skill | What it does |
 |---|---|---|
@@ -338,70 +338,71 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 34 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
 | 35 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
 | 36 | [`experimentation-analytics`](skills/experimentation-analytics/SKILL.md) | Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation |
+| 37 | [`experimentation-platform-orchestrator`](skills/experimentation-platform-orchestrator/SKILL.md) | Pick the right experimentation platform, migrate when wrong, coordinate when multi-platform: a decision framework for Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 37 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 38 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 39 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 40 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 38 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 39 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 40 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 41 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 41 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 42 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 42 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 43 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 44 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 45 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 46 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 47 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 48 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 49 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 50 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 43 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 44 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 45 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 46 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 47 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 48 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 49 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 50 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 51 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 51 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 52 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 52 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 53 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 53 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 54 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 55 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 54 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 55 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 56 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 56 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 57 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 58 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 59 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 60 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 57 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 58 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 59 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 60 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 61 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 61 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 62 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 63 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 64 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 65 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 62 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 63 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 64 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 65 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 66 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/skills/experimentation-platform-orchestrator/SKILL.md
+++ b/skills/experimentation-platform-orchestrator/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: experimentation-platform-orchestrator
+description: "A platform decision framework for experimentation. When to use Statsig vs PostHog vs GrowthBook vs Optimizely vs Amplitude vs Eppo vs Kameleoon. How to migrate between them. How to coordinate when multi-platform is genuinely warranted. The decisions that compound for years and the ones you can defer. Triggers on which experimentation platform, choose Statsig vs PostHog, evaluate experimentation tools, switch experimentation platform, migrate from Optimizely, consolidate experimentation tools, multi-platform experimentation, experimentation platform decision, ab test platform selection, feature flag platform vs experiment platform, warehouse-native experiments, vendor lock-in experimentation. Also triggers when a team is asking about cost, governance, or migration cost across experimentation tools, or when an evaluation is starting."
+category: product
+catalog_summary: "Pick the right experimentation platform, migrate when wrong, coordinate when multi-platform: a decision framework for Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon"
+display_order: 7
+---
+
+# Experimentation Platform Orchestrator
+
+A senior product and engineering leader's playbook for making the experimentation platform decision and recovering from making it wrong.
+
+Picking an experimentation platform is one of those decisions that looks easy at the start and compounds for years afterward. The wrong choice costs you in lost experiments (because the team avoids the painful workflow), in cost (because the wrong pricing model penalizes your usage shape), in vendor lock-in (because migration is real engineering work, not a config change), and in cultural drift (because the platform's defaults shape what your team thinks experimentation is).
+
+This skill is the discipline that makes the decision well the first time and the migration plan when you didn't.
+
+When to use this skill: choosing a platform from scratch, evaluating whether to switch, deciding whether to consolidate from multi-platform to single, or planning a migration that has already been approved.
+
+---
+
+## What this skill is for
+
+This skill spans platform selection, multi-platform decisions, migration planning, and governance setup. It does not cover experiment design (use `experiment-design`), result interpretation (use `experimentation-analytics`), or feature flag operations (use `feature-flagging`). Pair this skill with the relevant integrations microsite when you need platform-specific MCP details.
+
+The audience is a PM, engineering leader, or data lead who is making the decision or recovering from a previous one. The voice is decisive. There is no "it depends, evaluate them all yourself." The decision space has real shape, and a senior advisor can map your situation to a defensible answer in an afternoon.
+
+---
+
+## The 7 considerations for the platform decision
+
+Every platform evaluation walks the same seven questions. Answer them honestly first, then read the per-platform profiles, then consult the decision matrix. The order matters: data architecture and statistical rigor are foundational; the rest are layered on top.
+
+1. **Data architecture.** Where does experiment data live? Three patterns. Vendor-native (Statsig, Optimizely) keeps the data in the vendor's storage. Product-suite (PostHog, Amplitude) combines analytics and experiments behind one event pipeline. Warehouse-native (GrowthBook, Eppo) runs SQL on your existing data warehouse. The pattern dictates security review depth, residency, statistical depth, and cost shape.
+
+2. **Statistical rigor.** Does the platform implement CUPED, sequential testing, the delta method for ratio metrics, and multiple testing corrections? Cheap to verify in a sales call: ask "what variance estimator do you use for ratio metrics?" and "do you support always-valid p-values?" Modern platforms (Statsig, Eppo, parts of PostHog) have these. Older or homegrown platforms often do not.
+
+3. **MCP availability.** All seven platforms covered here have a first-party or hosted MCP except Eppo (as of May 2026). MCP availability matters more for agentic workflows where AI agents create and read experiments end to end. It matters less for traditional human-driven experimentation. Worth weighting if your team is AI-forward.
+
+4. **Feature flag integration.** Do experiments and feature flags live in the same platform? Statsig, Optimizely, GrowthBook, and PostHog all unify them. Eppo is experiment-only. Kameleoon is creative-personalization-focused. If you also need feature flag operations as production infrastructure, check `feature-flagging` for the operational discipline; the platform choice has to support both surfaces or you accept a second tool.
+
+5. **Analytics depth.** Can you see funnels, retention, and cohorts in the same surface as experiment results? PostHog and Amplitude are strongest here (analytics-first products). Statsig has a strong analytics overlay. Optimizely and GrowthBook are experiment-first, with analytics as a supplementary feature.
+
+6. **Governance and audit.** Who can change targeting in production, who can ship experiments, who can read sensitive metrics? Enterprise tiers (Optimizely, LaunchDarkly Federal) handle this with maturity. Open-source platforms (GrowthBook, PostHog self-hosted) require self-built governance. For regulated industries (healthcare, finance, public sector), this question is the deciding factor.
+
+7. **Cost shape.** Vendor-native scales with events. Warehouse-native scales with seats and warehouse compute. Product-suite scales with combined event volume across all features. Match the pricing shape to your actual usage shape. A high-traffic startup pays vendor-native pricing differently from a lower-traffic enterprise; pick the shape that is friendly to your trajectory, not just your current month.
+
+---
+
+## Statsig
+
+Modern experimentation and feature management combined in one platform. CUPED and sequential testing built in. Strong PM-led ergonomics. Used by OpenAI, Notion, Brex, Figma.
+
+**Strengths.** Fast time to first experiment. Combined experiments and feature flags eliminate the second-tool tax. Statistical rigor is current with the literature. The MCP exposes full CRUD across experiments, gates, dynamic configs, and metrics.
+
+**Gotchas.** Pricing scales with events, which can become expensive at high scale. The platform has strong opinions about how experiments should run; teams that want a custom statistical workflow will fight the defaults. Self-host is not a first-class option.
+
+**Ideal customer.** Fast-growing SaaS that wants one platform for flags and experiments, values out-of-the-box statistical depth, and is comfortable with vendor-native data architecture.
+
+---
+
+## PostHog
+
+Open-source product OS combining product analytics, experiments, feature flags, surveys, session replays, error tracking, and LLM analytics. Free tier available.
+
+**Strengths.** Full-funnel context. Experiments live next to the analytics that contextualize them. The MCP exposes 200+ tools (use scoping like `?features=` to keep the agent context tight). Self-host option is mature. Open-source license keeps you outside the vendor lock-in trap.
+
+**Gotchas.** Combined event volume across all features can make pricing surprising at scale. The breadth of features can make onboarding feel busy. Statistical depth in experiments is good but a step behind dedicated experiment platforms (Statsig, Eppo) on advanced features like CUPED defaults.
+
+**Ideal customer.** Product-led-growth SaaS that wants analytics, experiments, and feature flags in one surface, values open-source flexibility, and is comfortable with the breadth.
+
+---
+
+## GrowthBook
+
+Open-source warehouse-native experimentation. Data stays in your warehouse (Snowflake, BigQuery, Redshift, Postgres). Self-host or cloud.
+
+**Strengths.** Data sovereignty. Cost control at scale because the warehouse is already paid for. First open-source production MCP for experimentation per their announcement. Mature statistical defaults including Bayesian and frequentist toggles. Bring-your-own metrics from the warehouse means experiment metrics match analytics metrics by definition.
+
+**Gotchas.** Setup overhead is higher than vendor-native. You own the warehouse compute cost (this is usually a feature, not a bug, but it shows up in different finance line items). Smaller community than Statsig or PostHog. UI polish lags vendor platforms by half a step.
+
+**Ideal customer.** Data-mature teams that already run a warehouse, regulated industries that need data residency, and teams that prefer open-source for the exit option.
+
+---
+
+## Optimizely
+
+Long-time enterprise leader. Web Experimentation plus Feature Experimentation. Strong personalization and visual editing for non-technical users.
+
+**Strengths.** Enterprise governance is mature. Visual editing lets marketers ship experiments without engineer help. Strong customer success organization. Hosted Remote MCP works in browser-based ChatGPT and Claude.ai.
+
+**Gotchas.** Expensive. Pricing targets marketing budgets, not engineering budgets. The product has decades of accumulated features; navigating it takes time. Statistical defaults are conservative but the platform is not the place to look for the latest variance reduction techniques.
+
+**Ideal customer.** Marketing-led organizations, enterprises with mature experimentation programs, and teams where non-technical experiment creation is a hard requirement.
+
+---
+
+## Amplitude
+
+Behavioral analytics platform with experiments and feature flags as additional features. Hosted MCP available to all customers including the free tier.
+
+**Strengths.** If your team already lives in Amplitude for analytics, adding experiments is the path of least resistance. Cohort and behavioral segmentation are excellent. Free tier (10M events/month) is generous.
+
+**Gotchas.** Experiments are a secondary feature, not the headline. Statistical depth is moderate. If experimentation is your team's primary discipline, Amplitude is rarely the right choice; if experimentation is a supporting capability and analytics is the headline, it works.
+
+**Ideal customer.** Analytics-first teams that need experiments as a supplementary capability, not the centerpiece. Pre-PMF teams that want a free tier with analytics and experiments together.
+
+---
+
+## Eppo
+
+Warehouse-native, statistically rigorous, used by Twitch, DraftKings, Perplexity. Strong statistical defaults including Bayesian and frequentist toggles, sequential testing, and CUPED.
+
+**Strengths.** Statistical correctness is the headline. The team is heavy on data scientists and statisticians, and it shows in the defaults. Warehouse-native architecture matches the pattern data-mature teams already run. Reporting is clear and oriented to decisions.
+
+**Gotchas.** No first-party MCP as of May 2026. REST API only. If your workflow depends on AI agents reading and writing experiments, Eppo is currently a gap. Track for a future MCP release. Pricing is enterprise; no meaningful free tier.
+
+**Ideal customer.** Data-team-led organizations where statistical correctness is paramount, the warehouse is already the system of record, and AI agent workflows are a future concern rather than a current requirement.
+
+---
+
+## Kameleoon
+
+Specialty platform focused on the winning-experiment-to-production-code workflow. AI-driven personalization. Hosted MCP at `mcp.kameleoon.com/mcp` with OAuth and 7 specialized tools.
+
+**Strengths.** Converts marketing-site experiment wins into permanent React components, which is a real workflow that other platforms force teams to handle manually. AI-driven personalization for content sites. The MCP is purpose-built for the win-to-code path.
+
+**Gotchas.** Narrower than the others. Not a replacement for Statsig or Optimizely on product experiments. Often shows up alongside another platform rather than as the primary.
+
+**Ideal customer.** Teams running experiments on marketing or content sites that need the winning variant to become permanent code. Almost always layered with a primary product-experiment platform.
+
+---
+
+## Decision matrix: which platform for which context
+
+The matrix lives in `references/platform-decision-matrix.md` with worked examples. The summary:
+
+- Pure SaaS, fast-growing, want one platform for flags and experiments. Choose Statsig. Choose PostHog if you also want analytics.
+- Open-source preference, want data sovereignty, warehouse-native. Choose GrowthBook or Eppo.
+- Enterprise, marketing-led, deep personalization. Choose Optimizely.
+- Already deeply on Amplitude for analytics. Stay on Amplitude unless statistical depth becomes the bottleneck.
+- Data-team-led, statistical correctness paramount, MCP not yet required. Choose Eppo.
+- Need to convert marketing-site wins into production code. Add Kameleoon alongside your primary platform.
+- Regulated industry (HIPAA, FedRAMP), self-hosting required. Choose GrowthBook self-hosted. PostHog self-hosted is also viable.
+- Pre-PMF startup, low traffic, need a free tier. Use PostHog free tier or Statsig free tier; defer the real decision until traffic justifies the cost calculation.
+- 100M+ events per month, cost control is the headline constraint. Choose GrowthBook or Eppo. Warehouse-native pricing scales better at this volume.
+- AI-forward team, MCP-first workflow. Choose Statsig, PostHog, or Optimizely. Defer Eppo until its MCP ships.
+
+---
+
+## Multi-platform: when warranted, when a mess
+
+Multi-platform is warranted when the surfaces are genuinely different and the platforms overlap zero. Marketing site personalization on Kameleoon plus product experiments on Statsig is a clean split: different surface, different audience, different metric set, no overlap. The cost of the second tool is justified because the workflows do not collide.
+
+Multi-platform is a mess when the surfaces overlap. Running both Statsig and Optimizely for product experiments creates duplicate cost, split data, and a "which one is the source of truth" problem that surfaces in the worst possible moment, which is when a leadership disagreement needs an answer.
+
+The 80/20 rule. Eighty percent of teams should pick one platform and consolidate. The 20% with genuine multi-surface needs (marketing site plus product app plus content site) can justify multi-platform with clear ownership boundaries.
+
+When multi-platform is genuine, three coordination patterns are non-negotiable. An ownership matrix names which platform owns which surface. Shared metric definitions ensure that "activation rate" computes the same way in both platforms (this is hard, and it is the reason most multi-platform setups quietly drift). Reconcilable dashboards let you see the same metric across both platforms with the same definitions. Detail in `references/multi-platform-orchestration.md`.
+
+---
+
+## Migration patterns
+
+Migration is the unglamorous engineering work that makes the platform decision recoverable. Five common paths.
+
+**Statsig to PostHog.** Typical when a company outgrows pure experimentation and wants analytics plus experiments combined. Effort: 3 to 5 engineer-weeks. Parallel-run for 4 to 8 weeks, validate experiments produce the same results on both, cut over once trust is established.
+
+**Optimizely to Statsig.** Typical under budget pressure or modernization. Effort: 4 to 8 engineer-weeks. Audit for feature parity first (Optimizely has personalization features Statsig does not). Migrate experiments before flags. Retire Optimizely only after all in-flight experiments complete on the old platform.
+
+**PostHog to Eppo.** Typical when statistical rigor becomes the binding constraint and the warehouse is already the system of record. Effort: 6 to 10 engineer-weeks. Often results in PostHog staying for analytics and Eppo running experiments. Plan for the dual-platform end state, not a clean replacement.
+
+**GrowthBook to Eppo.** Typical when commercial support and deeper statistical features become worth the price. Effort: 2 to 4 engineer-weeks because both are warehouse-native; the data already lives in your stack.
+
+**Any to Statsig.** Typical consolidation move from multi-platform mess. Effort scales with the number of platforms and in-flight experiments; a clean consolidation can run 6 to 12 engineer-weeks.
+
+The migration discipline is in `references/migration-playbook.md`. Three rules apply to every migration: do not parallel-run forever, do not big-bang switch, and do not retire the old platform before all in-flight experiments complete.
+
+---
+
+## The cost reality
+
+Plain talk. Vendor-native (Statsig, Optimizely) bills on events, typically $0.10 to $0.50 per million events. Easy to predict at small scale, painful at very high scale. Warehouse-native (Eppo, GrowthBook paid) bills on seats and warehouse compute; $5K to $50K per year is the typical range for paid tiers, with warehouse compute showing up on a different finance line. Product-suite (PostHog, Amplitude) bills on combined event volume across all features; often the most cost-effective when used heavily and the most expensive when only experiments are needed.
+
+Free tiers. PostHog gives 1M events per month free. Statsig gives 1M events free. Amplitude gives 10M events per month free with basic features. GrowthBook is free open-source. Optimizely and Eppo do not have meaningful free tiers.
+
+The trap. Optimizing for sticker price ignores total cost. Total cost includes engineer time, statistical correctness (a wrong-result experiment can cost more than a year of platform fees), governance overhead, and migration risk. Sticker price matters for finance; total cost matters for product velocity. Detail and finance conversation patterns in `references/cost-and-pricing-models.md`.
+
+---
+
+## Governance and team fit
+
+Permission tiers, approval workflows, audit trails, and environment promotion are the four pillars of governance. Who creates experiments, who modifies targeting in production, who reads sensitive metrics, who approves a rollout. Enterprise tiers handle these out of the box. Open-source self-hosted requires you to build them, which is fine if you have the engineering capacity and a dealbreaker if you do not.
+
+Team fit shapes the decision more than most evaluations admit. PostHog and GrowthBook suit engineer-led and PLG teams. Optimizely suits marketing-led teams. Eppo and GrowthBook suit data-team-led teams. Statsig suits PM-led teams. The platform's defaults will pull your team's experimentation culture in the direction of its primary user; pick the alignment that matches who you actually want running experiments.
+
+Onboarding cost. How long until a new PM can ship their first experiment? Statsig and PostHog: hours to days. Optimizely: days to weeks. Eppo and GrowthBook: depends on whether the warehouse and metrics are already wired in (days if yes, weeks if no). Detail in `references/governance-and-team-setup.md`.
+
+---
+
+## The MCP capability layer
+
+For AI-forward teams, the MCP capability layer is becoming the deciding factor. The current state as of May 2026:
+
+- All seven covered platforms have first-party or hosted MCPs, with the exception of Eppo. Eppo offers REST API only.
+- Capability differs by an order of magnitude. PostHog exposes 200+ tools; Kameleoon exposes 7. More is not better; the right size depends on your workflow.
+- For agentic workflows where AI agents run experiments end to end, prefer platforms with full CRUD via MCP: Statsig, PostHog, GrowthBook, Optimizely.
+- For human-driven workflows where MCP supplements human action, any of the seven works (Eppo via the REST path).
+
+MCP availability is evolving fast. Check the current state of any platform before committing. Eppo is worth tracking for a future MCP release that would close its current gap. Side-by-side capability matrix in `references/mcp-capability-comparison.md`.
+
+---
+
+## When to defer the decision
+
+Sometimes the right answer is "not now." Four cases.
+
+Pre-PMF. Experimentation infrastructure is premature. Use a free tier (PostHog or Statsig) to remove blockers, defer the real decision until you have enough traffic to make any platform meaningful.
+
+Single-experiment validation. Do not pick a platform for one experiment. Use whatever is free and easy. The platform decision is for the team that runs experiments as a discipline, not the team running its first.
+
+No experimentation culture yet. Tooling does not fix culture. If your team is not running experiments, picking a fancy platform will not change that. Build the culture first; the platform decision becomes obvious once experiments are flowing.
+
+Pending acquisition or major pivot. Defer until the dust settles. The acquirer will likely have a preferred platform anyway.
+
+---
+
+## Common mistakes
+
+Twelve patterns recur across platform decisions. The short version:
+
+- Picked the cheapest. Total cost dominates sticker price.
+- Picked the most-featured. Features you do not use are technical debt.
+- Tried multi-platform first. Almost always becomes a consolidation project later.
+- Outgrew the platform but stayed for migration cost. The platform tax compounds; migration cost is fixed.
+- Picked based on a demo. Demos optimize for the show; real usage reveals real tradeoffs.
+- Did not check governance. Discovered after rollout that anyone can modify production targeting.
+- Picked a platform that does not fit team type. PM-led team on a marketing-led platform is constant friction.
+- Underestimated the warehouse setup. Warehouse-native platforms expect the warehouse to already be there.
+- Skipped statistical depth review. Then a critical experiment surfaced a wrong-result decision.
+- Ignored MCP trajectory. Picked a platform without MCP for an AI-forward team.
+- Locked the brief on the demo, not the trial. Brief assumptions did not survive contact with real usage.
+- Renewed without re-evaluating. The market changed; the brief did not.
+
+Detail in `references/common-mistakes.md` with symptoms, root causes, fixes, and prevention.
+
+---
+
+## The framework: 11 considerations for sustainable platform choice
+
+When choosing or evaluating an experimentation platform, walk these 11 considerations. Answer each one before reaching a recommendation. Skipping any of them is how teams end up in a migration project a year later.
+
+1. **Data architecture.** Vendor-native, product-suite, or warehouse-native. The pattern is downstream of every other decision.
+2. **Statistical rigor.** CUPED, sequential testing, delta method for ratio metrics, multiple testing corrections. Verify at the sales-call level; do not assume.
+3. **MCP availability.** Current capability and trajectory. Weight higher if your team is AI-forward.
+4. **Feature flag integration.** Same platform or separate. Decide once and live with the implications.
+5. **Analytics depth.** Funnels, retention, cohorts in the same surface. Decides whether you need a second tool for the analytics layer.
+6. **Governance.** Permissions, audit, approval workflows, environment promotion. Non-negotiable for regulated industries.
+7. **Cost shape.** Events vs seats vs warehouse compute. Match the shape to your usage trajectory.
+8. **Team fit.** PM-led, engineer-led, data-led, marketing-led. The platform's defaults will pull your culture in the direction of its primary user.
+9. **Onboarding cost.** Time to first experiment for a new team member. Faster is better; varies wildly across platforms.
+10. **Migration cost.** What is the exit plan if you choose wrong. Higher migration cost means higher confidence required at decision time.
+11. **Multi-platform fit.** Does this layer cleanly with platforms you already have, or does it create overlap.
+
+The output of this framework is one of three answers. A primary recommendation with reasoning. A short list of two if the situation is genuinely ambiguous. A "defer" if a precondition is not met (no traffic, no culture, pending pivot).
+
+---
+
+## Reference files
+
+- [`references/platform-decision-matrix.md`](references/platform-decision-matrix.md) - Context-to-platform matrix with worked examples for the most common decision contexts.
+- [`references/migration-playbook.md`](references/migration-playbook.md) - Step-by-step migration patterns for the five common migrations including effort estimates and validation approaches.
+- [`references/mcp-capability-comparison.md`](references/mcp-capability-comparison.md) - Side-by-side MCP capability matrix across the seven platforms.
+- [`references/multi-platform-orchestration.md`](references/multi-platform-orchestration.md) - Ownership boundaries, shared metric definitions, and reconciliation dashboards for genuine multi-platform setups.
+- [`references/cost-and-pricing-models.md`](references/cost-and-pricing-models.md) - Pricing shapes, real-world cost ranges at different traffic tiers, and finance conversation patterns.
+- [`references/governance-and-team-setup.md`](references/governance-and-team-setup.md) - Permission tiers, audit trail requirements, environment promotion rules, and team fit assessment.
+- [`references/common-mistakes.md`](references/common-mistakes.md) - Twelve failure patterns with symptom, root cause, fix, and prevention for each.
+
+---
+
+## Closing: when in doubt, pick boring
+
+When the analysis is genuinely ambiguous, pick the boring choice. Boring means mature, well-documented, large user base, and a recoverable migration if you turn out to be wrong. Statsig is boring for SaaS. PostHog is boring for product-led growth. Optimizely is boring for enterprise. GrowthBook is boring for warehouse-native.
+
+Boring is not the optimum, but it is almost never wrong. The optimum can come later, when the situation has clarified and the team has the experience to know what it actually needs. The cost of picking boring is a small efficiency tax. The cost of picking exotic and being wrong is a migration project that interrupts a year of product work.
+
+If the team disagrees on which boring choice is the right one, that is a data signal: the situation is not yet clear enough for any answer to be obviously correct. Run a 30-day trial on the top two, evaluate against the 11-consideration framework with real usage data, and pick. Do not skip the trial; demos lie about real usage in ways that only the trial reveals.

--- a/skills/experimentation-platform-orchestrator/references/common-mistakes.md
+++ b/skills/experimentation-platform-orchestrator/references/common-mistakes.md
@@ -1,0 +1,155 @@
+# Common mistakes
+
+Twelve failure patterns that recur in platform decisions. For each: name, symptom, root cause, fix, and prevention.
+
+---
+
+## 1. Picked the cheapest
+
+**Symptom.** Six months in, the team is paying more in engineer time than they saved on the platform fee. Velocity is below the pre-decision projection.
+
+**Root cause.** Sticker-price optimization without a total-cost frame. Engineer time, statistical correctness, and migration risk were not priced in.
+
+**Fix.** Run a total-cost-of-ownership review. If TCO is materially worse, plan a migration to a better-fit platform. Counter-intuitively, paying more in platform fees can save more in engineer time.
+
+**Prevention.** Use the total cost frame at decision time. The cheapest sticker price is rarely the cheapest TCO. See `cost-and-pricing-models.md` for the framing.
+
+---
+
+## 2. Picked the most-featured
+
+**Symptom.** The team uses 20% of the platform's features. The other 80% are noise that complicates onboarding and inflates the bill.
+
+**Root cause.** Demo-driven feature comparison. The platform's depth was impressive in the demo and translated into a "more features means more value" assumption.
+
+**Fix.** Audit feature usage. If 80% of the platform is unused, evaluate whether a simpler platform serves the team better. Migrating to a smaller-surface platform reduces operational complexity.
+
+**Prevention.** Build a "features needed" list before evaluating platforms. Use the list to filter out features you do not need; do not let demo-time enthusiasm expand it.
+
+---
+
+## 3. Tried multi-platform first
+
+**Symptom.** Two platforms running, both partially used, neither fully embraced. Stakeholders cannot tell which one is the source of truth.
+
+**Root cause.** "Best of both worlds" thinking. The team picked two platforms hoping to combine their strengths, but the integration cost exceeded the combined benefit.
+
+**Fix.** Plan a consolidation. See `multi-platform-orchestration.md` for when consolidation is the right answer (almost always for teams in this state).
+
+**Prevention.** Default to single-platform unless the surfaces genuinely do not overlap. Multi-platform is a 20% case, not the default.
+
+---
+
+## 4. Outgrew the platform but stayed for migration cost
+
+**Symptom.** The team is hitting limits the platform cannot serve (statistical depth, governance, scale). They know it. They have not migrated because the migration project feels expensive.
+
+**Root cause.** Migration cost is overweighted relative to the ongoing platform tax. The platform tax compounds; migration cost is fixed.
+
+**Fix.** Run the migration. Set a 90-day window. Use the migration playbook.
+
+**Prevention.** Do an annual platform fit review. If the platform is not the right fit, the answer is to migrate, not to defer. Deferral makes the migration harder, not easier.
+
+---
+
+## 5. Picked based on a demo
+
+**Symptom.** Real usage reveals workflows that did not show up in the demo. Team velocity is below expectations. Frustration is mounting.
+
+**Root cause.** Demos optimize for the show. Real usage reveals real tradeoffs. The decision was made before the team had data on actual workflows.
+
+**Fix.** Run a 30-day trial on the next-best alternative. Compare real-usage friction. If the alternative is materially better, plan the migration.
+
+**Prevention.** Always run a real trial, never just a demo. The trial should ship at least one experiment end to end on each platform under evaluation.
+
+---
+
+## 6. Did not check governance
+
+**Symptom.** Discovered after rollout that anyone with platform access can modify production targeting. A bad change shipped because no review was required.
+
+**Root cause.** Governance was not part of the evaluation. The team assumed defaults would be acceptable; they were not.
+
+**Fix.** Build the governance layer immediately. Permission tiers, approval workflows, audit trails, environment promotion. See `governance-and-team-setup.md`.
+
+**Prevention.** Make governance a non-negotiable evaluation criterion. For any platform under consideration, document the permission model, audit capabilities, and approval workflow before signing.
+
+---
+
+## 7. Picked a platform that does not fit team type
+
+**Symptom.** Constant friction in experiment authoring. The team that should be shipping experiments is instead filing tickets. Experiment volume is below target.
+
+**Root cause.** Team-fit mismatch. A PM-led team on a marketing-led platform, or vice versa. The platform's defaults pull the workflow in a direction the team cannot follow.
+
+**Fix.** Either change the team's workflow to match the platform, or migrate to a platform that matches the team. The migration is usually the right answer because team workflow is hard to change quickly.
+
+**Prevention.** Assess team fit explicitly. See the team-fit framework in `governance-and-team-setup.md`.
+
+---
+
+## 8. Underestimated the warehouse setup
+
+**Symptom.** Picked a warehouse-native platform. Three months in, still not running experiments because the warehouse layer is not ready.
+
+**Root cause.** Warehouse-native platforms expect the warehouse to already be the system of record with metrics defined and refresh cadences in place. The team did not have that foundation.
+
+**Fix.** Either complete the warehouse setup (real engineering project) or migrate to a vendor-native platform that does not require it.
+
+**Prevention.** Verify warehouse readiness before committing to warehouse-native. The platform decision should follow the warehouse decision, not lead it.
+
+---
+
+## 9. Skipped statistical depth review
+
+**Symptom.** A critical experiment surfaced a wrong-result decision. The platform's defaults did not catch the issue (peeking, ratio metric, multiple testing, network effects).
+
+**Root cause.** Statistical depth was not part of the evaluation. The team assumed all platforms compute the same numbers correctly; they do not.
+
+**Fix.** Add the missing rigor. Either configure the current platform's advanced features (sequential testing, CUPED, delta method) or migrate to a platform with stronger defaults. Pair with the `experimentation-analytics` skill to interpret results going forward.
+
+**Prevention.** Verify statistical depth at evaluation time. Ask specifically about CUPED, sequential testing, delta method for ratio metrics, and multiple testing corrections. Do not accept "we have statistical features" without specifics.
+
+---
+
+## 10. Ignored MCP trajectory
+
+**Symptom.** AI-forward team picked a platform without MCP. Six months later, the team is hitting the limit of agent-driven workflows and the platform is the bottleneck.
+
+**Root cause.** MCP trajectory was not weighted in the decision. The platform's strengths in other areas were assumed to make up for the gap.
+
+**Fix.** Either wait for the platform to ship an MCP (uncertain timeline) or migrate to a platform with mature MCP. Eppo specifically is worth tracking for a future MCP release.
+
+**Prevention.** For AI-forward teams, MCP availability is a primary criterion, not a tiebreaker. See `mcp-capability-comparison.md` for current state.
+
+---
+
+## 11. Locked the brief on the demo, not the trial
+
+**Symptom.** Brief-time assumptions did not survive contact with real usage. The platform is technically capable but operationally uncomfortable in ways the demo did not reveal.
+
+**Root cause.** The decision was made on the strength of the demo, with the trial running as a formality afterward. Real-usage signals were not weighted.
+
+**Fix.** Do another trial of the next-best alternative. If the alternative removes the operational discomfort, migrate.
+
+**Prevention.** Run the trial first. Use trial outcomes to update the brief, not the other way around. Demos are useful for screening; trials are required for committing.
+
+---
+
+## 12. Renewed without re-evaluating
+
+**Symptom.** Renewal cycle came up. The team renewed because the platform was working "well enough." Six months later, an alternative shipped a feature that would have changed the decision.
+
+**Root cause.** Renewal treated as a status-quo extension. The platform market changes faster than annual contracts, and a yearly renewal without re-evaluation drifts away from the optimal choice.
+
+**Fix.** Run the platform decision framework at every renewal. If the answer is the same platform, renew with confidence. If the answer is different, plan a migration.
+
+**Prevention.** Build the annual platform review into the team's calendar. Tie it to the renewal date so the review informs the renewal decision rather than competing with it.
+
+---
+
+## The pattern across all twelve
+
+Most platform mistakes share one root cause: under-investment in the decision itself. A two-week evaluation that catches all twelve patterns is cheaper than a year on the wrong platform.
+
+The fix at the meta level. Treat the platform decision as a real engineering project. Allocate time. Run trials. Audit governance. Verify statistical depth. Check MCP trajectory. Document the decision and the reasoning. Review annually.

--- a/skills/experimentation-platform-orchestrator/references/cost-and-pricing-models.md
+++ b/skills/experimentation-platform-orchestrator/references/cost-and-pricing-models.md
@@ -1,0 +1,125 @@
+# Cost and pricing models
+
+Pricing shapes per platform, real-world cost ranges at different traffic tiers, the total cost frame, and finance conversation patterns.
+
+Pricing on experimentation platforms is rarely transparent on the public site for paid tiers. The numbers below are typical ranges from real customer conversations as of May 2026. Verify with each vendor before committing.
+
+---
+
+## The three pricing shapes
+
+**Vendor-native (event-based).** Statsig, Optimizely. Billing scales with the number of events sent to the platform. Easy to predict at small scale: events per month times rate per million. Painful at very high scale because the rate per million does not always decrease quickly.
+
+**Warehouse-native (seat plus warehouse compute).** GrowthBook (paid), Eppo. Billing scales with the number of seats and the warehouse compute the platform consumes. Warehouse compute is your existing line item, so the marginal cost of more experiments is small once the platform is paid for. Less elastic on team size, more elastic on experiment volume.
+
+**Product-suite (combined event volume).** PostHog, Amplitude. Billing scales with combined event volume across all features (analytics, experiments, replays, error tracking, surveys). Often the most cost-effective when used heavily; can be the most expensive when only one feature is needed.
+
+---
+
+## Free tiers
+
+Free tiers exist for the early-stage and pre-PMF cases. The numbers below are current as of May 2026.
+
+| Platform | Free tier shape |
+|---|---|
+| PostHog | 1M events per month free across all features |
+| Statsig | 1M events per month free; full feature access |
+| Amplitude | 10M events per month free with basic features (some advanced features paid) |
+| GrowthBook | Free open-source self-hosted; cloud has a free tier with 3 users and 5 active experiments |
+| Optimizely | No meaningful free tier |
+| Eppo | No meaningful free tier |
+| Kameleoon | No meaningful free tier; free trial only |
+
+For pre-PMF and early-stage teams, the free-tier choice is between PostHog and Statsig. Both work. Pick the one whose product surface matches your needs (PostHog if you also want analytics; Statsig if you want experiments and flags primarily). The decision is reversible at low cost while you are still on the free tier.
+
+---
+
+## Real-world cost ranges
+
+Approximate ranges for paid tiers. Bands are wide because pricing varies by contract size, sales discount, and feature mix.
+
+### Vendor-native (events per month)
+
+| Volume | Statsig (typical) | Optimizely (typical) |
+|---|---|---|
+| 1M to 10M | $0 (free) to $1K/month | Custom contract; rarely under $30K/year |
+| 10M to 100M | $1K to $8K/month | $30K to $100K/year |
+| 100M to 1B | $8K to $40K/month | $100K to $400K/year |
+| 1B+ | $40K+/month with custom negotiation | $400K+/year with custom negotiation |
+
+Optimizely consistently sits at a higher absolute price point than Statsig for the same volume. The premium pays for the marketing-led ergonomics, the visual editor, and the personalization features. Whether the premium is justified is a per-team judgment.
+
+### Warehouse-native (seats and compute)
+
+| Team size | Eppo (typical) | GrowthBook paid (typical) |
+|---|---|---|
+| 5 to 10 seats | $20K to $40K/year | $5K to $15K/year |
+| 10 to 30 seats | $40K to $120K/year | $15K to $50K/year |
+| 30+ seats | Custom contract | Custom contract |
+
+Plus warehouse compute. For a Snowflake-based setup running 100 to 300 active experiments per year, expect $2K to $20K/year of additional warehouse compute attributable to experimentation queries. The exact number depends on metric complexity and refresh cadence.
+
+### Product-suite (combined events)
+
+| Volume | PostHog (typical) | Amplitude (typical) |
+|---|---|---|
+| 1M to 10M | $0 (free) to $500/month | $0 (free) to $2K/month |
+| 10M to 100M | $500 to $5K/month | $2K to $20K/month |
+| 100M to 1B | $5K to $30K/month | $20K to $100K/month |
+| 1B+ | Custom negotiation | Custom negotiation |
+
+PostHog is consistently more cost-effective for combined product analytics plus experiments. Amplitude charges a premium for the depth of its behavioral analytics; if experiments are the primary use, PostHog is hard to justify against.
+
+---
+
+## The total cost frame
+
+Sticker price is one input to the cost decision. Total cost is the right frame.
+
+**Engineer time.** Wiring, maintenance, dashboard upkeep, debugging integration issues. Ranges from 5% to 30% of an engineer's time depending on platform and team size. Vendor-native is usually lower; warehouse-native is usually higher (more setup); multi-platform is usually highest.
+
+**Statistical correctness.** A single wrong-result experiment can cost more than a year of platform fees. If a platform's defaults produce confidently-wrong recommendations, the cost is the experiment that shipped wrong, not the platform fee. Worth a real review at platform decision time.
+
+**Governance overhead.** Self-hosted open-source platforms require self-built governance (audit, permissions, approval workflows). For regulated industries, this is hours of compliance review per quarter. Enterprise tiers absorb this overhead in their pricing.
+
+**Migration risk.** What is the cost if you choose wrong and need to migrate? See `migration-playbook.md` for engineer-week ranges. Multiply by the probability you will need to migrate, and that is the migration risk component of total cost.
+
+**Cultural drift.** The platform's defaults shape what the team thinks experimentation is. PM-led platforms produce PM-led cultures. Marketing-led platforms produce marketing-led cultures. The drift is hard to price but real.
+
+---
+
+## Finance conversation patterns
+
+Three patterns that work when justifying a platform decision to finance.
+
+### Pattern 1: cost per experiment
+
+Compute the all-in cost per experiment shipped: platform fees plus engineer time amortized across experiments per year. This converts platform cost into a unit that finance understands. A team running 50 experiments per year on a $40K platform fee is paying $800 per experiment in platform alone, plus engineer time. A team running 200 experiments on the same fee is paying $200 per experiment.
+
+The frame: more experiments per year reduces unit cost. Justify investment by showing a path to higher experiment throughput.
+
+### Pattern 2: avoided wrong-result experiments
+
+Estimate the cost of a wrong-result decision. For revenue experiments, this is often $50K to $500K (the value of the experiment shipped wrong). Multiply by the rate of wrong-result decisions before and after a platform change.
+
+The frame: a more rigorous platform avoids wrong-result decisions. A few avoided wrong-results per year easily justify the platform premium.
+
+### Pattern 3: total cost of ownership across alternatives
+
+Build a 3-year TCO model for the top two or three candidates. Include platform fees, engineer time, migration costs, and governance overhead. Show the comparison.
+
+The frame: the cheapest sticker price is rarely the cheapest TCO. The platform that minimizes engineer time often wins on TCO even if it costs more per month.
+
+Use whichever pattern matches finance's mental model. Pattern 1 works for ROI-focused finance leaders. Pattern 2 works for risk-focused leaders. Pattern 3 works for procurement-focused leaders.
+
+---
+
+## Negotiation tips
+
+Three patterns work in vendor negotiations.
+
+1. **Multi-year commits unlock 15 to 30% discounts.** If the team is confident in the platform, lock in the discount.
+2. **Event volume tiers are negotiable.** The published pricing is the starting position. Custom contracts at scale always run below it.
+3. **Bundle features for unit-cost reduction.** Combining experiments and feature flags in one contract often costs less than the same features separately.
+
+Do not negotiate from desperation. If the team is in a "we have to migrate this quarter" position, the vendor knows and the discount evaporates. Negotiate from a position of optionality: keep the trial of the alternative platform live until the contract closes.

--- a/skills/experimentation-platform-orchestrator/references/governance-and-team-setup.md
+++ b/skills/experimentation-platform-orchestrator/references/governance-and-team-setup.md
@@ -1,0 +1,133 @@
+# Governance and team setup
+
+Permission tiers, approval workflows, audit trail requirements, environment promotion, team fit assessment, and onboarding playbooks.
+
+Governance is the unglamorous discipline that prevents the worst outcomes. A team that ships fast without governance will eventually have an "anyone can modify production targeting" incident. This reference is the structure that prevents it.
+
+---
+
+## The four governance pillars
+
+### Permission tiers
+
+A typical permission model has four tiers.
+
+1. **Read.** See experiments, flags, and results. Default for analysts, partners, and read-only stakeholders.
+2. **Author.** Create and modify experiments and flags in non-production environments. Default for PMs and engineers shipping experiments.
+3. **Production.** Modify production targeting. Reserved for senior engineers, leads, or designated experiment owners.
+4. **Admin.** Manage users, billing, integrations. Reserved for engineering leadership and platform owners.
+
+Map roles to tiers. Document who has which tier. Review quarterly. Remove access proactively when someone changes roles.
+
+For platforms that do not natively support fine-grained permissions (some open-source self-hosted setups), build the permission model in the deployment process. For example, only certain CI/CD pipelines can push to production targeting.
+
+### Approval workflows
+
+Production-impacting changes go through review. The minimum approval workflow has three steps.
+
+1. The author proposes the change (new experiment, modified targeting, rollout to higher percentage).
+2. A second person reviews. The reviewer is not the author.
+3. The change is logged with actor, timestamp, before-and-after, and reason.
+
+Lighter approval is acceptable for low-risk experiments (5% rollout to internal users). Stricter approval applies to high-risk experiments (revenue, billing, security-adjacent).
+
+Some platforms (Optimizely Enterprise, Statsig Enterprise) build the approval workflow into the platform. Others require self-built workflows in your deployment process or change management tool.
+
+### Audit trails
+
+Every change logged. The log includes actor, timestamp, before state, after state, and reason. The log is immutable and queryable.
+
+Audit trails matter for two reasons. The first is compliance: regulated industries require them. The second is post-incident analysis: when a wrong-result decision ships, the audit trail tells you exactly when and why the experiment was modified.
+
+For platforms that do not natively log every change (smaller open-source setups), build the audit at the deployment-pipeline level. Every push to the experimentation platform's API runs through a logging proxy.
+
+### Environment promotion
+
+Experiments and flags promoted through environments: dev, staging, production. The promotion is not automatic. Each promotion is a deliberate decision.
+
+The minimum environment model is dev plus production. The fuller model is dev, staging, production. Larger organizations add a pre-production environment that mirrors production traffic for risk-free smoke testing.
+
+Promotion rules. Experiments are tested in dev first. The experiment definition (targeting, variants, metrics) is identical across environments. Only the user population differs. Promotion to production requires approval.
+
+---
+
+## Team fit assessment
+
+The platform's defaults shape the team's experimentation culture. Pick the alignment that matches who you actually want running experiments.
+
+**PM-led culture.** PMs author and own experiments. Engineers wire metrics and SDK changes. The platform should have a low-overhead experiment authoring surface, clear analytics, and good metric documentation.
+
+Best fit: Statsig, PostHog. Both have PM-friendly authoring surfaces.
+
+**Engineer-led culture.** Engineers author and own experiments. PMs review and prioritize. The platform should have a code-first authoring surface and good SDK ergonomics.
+
+Best fit: PostHog, GrowthBook. Both have strong code-first paths.
+
+**Data-team-led culture.** Analysts and data scientists author experiments. The platform should have warehouse-native architecture, deep statistical defaults, and SQL-first metric definitions.
+
+Best fit: Eppo, GrowthBook. Both are warehouse-native.
+
+**Marketing-led culture.** Marketing teams author experiments without engineer involvement. The platform should have a visual editor and non-technical experiment authoring.
+
+Best fit: Optimizely, Kameleoon. Both have mature visual editors.
+
+The wrong fit is constant friction. A PM-led team on a marketing-led platform will struggle with the visual-editor-first authoring surface. A marketing-led team on an engineer-led platform will not be able to ship without filing engineering tickets.
+
+---
+
+## Onboarding cost
+
+Time to first experiment for a new team member is a real metric. Track it after platform decisions.
+
+**Statsig and PostHog.** Hours to days. The authoring surfaces are PM-friendly; new team members can ship a low-risk experiment in a single afternoon with documentation.
+
+**Optimizely.** Days to weeks. The visual editor is approachable for non-engineers, but the platform's depth means navigation takes time. New marketing team members can ship faster than new engineering team members.
+
+**Eppo and GrowthBook.** Days if the warehouse and metrics are already wired in. Weeks if not. The setup overhead is in the warehouse layer, not the platform itself.
+
+**Amplitude.** Hours if the team is already using Amplitude for analytics. The experiments surface is a small extension of the analytics surface. New team members already familiar with Amplitude pick it up quickly.
+
+**Kameleoon.** Hours for the visual editor. Days for the win-to-code workflow. The specialty workflow has its own learning curve.
+
+---
+
+## Onboarding playbook
+
+A repeatable onboarding playbook for a new PM or engineer joining an experimentation discipline.
+
+### Day 1: orientation
+
+- Read the platform documentation overview (1 hour).
+- Walk through one completed experiment in the platform with the team owner (30 minutes).
+- Review the team's metric definitions and ownership matrix (30 minutes).
+- Get permissions provisioned at the Author tier (varies; aim for same day).
+
+### Day 2 to 5: shadow
+
+- Sit in on one experiment review meeting.
+- Read the last 3 to 5 experiment writeups.
+- Pair with a senior team member on a low-risk experiment.
+
+### Week 2: ship
+
+- Author and ship a low-risk internal experiment (5% rollout to internal users).
+- Write up results.
+- Get feedback from a senior team member.
+
+### Week 3 to 4: own
+
+- Take ownership of a backlogged experiment.
+- Ship it end to end.
+- Present results to stakeholders.
+
+After week 4, the new team member is fully onboarded. Track the time to first experiment as a metric. Investigate when it exceeds two weeks; that is a signal of either platform friction or onboarding-process drift.
+
+---
+
+## Common governance failures
+
+Three patterns recur.
+
+1. **Permission creep.** Everyone gets Production tier "for convenience." Six months later, no one knows who can modify production targeting. The fix is quarterly access reviews and a strict default to Read or Author tier.
+2. **Approval theater.** Changes go through an approval workflow but reviewers do not actually review. The fix is to require a substantive comment on every approval, not just a click.
+3. **Audit log drift.** The audit log exists but no one reads it. The fix is to surface audit log highlights (high-risk changes, unusual targeting modifications) in a weekly digest.

--- a/skills/experimentation-platform-orchestrator/references/mcp-capability-comparison.md
+++ b/skills/experimentation-platform-orchestrator/references/mcp-capability-comparison.md
@@ -1,0 +1,97 @@
+# MCP capability comparison
+
+Side-by-side capability matrix across the seven covered platforms. Current as of May 2026. MCP capability evolves quickly; verify before committing.
+
+The matrix is organized by capability category. Read it as "if my workflow needs X, which platforms support it." If your workflow needs every capability across the board, the answer is Statsig, PostHog, or Optimizely (the most mature MCPs). If your workflow needs a specific subset, smaller MCPs may be a better fit.
+
+---
+
+## Capability matrix
+
+| Capability | Statsig | PostHog | GrowthBook | Optimizely | Amplitude | Eppo | Kameleoon |
+|---|---|---|---|---|---|---|---|
+| Read feature flags | Yes | Yes | Yes | Yes | Yes | No (REST) | Yes |
+| Create or update feature flags | Yes | Yes | Yes | Yes | Yes | No (REST) | Yes |
+| Read experiments | Yes | Yes | Yes | Yes | Yes | No (REST) | Yes |
+| Create or update experiments | Yes | Yes | Yes | Yes | Yes | No (REST) | Yes |
+| Read experiment results | Yes | Yes | Yes | Yes | Yes | No (REST) | Yes |
+| Query analytics or events | Yes | Yes (200+ tools) | Limited | Limited | Yes | No (REST) | No |
+| Manage segments and audiences | Yes | Yes | Yes | Yes | Yes | No (REST) | Yes |
+| Governance actions (permissions, audit) | Partial | Partial | No | Yes | Partial | No | No |
+| Code generation (variant to component) | No | No | No | No | No | No | Yes |
+| Hosting model | First-party (managed) | First-party + self-host | First-party + OSS self-host | Hosted Remote | Hosted | n/a (REST) | Hosted Remote |
+| Auth method | API key | API key | API key | OAuth | API key | n/a | OAuth |
+| Approximate tool count | ~30 | 200+ | ~25 | ~20 | ~15 | n/a | 7 |
+| Recommended scoping | Default | `?features=` to scope | Default | Default | Default | n/a | Default |
+
+---
+
+## Notes per platform
+
+### Statsig
+
+The MCP is mature and covers the full Statsig surface (gates, dynamic configs, experiments, holdouts, layers). The tool count is moderate, which keeps the agent context window tight without sacrificing capability. Authentication is API-key based; provision a service account for agent workflows so the audit trail is clean.
+
+Recommended for AI-forward teams that want full CRUD without context window concerns.
+
+### PostHog
+
+The MCP is the most expansive of any platform here. 200+ tools cover analytics, experiments, flags, surveys, replays, and more. The breadth comes with a cost: without scoping, the agent's context window fills with tool definitions before it can do useful work.
+
+Use the `?features=` scoping parameter to load only the surfaces you need. For an experimentation-focused workflow, scope to flags, experiments, and analytics; skip replays, surveys, and error tracking unless they are part of the workflow.
+
+Recommended for AI-forward teams that need broad coverage and are willing to invest in scoping discipline.
+
+### GrowthBook
+
+The MCP is the first open-source production MCP for experimentation. It covers the GrowthBook surface (experiments, flags, metrics, segments). Tool count is moderate. Self-host means you can run the MCP inside your network for data sovereignty.
+
+Recommended for OSS-preferring teams and regulated industries that need the MCP inside their VPC.
+
+### Optimizely
+
+The hosted Remote MCP works in browser-based ChatGPT and Claude.ai. Authentication is OAuth, which integrates cleanly with enterprise SSO. Tool count is moderate. Coverage is solid on Web Experimentation and Feature Experimentation; Personalization features are accessed via the same surface.
+
+Recommended for enterprise teams that need OAuth and SSO compatibility for compliance.
+
+### Amplitude
+
+The hosted MCP is available to all customers including the free tier. Tool count is smaller than Statsig or PostHog. Coverage is strongest on analytics queries (cohorts, funnels, retention) and adequate on experiments and flags.
+
+Recommended for teams that primarily need analytics queries and use experiments as a supplementary capability.
+
+### Eppo
+
+No first-party MCP as of May 2026. REST API is the integration path. Workflows that depend on agent-driven experiment creation need a custom adapter or a wait until Eppo ships an MCP.
+
+Track for a future MCP release. The platform has the underlying API; an MCP wrapper is a likely future development.
+
+### Kameleoon
+
+Hosted Remote MCP at `mcp.kameleoon.com/mcp` with OAuth and 7 specialized tools. The tool surface is purpose-built for the win-to-code workflow. The smallest MCP in this matrix and the most opinionated.
+
+Recommended for teams running the marketing-site-to-product-code workflow. Layer with another MCP if your needs go beyond that scope.
+
+---
+
+## Choosing by workflow
+
+**Agent-driven full experiment lifecycle (create, run, monitor, conclude).** Statsig, PostHog, GrowthBook, or Optimizely. All four support full CRUD via MCP.
+
+**Agent-driven analytics queries plus light experiment work.** PostHog (with scoping) or Amplitude. Both have strong analytics MCP coverage.
+
+**Agent-driven win-to-code conversion.** Kameleoon. The only platform with this workflow as a primary feature.
+
+**Human-driven workflow where MCP is supplementary.** Any of the seven. Eppo via REST works for the supplementary case.
+
+**Compliance-sensitive workflow (SSO, audit, data residency).** Optimizely (OAuth, hosted) or GrowthBook self-hosted (data residency, OSS auditable).
+
+---
+
+## Things to check before committing
+
+1. **Tool count and scoping.** Verify the agent context window is comfortable with the platform's tool surface. PostHog without scoping fills the window fast.
+2. **Auth model.** API key is faster to provision; OAuth is required for compliance-sensitive deployments.
+3. **CRUD coverage.** Read-only MCPs limit your workflow. Verify create and update are supported for your target objects.
+4. **Hosting model.** Hosted is faster to start; self-host is required for data sovereignty.
+5. **Trajectory.** MCP capability evolves monthly. Check the platform's changelog before committing for a future-sensitive workflow.

--- a/skills/experimentation-platform-orchestrator/references/migration-playbook.md
+++ b/skills/experimentation-platform-orchestrator/references/migration-playbook.md
@@ -1,0 +1,139 @@
+# Migration playbook
+
+Five common migration paths with effort estimates, the first 30 days plan, the 30-90 day cutover plan, and what NOT to do.
+
+The discipline applies to every migration. Three rules are non-negotiable:
+
+1. Do not parallel-run forever. Set a cutover date and hold to it.
+2. Do not big-bang switch. The risk of a silent miscount is too high; you cannot tell whether the new platform is computing correctly without overlap.
+3. Do not retire the old platform before all in-flight experiments complete.
+
+---
+
+## Statsig to PostHog
+
+Trigger. Company has outgrown a pure experimentation platform and wants analytics, experiments, and feature flags in one surface. Often coincides with consolidating away from a separate analytics tool.
+
+Effort. 3 to 5 engineer-weeks. Add 2 to 4 weeks if you are also consolidating analytics.
+
+First 30 days plan.
+- Week 1: Provision PostHog. Wire the SDK alongside Statsig. Verify event volume matches.
+- Week 2: Recreate the top 5 metrics in PostHog. Compare totals against Statsig over a 7-day window. Investigate any variance over 1%.
+- Week 3: Recreate 1 active experiment in PostHog as a parallel experiment. Run both for 7 to 14 days. Confirm results agree within statistical noise.
+- Week 4: Decision review. Either commit to migration or roll back to Statsig only. Document the decision.
+
+30-90 day cutover plan.
+- Migrate experiments one at a time. New experiments start in PostHog. Existing experiments complete in Statsig.
+- Migrate feature flags by service. Highest-risk services move last.
+- Build dashboards in PostHog before retiring Statsig dashboards.
+- Final week: retire Statsig SDK from the codebase. Remove credentials.
+
+What NOT to do.
+- Parallel-run the SDKs for more than 90 days. The dual cost compounds; the integration tax distracts.
+- Migrate flags before experiments. Flags are operational; experiments are time-bound. Flag migration creates production risk that overshadows the migration value.
+- Skip the metric reconciliation. Discovering a metric definition mismatch a month into the migration is the worst possible time.
+
+---
+
+## Optimizely to Statsig
+
+Trigger. Budget pressure or modernization push. Often coincides with a CFO-led cost review.
+
+Effort. 4 to 8 engineer-weeks. Add weeks proportional to how heavily personalization features are used (Optimizely has personalization that Statsig does not match).
+
+First 30 days plan.
+- Week 1: Feature parity audit. List every Optimizely feature in active use. Mark which ones Statsig covers, which it does not, and which need a workaround.
+- Week 2: Migrate the simplest 3 experiments. Validate results match.
+- Week 3: Address the personalization gap. If personalization is heavy, plan a hybrid (Statsig for product experiments, Optimizely retained for personalization, with a retirement date in 6 to 12 months).
+- Week 4: Decision review. Commit to full migration or hybrid.
+
+30-90 day cutover plan.
+- Migrate experiments first, flags second. Personalization last (or retain in Optimizely).
+- Communicate clearly with non-engineering experiment authors. The visual editor change is the friction point.
+- Train non-engineering authors on Statsig's experiment definition format.
+- Final phase: cancel Optimizely contract on its renewal date. Do not cancel mid-term; the savings rarely justify the early-termination friction.
+
+What NOT to do.
+- Underestimate the non-engineering author retraining. Marketing-led teams will resist the platform change harder than engineering-led teams.
+- Force personalization into Statsig if the use case does not fit. A hybrid setup is cheaper than a forced consolidation that the team cannot use.
+- Cancel the Optimizely contract before all in-flight experiments complete on the old platform.
+
+---
+
+## PostHog to Eppo
+
+Trigger. Statistical rigor becomes the binding constraint. A data team has joined or grown, and a critical experiment surfaced a wrong-result decision that PostHog's defaults did not catch.
+
+Effort. 6 to 10 engineer-weeks. The migration is harder because PostHog includes session replay, error tracking, and analytics that Eppo does not replace. Plan for a dual-platform end state.
+
+First 30 days plan.
+- Week 1: Define the scope. Eppo replaces experiments. PostHog stays for analytics, replay, and tracking. Document which surface owns what.
+- Week 2: Wire Eppo SDK alongside PostHog. Configure metric definitions in the warehouse.
+- Week 3: Run one parallel experiment. Compare statistical conclusions. Investigate any disagreement; this is where the rigor difference shows up.
+- Week 4: Decision review. Commit to the dual-platform end state or rethink scope.
+
+30-90 day cutover plan.
+- New experiments start in Eppo. Existing experiments complete in PostHog.
+- Build the metric definition layer in the warehouse so both platforms can agree on what "activation" means.
+- Set up reconciliation dashboards. The two platforms will disagree on edge metrics; surface those proactively rather than letting stakeholders find them.
+
+What NOT to do.
+- Try to retire PostHog. The non-experiment features (replay, tracking, analytics) do not have a clean Eppo replacement.
+- Skip the warehouse metric layer. Without it, the two platforms compute metrics differently and stakeholders lose trust in both.
+- Use Eppo for the small experiments where statistical depth is overkill. The analyst overhead per experiment is higher in Eppo than in PostHog.
+
+---
+
+## GrowthBook to Eppo
+
+Trigger. Team growth and a desire for commercial support, deeper Bayesian and sequential testing features, and decision-oriented reporting.
+
+Effort. 2 to 4 engineer-weeks. This is the easiest migration in the playbook because both platforms are warehouse-native; the data already lives in your stack.
+
+First 30 days plan.
+- Week 1: Provision Eppo. Reuse the warehouse connection.
+- Week 2: Recreate metric definitions. Most translate cleanly.
+- Week 3: Run 1 to 2 parallel experiments to validate.
+- Week 4: Cutover. New experiments in Eppo. In-flight in GrowthBook complete on GrowthBook.
+
+30-90 day cutover plan.
+- Migrate active flag rollouts to Eppo if Eppo's flag features are sufficient.
+- Retire GrowthBook 30 to 60 days after the last in-flight experiment completes.
+
+What NOT to do.
+- Migrate flags if Eppo's flag features do not match. Run a separate flag platform if needed.
+- Cancel GrowthBook before all dashboards are recreated.
+
+---
+
+## Any to Statsig (consolidation)
+
+Trigger. Multi-platform mess. Common when a company has accumulated 2 to 3 platforms over time and wants to consolidate.
+
+Effort. 6 to 12 engineer-weeks, scaling with the number of platforms and in-flight experiments.
+
+First 30 days plan.
+- Week 1: Inventory. List every experiment, flag, and dashboard across all platforms. Identify the canonical source of truth where they disagree.
+- Week 2: Statsig provisioning. Configure metrics. Validate event volume matches.
+- Week 3: Migrate the simplest 5 experiments. Validate results.
+- Week 4: Migration plan with explicit retirement dates per old platform.
+
+30-90 day cutover plan.
+- Per-platform retirement. Pick one of the old platforms to retire first (usually the smallest user base).
+- Communicate retirement dates clearly. Stakeholders need 30 days of warning per platform.
+- Build dashboards before retiring; never after.
+
+What NOT to do.
+- Try to retire all old platforms at once. Sequential retirement is slower but lower risk.
+- Skip the inventory step. Discovering a forgotten experiment in production after retirement is the failure mode.
+- Underestimate the team training cost. Multi-platform teams have built workflow muscle memory across all of them; consolidation requires retraining.
+
+---
+
+## Validation: how to know the migration succeeded
+
+Three signals that the migration is complete and successful.
+
+1. **All in-flight experiments completed on the original platform.** No experiment was stranded mid-test.
+2. **Metric values match within statistical noise on the new platform** for at least 30 days post-cutover. Variance over 1 to 2% needs investigation.
+3. **The team is shipping experiments at the pre-migration rate or faster** within 60 days of cutover. If velocity has not recovered, retraining or workflow changes are still needed.

--- a/skills/experimentation-platform-orchestrator/references/multi-platform-orchestration.md
+++ b/skills/experimentation-platform-orchestrator/references/multi-platform-orchestration.md
@@ -1,0 +1,99 @@
+# Multi-platform orchestration
+
+When multi-platform is genuine, three coordination patterns are non-negotiable: an ownership matrix, shared metric definitions, and reconciliable dashboards.
+
+This reference is for the 20% of teams whose surfaces genuinely warrant more than one platform. The 80% should consolidate. If you are not sure which group you are in, the test is whether the platforms overlap. Zero overlap is a candidate for multi-platform; any overlap is a candidate for consolidation.
+
+---
+
+## When multi-platform is warranted
+
+The pattern is: different surface, different audience, different metric set, no overlap.
+
+**Marketing site plus product app.** Kameleoon for personalization on the marketing site. Statsig for product experiments. The marketing site's metrics (conversion to signup, page-level engagement) do not collide with the product app's metrics (activation, retention, revenue). The two surfaces are run by different teams with different cadences.
+
+**Content site plus product app.** Optimizely or Kameleoon for content experiments. PostHog or Statsig for product. Same pattern: different surface, different audience.
+
+**Pre-acquisition multi-tool reality.** Two products from two acquired companies on different platforms. Multi-platform is the temporary reality; consolidation is the eventual answer. Plan a retirement date during the integration project.
+
+**Specialized statistical needs.** A core product on Statsig plus a specialized statistical workload (causal inference, network effects analysis) running on a separate tool. Rare but legitimate when the specialty platform has capabilities the primary platform lacks.
+
+---
+
+## When multi-platform is a mess
+
+Three signals that the multi-platform setup has drifted into a consolidation candidate:
+
+1. **The same experiment can be defined on more than one platform.** Stakeholders ask "which one are we using?" and the answer is unclear.
+2. **Metrics differ between platforms.** "Activation rate" computes one way in Statsig and another way in PostHog. Stakeholders see two numbers and trust neither.
+3. **Operational overhead exceeds the value of platform diversity.** Engineers spend more time keeping platforms in sync than they save by using each platform's strengths.
+
+If two of three apply, plan a consolidation.
+
+---
+
+## The ownership matrix
+
+The first artifact of a multi-platform setup is an explicit ownership matrix. It names which platform owns which surface, which metrics, and which experiments. Disagreements between platforms are resolved against the matrix.
+
+| Surface | Primary platform | Secondary platform (if any) | Owner |
+|---|---|---|---|
+| Marketing site | Kameleoon | None | Marketing team |
+| Product app | Statsig | None | Product team |
+| Mobile app | Statsig | None | Mobile team |
+| Email | None | None | n/a |
+| Pricing page | Kameleoon | Statsig (revenue metrics) | Marketing team primary, product team consulted |
+
+Where two platforms touch the same surface (the pricing page row), name a primary and clarify what the secondary is responsible for. Ambiguity here is the source of every multi-platform drift.
+
+The ownership matrix lives in a single document, version-controlled, reviewed quarterly. Stakeholders refer to it instead of arguing.
+
+---
+
+## Shared metric definitions
+
+The second artifact is a shared metric definitions document. The same metric should compute the same way across platforms.
+
+Example. "Activation rate" might be defined as: percentage of users who completed onboarding within 7 days of signup. The definition includes the event name, the time window, the denominator population, and any exclusions. Both platforms reference the same definition.
+
+In practice, sharing definitions across platforms is hard. Three approaches.
+
+**Single source warehouse layer.** Define metrics in your warehouse using a metrics layer (dbt, Cube, Metricflow). Both platforms query the warehouse. This is the strongest pattern. It works if both platforms support warehouse-native metrics (GrowthBook, Eppo) or have warehouse integration paths.
+
+**Documented definitions with periodic reconciliation.** Each platform has its own metric. The definitions document records what each is supposed to compute. A weekly or monthly reconciliation job compares the two and surfaces variance. This works for vendor-native platforms that do not share a warehouse.
+
+**Tolerance for variance.** Accept that the two platforms compute slightly differently and document the expected variance range. Over 1 to 2% triggers an investigation. Under 1% is treated as noise. This works when the platforms are used for different surfaces and the metrics are not directly compared across them.
+
+The wrong approach is no approach. Without one of these three patterns, the platforms drift, and a leadership disagreement surfaces in the worst possible moment.
+
+---
+
+## Reconciliable dashboards
+
+The third artifact is dashboards that surface the same metrics from both platforms side by side. The point is not that the numbers always agree (they will not). The point is that disagreements are visible and explainable.
+
+A reconciliation dashboard has three columns per metric: the value from platform A, the value from platform B, and the variance with a threshold. Variance over the threshold triggers a notification. Owners investigate and either explain the variance or fix the underlying definition mismatch.
+
+Reconciliation runs daily for high-stakes metrics, weekly for everything else. Outputs go to a shared channel where the team sees them; do not let reconciliation reports live in a folder no one reads.
+
+---
+
+## The "primary platform" rule
+
+In every multi-platform setup, one platform is canonical. If the platforms disagree, the canonical answer wins. Pick the canonical platform once, document it, and stop arguing.
+
+The canonical platform is usually the one that owns the surface where the metric originates. Revenue metrics: the warehouse is canonical. Product engagement: the product analytics platform is canonical. Marketing-site conversion: the marketing experiment platform is canonical.
+
+Without a canonical, every disagreement becomes a debate. With a canonical, disagreements become investigations into why the non-canonical platform diverged.
+
+---
+
+## When to consolidate
+
+Three signals that consolidation is overdue:
+
+1. **The reconciliation dashboard reports variance more often than not.** The platforms drift faster than the team can reconcile. The cost of staying multi-platform exceeds the cost of consolidating.
+2. **A leadership disagreement surfaces a "which one is the source of truth" debate.** Multi-platform is meant to support different surfaces, not different versions of the same answer. If the same answer has two values, consolidation is the fix.
+3. **The team is spending more than 10% of its experimentation operational time on platform coordination.** That time should be on experiments, not platform plumbing.
+
+When consolidation is the right answer, see `migration-playbook.md` for the patterns. The consolidation move is almost always to whichever platform is closest to the canonical for the highest-stakes surface.

--- a/skills/experimentation-platform-orchestrator/references/platform-decision-matrix.md
+++ b/skills/experimentation-platform-orchestrator/references/platform-decision-matrix.md
@@ -1,0 +1,61 @@
+# Platform decision matrix
+
+A context-to-platform map. The left column is the situation. The center column is the recommendation. The right column is the reasoning and the common alternative.
+
+Read top to bottom and stop at the first row that matches your situation in three or more dimensions. The remaining rows are useful as cross-checks rather than primary picks.
+
+---
+
+## The matrix
+
+| Situation | Primary recommendation | Reasoning and common alternative |
+|---|---|---|
+| Pure SaaS, fast-growing, want one platform for flags and experiments | Statsig | Combined feature flags and experiments, modern statistical defaults, fast time to first experiment. Alternative: PostHog if you also want analytics. |
+| Product-led growth, want analytics and experiments together | PostHog | Full-funnel context, free tier covers early growth, mature MCP for AI workflows. Alternative: Amplitude if analytics depth matters more than experiment depth. |
+| Open-source preference, data sovereignty, warehouse-native | GrowthBook | Data stays in your warehouse, OSS license avoids vendor lock-in, mature statistical defaults. Alternative: PostHog self-hosted if you also need analytics. |
+| Enterprise, marketing-led, deep personalization | Optimizely | Visual editing for non-engineers, mature governance, decades of features. Alternative: Adobe Target if you are already on the Adobe stack. |
+| Already deep on Amplitude for analytics | Amplitude | Adding experiments is the path of least resistance. Alternative: layer Statsig or Eppo only if statistical depth becomes the binding constraint. |
+| Data-team-led, statistical correctness paramount, MCP not yet required | Eppo | Strongest statistical defaults among warehouse-native platforms, decision-oriented reporting. Alternative: GrowthBook if open-source is non-negotiable. |
+| Convert marketing-site wins into permanent code | Kameleoon | Purpose-built for the win-to-code path; the only platform with this workflow as a primary feature. Use alongside a primary product-experiment platform. |
+| Regulated industry (HIPAA, FedRAMP, healthcare), self-hosting required | GrowthBook self-hosted | Full data residency, audit-friendly, OSS auditable. Alternative: PostHog self-hosted if you also need analytics. |
+| Pre-PMF, low traffic, need free tier | PostHog free or Statsig free | Both free tiers cover the early phase. Defer the real platform decision until you have the traffic to make any platform meaningful. |
+| 100M+ events per month, cost control is the binding constraint | GrowthBook or Eppo | Warehouse-native pricing scales better than vendor-native at this volume. Alternative: negotiate a custom contract with Statsig or PostHog; only worth it if vendor-native features justify the premium. |
+| AI-forward team, MCP-first workflow important | Statsig, PostHog, GrowthBook, or Optimizely | All four have mature MCPs with full CRUD coverage. Avoid Eppo for now (REST only). |
+| Mid-market SaaS, governance important, single tool preference | Statsig | Enterprise governance is mature, combined flags and experiments simplify the operational surface. Alternative: Optimizely if marketing-led, GrowthBook if open-source preferred. |
+| Web-only personalization, content site, no product app | Kameleoon or Optimizely | Both are strong on visual editing and personalization. Kameleoon for the win-to-code workflow; Optimizely for enterprise governance. |
+| Data warehouse already in place (Snowflake, BigQuery), small data team | Eppo | Statistical defaults are decision-grade, warehouse compute is already a line item, low operational burden. Alternative: GrowthBook if commercial support is not required. |
+| Solo founder or pre-seed startup | PostHog free or Statsig free | Both work, both are free at this stage. Pick whichever you are more familiar with; the decision is reversible. |
+
+---
+
+## Worked examples
+
+### Example 1: Series B SaaS, 5M events/month, PM-led, considering Statsig vs PostHog
+
+The team has feature flags in LaunchDarkly already, has analytics in Amplitude, and is considering experiments. The PM-led culture wants experiments shipped weekly with low engineer overhead.
+
+**Recommendation.** Statsig. The PM-led culture matches Statsig's defaults. The 5M event volume is comfortably in the free tier or a small paid contract. Combined flags and experiments will likely cause a LaunchDarkly migration in 12 to 18 months, but that is a future decision, not a current one. PostHog is the alternative if the team also wants to consolidate analytics, but Amplitude is already paid for and migrating analytics is a bigger project than starting experiments.
+
+### Example 2: 50-person fintech, regulated industry, need data residency
+
+The team needs HIPAA-equivalent controls (financial regulations), data must stay in their VPC, and the engineering team is comfortable with a more hands-on platform.
+
+**Recommendation.** GrowthBook self-hosted. Data residency is a hard requirement and rules out all vendor-native options. The engineering team has the capacity to operate self-hosted. PostHog self-hosted is the alternative if analytics is also needed.
+
+### Example 3: Marketing-led brand, want non-engineer-shipped experiments
+
+The team is a marketing organization with a small engineering function. The marketing leads want to ship experiments without filing engineering tickets.
+
+**Recommendation.** Optimizely. Visual editing for non-engineers is a hard requirement. Statsig and PostHog can be used by non-engineers but require more comfort with structured experiment definitions. Kameleoon is the alternative if the win-to-code workflow is important.
+
+### Example 4: Data-team-led, 100M events/month, statistical depth required
+
+The data science team owns experimentation, runs the warehouse, and has been burned by misleading results from a less rigorous platform.
+
+**Recommendation.** Eppo. Statistical correctness is the headline. The 100M event volume makes warehouse-native pricing more attractive. The lack of MCP is acceptable because the team's workflow is data-scientist-driven, not agent-driven. GrowthBook is the alternative if open-source is required.
+
+### Example 5: Pre-PMF startup, 200K events/month
+
+The team has a product but no product-market fit. They want to start experimenting to find the wedge.
+
+**Recommendation.** PostHog free tier. Free covers the volume. Analytics plus experiments in one place lets the team learn. Defer the real platform decision until traffic is 10x higher and the platform tax becomes a real number.


### PR DESCRIPTION
## Summary

Completes the PM-experimentation suite (4th of 4). Pairs with all 7 experimentation platforms in the integrations catalog: Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon.

The skill is the strategic-advisor companion to the existing tactical skills:

- `experiment-design` covers how to design a single experiment
- `experimentation-analytics` covers how to read the result panel
- `feature-flagging` covers flags as production infrastructure
- `experimentation-platform-orchestrator` (this PR) covers the platform decision itself

Voice: senior product and engineering leader to platform decision-maker. Decisive recommendations rather than open evaluations.

## Files

- `SKILL.md` (~3700 words, 286 lines) across 14 sections including the required framework section (11 considerations) and reference files section
- 7 reference files:
  - `platform-decision-matrix.md` (worked examples for the most common decision contexts)
  - `migration-playbook.md` (5 common migration paths with effort estimates)
  - `mcp-capability-comparison.md` (capability matrix across the 7 platforms)
  - `multi-platform-orchestration.md` (when warranted, ownership boundaries, shared metrics)
  - `cost-and-pricing-models.md` (real-world ranges and finance conversation patterns)
  - `governance-and-team-setup.md` (permissions, audit, environment promotion, team fit)
  - `common-mistakes.md` (12 patterns with symptom, root cause, fix, prevention)

## Generator output

```
Updated 7 sections in README.md, 66 skills, 139 reference files
```

Skill count 65 to 66. Reference files 132 to 139. Product section grows to 7 entries with `experimentation-platform-orchestrator` at `display_order` 7 (overall catalog index 37).

## Quality gates

- Lint passes 66 skills with both `check_readme_catalog_count` and `check_readme_catalog_generated` rules green
- Generator idempotent (running `--write` twice produces no diff)
- Em-dash audit zero on new content
- Forbidden-phrase audit zero on new content
- Real-firm scrub clean
- Cross-skill references resolve (`experiment-design`, `experimentation-analytics`, `feature-flagging` all valid sibling slugs)

## Test plan

- [ ] CI lint passes (includes `check_readme_catalog_generated`)
- [ ] Catalog row 37 renders correctly in the GitHub "Files changed" view
- [ ] Cross-skill links from SKILL.md resolve in the GitHub UI

Companion landing page lands in `rampstackco-app` in a follow-up dispatch.