### PR TITLE
fix(readme): render COUNT_BADGE inline to preserve badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-<!-- COUNT_BADGE:START -->
-[![Skills](https://img.shields.io/badge/Skills-66-blue.svg)](#the-66-skill-catalog)
-<!-- COUNT_BADGE:END -->
+<!-- COUNT_BADGE:START -->[![Skills](https://img.shields.io/badge/Skills-66-blue.svg)](#the-66-skill-catalog)<!-- COUNT_BADGE:END -->
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)

--- a/scripts/generate_readme_catalog.py
+++ b/scripts/generate_readme_catalog.py
@@ -91,6 +91,12 @@ MARKERS = [
     "CATALOG",
 ]
 
+# Markers whose content must render inline (no surrounding newlines) to
+# preserve markdown rendering. The badge sits in a <div align="center">
+# block where consecutive image-link lines render as a single horizontal
+# row; newlines around the marker comments would break that joining.
+INLINE_MARKERS: set[str] = {"COUNT_BADGE"}
+
 
 @dataclass(frozen=True)
 class Skill:
@@ -271,11 +277,20 @@ def generate_catalog_intro(total: int) -> str:
 def replace_block(text: str, marker: str, new_content: str) -> str:
     """Replace the body between a START/END marker pair.
 
-    The replacement body is sandwiched by single newlines, producing:
+    For block-level markers (default), the replacement body is sandwiched
+    by single newlines, producing::
 
         <!-- MARKER:START -->
         {new_content}
         <!-- MARKER:END -->
+
+    For markers in INLINE_MARKERS, the replacement body has NO surrounding
+    newlines, producing::
+
+        <!-- MARKER:START -->{new_content}<!-- MARKER:END -->
+
+    This preserves markdown line continuity for content that must render
+    inline (such as a badge inside a centered div).
     """
     pattern = re.compile(
         rf"(<!-- {re.escape(marker)}:START -->)(.*?)(<!-- {re.escape(marker)}:END -->)",
@@ -286,7 +301,10 @@ def replace_block(text: str, marker: str, new_content: str) -> str:
         raise ValueError(f"Marker pair '{marker}' not found in README.md")
     if len(matches) > 1:
         raise ValueError(f"Marker pair '{marker}' appears more than once in README.md")
-    replacement = f"\\1\n{new_content}\n\\3"
+    if marker in INLINE_MARKERS:
+        replacement = rf"\1{new_content}\3"
+    else:
+        replacement = f"\\1\n{new_content}\n\\3"
     return pattern.sub(replacement, text, count=1)
 
 


### PR DESCRIPTION
## Summary

Block-level marker behavior was breaking the badge row in the centered div. Adds an `INLINE_MARKERS` set to the generator and updates `COUNT_BADGE` in `README.md` to inline form. Generator remains idempotent.

Two-line edit to the generator + one-line edit to README.md. ~5 lines changed substantively.

## The bug

The generator's `replace_block` always sandwiched the replacement body with newlines:

```python
replacement = f"\1\n{new_content}\n\3"
```

That is correct for block-level markers (blockquote, headings, lists, paragraphs, the big catalog table). It breaks the Skills badge because the badge sits inside a `<div align=\"center\">` block where consecutive image-link lines render as a single horizontal row. Newlines around the marker comments break that joining and stack the Skills badge below the others.

## The fix

- New `INLINE_MARKERS` set listing markers whose body must render inline. Currently `{\"COUNT_BADGE\"}`.
- `replace_block` branches on `INLINE_MARKERS` to omit surrounding newlines.
- `README.md` `COUNT_BADGE` markers collapsed to a single line.

## Verification

```
$ python scripts/generate_readme_catalog.py --write
Updated 7 sections in README.md, 66 skills, 139 reference files

$ python scripts/generate_readme_catalog.py --check
(exit 0)

$ python scripts/generate_readme_catalog.py --write && diff after.md before.md
IDEMPOTENT (no output)

$ python .github/scripts/lint_skills.py
[OK] check_readme_catalog_count
[OK] check_readme_catalog_generated
PASSED: 66 skills validated, 32 warnings.
```

## Test plan

- [ ] CI lint passes
- [ ] In the Files changed view, all four badges (License, PRs Welcome, Skills, Made for Claude) render in a single horizontal row