### PR TITLE
feat(skills): add paid-media-strategy (11th flagship, marketing suite skill 1 of 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-<!-- COUNT_BADGE:START -->[![Skills](https://img.shields.io/badge/Skills-66-blue.svg)](#the-66-skill-catalog)<!-- COUNT_BADGE:END -->
+<!-- COUNT_BADGE:START -->[![Skills](https://img.shields.io/badge/Skills-67-blue.svg)](#the-67-skill-catalog)<!-- COUNT_BADGE:END -->
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 66 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 67 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -35,7 +35,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 66-skill catalog](#the-66-skill-catalog)
+- [The 67-skill catalog](#the-67-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -63,8 +63,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **66 skills** across 14 categories, every one with a complete `SKILL.md` and at least one reference file
-- **139 reference files** (templates, checklists, decision matrices, worked examples)
+- **67 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
+- **146 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -253,11 +253,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 66-skill catalog
+## The 67-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 66 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 67 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -374,33 +374,41 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 52 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
 | 53 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
+### Marketing (1)
+
+Paid media discipline: strategy, creative, and performance analytics. Pairs with the paid media platforms in the /integrations catalog at rampstack.co.
+
+| # | Skill | What it does |
+|---|---|---|
+| 54 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
+
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 54 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 55 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 56 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 55 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 56 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 57 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 57 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 58 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 59 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 60 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 61 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 58 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 59 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 60 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 61 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 62 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 62 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 63 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 64 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 65 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 66 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 63 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 64 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 65 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 66 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 67 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/scripts/generate_readme_catalog.py
+++ b/scripts/generate_readme_catalog.py
@@ -74,6 +74,13 @@ CATEGORIES: list[tuple[str, str, str | None]] = [
     ("qa", "Quality assurance", None),
     ("operations", "Operations", None),
     ("growth", "Growth", None),
+    (
+        "marketing",
+        "Marketing",
+        "Paid media discipline: strategy, creative, and performance "
+        "analytics. Pairs with the paid media platforms in the "
+        "/integrations catalog at rampstack.co.",
+    ),
     ("research", "Research", None),
     ("cross-cutting", "Cross-cutting workflows", None),
     ("process-and-team", "Process and team", None),

--- a/skills/paid-media-strategy/SKILL.md
+++ b/skills/paid-media-strategy/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: paid-media-strategy
+description: "A discipline for running paid media that does not light money on fire. Hypothesis writing for paid spend, channel selection, budget allocation, audience targeting, bid strategy, campaign types, what NOT to spend on, attribution reality, and the failure modes that produce expensive lessons. Triggers on paid media strategy, ad budget allocation, channel selection, paid media plan, audit my Google Ads, audit my Meta Ads, scale paid media, kill underperforming campaign, paid media hypothesis, ad spend strategy, attribution reality, performance marketing strategy. Also triggers when a team is asking how to scale paid media, or whether to add a new channel, or how to reallocate spend across channels."
+category: marketing
+catalog_summary: "Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets"
+display_order: 1
+---
+
+# Paid Media Strategy
+
+A senior performance marketer's playbook for running paid media that produces real outcomes.
+
+The default state of paid media is wasted spend. Most accounts have campaigns running because they always have, audiences targeting because the rep suggested it, bid strategies on auto because manual is hard, creative not refreshed because there is no system. The cost compounds. A 20% efficiency gain on a $500K-per-year account is $100K back to the business. A 50% gain on a $5M-per-year account is $2.5M.
+
+This skill is the discipline that produces those gains. It assumes you have a paid media platform (Google Ads, Meta, LinkedIn, TikTok, or aggregators like Synter) connected. It assumes you have working analytics and conversion tracking. The hard part is the strategic discipline behind the spend, and that is what is here.
+
+When to use this skill: any time you are designing a paid media plan, evaluating whether to scale or kill a campaign, allocating budget across channels, or auditing an existing account.
+
+---
+
+## What this skill is for
+
+This skill spans paid media strategy and operations. It does not cover ad creative production (use `ads-creative-development` once it ships), result interpretation in depth (use `ads-performance-analytics` once it ships), or platform-specific MCP tooling (covered in the `/integrations` microsites at rampstack.co).
+
+The audience is a performance marketer (in-house or agency), a growth lead allocating spend across channels, or a founder making early paid budget decisions. The voice is tactical. There is no "evaluate every option yourself with no opinion." Paid media decisions have shape, and a senior practitioner can map a situation to a defensible plan in an afternoon.
+
+---
+
+## Hypothesis discipline for paid spend
+
+Most paid media failures start with a vague reason for spending. A real spend hypothesis has five parts: audience, offer, channel, outcome metric, and magnitude. Missing any of them and the campaign cannot be evaluated honestly.
+
+A bad reason: "We need to scale Google Ads spend." No audience, no outcome metric, no magnitude. Nothing is falsifiable.
+
+A good hypothesis: "Top-of-funnel SaaS prospects searching for project management tools convert from a free-trial CTA at 3.2% CAC under $80. Increasing Search budget from $40K to $80K per month should hold CAC under $80 and add roughly 500 trial signups based on Q3 search volume."
+
+That hypothesis names the audience (top-of-funnel SaaS prospects on PM-tool keywords), the offer (free trial), the channel (Google Search), the outcome metric (CAC, trial signups), and the magnitude (500 signups, CAC under $80). It is falsifiable: if CAC blows past $80 or signups come in below 250, the hypothesis is wrong and you pull back.
+
+Pre-commit the falsification rule. Decide before scale: at what CAC do we hold? At what CAC do we pull back? At what trial-signup count do we kill? Without pre-commit, every result becomes a debate. With pre-commit, the decision is mechanical.
+
+Primary metric is the one you are optimizing for (CAC, ROAS, CPL). Guardrails are the metrics you do not want to break (LTV, retention, brand search lift). Scaling the primary metric while breaking a guardrail is a Pyrrhic win.
+
+---
+
+## Channel selection: when to use which platform
+
+Pick the channel where intent matches your offer. Run the wrong channel and your CAC reads as a channel problem when it is actually a fit problem.
+
+**Google Search.** High-intent demand capture. Best when you have a real product people search for and the query volume justifies the floor. Worst when category awareness is low and no one is searching. Predictable, expensive at scale, the highest floor of any channel.
+
+**Google Performance Max.** Automated multi-channel within the Google ecosystem. Best when you have a strong product feed (e-commerce) or want to lean into Google's automation. Worst when you need control over placements; PMax is a black box and disagreements with the algorithm cost money.
+
+**Meta (Facebook plus Instagram).** Broad-targeting demand creation. Best for visual products, lifestyle brands, B2C scale, and direct response with strong creative. Worst when targeting is too narrow (audiences saturate fast) or when the offer is high-consideration B2B.
+
+**TikTok.** Discovery-mode advertising. Best for native-feeling video creative, younger audiences, and brand awareness. Worst for direct response with high consideration cycles. Spark Ads (boosting organic posts) outperform pure paid creative.
+
+**LinkedIn.** B2B targeting precision. Best for high-LTV B2B with clear job-title targeting. Worst for low-AOV products; the floor is too high to be efficient.
+
+**Reddit, Pinterest, Snapchat, X.** Niche or supplementary. Best as scale-out channels after primary channels are working. Worst as starting points; spreading thin across niches before you have proven any channel is the most common waste pattern.
+
+**YouTube (Google).** Video at scale. Best for awareness or for B2C consideration. Underrated for B2B SaaS in some categories where the buyer-research path includes long-form video.
+
+The decision rule. Start with the channel where intent matches your offer. Search for high-intent demand capture. Meta or TikTok for demand creation. LinkedIn for B2B precision. Do not run all of them at once until you have proven any of them. Detail in `references/channel-decision-matrix.md`.
+
+---
+
+## Budget allocation: brand vs performance, baseline vs test
+
+Four splits operate at the same time. Get them all right and the budget compounds.
+
+**Brand vs performance.** Brand keeps the demand pipeline filled (long term); performance captures it (short term). 70-30 to 80-20 performance-heavy is typical for most B2C. Brand-heavy splits fit high-consideration B2B where the buying cycle is months long and pipeline visibility matters more than week-over-week conversions.
+
+**Baseline vs test.** 70 to 80% of budget to channels, campaigns, and audiences that are working. 20 to 30% to systematic testing of new channels, new audiences, new creative. Without test budget, you stagnate. Without baseline budget, you have nothing to scale.
+
+**Primary vs secondary channel.** One channel does the heavy lifting (60 to 70% of budget). Others scale supplementally. Resist the equal-split temptation; spreading across channels before any one is proven is the most expensive way to learn nothing.
+
+**Daily vs lifetime budgets.** Daily for ongoing campaigns where you want a stable spend floor. Lifetime for finite tests where the platform should pace itself across the test window. Lifetime budgets prevent runaway spend during testing.
+
+Budget pacing matters too. Front-load some weeks to test creative aggressively. Back-load others to capture seasonality (holiday, end-of-quarter, category-specific moments). Do not run flat; flat budgets miss the demand peaks.
+
+Detail and templates in `references/budget-allocation-templates.md`.
+
+---
+
+## Audience targeting: prospecting vs retargeting vs exclusion
+
+Three audience types. Treat them as separate strategies.
+
+**Prospecting.** New people who have not heard of you. Lookalike audiences (Meta), in-market audiences (Google), interest stacks, lookalikes seeded from high-LTV customers. Largest budget share for growth-mode brands; this is where new demand comes from.
+
+**Retargeting.** People who engaged but did not convert. Smaller audience size, higher CTR, lower CAC. Do not bid too aggressively or you train the platform to charge a premium for users who would have converted anyway.
+
+**Exclusion.** Current customers and recent converters kept out of prospecting and retargeting. Saves spend, keeps frequency low, prevents creative fatigue from people who are already paying you.
+
+Common mistakes. Prospecting too narrow (not enough audience for the platform to optimize). Retargeting too aggressive (cannibalizing organic conversions). No exclusions (paying to advertise to your own paying customers). Lookalikes off the wrong source (use top-LTV customers, not all customers).
+
+Detail in `references/audience-segmentation-patterns.md`.
+
+---
+
+## Bid strategy: when each fits
+
+Bid strategy depends on data state. New campaigns need a different strategy than mature ones. Switching too often resets the learning phase and wastes the data you just gathered.
+
+**Manual CPC or CPM.** Full control, slow to scale. Useful for diagnostics and very early campaigns where you do not trust the platform's machine learning yet.
+
+**Maximize Conversions.** Platform optimizes for volume within budget; the platform decides CPC. Use when you want as many conversions as possible regardless of cost. Good early-stage strategy while you gather data.
+
+**Target CPA (tCPA).** Set a max CPA, platform delivers within. Use when CPA is the constraint and you have at least 30 conversions in the recent window for the platform to optimize against.
+
+**Target ROAS (tROAS).** Set a min ROAS, platform delivers above. Use when revenue per conversion varies and you care about value, not count.
+
+**Maximum Conversion Value.** Like maximize conversions but optimizes for total revenue, not count. Use when high-value conversions are the goal and you have the conversion-value data wired in.
+
+**Enhanced CPC.** Manual CPC with platform adjustments. Hybrid; rarely the right answer because it muddies the signal.
+
+The progression for new campaigns: start manual or maximize conversions to gather data, switch to tCPA or tROAS once you have 30+ conversions, revisit periodically.
+
+Common mistakes. Using tCPA before you have 30+ conversions (no data to optimize against). Setting tROAS too aggressively (platform throttles delivery). Switching strategies too often (each change resets the learning phase). Detail in `references/bid-strategy-reference.md`.
+
+---
+
+## Campaign types
+
+For each major platform, the campaign types and when to use them.
+
+**Google Ads.** Search, Shopping, Performance Max, Display, Video (YouTube), Demand Gen, Discovery, App. Search for direct demand capture. PMax for catalog-driven e-commerce. Display for retargeting. Video for awareness or consideration.
+
+**Meta.** Sales, Leads, Engagement, Awareness, Traffic, App Promotion. Sales for direct response. Awareness for brand at scale. Leads for B2B with native lead forms.
+
+**LinkedIn.** Sponsored Content, Message Ads, Conversation Ads, Lead Gen Forms. Format types: Single Image, Carousel, Video. Lead Gen Forms convert hardest because they pre-fill from LinkedIn profile data. Message Ads have stigma in many B2B segments; use carefully.
+
+**TikTok.** In-Feed, TopView, Spark Ads, Branded Hashtag Challenge. Spark Ads (boost organic posts) outperform pure paid creative because they retain organic-feel signal. Use Spark when you have organic posts performing.
+
+Detail per platform in `references/campaign-type-reference.md`.
+
+---
+
+## What NOT to spend on
+
+Direct list. Audit any account against these and you will usually find easy savings.
+
+- **Branded keywords beyond defensive.** When ranking number one organically, branded paid clicks cannibalize free traffic. Some defensive spend is fine to block competitor bidding. Aggressive bidding on your own brand is waste.
+- **Display network without targeting.** Broad display drives garbage traffic. Use only for retargeting unless you have specific contextual targeting.
+- **Geographic markets you do not serve.** Sounds obvious, fails 30% of accounts. Audit geo targeting quarterly.
+- **Hours you cannot service.** For service businesses (legal, B2B, medical). Pause off-hours unless lead form clearly converts asynchronously.
+- **Devices that do not convert.** If mobile converts at 1% and desktop at 5% with the same CPC, bid down mobile aggressively.
+- **Audiences who never convert.** Pull last 90 days of converters, build exclusion lists for everyone else who repeatedly clicks but never converts.
+- **Creative that is tired.** Frequency above 4 with declining CTR means refresh. Refusing to refresh because "it still works ok" is incremental loss.
+
+The pattern across these is the same. Default settings or accumulated cruft generate spend without producing outcomes. Audit, exclude, and reclaim.
+
+---
+
+## Creative testing: within campaign vs across campaign
+
+Two modes. Different learning rates, different overhead.
+
+Within-campaign testing rotates 4 to 6 ad variations and lets the platform optimize delivery to top performers. Lower test risk because all variations live inside one campaign with one budget. Slower learning because the platform's optimization muddies the signal of which variation actually wins.
+
+Across-campaign testing runs entire campaign concepts (audience plus offer plus creative) against each other. Higher learning rate because each campaign has its own audience and budget. Higher setup overhead and harder to keep apples-to-apples.
+
+Cadence. Refresh top creative every 30 to 60 days at scale. Weekly for high-frequency campaigns. Keep the top one or two evergreen winners running and rotate others.
+
+The "winning creative is the floor" principle. Do not kill winners to test new ideas. Test alongside. The downside of running the proven winner is small; the downside of killing it for an unproven concept is large.
+
+---
+
+## Frequency capping
+
+Ad fatigue is real. Same audience seeing the same creative eight times in a week tunes it out, or worse, develops negative associations.
+
+Typical caps. Three to four impressions per user per week for Awareness campaigns. Six to eight per week for Direct Response. Lower for B2B (one to two per week per LinkedIn target). Platform defaults are usually too high; set explicit caps.
+
+Rotation as alternative. If you have enough creative variants, rotate often enough that no individual creative hits fatigue threshold. Rotation plus capping is the strongest pattern for high-spend, long-running campaigns.
+
+---
+
+## Attribution mismatch: platform-reported vs actual
+
+The trap. Platform-reported conversions are inflated by view-through attribution, generous click attribution windows, and platform self-attribution bias.
+
+**Last-click in GA vs platform-reported.** Google Ads typically reports 1.3 to 1.5x the conversions GA reports. The gap comes from multi-touch attribution differences and view-through that GA does not credit.
+
+**iOS 14.5+ impact.** Meta and other platforms underreport iOS conversions because of App Tracking Transparency. Modeled conversions try to fill the gap; they are imperfect. Treat iOS-heavy reporting with extra skepticism.
+
+**View-through attribution.** Counted by Meta and Google for users who saw but did not click. Often half the reported "conversions" are view-through. Useful for awareness; misleading for performance optimization.
+
+**Cross-platform interference.** Meta retargeting captures users who would have converted from Google Search anyway. Both platforms claim the conversion. You pay for the same conversion twice.
+
+The discipline. Single source of truth in your warehouse or analytics platform. Report against that for incrementality decisions. Use platform metrics for in-flight optimization only. The deeper interpretation work belongs in `ads-performance-analytics` (forthcoming); this skill names the trap so you do not optimize against the wrong number.
+
+Per-platform reporting quirks in `references/ads-platform-comparison.md`.
+
+---
+
+## Common failures
+
+Twelve patterns recur across paid media work. The short version. Detail in `references/common-failures.md`.
+
+- "We are scaling but CAC went up." Saturation on the primary audience. Expand the audience or diversify the channel mix.
+- "Conversions look fine in the platform, terrible in revenue." Attribution mismatch plus customer quality, not just count. The platform is selecting low-LTV converters because they are easier to find.
+- "We A/B tested and one wins, but only by 5%." Within margin of platform noise. Not a real signal.
+- "We turned off the underperforming campaign and conversions dropped overall." View-through or assist conversions you were not counting. Test with hold-out, not flat off.
+- "Frequency hit 8 last week." Refresh creative. Do not blame the audience.
+- "We are trying to scale Meta to $100K per day from $20K per day." That is not scaling, that is a 5x jump. Expect efficiency drop; phase the increase.
+- "We tried LinkedIn for our B2C product." Wrong channel for the offer. Not a LinkedIn problem.
+- "tROAS will not deliver." You set it too aggressive. Loosen the target or switch strategy.
+- "We saw a click-through bump after the Super Bowl ad." That is brand effect on existing demand, not paid attribution. Read it as a brand signal.
+- "Search Impression Share dropped." Either competition increased or budget is constrained. Check both before tuning bids.
+- "PMax is hard to optimize." Yes. Treat PMax as a tested channel with constrained levers, not a place to fine-tune at the keyword level.
+- "Lookalike performance dropped after we expanded to 5%." Wider lookalikes are looser; the floor is lower. Tighten back to 1 to 2% if CAC is the constraint.
+
+---
+
+## The framework: 11 considerations for sustainable paid media
+
+When designing or auditing paid media, walk these 11 considerations. Skipping any of them is how teams burn budget at scale.
+
+1. **Hypothesis.** Audience, offer, channel, outcome metric, magnitude. Pre-commit the falsification rule.
+2. **Channel fit.** Intent matches offer. Search for capture, Meta and TikTok for creation, LinkedIn for B2B precision.
+3. **Budget shape.** Brand vs performance, baseline vs test, primary vs secondary channel, daily vs lifetime.
+4. **Audience strategy.** Prospecting, retargeting, exclusion. Treated as separate strategies.
+5. **Bid strategy.** Manual, max conversions, tCPA, tROAS, max conversion value. Matched to data state.
+6. **Campaign type.** Right type for the platform and the goal.
+7. **What not to spend on.** Branded beyond defensive, untargeted display, wrong geos, off-hours, low-converting devices, never-convert audiences, tired creative.
+8. **Creative testing.** Within campaign and across campaign, plus refresh cadence.
+9. **Frequency capping.** Explicit caps and creative rotation.
+10. **Attribution reality.** Single source of truth, platform metrics for in-flight only.
+11. **Decision rule.** Pre-committed scale up, hold, or pull back at known thresholds.
+
+The output of the framework is one of three answers. Scale (the hypothesis is confirmed at the magnitude needed to justify more spend). Hold (results are at the falsification line; gather more data before committing). Kill (the hypothesis is wrong or the campaign is no longer pulling its weight).
+
+---
+
+## Reference files
+
+- [`references/channel-decision-matrix.md`](references/channel-decision-matrix.md) - Context-to-channel matrix with worked examples for the most common business contexts.
+- [`references/budget-allocation-templates.md`](references/budget-allocation-templates.md) - Typical splits and pacing patterns: growth-mode, steady-state, brand-heavy, performance-heavy.
+- [`references/audience-segmentation-patterns.md`](references/audience-segmentation-patterns.md) - Prospecting, retargeting, exclusion templates plus cross-platform reconciliation.
+- [`references/bid-strategy-reference.md`](references/bid-strategy-reference.md) - Each strategy's fit, common mistakes, and migration paths as data accumulates.
+- [`references/campaign-type-reference.md`](references/campaign-type-reference.md) - Per-platform campaign type guide with pitfalls.
+- [`references/ads-platform-comparison.md`](references/ads-platform-comparison.md) - Platform reporting quirks, attribution differences, and the single-source-of-truth pattern.
+- [`references/common-failures.md`](references/common-failures.md) - Twelve failure patterns with symptom, root cause, fix, and prevention.
+
+---
+
+## Closing: when in doubt, kill the campaign
+
+Most paid media decisions reduce to scale, hold, or kill. When the analysis is genuinely ambiguous, default to kill.
+
+The cost of a campaign that is not clearly working is real money flowing out the door every day. The cost of killing a marginal campaign is mostly just the inconvenience of restarting it later. Asymmetric risk. Default to kill.
+
+The follow-on rule is symmetric. When the hypothesis is clearly confirmed at the magnitude that matters, scale aggressively. The cost of slow-rolling a working campaign is opportunity cost; competitors compound on the same demand pool. Default to scale once the data justifies it.
+
+Marginal results are the trap. They invite more analysis, more meetings, more "let us give it another two weeks." Two weeks of marginal CAC is two weeks of lost money. Pre-commit the decision rule and execute it.

--- a/skills/paid-media-strategy/references/ads-platform-comparison.md
+++ b/skills/paid-media-strategy/references/ads-platform-comparison.md
@@ -1,0 +1,106 @@
+# Ads platform comparison
+
+Per-platform reporting quirks, attribution differences, and the single-source-of-truth pattern.
+
+The platforms do not agree on what counts as a conversion or how long a click should attribute. Reading the platform's reported numbers as truth is the most expensive mistake in paid media.
+
+---
+
+## Google Ads
+
+**Default attribution model.** Data-driven attribution (DDA) is the default. DDA distributes credit across multiple touchpoints based on the platform's machine learning. Single touch attribution (last-click) is available but no longer the default.
+
+**Conversion windows.** Default 30-day click attribution and 1-day view-through. Both adjustable. The 30-day click window is wider than what GA reports by default, which produces the typical 1.3 to 1.5x conversion overcount versus GA.
+
+**Quirks to know.**
+- DDA gives partial credit to keywords that touched the path even if the user did not click. The reported conversion volume under DDA is higher than under last-click.
+- Smart Bidding optimizes against the DDA-reported conversions, not GA-reported. Optimizing for one number while measuring against another produces drift.
+- View-through attribution on Display and Video is opt-in; default is off.
+
+**Reading the numbers.** Compare Google Ads conversions against GA's "Google Ads" channel rather than against total GA conversions. The gap between the two is the attribution-model gap; treat with awareness.
+
+---
+
+## Meta (Facebook + Instagram)
+
+**Default attribution.** 7-day click and 1-day view-through. Adjustable to 7-day click only or 1-day click only.
+
+**Conversion windows.** 7-day click is the standard. Wider windows are more generous to Meta; narrower windows are more conservative.
+
+**iOS 14.5+ impact.** App Tracking Transparency (ATT) reduced Meta's ability to track iOS conversions. Meta filled the gap with modeled conversions (statistically estimated based on aggregated behavior) and Conversions API (server-side event tracking). Both help, neither fully restores pre-ATT visibility.
+
+**Quirks to know.**
+- View-through attribution counts impressions even if the user did not click. Often half the reported conversions are view-through. Treat with skepticism for direct response.
+- Modeled conversions are a meaningful share of iOS-reported conversions in 2025-2026. They are statistically estimated, not directly observed; do not trust them with the precision you would trust click-based conversions.
+- Conversions API (CAPI) sends server-side events that complement pixel events. Setting up CAPI is one of the highest-impact technical investments for a Meta-heavy account.
+
+**Reading the numbers.** Disaggregate by attribution window in the Ads Manager (1-day click, 7-day click, 1-day view, 7-day view). The 1-day click number is the most conservative and the closest to incremental.
+
+---
+
+## LinkedIn
+
+**Default attribution.** 30-day click and 7-day view-through.
+
+**Conversion windows.** Longer than B2C platforms because B2B buying cycles are longer. The 30-day click window matches the typical B2B consideration cycle for many categories.
+
+**Quirks to know.**
+- LinkedIn's reporting tends to under-credit cross-device journeys (work computer click, personal phone visit). Pair with self-reported attribution surveys for B2B.
+- Lead Gen Forms count form submissions as conversions; downstream lead qualification is on you to track.
+- Demographic insights (job title, seniority, company size, industry) are unique to LinkedIn and uniquely valuable for B2B audience refinement.
+
+**Reading the numbers.** Lead Gen conversions are easy to overcount because form friction is low; some leads are accidental. Filter at CRM ingestion before treating LinkedIn-reported lead counts as the truth.
+
+---
+
+## TikTok
+
+**Default attribution.** 7-day click and 1-day view-through (similar to Meta).
+
+**Conversion windows.** Adjustable. TikTok also supports a "video view" event that is unique to the platform.
+
+**Quirks to know.**
+- Video-completion-based attribution: TikTok counts conversions even when the user did not click but watched the full video. This is real signal for awareness; it inflates direct-response numbers.
+- iOS impact similar to Meta but less mature in the modeling.
+- Spark Ads attribution is shared between paid and organic. The same view that drove a conversion shows up in both surfaces; be careful not to double-count when reconciling.
+
+**Reading the numbers.** Click-based conversions are the most reliable. Video-view-based conversions are real signal but should be reported separately.
+
+---
+
+## Cross-platform interference
+
+Two platforms claiming the same conversion is the single most common attribution mistake.
+
+**The classic case.** A user sees a Meta ad, then later searches for the brand on Google, clicks a brand keyword, and converts. Meta claims the conversion (view-through). Google Ads claims the conversion (last-click on the brand search). GA might attribute it to organic if the brand search was not paid. Three different views of one conversion.
+
+**The defense.** A single source of truth in your warehouse or analytics platform. Multi-touch attribution at the warehouse level distributes credit fairly. Marketing-mix modeling (MMM) at the budget-allocation level cuts through the platform-self-attribution bias.
+
+---
+
+## Single-source-of-truth pattern
+
+Three layers, each serving a different decision.
+
+**Layer 1: platform metrics.** Use for in-flight optimization only. Ad set-level CAC, creative-level CTR, audience-level frequency. The platform's view of its own performance is fine for optimizing the platform's own levers.
+
+**Layer 2: warehouse multi-touch attribution.** Use for cross-platform comparison. Each conversion gets attributed across all platforms that touched the path. Common patterns: last-click, first-click, linear, position-based, time-decay, data-driven. Pick one and standardize across the team.
+
+**Layer 3: marketing-mix modeling (MMM).** Use for budget allocation across channels. MMM treats spend as an input and revenue as an output, modeling the contribution of each channel net of the others. The strongest defense against platform-self-attribution bias.
+
+The cadence. Layer 1 in real time. Layer 2 weekly. Layer 3 quarterly.
+
+---
+
+## What the numbers mean in practice
+
+A typical mid-stage account has the following attribution gap pattern:
+
+- Google Ads reports: 1.3 to 1.5x what GA reports for "Google Ads" channel.
+- Meta reports: 1.5 to 2.5x what GA reports for "Facebook" channel (more on iOS-heavy audiences).
+- LinkedIn reports: roughly equal to GA for click-based conversions.
+- TikTok reports: 1.5 to 3.0x what GA reports (high view-through component).
+
+If you sum all platforms' reported conversions and compare to actual revenue, the sum is typically 2 to 4x actual. The "extra" conversions are attribution overlap, view-through credit, and platform-self-attribution.
+
+The discipline. Trust the warehouse number for incrementality decisions. Use platform numbers for in-flight tuning. Do not optimize one platform's CAC against another platform's CAC; you are comparing different definitions of the same word.

--- a/skills/paid-media-strategy/references/audience-segmentation-patterns.md
+++ b/skills/paid-media-strategy/references/audience-segmentation-patterns.md
@@ -1,0 +1,87 @@
+# Audience segmentation patterns
+
+Three audience types treated as separate strategies: prospecting, retargeting, exclusion. Plus cross-platform reconciliation patterns and the most common anti-patterns.
+
+---
+
+## Prospecting
+
+New people who have not engaged with your brand. The largest budget share for growth-mode brands.
+
+**Lookalike audiences (Meta, TikTok).** Seed from a high-quality source (top 10% LTV customers, paying customers from the last 90 days, repeat purchasers) and ask the platform for similar users. 1 to 2% lookalikes are tightest and convert best at lower volumes; 5 to 10% lookalikes are looser and scale to volume but convert at lower rates. Start narrow, expand only if the floor holds.
+
+**In-market audiences (Google).** Google's behavioral signals identify users actively researching a category. Pair with category-relevant keywords for capture, or use as broad targeting on Display, Video, and PMax.
+
+**Interest stacks (Meta).** Stack multiple interest groups within an ad set. The stack approach lets the algorithm find the overlap. Single interests are usually too narrow; flat lists of 30 interests are too broad. Aim for 5 to 10 related interests.
+
+**Custom intent or affinity (Google).** Build audiences from URL lists or keyword lists. Useful for niche categories where in-market is not a clean fit.
+
+**Account lists (LinkedIn).** Upload a target account list and target by company. Pair with job-title or seniority filters to narrow further. The strongest pattern for ABM-style B2B paid.
+
+The prospecting principle. Start with one well-defined audience that matches your hypothesis. Prove CAC. Then expand. Running five prospecting audiences in parallel before any one is proven is the most expensive way to learn nothing.
+
+---
+
+## Retargeting
+
+People who engaged but did not convert. Smaller audience size, higher CTR, lower CAC if executed correctly.
+
+**Window splits.** Different windows have different conversion intents. Run three retargeting tiers with different creative.
+
+| Window | Audience intent | Creative |
+|---|---|---|
+| 0 to 7 days | Hot. Recent visitors. | Direct conversion offer. Reinforce value prop. |
+| 8 to 30 days | Warm. Considered but did not convert. | Address objections. Social proof. Comparison content. |
+| 31 to 90 days | Cool. Long consideration cycle or churned interest. | Reactivate with new offers, new content, or value updates. |
+
+**Cart abandoner specific.** If e-commerce, cart abandonment is its own retargeting tier. Window: 0 to 7 days. Creative: cart contents reminder, often with a small incentive (free shipping, 10% off). CTR and CAC are usually the strongest of any retargeting segment.
+
+**Page-specific retargeting.** Visitors to high-intent pages (pricing, demo request, product detail) are warmer than homepage visitors. Run page-specific retargeting at higher bids.
+
+The retargeting trap. Bidding too aggressively trains the platform to charge a premium for users who would have converted anyway. Cap retargeting CPM and CPC; the high CTR and conversion rate produce strong results without aggressive bids.
+
+---
+
+## Exclusion
+
+The audiences you do not want paying for clicks from. Saves spend and keeps frequency low.
+
+**Current customers.** Users with active subscriptions, recent purchases, or active accounts. Exclude from prospecting and most retargeting. Exception: lapsed-cart-from-paying-customer retargeting, which can lift add-to-cart-to-purchase rates.
+
+**Recent converters.** Users who converted in the last 30 to 90 days. Exclude from prospecting. The platform will keep showing them ads otherwise, which produces frequency fatigue and zero new revenue.
+
+**Failed-conversion audiences.** Users who clicked repeatedly across a 60 to 90 day window without converting. Build an exclusion list from this segment. They have signaled they are not converting from paid; stop paying to show them ads.
+
+**Employee lists.** Upload employee email lists and exclude from all paid traffic. Employees clicking on company ads inflate spend and pollute attribution.
+
+**Cross-platform exclusion.** When running both Meta and Google, exclude Meta retargeting from Google retargeting (and vice versa). Two platforms hitting the same user with the same offer produces frequency fatigue and double-billing.
+
+---
+
+## Cross-platform audience reconciliation
+
+When running multiple platforms, audience definitions should align so attribution comparisons are meaningful.
+
+**The seed list problem.** If Meta sees a customer file and Google sees a different customer file, the lookalike sources differ. Reconcile by uploading the same customer list to both, segmented identically (top 10% LTV, last 90 days, etc.).
+
+**The retargeting overlap problem.** A user who visited the site appears in both Meta retargeting and Google retargeting. Both platforms claim the conversion. Reconcile by running one retargeting platform at a time, or by setting platform-specific retargeting budgets that match the actual incremental contribution.
+
+**The exclusion problem.** A user who converts on Meta should be excluded from Google paid prospecting (and vice versa). Without cross-platform exclusion, you pay to advertise the same offer to the same user twice. Pipe conversions to a unified audience layer (CDP, warehouse, or audience-sync tool like Synter or Hightouch) and push exclusions back to each platform.
+
+---
+
+## Anti-patterns
+
+Common mistakes that recur across accounts.
+
+**Prospecting too narrow.** Audience size below the platform's optimization minimum (Meta: roughly 1M users; Google: roughly 100K). The platform cannot optimize against signal that thin. Expand the audience until it has at least 1 to 5 million reachable users (Meta) or in-market scale (Google).
+
+**Retargeting too aggressive.** Bidding above the value of the incremental conversion. Half the retargeting "conversions" would have happened anyway from organic; if you bid for them at full attribution, you overpay.
+
+**No exclusions.** The most common audit finding. Current customers, recent converters, and employees all clicking on paid ads.
+
+**Lookalike from the wrong source.** Building a 5% lookalike from "all customers" (including low-LTV churners). The platform returns users similar to the average, not similar to your best. Always seed from top-LTV or paid-and-retained customers.
+
+**Too many ad sets per campaign.** Splitting one campaign into 10 ad sets fractures the data the platform needs to optimize. Consolidate into 2 to 4 ad sets per campaign with audience size sufficient for each to learn.
+
+**Audience overlap across ad sets.** Two ad sets in the same campaign targeting similar users compete with each other and inflate CPC. Audit overlap with the platform's overlap tool; consolidate ad sets that overlap above 30%.

--- a/skills/paid-media-strategy/references/bid-strategy-reference.md
+++ b/skills/paid-media-strategy/references/bid-strategy-reference.md
@@ -1,0 +1,104 @@
+# Bid strategy reference
+
+Each major bid strategy with definition, fit criteria, common mistakes, and the migration path as data accumulates.
+
+The decision shape. Bid strategy depends on data state. New campaigns need a different strategy than mature ones. Switching too often resets the learning phase and wastes the data you just gathered. Pick the strategy that fits the current data state, run it long enough to gather signal, then promote.
+
+---
+
+## Manual CPC or CPM
+
+**Definition.** Set a max cost per click or cost per thousand impressions. The platform charges no more than the cap.
+
+**When to use.** Diagnostics. Very early campaigns with no data history. Niche audiences where the platform's machine learning would over-broaden. Branded keyword campaigns where you want explicit cost control.
+
+**When not to use.** Most production campaigns at scale. Manual scales slowly because every adjustment requires a human decision; automated strategies optimize across thousands of micro-decisions per hour.
+
+**Common mistakes.** Setting CPC caps below the auction floor (the campaign delivers nothing). Switching from manual to automated too early before there is enough data for the automated strategy to optimize against.
+
+---
+
+## Maximize Conversions
+
+**Definition.** Platform optimizes for conversion volume within the budget. The platform decides CPC.
+
+**When to use.** Early-stage campaigns where you want as many conversions as possible regardless of unit cost. Good for gathering the conversion data needed to graduate to tCPA later. Good for awareness or list-building campaigns where volume matters more than per-unit cost.
+
+**When not to use.** Once CAC is the binding constraint. Maximize Conversions does not respect CAC; it just optimizes for count.
+
+**Common mistakes.** Running Maximize Conversions for too long when CAC is creeping up. Set a cadence to evaluate the migration to tCPA once you have 30+ conversions in the recent window.
+
+---
+
+## Target CPA (tCPA)
+
+**Definition.** Set a max CPA. Platform delivers conversions within the target.
+
+**When to use.** Once you have 30+ conversions in the recent 30 day window for the platform to optimize against. Use when CPA is the constraint and you have enough data for the platform's machine learning to converge.
+
+**When not to use.** Before you have enough conversion data. The platform cannot optimize tCPA without enough signal; it will either underdeliver or learn against noise.
+
+**Common mistakes.** Setting tCPA below the prior 30-day actual CPA (platform throttles delivery to almost zero). Setting tCPA too aggressive in a thin-data campaign (same effect; throttled delivery and no learning). Switching tCPA targets every week (each change resets the learning phase). Set the target reasonably (within 15% of recent actual) and let it run.
+
+---
+
+## Target ROAS (tROAS)
+
+**Definition.** Set a min ROAS. Platform delivers conversions above the target.
+
+**When to use.** When revenue per conversion varies substantially (e-commerce with mixed AOV, marketplaces with mixed take rates). Once you have 50+ conversions and conversion-value tracking is wired in.
+
+**When not to use.** Before conversion-value tracking is reliable. Without conversion values, tROAS has nothing to optimize against and falls back to behavior similar to Maximize Conversions but with throttled delivery.
+
+**Common mistakes.** Setting tROAS too aggressively (platform delivers almost nothing). Not feeding accurate conversion values (the platform optimizes for the wrong number). Switching tROAS targets too often.
+
+---
+
+## Maximum Conversion Value
+
+**Definition.** Like Maximize Conversions, but the platform optimizes for total conversion value rather than count.
+
+**When to use.** Same conditions as tROAS, but without a fixed target. Good when you want to maximize revenue within budget without specifying the per-unit ROAS floor.
+
+**When not to use.** Without conversion-value tracking. Without volume confidence; same as tROAS, the platform needs enough conversions to optimize against value.
+
+**Common mistakes.** Running without conversion values configured (the platform falls back to count). Treating it identically to Maximize Conversions; the value optimization changes which conversions the platform finds.
+
+---
+
+## Enhanced CPC
+
+**Definition.** Manual CPC with platform adjustments based on conversion likelihood.
+
+**When to use.** Rarely. The hybrid muddies the signal. If you want manual control, run pure manual CPC. If you want automation, graduate to Maximize Conversions or tCPA.
+
+**When not to use.** Most situations. The hybrid is a transitional state from a previous platform default; modern campaigns should pick a clear strategy.
+
+**Common mistakes.** Treating Enhanced CPC as the safe default. It is neither full control nor full automation; the worst of both.
+
+---
+
+## The migration path
+
+The progression for a new campaign as data accumulates.
+
+| Data state | Strategy | Rationale |
+|---|---|---|
+| Day 1 to ~30 conversions | Manual CPC or Maximize Conversions | Gather data. Platform machine learning has nothing to optimize against yet. |
+| 30 to 100 conversions | Target CPA | Platform has enough signal to optimize against a CPA target. Set within 15% of recent actual. |
+| 100+ conversions, value tracking on | Target ROAS or Max Conversion Value | Optimize for revenue or ROAS rather than count. |
+| Mature campaign at scale | Whichever produces best CAC + ROAS | Stay there. Switching strategies on a mature campaign restarts the learning phase. |
+
+The migration cadence. Evaluate the migration after every 30 days or every 50% conversion volume increase, whichever comes first. Do not switch every week; the learning phase reset cost is real.
+
+---
+
+## When to NOT switch strategy
+
+Three signals that suggest staying on the current strategy even when something else looks better.
+
+1. **Recent change.** If you switched strategy in the last 14 days, give it more time. The learning phase needs at least 2 weeks of consistent volume to converge.
+2. **Volatile conversion volume.** If conversion volume is bouncing 50%+ week-over-week, the platform's optimization signal is noisy. Stabilize volume before switching.
+3. **Active creative test.** If you are mid-test on creative or audience, do not also change bid strategy. One variable at a time. The bid strategy change muddies the creative test signal.
+
+The rule. Switch strategy when one variable is stable and the data state has clearly progressed. Avoid stacking changes; you cannot tell which change drove the result.

--- a/skills/paid-media-strategy/references/budget-allocation-templates.md
+++ b/skills/paid-media-strategy/references/budget-allocation-templates.md
@@ -1,0 +1,107 @@
+# Budget allocation templates
+
+Four split patterns plus pacing guidance. Pick the template closest to your situation and adapt.
+
+The splits operate at the same time: brand vs performance, baseline vs test, primary vs secondary channel, daily vs lifetime.
+
+---
+
+## Template 1: Growth-mode allocation
+
+For brands actively scaling with a working unit economic model.
+
+| Bucket | Share | Notes |
+|---|---|---|
+| Prospecting | 70% | New audience reach. Largest share because growth comes from new demand. |
+| Retargeting | 20% | Engaged-but-not-converted users. Small audience, high CTR, low CAC. |
+| Test | 10% | Systematic tests of new audiences, channels, or creative concepts. |
+
+Plus brand-vs-performance: 25% brand, 75% performance for B2C. 50-50 for B2B with longer cycles.
+
+Plus channel: 60-70% to one primary channel that has proven its CAC, 25% to a secondary, 5-15% to scale-out experiments.
+
+---
+
+## Template 2: Steady-state allocation
+
+For brands holding scale rather than aggressively pushing it.
+
+| Bucket | Share | Notes |
+|---|---|---|
+| Prospecting | 50% | Lower share because steady-state needs less new demand. |
+| Retargeting | 30% | Higher share because the existing pipeline is the main flow. |
+| Test | 20% | Higher share than growth-mode; steady-state is when systematic testing pays off. |
+
+Plus brand-vs-performance: 40% brand, 60% performance. The brand share is higher than growth-mode because steady-state is about defending position.
+
+---
+
+## Template 3: Brand-heavy allocation
+
+For categories where brand investment compounds (premium consumer, B2B with long consideration, regulated industries).
+
+| Bucket | Share | Notes |
+|---|---|---|
+| Brand | 60% | Awareness, reach, video at scale. Long-term demand pipeline. |
+| Performance | 40% | Search and retargeting on the demand the brand creates. |
+
+Within performance, 60% prospecting and 40% retargeting is typical. Test budget comes out of the brand share.
+
+---
+
+## Template 4: Performance-heavy allocation
+
+For DTC and direct-response B2C where the unit economics are tight and brand effects are slow to compound.
+
+| Bucket | Share | Notes |
+|---|---|---|
+| Brand | 20% | Minimum viable awareness investment. Mostly content and organic. |
+| Performance | 80% | Direct-response paid; CAC is the binding metric. |
+
+Within performance, growth-mode splits apply: 70% prospecting, 20% retargeting, 10% test.
+
+---
+
+## Pacing patterns
+
+Budgets that run flat through the month miss the demand peaks and overspend during the troughs. Three pacing patterns to layer onto the daily template.
+
+**Front-load testing weeks.** When launching a new creative concept or a new audience, front-load 60% of the test budget in the first 7 to 10 days. The platform learning phase needs concentrated signal; spreading too thin means slower convergence.
+
+**Back-load seasonality.** For categories with a seasonal peak (holiday, end-of-quarter, category-specific moments), shift 30 to 50% of monthly budget into the peak two-week window. Flat budgets through Q4 leave money on the table.
+
+**Front-load for launch.** For new campaigns with no historical data, front-load creative testing in week one. Accept lower efficiency in week one in exchange for picking the winning creative quickly. By week three the winning concept should be running at scale.
+
+**Steady for evergreen.** For mature campaigns hitting consistent CAC at scale, run flat daily. The platform's learning is stable; introducing pacing variance creates noise that reduces optimization quality.
+
+---
+
+## Daily vs lifetime budgets
+
+**Daily budget.** Use for ongoing campaigns where you want a stable spend floor. The platform charges up to your daily cap regardless of opportunity, which is what you want for predictable production work.
+
+**Lifetime budget.** Use for finite tests where the platform should pace itself across a defined window. Lifetime budgets prevent runaway spend during testing; the platform optimizes pacing so the test ends on the planned date with the planned spend.
+
+Mistakes. Using daily for tests (the test runs forever or stops abruptly when budget is paused). Using lifetime for evergreen campaigns (the platform front-loads or back-loads in ways you do not want).
+
+---
+
+## Channel split mistakes
+
+The most common channel-budget mistake is the equal split. Spreading $100K across four channels at $25K each produces four underperforming campaigns; one campaign at $80K plus three at $7K each produces one strong learning signal and three quick reads on whether the others are worth scaling.
+
+The principle. One channel does the heavy lifting (60 to 70% of budget). Others scale supplementally. Resist the temptation to be balanced. Balanced budgets across unproven channels is the most expensive way to learn nothing.
+
+The exception. After two channels are proven independently, splitting toward equal is fine because each channel has its own efficient scale. Before that point, concentrate.
+
+---
+
+## Reallocation triggers
+
+Three signals that the current split needs to shift.
+
+1. **Primary channel CAC drifted up by 25% over two weeks.** The audience is saturating or competition increased. Shift some budget to the secondary channel and drop the primary's daily.
+2. **Test budget produced a new winner.** A test channel or audience is hitting CAC equal to or better than baseline. Promote it to baseline at 15% of total budget; the previous baseline holds 55 to 60%.
+3. **Frequency exceeded threshold across the prospecting audience.** The audience saw the creative more than the cap. Either rotate creative or expand the audience; if both are constrained, pull back budget.
+
+Reallocation cadence: monthly review minimum. Weekly during high-spend periods or active scale-up.

--- a/skills/paid-media-strategy/references/campaign-type-reference.md
+++ b/skills/paid-media-strategy/references/campaign-type-reference.md
@@ -1,0 +1,197 @@
+# Campaign type reference
+
+Per-platform campaign type guide. For each campaign type: what it is, when it fits, common pitfalls.
+
+---
+
+## Google Ads
+
+### Search
+
+**What it is.** Text ads on Google search results pages, triggered by keyword auctions.
+
+**When to use.** Direct demand capture. Users searching for category, product, or competitor terms.
+
+**Pitfalls.** Branded over-spend (cannibalizing free traffic). Broad match on weak keywords (drives garbage clicks). Missing negative keyword lists (paying for irrelevant search terms). Audit search-term reports monthly and add negatives.
+
+### Shopping
+
+**What it is.** Product listing ads driven by your Google Merchant Center feed.
+
+**When to use.** E-commerce with a structured catalog. Comparison-shopping intent.
+
+**Pitfalls.** Bad feed quality (missing GTINs, weak titles, wrong categories). The feed is the bottleneck; clean it before scaling spend.
+
+### Performance Max (PMax)
+
+**What it is.** Automated multi-channel campaign that runs across Search, Shopping, Display, YouTube, Discover, and Gmail. The platform decides placement.
+
+**When to use.** E-commerce with a strong feed. When you want Google's automation to do the placement work. As a complement to Search, not a replacement.
+
+**Pitfalls.** Black box optimization makes manual tuning hard. Cannibalizes branded Search traffic; exclude branded queries via account-level negatives. Asset group quality drives results; weak creative produces weak results regardless of platform automation.
+
+### Display
+
+**What it is.** Banner and image ads on the Google Display Network (millions of partner sites).
+
+**When to use.** Retargeting (small audiences, defined intent). Specific contextual targeting where you trust the placement list.
+
+**Pitfalls.** Display without targeting drives garbage traffic. Default placements include low-quality sites that hurt brand. Use only for retargeting unless you have explicit placement controls.
+
+### Video (YouTube)
+
+**What it is.** Video ads on YouTube. Various formats (skippable, non-skippable, bumper, in-feed).
+
+**When to use.** Awareness at scale. B2C consideration. Underrated for B2B SaaS in some categories where buyer research includes long-form video.
+
+**Pitfalls.** Direct-response on Video rarely works as well as Meta video. Use for awareness or as an upper-funnel layer. Skippable ads with strong first-5-seconds work; non-skippable annoys.
+
+### Demand Gen
+
+**What it is.** Successor to Discovery ads. Visual ads across Discover, Gmail, YouTube Shorts, and YouTube in-feed.
+
+**When to use.** Visual-first products targeting users in discovery mode (not search mode).
+
+**Pitfalls.** Newer campaign type with less optimization history; results are more volatile than Search or Shopping. Treat as a tested channel.
+
+### Discovery
+
+**What it is.** Visual ads across Google's discovery surfaces. Being merged with Demand Gen.
+
+**When to use.** Largely deprecated in favor of Demand Gen. Migrate existing Discovery campaigns.
+
+### App
+
+**What it is.** Universal App Campaigns for app installs and engagement.
+
+**When to use.** App promotion. Mostly automated; you provide creative and budget.
+
+**Pitfalls.** Hard to optimize beyond budget and creative inputs. Track post-install events (subscription, retention) not just installs.
+
+---
+
+## Meta (Facebook + Instagram)
+
+### Sales
+
+**What it is.** Campaigns optimized for conversions. The default for direct response.
+
+**When to use.** E-commerce, subscriptions, lead capture with measurable conversion events.
+
+**Pitfalls.** Wrong conversion event optimization (optimizing for "Add to Cart" when "Purchase" is what matters). Inadequate pixel setup (the conversion data feeding the algorithm is incomplete).
+
+### Leads
+
+**What it is.** Campaigns with native lead forms inside Facebook or Instagram.
+
+**When to use.** B2B with mid-funnel offers (whitepaper, demo request, newsletter signup). Native forms have lower friction than off-platform forms.
+
+**Pitfalls.** Lead quality is lower than off-platform forms (less friction, more accidental submissions). Build a CRM enrichment step to filter low-quality leads before passing to sales.
+
+### Engagement
+
+**What it is.** Optimizes for likes, comments, shares, page follows.
+
+**When to use.** Building an organic audience. Almost never as a primary objective for performance work.
+
+**Pitfalls.** Engagement does not predict conversion. Vanity metrics if used as a primary objective for revenue work.
+
+### Awareness
+
+**What it is.** Optimizes for reach and frequency. Brand-style budget.
+
+**When to use.** Brand at scale. New product launches. Competitor-conquest moments.
+
+**Pitfalls.** No conversion signal feeding the algorithm. Cannot evaluate against CAC. Use as a brand layer, not a performance layer.
+
+### Traffic
+
+**What it is.** Optimizes for clicks (link clicks or landing page views).
+
+**When to use.** Driving traffic to long-form content, blog posts, awareness pages where the user journey is multi-touch.
+
+**Pitfalls.** Click-optimized traffic does not predict conversion. The platform finds users likely to click, not users likely to convert. Only use for top-funnel content distribution.
+
+### App Promotion
+
+**What it is.** App install campaigns within Meta.
+
+**When to use.** App promotion specifically. Compare against Google App Campaigns.
+
+**Pitfalls.** iOS 14.5+ tracking restrictions impact attribution; modeled conversions fill the gap imperfectly.
+
+---
+
+## LinkedIn
+
+### Sponsored Content
+
+**What it is.** Sponsored posts in the LinkedIn feed.
+
+**When to use.** B2B awareness and consideration. Native to the LinkedIn experience.
+
+**Pitfalls.** High floor (CPM 5 to 10x consumer platforms). Justify with B2B LTV; otherwise unprofitable.
+
+### Message Ads
+
+**What it is.** Direct messages delivered via LinkedIn InMail.
+
+**When to use.** High-intent B2B nudges where the message reads as a personal note.
+
+**Pitfalls.** Stigma in many segments. Treated as spam if the message reads generic. Personalize aggressively or skip.
+
+### Conversation Ads
+
+**What it is.** Multi-step interactive messages with branching CTAs.
+
+**When to use.** Mid-funnel B2B where multiple value propositions need to be tested in one experience.
+
+**Pitfalls.** Setup complexity. Many teams underuse the branching capability and run them as glorified Message Ads.
+
+### Lead Gen Forms
+
+**What it is.** Native lead forms pre-filled from LinkedIn profile data.
+
+**When to use.** Highest converting LinkedIn objective. Use whenever the offer is a lead capture (demo, whitepaper, content offer).
+
+**Pitfalls.** Lead quality varies by form length. Shorter forms get more leads; longer forms filter to higher quality. Iterate.
+
+### Format types
+
+Single image, carousel, video. Carousel often outperforms single image for product or feature explainers. Video performs best when shot LinkedIn-native with first-3-seconds hook and captions on by default.
+
+---
+
+## TikTok
+
+### In-Feed
+
+**What it is.** Standard ads in the For You Page feed.
+
+**When to use.** Default TikTok format. Most direct-response and awareness work runs here.
+
+**Pitfalls.** Polished ad creative is rejected by the algorithm; native-feeling content wins. Iterate creative weekly to avoid fatigue.
+
+### TopView
+
+**What it is.** Premium first-impression placement when users open the app.
+
+**When to use.** Brand moments at scale. Product launches.
+
+**Pitfalls.** Expensive. Only justify with measurable brand lift or product launch impact.
+
+### Spark Ads
+
+**What it is.** Boost an existing organic post as an ad. Retains organic engagement and signal.
+
+**When to use.** Whenever you have organic posts performing. Spark Ads outperform pure paid creative because they retain the organic-feel signal.
+
+**Pitfalls.** Requires organic content to exist. If the brand has no organic presence, build one first.
+
+### Branded Hashtag Challenge
+
+**What it is.** Sponsored hashtag with branded content prompts.
+
+**When to use.** Major brand campaigns where user-generated participation matters.
+
+**Pitfalls.** Expensive. Hard to measure direct response. Best for brands with cultural-moment ambitions, not direct response.

--- a/skills/paid-media-strategy/references/channel-decision-matrix.md
+++ b/skills/paid-media-strategy/references/channel-decision-matrix.md
@@ -1,0 +1,56 @@
+# Channel decision matrix
+
+A context-to-channel map. The left column is the situation. The center columns are the recommended channels. The right column is reasoning and what NOT to start with.
+
+Read top to bottom and stop at the first row that matches your situation in three or more dimensions. Use the remaining rows as cross-checks.
+
+---
+
+## The matrix
+
+| Situation | Primary channel | Secondary channel | Reasoning and what to avoid early |
+|---|---|---|---|
+| Pre-PMF B2B SaaS | LinkedIn (precision) or Google Search (intent) | Content + organic; defer paid scale | Avoid Meta and TikTok early; the audience is not on those platforms. Avoid PMax; you do not have the data state for it. |
+| High-AOV B2B (>$5K LTV) | LinkedIn Sponsored Content + Lead Gen Forms | Google Search on category and intent terms | LinkedIn floor is high but justified at this LTV. Avoid TikTok, Reddit, and broad Meta until the LinkedIn motion is repeating. |
+| Low-AOV consumer product (<$50 LTV) | Meta (Sales objective) | TikTok (Spark Ads if organic exists) | Avoid LinkedIn (floor too high). Avoid Search unless category-defining query volume exists. Watch payback period; low LTV with paid CAC is razor-thin. |
+| DTC with strong visual brand | Meta (Sales + Reels) | TikTok In-Feed and Spark Ads | Avoid LinkedIn. Avoid Display network. Visual-first creative is the moat; double down on the platforms that surface it. |
+| Local services | Google Search + Local Service Ads | Meta with geo radius targeting | Avoid TikTok and LinkedIn (wrong intent). Pause off-hours. Geo-radius is the most important targeting lever. |
+| Enterprise SaaS (>$50K ACV) | LinkedIn (job-title precision) | Account-Based Marketing platforms + Google Search on category terms | Avoid Meta and TikTok. Avoid broad Display. Pair with ABM on a target account list; audiences are too small for Meta lookalikes to work. |
+| E-commerce with catalog | Google Performance Max + Shopping | Meta (Catalog Sales) | Avoid Search-only spend; PMax includes Search and adds catalog placements. Avoid LinkedIn. Feed quality is the bottleneck; fix the feed before spending on PMax. |
+| Subscription consumer | Meta (Sales objective with subscriber LTV) | Google Search on intent + brand terms | Avoid LinkedIn. Watch retention; CAC paid back over multiple months means the unit economics window matters more than first-month CAC. |
+| Marketplace (two-sided) | Channel-by-side: Meta for consumer side, LinkedIn or Search for supplier side | Reddit niche communities for the supplier side | Run two separate strategies, not one unified plan. The two sides have different intent and need different channels. |
+| Pre-launch waitlist | Meta (Engagement or Lead) | Reddit and TikTok organic + light paid | Avoid Search; no one is searching for an unlaunched product. Avoid LinkedIn unless B2B. Cheap CPL but low intent; expect waitlist conversion under 20%. |
+
+---
+
+## Worked examples
+
+### Example 1: Series B B2B SaaS, $25K ACV, North American sales motion
+
+The team has a working sales motion and is scaling outbound. They want paid media to add inbound demand without killing CAC.
+
+**Recommendation.** LinkedIn Sponsored Content as the primary, plus Google Search on category and competitor terms as secondary. Run Lead Gen Forms within LinkedIn to capture demos. Avoid Meta and TikTok early; the buying committee is on LinkedIn and at the office. Budget split: 60% LinkedIn, 30% Search, 10% test (Reddit B2B subreddits, niche newsletters). Watch CAC against the $25K ACV and a 3:1 LTV-to-CAC target.
+
+### Example 2: DTC adaptogenic soda, $24 AOV, US-only
+
+The brand has strong visual identity and an organic TikTok presence with one viral post per month. They want to scale paid.
+
+**Recommendation.** Meta (Sales objective with Catalog) as the primary. TikTok Spark Ads on the existing organic posts as the secondary. Avoid LinkedIn entirely. Avoid Search unless brand search volume justifies defensive spend. Budget split: 60% Meta, 30% TikTok, 10% test (Pinterest for visual discovery). The viral organic posts are the asset; Spark Ads recycle them at scale. Watch payback period; $24 AOV with paid CAC is razor-thin.
+
+### Example 3: Local home services, three-state operating area
+
+The team operates plumbing services across three states. They want predictable lead flow.
+
+**Recommendation.** Google Search plus Local Service Ads as the primary. Meta with geo radius as the secondary for awareness in the operating area. Avoid LinkedIn and TikTok (wrong intent). Pause off-hours unless 24-hour service is a positioning angle. Budget split: 70% Search and LSAs, 20% Meta geo, 10% test (Nextdoor where available). The geo-radius lever is the most important; a 2% mistargeting rate compounds at scale.
+
+### Example 4: E-commerce, 2,000 SKU catalog, $80 AOV
+
+The brand has a working e-commerce operation and wants to scale paid media efficiently.
+
+**Recommendation.** Google Performance Max as the primary (it includes Search, Shopping, Display, YouTube, Discover all in one). Meta Catalog Sales as the secondary. Avoid LinkedIn. Avoid Search-only campaigns; PMax already includes Search. Feed quality is the bottleneck; clean the feed (titles, categories, attributes, GTINs) before spending on PMax. Budget split: 70% PMax, 25% Meta, 5% test. Audit the geo and device cuts inside PMax weekly until the algorithm stabilizes.
+
+### Example 5: Pre-PMF B2B SaaS, $300K ARR, founders selling
+
+The team is pre-PMF. The founders are still doing all sales. They want to test paid media without burning runway.
+
+**Recommendation.** Defer paid scale. Use small Search budget ($2K to $5K per month) on category terms to capture in-market intent. Use LinkedIn organic plus founder-led content as the primary growth motion until PMF is clearer. The signal you would get from paid spend at this stage is too noisy to act on; the budget is better spent on content and outbound. Revisit paid in 6 months if PMF signals firm up.

--- a/skills/paid-media-strategy/references/common-failures.md
+++ b/skills/paid-media-strategy/references/common-failures.md
@@ -1,0 +1,155 @@
+# Common failures
+
+Twelve patterns that recur across paid media accounts. For each: name, symptom, root cause, fix, prevention.
+
+---
+
+## 1. Scaling but CAC went up
+
+**Symptom.** You doubled budget on the primary audience. Conversion volume rose less than 2x. CAC drifted up by 20 to 40%.
+
+**Root cause.** Audience saturation on the primary segment. The platform finds the easiest converters first; pushing more spend into the same audience produces diminishing returns at higher cost.
+
+**Fix.** Either expand the audience (broader lookalike, additional interests, geo expansion) or diversify across channels. Do not keep pushing the same audience harder; the marginal CAC will keep climbing.
+
+**Prevention.** Project the saturation curve before scaling. If a 1.5x spend increase doubled CAC over the prior 90 days, expect another 1.5x to push CAC past your threshold. Plan the diversification before the saturation.
+
+---
+
+## 2. Conversions look fine in the platform, terrible in revenue
+
+**Symptom.** Platform reports stable conversion volume and CAC. Revenue per conversion or LTV is dropping.
+
+**Root cause.** Attribution mismatch plus customer-quality drift. The platform optimizes for finding "any conversion." The optimizer drifts toward lower-quality converters because they are easier to find.
+
+**Fix.** Switch from conversion-count optimization to conversion-value optimization (Maximum Conversion Value or tROAS). Feed accurate conversion values into the platform. Tighten audiences toward higher-LTV proxies.
+
+**Prevention.** Track LTV cohorts per channel monthly. If channel-LTV diverges from blended LTV by more than 15%, investigate the cohort quality before defending the channel.
+
+---
+
+## 3. A/B test winner by 5%
+
+**Symptom.** Two variations tested. One wins by 5%. The team wants to ship the winner.
+
+**Root cause.** 5% is within typical platform noise. Across-campaign tests have higher variance than statistical lift implies.
+
+**Fix.** Re-run the test with more volume. Or run it longer. Or accept that the difference is not meaningful and pick the one that is easier to maintain (cheaper to produce, easier to refresh).
+
+**Prevention.** Set the minimum detectable effect (MDE) before testing. If the test cannot detect anything below 10%, do not act on a 5% difference.
+
+---
+
+## 4. Turned off underperformer, total conversions dropped
+
+**Symptom.** A campaign was reading as underperforming. Pause it. Total account conversions drop more than the campaign's reported conversions would suggest.
+
+**Root cause.** View-through or assist conversions you were not counting in the campaign's CAC. The campaign was contributing upper-funnel exposure that drove conversions on other campaigns.
+
+**Fix.** Restart the campaign with a held-out portion of the audience to measure incrementality. Compare the held-out cohort against the exposed cohort over 30 days.
+
+**Prevention.** Run hold-out tests, not flat off-ons. The flat-off causes a discontinuity that is hard to attribute back to the right campaign.
+
+---
+
+## 5. Frequency hit 8 last week
+
+**Symptom.** Frequency report shows 8 impressions per user last week. CTR is dropping.
+
+**Root cause.** Creative fatigue. Audience has seen the creative too many times.
+
+**Fix.** Refresh creative. Rotate in 3 to 5 new variations. Cap frequency explicitly at 4 to 6 per week.
+
+**Prevention.** Set explicit frequency caps at campaign launch. Track frequency weekly. Refresh creative on a 30 to 60 day cadence at scale, weekly for high-frequency campaigns.
+
+---
+
+## 6. Trying to scale Meta from $20K to $100K per day
+
+**Symptom.** Aggressive scale plan. Budget multiplier is 5x in one move.
+
+**Root cause.** That is not scaling. That is a 5x jump that will crash through the audience at the new spend level. Expect efficiency drop of 30 to 50% in the first 14 days.
+
+**Fix.** Phase the increase. 25% per week is a typical safe pace. Larger jumps should pair with audience expansion or new channels to absorb the spend.
+
+**Prevention.** Plan the scale curve before starting. 5x in a month is fine if it is 4 weekly 1.4x increases. 5x in a single move is not fine.
+
+---
+
+## 7. LinkedIn for a B2C product
+
+**Symptom.** Tested LinkedIn for a $40 AOV consumer product. CAC came in at $200.
+
+**Root cause.** Wrong channel for the offer. LinkedIn's floor is set for B2B economics; B2C does not justify it.
+
+**Fix.** Stop. Move budget to Meta, TikTok, or Search.
+
+**Prevention.** Match channel to offer at the strategy stage. Use the channel decision matrix. Do not try platforms because "we should be on LinkedIn"; be on LinkedIn only when the math supports it.
+
+---
+
+## 8. tROAS will not deliver
+
+**Symptom.** Set tROAS at 4.0. Platform delivers almost no impressions.
+
+**Root cause.** tROAS target is too aggressive relative to recent performance. The platform throttles delivery to almost zero rather than deliver below the floor.
+
+**Fix.** Loosen the target to 110 to 115% of the prior 30-day actual ROAS. Let the platform learn at the new target, then incrementally tighten.
+
+**Prevention.** Set tROAS based on actual recent performance, not aspirational targets. Aspirational targets shut off delivery; pragmatic targets keep volume flowing while improving efficiency.
+
+---
+
+## 9. Search Impression Share dropped
+
+**Symptom.** Search Impression Share fell from 70% to 50% over two weeks. Conversions held but you are missing volume.
+
+**Root cause.** Either competition increased (someone else is bidding more aggressively) or budget is constrained (you ran out of daily budget at peak hours).
+
+**Fix.** Check both. Compare auction-insight reports for new entrants. Check the time-of-day spend distribution; if budget runs out at noon, raise the daily cap.
+
+**Prevention.** Track Impression Share weekly. Set alerts on 10%+ week-over-week drops. The signal is leading; conversion drops typically follow within 2 to 3 weeks.
+
+---
+
+## 10. PMax is hard to optimize
+
+**Symptom.** Performance Max is running. CAC is fine. You want to push it harder but cannot find levers.
+
+**Root cause.** PMax is by design a black box. The platform manages placements, audiences, and creative weighting. The levers you have are budget, asset groups, and exclusions.
+
+**Fix.** Treat PMax as a tested channel with constrained levers. Optimize via asset group quality (better creative, more variants), audience signals (Customer Match, in-market lists), and exclusions (branded queries, low-value SKUs).
+
+**Prevention.** Set expectations at launch. PMax is not a place to fine-tune at the keyword level. It is a place to feed strong inputs and let the platform optimize.
+
+---
+
+## 11. Lookalike performance dropped after expansion
+
+**Symptom.** Expanded the lookalike from 1% to 5% to add volume. CAC drifted up.
+
+**Root cause.** Wider lookalikes are looser; the floor is lower. The expansion brought in users less similar to the seed.
+
+**Fix.** Tighten back to 1 to 2% if CAC is the constraint. Or split into two ad sets: the 1% as the workhorse and the 1 to 5% as a separate scale-out audience with its own budget.
+
+**Prevention.** When you need volume, expand horizontally (add a new audience type) rather than vertically (loosen the existing audience). The horizontal expansion preserves the working audience's CAC.
+
+---
+
+## 12. Brand search lift after a Super Bowl-style ad
+
+**Symptom.** Brand search volume jumped after a brand campaign ran. Paid attribution did not credit it.
+
+**Root cause.** Brand effect on existing demand, surfaced in organic and branded paid search rather than the brand campaign's direct-attribution column. The platform's direct response metrics did not capture it.
+
+**Fix.** Track brand-search lift as a separate metric. Define a baseline brand-search rate before the campaign. Measure the lift during and after.
+
+**Prevention.** Plan brand campaigns with brand-search lift as a primary KPI, not direct response. Direct response measurement underrates brand campaigns; using it as the only success metric kills brand investment unfairly.
+
+---
+
+## The pattern across all twelve
+
+Most paid media failures share one root cause: optimizing one number without checking what the optimization did to the system. Scale CAC at the cost of LTV. Pause an underperformer at the cost of total volume. Expand the audience at the cost of the floor. Optimize one platform without checking incrementality.
+
+The fix at the meta level. Decide on the success metric (CAC, ROAS, LTV-adjusted) and the guardrails (volume, frequency, creative quality, customer-cohort quality) before scaling. Audit guardrails monthly. Pull back the moment a guardrail breaks, even if the success metric still looks fine.


### PR DESCRIPTION
## Summary

First skill in the marketing suite. Adds new 'marketing' category to claude-skills, positioned between Growth and Research. Pairs with the 5 paid media platforms in /integrations (Google Ads, Meta Ads, LinkedIn Ads, TikTok Ads, Synter).

15-section SKILL.md (~3150 words) plus 7 reference files. Voice: senior performance marketer to junior marketer or PM.

## Files

- \`scripts/generate_readme_catalog.py\` - registers \`marketing\` category between \`growth\` and \`research\` with an intro paragraph linking to the /integrations catalog
- \`SKILL.md\` (256 lines, 3146 words)
- 7 reference files:
  - \`channel-decision-matrix.md\` (context-to-channel matrix + 5 worked examples)
  - \`budget-allocation-templates.md\` (4 split templates + pacing patterns)
  - \`audience-segmentation-patterns.md\` (prospecting / retargeting / exclusion + cross-platform reconciliation)
  - \`bid-strategy-reference.md\` (each strategy + migration path)
  - \`campaign-type-reference.md\` (per-platform campaign types with pitfalls)
  - \`ads-platform-comparison.md\` (per-platform reporting quirks + single-source-of-truth pattern)
  - \`common-failures.md\` (12 patterns with symptom, root cause, fix, prevention)

## Generator output

\`\`\`
Updated 7 sections in README.md, 67 skills, 146 reference files
\`\`\`

Skill count 66 to 67. Reference files 139 to 146. New 'Marketing (1)' section added between Growth and Research with the intro paragraph rendered from the generator's CATEGORIES constant. paid-media-strategy renders at catalog index 54.

## Quality gates

- Lint passes 67 skills with both \`check_readme_catalog_count\` and \`check_readme_catalog_generated\` rules green
- Generator idempotent (running \`--write\` twice produces no diff)
- Em-dash audit zero on new content
- Forbidden-phrase audit zero on new content (caught one \`leverage\` instance and replaced with \`impact\`)
- Real-firm scrub clean

## Test plan

- [ ] CI lint passes
- [ ] Catalog row 54 renders correctly in the GitHub Files changed view
- [ ] New Marketing section header and intro paragraph render correctly in the README between Growth and Research

Companion landing page lands in \`rampstackco-app\` in a follow-up dispatch.