### PR TITLE
feat(skills): add ads-performance-analytics (13th flagship, completes marketing suite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-68-blue.svg)](#the-68-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-69-blue.svg)](#the-69-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 68 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 69 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -35,7 +35,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 68-skill catalog](#the-68-skill-catalog)
+- [The 69-skill catalog](#the-69-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -63,8 +63,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **68 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
-- **153 reference files** (templates, checklists, decision matrices, worked examples)
+- **69 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
+- **160 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -253,11 +253,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 68-skill catalog
+## The 69-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 68 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 69 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -374,7 +374,7 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 52 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
 | 53 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
-### Marketing (2)
+### Marketing (3)
 
 Paid media discipline: strategy, creative, and performance analytics. Pairs with the paid media platforms in the /integrations catalog at rampstack.co.
 
@@ -382,34 +382,35 @@ Paid media discipline: strategy, creative, and performance analytics. Pairs with
 |---|---|---|
 | 54 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
 | 55 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
+| 56 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 56 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 57 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 58 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 57 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 58 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 59 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 59 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 60 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 61 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 62 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 63 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 60 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 61 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 62 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 63 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 64 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 64 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 65 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 66 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 67 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 68 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 65 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 66 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 67 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 68 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 69 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/skills/ads-performance-analytics/SKILL.md
+++ b/skills/ads-performance-analytics/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: ads-performance-analytics
+description: "How to read paid media dashboards without fooling yourself. Attribution models, platform reporting quirks, multi-platform reconciliation, ROAS vs LTV horizon traps, statistical noise in performance metrics, incrementality testing, and the failure modes that produce expensive lessons. Triggers on read paid media dashboard, attribution analysis, ROAS vs LTV, multi-platform reconciliation, ad incrementality, geo holdout, conversion lift study, ghost bidding, paid media reporting, board-deck paid media metrics, blended CAC, MMM, MTA, last-click attribution. Also triggers when a marketer is about to scale, kill, or rebudget a campaign based on platform metrics, or when reconciling platform reports against warehouse revenue."
+category: marketing
+catalog_summary: "Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget"
+display_order: 3
+---
+
+# Ads Performance Analytics
+
+A data-team-mentor's playbook for interpreting paid media dashboards without fooling yourself.
+
+The dashboard is the moment of truth for paid media decisions. The numbers on it determine whether you scale, hold, or kill. They also expose every platform's self-attribution bias, every modeled-conversion shortcut, every cross-platform double-count. Most "scale this campaign" decisions trace back to misreading the dashboard.
+
+This skill is the discipline that prevents misreading. It assumes the campaign was strategically sound (see `paid-media-strategy`). It assumes the creative was tested properly (see `ads-creative-development`). The hard part is knowing what each number actually means, what it does not, and how to reconcile platform-reported metrics with the truth in your warehouse.
+
+When to use this skill: any time you are about to scale, kill, or rebudget a campaign based on platform metrics; reconciling platform reports with revenue data; evaluating an agency's reporting; or building a paid media dashboard that will not lie to you.
+
+---
+
+## What this skill is for
+
+This skill spans paid media result interpretation. It does not cover paid media strategy (use `paid-media-strategy`), creative production (use `ads-creative-development`), or platform-specific tooling (covered in the integrations microsites). Pair this skill with the relevant integrations microsite for platform-specific MCP commands and example prompts.
+
+The audience is a marketer, growth analyst, agency analyst, or founder evaluating paid media reports. The voice is patient and clinical. There is no "trust the platform's number" or "ignore the platform entirely." Both are wrong. The discipline is knowing which numbers from which platform mean what, and what to reconcile against to make the actual decision.
+
+---
+
+## The result panel: what every paid media platform should expose
+
+A trustworthy result panel exposes nine things. Anything missing is a signal to treat reported numbers with extra skepticism.
+
+1. **Spend, impressions, clicks.** Table-stakes metrics. Should match across platforms within rounding.
+2. **Conversions with definition and window visible.** Not just a count; the definition of what counts as a conversion and the attribution window applied. Without this, the count is unreadable.
+3. **Attribution breakdown.** Last-click vs view-through vs modeled. The mix of how the conversions were credited.
+4. **Frequency.** Impressions per unique user. The fatigue early-warning system.
+5. **Audience saturation.** Where the platform exposes it. A flat audience-saturation curve means there is room to scale; a steep curve means efficiency is dropping.
+6. **Time series.** Daily breakdown to spot novelty effects, fatigue, day-of-week patterns, and exogenous variance.
+7. **Cost metrics in clear currency.** CPC, CPM, CPA, ROAS with the math defined and the currency labeled. Do not assume USD.
+8. **Conversion path data.** Touchpoints before conversion, where available. Tells you whether a campaign is a closer or an opener.
+9. **Filters, segments, and exports.** Without these, the panel is a brochure, not a tool.
+
+Platforms hide what makes their reporting look weakest. Google PMax hides keyword-level and placement-level data. Meta hides the modeled-conversion share. LinkedIn hides cross-device click paths. Treat hidden metrics as the place to dig.
+
+---
+
+## Platform-reported vs reality
+
+Every platform's dashboard is optimized to make the platform look effective. This is not a moral failing; it is a structural incentive. Platforms with rosier reporting attract more spend.
+
+**Conversion windows.** Meta defaults to 7-day click plus 1-day view. Google defaults to 30-day click plus 1-day view. Different windows, same activity, different reported numbers. If you compare Google's 30-day-click count against Meta's 7-day-click count, you are comparing different definitions and pretending they are the same.
+
+**View-through attribution.** Counted by Meta and Google for users who saw but did not click. Often half the reported "conversions" are view-through. Treat view-through as a signal of awareness contribution, not as a direct response measurement. The user might have converted from organic search anyway.
+
+**Modeled conversions.** When iOS users opt out of tracking, Meta and others statistically model what the conversion would have been. Modeled numbers are educated guesses, not measurements. They are useful for direction; they are not reliable for precision.
+
+**Self-attribution bias.** Every platform's pixel fires on conversion and the platform claims credit. If you ran Meta, Google, and TikTok in the same week, all three platforms report your conversions as theirs. Sum-of-platforms is always greater than 100% of actual conversions.
+
+The discipline. Never report platform-reported numbers as fact in board decks. Always reconcile against the single source of truth (warehouse, GA4, or unified analytics platform). Detail in `references/platform-reporting-quirks.md`.
+
+---
+
+## Attribution models in practice
+
+Six models and one anti-model. None is right. They are all approximations. The discipline is picking one, committing, and reading the others as sanity checks.
+
+**Last-click.** Simple, reproducible, undercredits awareness. The conversion is fully credited to the last click before the conversion event. Easy to compute; easy to compare across channels; bad for understanding upper-funnel contribution.
+
+**First-click.** Opposite bias. Fully credits the first touchpoint, undercredits closing channels. Useful as a sanity check against last-click; rarely the right primary view.
+
+**Linear.** Equal credit across all touchpoints. Gives every channel something. Defensible; not informative. Most useful for board reporting where avoiding "Google gets 70% so we cut Meta" politics matters more than precision.
+
+**Time-decay.** More credit to recent touchpoints. Reflects the intuition that recent ads are more influential. Hard to argue against; hard to verify.
+
+**U-shaped (position-based).** Heavy on first and last (40% each), light on middle (20% distributed). Honors both opener and closer roles. The default in many MTA tools.
+
+**Data-driven attribution (DDA, Google).** Machine-learning model that distributes credit based on observed conversion paths. Opaque; hard to audit. The closest to "right" for digital channels but a black box.
+
+**Marketing mix modeling (MMM).** Regression-based, top-down. Uses spend and revenue time series across channels to estimate channel contributions. Requires 2+ years of data. The strongest defense against platform self-attribution because it does not rely on platform-reported conversions at all.
+
+**The anti-model: trusting platform-reported attribution.** Each platform's "DDA" or "attributed conversions" is the platform's self-attribution. Sum across platforms exceeds reality. Use platform attribution for in-flight optimization within the platform; use a unified attribution model for cross-channel decisions.
+
+Practical guidance.
+
+- Early-stage. Use last-click plus a single guardrail metric (warehouse-attributed CAC). Sophisticated attribution requires data volume you do not have.
+- Mid-stage. Data-driven attribution from Google plus GA4, with explicit awareness vs closing channel labeling.
+- Mature. MMM as the canonical incremental reference. MTA for in-flight optimization. Last-click for channel-level decisions where ambiguity is acceptable.
+
+Detail and a decision matrix in `references/attribution-model-comparison.md`.
+
+---
+
+## Multi-platform reconciliation
+
+The trap. Google says you spent $50K with 800 conversions. Meta says $30K with 600. LinkedIn says $20K with 200. Total reported equals 1,600 conversions. Your warehouse says 950. Where did 650 go?
+
+The answer. Nowhere. They never existed. Each platform claimed conversions other platforms also claimed.
+
+The reconciliation pattern.
+
+- Trust the warehouse for total conversions and total revenue.
+- Trust platforms for relative ranking within platform (which campaign won, which audience won).
+- Never trust platform sums.
+- Compute blended CAC as (total ad spend across platforms) divided by (total new customers from warehouse). Not from platform reports.
+
+The board-deck pattern. Report warehouse-attributed conversion counts, never platform-summed. Report blended CAC, not channel-by-channel CAC unless explicitly noted as platform-self-attributed. Detail and templates in `references/dashboard-reconciliation-patterns.md`.
+
+---
+
+## ROAS vs LTV: the time horizon trap
+
+ROAS is short-term. Revenue from purchases attributed to a campaign in a fixed window, often 7 to 30 days. LTV is long-term. Total customer lifetime revenue.
+
+Decisions made on ROAS can be wrong if LTV varies by channel. A worked example.
+
+Meta drives 2.5x ROAS at $40 CAC with $80 LTV. The 7-day-click revenue covers 1.5x payback over the customer lifetime.
+
+Google drives 1.8x ROAS at $60 CAC with $200 LTV. The 7-day-click revenue covers 3.3x payback over the customer lifetime.
+
+Google looks worse on ROAS, better on LTV-adjusted return. Allocating budget to Meta because the ROAS is higher is the wrong move.
+
+The fix. Cohort-based LTV by acquisition channel, updated quarterly. Compare channels on payback period or LTV-CAC ratio, not raw ROAS. The 2x ROAS heuristic is a dangerous shortcut. Same ROAS at different LTVs equals different actual returns.
+
+The trap that compounds. Performance teams optimize for short-term ROAS because the metric refreshes weekly. Brand and high-LTV channels get cut because their short-term ROAS is lower. Six months later, the brand pipeline has eroded and short-term ROAS itself drops because the cheap channels are saturated. The metric that drove the decision was the wrong horizon.
+
+---
+
+## Cohort analysis vs daily metrics
+
+Daily metrics tell you what happened today. Cohort analysis tells you whether today's customers are different from last month's.
+
+Three cohort cuts that matter for paid media.
+
+**By acquisition month.** Are users acquired in March retaining better than users acquired in January? A declining LTV over rolling acquisition cohorts means recent acquisition is lower quality; the daily metrics will show this two to three months later when the retention starts hurting.
+
+**By acquisition channel.** Are users from Meta retaining better than users from Google? Channel-level cohort divergence is the data behind the LTV-vs-ROAS argument. Meta might drive volume at lower LTV; Google might drive lower volume at higher LTV. The cohort tells the story the daily ROAS hides.
+
+**By acquisition campaign.** Campaign-level cohort signals. Useful for diagnosing why a campaign that "works" in week 1 produces no recurring revenue.
+
+The signal to act on. Declining cohort LTV over two consecutive months is the alarm. Pause the channel or campaign before the daily metrics force you to. Detail in `references/cohort-analysis-templates.md`.
+
+---
+
+## Statistical noise in performance metrics
+
+Most "the campaign improved 15% week over week" stories are noise. Real performance changes are 30% or more in metrics that vary 10 to 20% naturally. Below that threshold, you are looking at variance and calling it signal.
+
+Sources of noise in paid media metrics.
+
+- **Day-of-week effects.** B2C tends to weekend dips. B2B tends to weekend gains. A "Monday morning is better" hypothesis often dissolves when day-of-week is normalized.
+- **Holiday and seasonal effects.** Q4 dwarfs most "optimization" effects. A campaign launched in Q4 looks great because of seasonality, not strategy.
+- **Weather, news, competitor activity.** Real exogenous variance. Last week's news cycle can shift CPMs across an entire vertical.
+- **Pixel fire and reporting delay.** Conversions reported on a 7-day click window arrive incrementally. Reading the panel on Monday for last week's performance undercounts.
+
+The fix. Pre-commit to test duration before drawing conclusions. Use the experimentation discipline from `experimentation-analytics` for any directional change you want to claim is real. The signal-to-noise problem in paid media metrics is the same as the signal-to-noise problem in product experiments; the framework transfers.
+
+This is where `experimentation-analytics` bridges in. The statistical patterns are the same; the application is different. Read both for the full picture.
+
+---
+
+## Incrementality testing
+
+The honest test. If we had not run this ad, would we still have gotten the conversion? The number above zero is the incremental contribution.
+
+Most paid media is 30 to 70% incremental, not 100%. Some is zero. Branded search bidding is often 5 to 20% incremental (most converters would have found you organically). Retargeting is often 20 to 40% incremental (many of those users were going to convert anyway). Prospecting is often 50 to 90% incremental.
+
+Four methods.
+
+**Geo holdout.** Hold one region out from the campaign. Measure the difference in conversions between the holdout region and the matched test region. The cleanest causal test for paid media at scale.
+
+**Ghost bidding (Google).** Google's own incrementality tool. Bids on a holdout share of impressions but does not actually serve the ad. Reports incremental conversions. Honest signal; some teams find the math opaque.
+
+**Conversion lift studies (Meta).** Splits audiences into test and control. Test sees the ad; control does not. Reports incremental lift. The cleanest within-Meta test.
+
+**PSA tests.** Serve some users a public service announcement instead of your ad. Compare conversion rates. Useful for legacy brands with deep budget.
+
+Incremental rate ranges by channel type are in `references/incrementality-testing-playbook.md`. The discipline is to run incrementality tests at least quarterly on the highest-spend channels. Without them, you are optimizing against platform-reported attribution that systematically overcounts.
+
+---
+
+## Geo experiments and holdouts
+
+For paid media specifically, geo-based testing is the most reliable causal method.
+
+**Geo holdout.** Turn off paid media in one region. Measure baseline organic conversions. The difference between expected and actual conversions in the holdout region is the incremental paid contribution.
+
+**Geo lift.** Scale spend in one region by 2x. See if conversions scale linearly. A linear scale means the channel has headroom. A sublinear scale means saturation; further spend is diminishing returns.
+
+**Switchback.** Alternate weeks of campaign on and off. Compare on-weeks to off-weeks. Useful when geo splitting is not feasible.
+
+**Pre-and-post analysis.** Launch in a region; measure 30 days before vs 30 days after. Weak design because external factors confound the comparison. Use only when no other test is available.
+
+The right setup. Matched markets (similar demographics, similar baseline conversion rates). Statistical power calculation upfront (how big a difference can the test actually detect). Pre-committed analysis window (so you do not stop early when the data looks good or wait too long when it looks bad).
+
+The trap. Calling a geo test successful because of timing-correlated revenue lift. A campaign launched in October will see "lift" because Q4 is starting; without a control region, the lift is not attributable to the campaign.
+
+---
+
+## Platform self-attribution bias
+
+A specific failure mode worth its own section.
+
+The mechanism. Platform's pixel fires on conversion. Platform claims credit. The user might have converted from any channel; the platform that loaded the pixel last gets the credit on the platform's own dashboard.
+
+Why platforms reward this design. More credit on the platform dashboard equals better-looking ROAS equals more advertiser spend. Platforms have no incentive to underreport their own contribution.
+
+Detection patterns. When platform-reported conversions exceed warehouse-attributed conversions for the same channel by more than 30%, you have heavy double-counting. When sum-of-platform-reports exceeds total conversions in the warehouse, you have cross-platform double-counting.
+
+The fix. Warehouse as canonical for board reporting. Platform reporting as in-flight signal only. Incrementality tests at least quarterly to keep the channel-attribution honest.
+
+A worked example. A retargeting campaign in Meta showed 3.5x ROAS for six months. The team scaled spend from $20K to $80K per month. A geo holdout test revealed that 65% of the "conversions" would have happened anyway from organic. Real ROAS adjusted for incrementality was 1.2x, not 3.5x. The campaign got cut and warehouse-attributed CAC dropped 18% in the next quarter.
+
+---
+
+## Common interpretation failures
+
+Twelve patterns recur in paid media reporting work. Detail in `references/common-interpretation-failures.md`.
+
+- "ROAS dropped 20% week over week, kill the campaign." Could be noise. Pre-commit a test window before acting on weekly variance.
+- "Meta says 500 conversions, my warehouse says 200, who is right?" Both are wrong; warehouse is closer to truth, Meta self-attributes. Reconcile, do not pick a winner.
+- "We turned off Google PMax and conversions did not drop." PMax was harvesting branded search you would have gotten free. Audit branded queries inside PMax.
+- "The new campaign hit 5x ROAS in week 1." Likely retargeting hot leads. Check the audience composition before declaring victory.
+- "We A/B tested and one creative wins by 12%." Within margin of platform noise. Not significant.
+- "Our LTV calculation says this channel is profitable." Check cohort age. Recent cohorts may not have hit LTV yet; the calculation is a projection, not a measurement.
+- "The platform says high frequency is fine because conversions are still happening." Fatigue masked by free organic conversions. The campaign is taking credit for conversions that would have happened anyway.
+- "Last-click attribution shows Meta at 60% credit." Last-click bias. First-click view of the same data shows different. Pick a model and stick.
+- "We scaled spend 5x and conversions only doubled." Saturation. The channel found its ceiling; the marginal CAC at the new spend level is much higher.
+- "Brand campaigns underperform on direct ROAS." They do not have to. Brand impact shows up in other channels' efficiency. Measure brand against brand-search lift, not direct ROAS.
+- "ROAS held steady but profit dropped." The mix shifted toward lower-margin products. Channel-level ROAS hides product-mix effects.
+- "Agency reported a 4x ROAS month." Whose number? Platform-reported, warehouse-attributed, or model-adjusted? The unit of measurement matters more than the magnitude.
+
+---
+
+## The framework: 12 considerations for trustworthy paid media interpretation
+
+When reading a paid media dashboard about to inform a decision, walk these 12 considerations. Skipping any of them is how teams ship the wrong call.
+
+1. **Result panel completeness.** What is the platform showing vs hiding.
+2. **Platform-reported vs reality.** View-through, modeled conversions, conversion windows.
+3. **Attribution model.** Pick one and read the others as sanity checks.
+4. **Multi-platform reconciliation.** Sum-of-platforms is always inflated.
+5. **ROAS vs LTV horizon.** Short-term metric, long-term impact.
+6. **Cohort vs daily.** Cohort tells the quality story; daily tells the volume story.
+7. **Statistical noise.** Weekly variance, day-of-week, seasonal, exogenous.
+8. **Incrementality.** What would have happened without the spend.
+9. **Geo and holdout testing.** The honest causal test.
+10. **Self-attribution bias.** Platforms claim credit they do not deserve.
+11. **Decision rule.** Pre-committed scale up, hold, or pull back.
+12. **Single source of truth.** Warehouse over platform reporting for board metrics.
+
+The output of the framework is one of three answers. Scale (the campaign is incremental and unit economics work). Hold (data is ambiguous; gather more before deciding). Kill (the campaign is not incremental enough to justify the spend).
+
+---
+
+## Reference files
+
+- [`references/metric-definitions-glossary.md`](references/metric-definitions-glossary.md) - CTR, CPC, CPM, CPA, ROAS, LTV, AOV, frequency, reach, impressions, conversion window, view-through, modeled conversion, blended CAC, MER.
+- [`references/attribution-model-comparison.md`](references/attribution-model-comparison.md) - Last-click, first-click, linear, time-decay, U-shaped, DDA, MMM. Decision matrix by business stage.
+- [`references/platform-reporting-quirks.md`](references/platform-reporting-quirks.md) - Google PMax black box, Meta iOS impact and Conversions API, LinkedIn 30-day click defaults, TikTok video-completion attribution, programmatic viewability gates.
+- [`references/incrementality-testing-playbook.md`](references/incrementality-testing-playbook.md) - Geo holdout, ghost bidding, conversion lift, PSA tests, switchback designs. Setup, duration, analysis pattern, expected incremental rates.
+- [`references/dashboard-reconciliation-patterns.md`](references/dashboard-reconciliation-patterns.md) - Warehouse as canonical, platform as in-flight signal, blended CAC formula, board-deck patterns, reconciliation cadence.
+- [`references/cohort-analysis-templates.md`](references/cohort-analysis-templates.md) - By acquisition month, channel, and campaign. Retention curves, when to act on cohort signals.
+- [`references/common-interpretation-failures.md`](references/common-interpretation-failures.md) - Twelve failure patterns with symptom, root cause, fix, prevention.
+
+---
+
+## Closing: the courage to call it incremental zero
+
+Most paid media spend is not 100% incremental. Some channels are 70% incremental. Some are 30%. Some are zero, paying for conversions you would have gotten anyway.
+
+The discipline of accepting that channels can be incremental zero, and pulling spend accordingly, is the single highest-impact skill in paid media analytics. Most accounts have at least one campaign that looks profitable in the platform but is incremental zero in the warehouse. Branded paid search at $4 CPC when the same users find you at position one organically. Retargeting at $0.30 CPC for users who already added items to cart. PMax cannibalizing free brand traffic.
+
+The discipline of finding those campaigns and killing them is the work. The platform will not tell you. The platform's incentive is the opposite. The warehouse, paired with quarterly incrementality tests, is the only honest source.
+
+When in doubt about whether a campaign is incremental, run a geo holdout. The two-week test is cheaper than a quarter of unincremental spend. The team that does not run incrementality tests is optimizing against numbers that are systematically wrong, and the size of the error is exactly the size of the budget waste.

--- a/skills/ads-performance-analytics/references/attribution-model-comparison.md
+++ b/skills/ads-performance-analytics/references/attribution-model-comparison.md
@@ -1,0 +1,128 @@
+# Attribution model comparison
+
+For each major attribution model: definition, fit, bias direction, and a worked example showing how the same activity gets different attribution.
+
+The principle. No model is right. They are all approximations. The discipline is to pick one as the primary view, read the others as sanity checks, and report against the warehouse rather than against any single platform's view.
+
+---
+
+## The models
+
+### Last-click
+
+**Definition.** Full credit to the last clickable touchpoint before conversion.
+
+**When it fits.** Early-stage measurement where simplicity matters more than precision. Final-stage decisions where the closer matters more than the opener.
+
+**When it does not fit.** Awareness-channel evaluation. Brands with multi-touch sales cycles. Anything upper-funnel.
+
+**Bias direction.** Undercredits awareness channels (display, video, top-of-funnel social). Overcredits closing channels (branded search, retargeting).
+
+### First-click
+
+**Definition.** Full credit to the first touchpoint in the conversion path.
+
+**When it fits.** Awareness-channel evaluation. Comparing top-of-funnel sources.
+
+**When it does not fit.** Closing-channel evaluation. Performance optimization at the bid level.
+
+**Bias direction.** Mirror image of last-click. Undercredits closing; overcredits opening.
+
+### Linear
+
+**Definition.** Equal credit across every touchpoint in the conversion path.
+
+**When it fits.** Board-deck reporting where avoiding "Google gets 70% so we cut Meta" politics matters more than precision. Defensible-by-default.
+
+**When it does not fit.** Decisions where the marginal contribution of each channel matters. Linear treats first-click and last-click the same; reality usually does not.
+
+**Bias direction.** Diffuses credit. Channels that touched the path always get something; channels that drove the conversion do not get more.
+
+### Time-decay
+
+**Definition.** More credit to recent touchpoints. Older touchpoints get progressively less.
+
+**When it fits.** When the intuition is that recent ads are more influential. Reasonable for short-cycle B2C.
+
+**When it does not fit.** Long sales cycles where the first touchpoint may have been months before the close. Decay underweights the opener.
+
+**Bias direction.** Skews toward the closer. Slightly less aggressive than last-click.
+
+### U-shaped (position-based)
+
+**Definition.** 40% credit to first touch. 40% credit to last touch. 20% distributed across middle touches.
+
+**When it fits.** When you want to honor both opener and closer roles without flattening to linear. Reasonable default for most B2C.
+
+**When it does not fit.** Single-touch paths (awards 80% to a single touchpoint, which is over-attributing). Long paths where the middle touchpoints matter as much as the ends.
+
+**Bias direction.** Balances the last-click and first-click views into one number.
+
+### Data-driven attribution (DDA, Google)
+
+**Definition.** Machine-learning model that distributes credit based on observed conversion paths. Compares paths that did and did not convert; assigns credit to touchpoints that correlate with conversion.
+
+**When it fits.** Mature accounts with sufficient conversion volume (Google requires 600+ conversions per month for DDA). Cross-channel optimization.
+
+**When it does not fit.** Sub-scale accounts. Accounts that need explainability for regulators or boards. The black-box nature is hard to audit.
+
+**Bias direction.** Best in class for digital channels where the data is clean. Still suffers from platform self-attribution bias because Google's DDA only sees Google touchpoints.
+
+### Marketing mix modeling (MMM)
+
+**Definition.** Regression-based, top-down. Models the relationship between spend across channels and revenue over time. Typically requires 2 to 3 years of data.
+
+**When it fits.** Mature accounts with cross-channel spend at scale. Brands where offline channels (TV, OOH, podcast) contribute. Anywhere platform self-attribution bias is a real concern.
+
+**When it does not fit.** Early-stage accounts without enough historical data. Fast-changing channel mixes where the historical data does not represent current reality.
+
+**Bias direction.** The strongest defense against platform self-attribution because MMM does not rely on platform-reported conversions. Limitations are statistical: confidence intervals are wide; granularity is low (channel-level, not campaign-level).
+
+---
+
+## The same path under each model
+
+A worked example. A B2C SaaS user converts after this path:
+
+1. Sees a YouTube awareness ad (impression, not click).
+2. Clicks a Meta retargeting ad three days later.
+3. Searches for the brand on Google. Clicks a paid branded search ad.
+4. Returns directly the next day. Converts.
+
+Attribution by model.
+
+| Model | YouTube | Meta | Branded Search | Direct |
+|---|---|---|---|---|
+| Last-click | 0% | 0% | 0% (depending on direct vs paid) | 100% |
+| First-click | 0% (impressions excluded) | 100% | 0% | 0% |
+| Linear | 0% | 33% | 33% | 33% |
+| Time-decay | 0% | 15% | 35% | 50% |
+| U-shaped | 0% | 40% | 20% | 40% |
+| Google DDA | (only sees Google touchpoints) | (only sees Meta touchpoints if Conversions API integration) | varies | varies |
+| MMM | partial credit (spend in YouTube correlates with conversions) | partial credit | partial credit | (organic, not modeled) |
+
+The takeaway. Same path. Five different attribution stories. None is right. Each tells you something different.
+
+---
+
+## Decision matrix by business stage
+
+| Stage | Primary model | Secondary check | Why |
+|---|---|---|---|
+| Pre-PMF | Last-click + warehouse-attributed CAC | None; insufficient volume for sophisticated models | Sophisticated attribution needs volume you do not have |
+| Series A or early growth | Last-click + GA4 data-driven | First-click as sanity check on awareness | Volume insufficient for MMM; DDA requires more conversions than most early-stage accounts have |
+| Mid-stage (10K+ conversions per month) | Google DDA + GA4 path data | Last-click for channel decisions; first-click for awareness | DDA gets reliable here; cross-validate with simple models |
+| Mature (100K+ conversions per month, 2+ years data) | MMM as canonical | Last-click for in-flight; DDA for cross-channel | MMM is the strongest defense against self-attribution at scale |
+| Multi-channel including offline | MMM mandatory | DDA for digital | MMM is the only model that captures offline contribution |
+
+The progression. As volume grows and channel mix expands, the model that fits changes. Locking in last-click forever is fine if the business stays simple; the moment offline or upper-funnel channels matter, the model has to advance.
+
+---
+
+## How to communicate which model produced which number
+
+Three rules for honest reporting.
+
+1. **Always label the model.** "Meta drove 800 conversions" is unreadable. "Meta drove 800 conversions on last-click attribution with a 7-day-click window" is honest.
+2. **Report the same number under at least two models when stakes are high.** Board decks should show the conservative view (last-click) and the generous view (linear or DDA). The range tells stakeholders what they are not learning.
+3. **Reconcile against the warehouse before reporting in dollars.** Dollar figures attached to platform-reported conversions inherit all the platform's attribution biases. Warehouse-attributed dollars are the only dollars that have been independently verified.

--- a/skills/ads-performance-analytics/references/cohort-analysis-templates.md
+++ b/skills/ads-performance-analytics/references/cohort-analysis-templates.md
@@ -1,0 +1,113 @@
+# Cohort analysis templates
+
+Three cohort cuts that matter for paid media. By acquisition month, by channel, by campaign. Plus retention curves and when to act.
+
+The principle. Daily metrics tell you what happened today. Cohort analysis tells you whether today's customers are different from last month's. The difference is the leading indicator that a channel or campaign is degrading; daily metrics catch the same problem two to three months later when it shows up in revenue.
+
+---
+
+## Template 1: Cohort by acquisition month
+
+The standard rolling 12-month view of LTV growth.
+
+**Setup.** For each acquisition month over the last 12 months, compute the cumulative revenue per customer at month 1, month 3, month 6, and month 12 (where data is available).
+
+**Output.**
+
+| Acquisition month | M1 revenue/customer | M3 revenue/customer | M6 revenue/customer | M12 revenue/customer |
+|---|---|---|---|---|
+| 2025-05 | $42 | $86 | $128 | $185 |
+| 2025-06 | $44 | $89 | $135 | $192 |
+| 2025-07 | $40 | $82 | $122 | $178 |
+| 2025-08 | $43 | $85 | $130 | (incomplete) |
+| 2025-09 | $38 | $78 | (incomplete) | (incomplete) |
+| 2025-10 | $35 | $72 | (incomplete) | (incomplete) |
+| 2025-11 | $33 | $68 | (incomplete) | (incomplete) |
+| 2025-12 | $34 | (incomplete) | (incomplete) | (incomplete) |
+
+**The signal.** The M3 revenue per customer dropped from $86 to $68 over six months. Recent acquisitions are lower-quality customers. The daily metrics will show this as ROAS deterioration in two to three months when the recent cohorts hit their declining LTV plateau.
+
+**Action.** Investigate which channels or campaigns shifted in the last six months. The drop usually correlates with a specific channel scaling into lower-quality audiences.
+
+---
+
+## Template 2: Cohort by acquisition channel
+
+The channel-level LTV story that ROAS hides.
+
+**Setup.** For each channel, compute LTV at fixed time windows (30, 60, 90, 180, 365 days post-acquisition). Track the trend over multiple acquisition cohorts.
+
+**Output (cohort: 2025-Q3 acquisitions, measured at 90 days post-acquisition).**
+
+| Channel | New customers | CAC | 90-day revenue/customer | 90-day LTV/CAC | Verdict |
+|---|---|---|---|---|---|
+| Google brand search | 420 | $45 | $128 | 2.8x | Strong |
+| Google generic search | 280 | $95 | $112 | 1.2x | Marginal |
+| Meta prospecting | 540 | $72 | $84 | 1.2x | Marginal |
+| Meta retargeting | 320 | $48 | $156 | 3.3x | Strong |
+| LinkedIn Sponsored | 95 | $320 | $580 | 1.8x | Long payback; B2B-typical |
+| TikTok In-Feed | 180 | $58 | $61 | 1.1x | Marginal |
+| Direct (organic) | 1,200 | n/a | $145 | n/a | Reference baseline |
+
+**The signal.** Meta retargeting and Google brand search are the strong performers on LTV-CAC. Meta prospecting and TikTok In-Feed are marginal; the customer quality is lower than the platform-reported ROAS suggests.
+
+**Action.** The marginal channels need either CAC reduction or audience-quality improvement. Pulling back on the marginal channels and reallocating to the strong ones improves blended LTV-CAC.
+
+---
+
+## Template 3: Cohort by acquisition campaign
+
+Campaign-level cohort signals. Use sparingly; sample sizes get small fast.
+
+**Setup.** For each campaign with sufficient acquisition volume (typically 100+ customers per cohort), compute LTV at 30 and 60 days. Compare against the channel average.
+
+**Output.**
+
+| Campaign | New customers | CAC | 60-day revenue/customer | vs channel average |
+|---|---|---|---|---|
+| Meta-Lookalike-1pct | 320 | $58 | $112 | +30% |
+| Meta-Lookalike-5pct | 180 | $48 | $74 | -15% |
+| Meta-Interest-SaaS | 90 | $72 | $86 | -5% |
+| Meta-Retargeting-30day | 240 | $42 | $148 | +60% |
+
+**The signal.** The 5% lookalike is finding lower-quality customers than the 1% lookalike, even at lower CAC. The ROAS view favors the 5% lookalike (lower CAC, decent revenue); the cohort view shows the customer quality dropped.
+
+**Action.** Pull back the 5% lookalike. Concentrate spend on the 1% lookalike and the retargeting segments. Watch for next-cohort confirmation before a permanent reallocation.
+
+---
+
+## Retention curves
+
+A retention curve plots customer activity over time. Three patterns to recognize.
+
+**Plateau curve.** Activity drops in the first 30 days, then stabilizes at a level it sustains long-term. The plateau height is the long-run user value. Healthy SaaS, subscription consumer, marketplace.
+
+**Smile curve.** Activity drops, plateaus, then trends upward (resurrection effect). Less common; characteristic of products with seasonal or lifecycle re-engagement.
+
+**Decay curve.** Activity drops continuously without stabilizing. The product is not retaining; the unit economics will not work no matter what CAC the channel produces. Common in low-engagement consumer apps.
+
+**The curve to watch by acquisition channel.** A channel whose retention curve plateaus higher than another is delivering higher-LTV customers, regardless of the CAC ratio. This is the data behind LTV-CAC channel comparisons.
+
+---
+
+## When to act on cohort signals
+
+Three triggers.
+
+1. **Two consecutive months of LTV decline at the same time horizon.** A single month is noise; two is signal. Investigate which channels shifted.
+2. **Channel-level LTV-CAC ratio falls below 2x for two consecutive cohorts.** Pause or reallocate the channel. The 2x threshold accounts for gross margin, payback period, and the variance in LTV measurement.
+3. **A campaign-level cohort underperforms the channel average by 20%+ for two consecutive cohorts.** The campaign is bringing in lower-quality audiences than the rest of the channel. Pause or reallocate.
+
+The discipline. Watch cohort signals on a monthly cadence. Most teams over-index on weekly platform metrics and under-index on cohort signals; the cohort-watchers see the problems first.
+
+---
+
+## Common cohort mistakes
+
+**Reading recent cohorts as final.** A 30-day cohort's "LTV" is actually 30-day revenue, not LTV. Naming matters. If the team treats 30-day revenue as LTV in spreadsheets, they will undercount channels with longer payback periods.
+
+**Comparing cohorts at different ages.** A January cohort measured at 12 months vs a November cohort measured at 2 months is comparing different things. Always compare at matched ages.
+
+**Ignoring seasonal cohorts.** Q4 cohorts often have higher first-purchase value but lower retention because Q4 acquisition includes one-time gifters. Account for the seasonal pattern; do not over-index on Q4 cohort numbers.
+
+**Not segmenting by channel.** Aggregate LTV trends hide channel-level shifts. The channel-segmented cohort is where the action signal lives.

--- a/skills/ads-performance-analytics/references/common-interpretation-failures.md
+++ b/skills/ads-performance-analytics/references/common-interpretation-failures.md
@@ -1,0 +1,155 @@
+# Common interpretation failures
+
+Twelve failure patterns that recur in paid media reporting work. For each: name, symptom, root cause, fix, prevention.
+
+---
+
+## 1. ROAS dropped 20% week-over-week, kill the campaign
+
+**Symptom.** Weekly ROAS chart shows a drop. Team wants to pause the campaign.
+
+**Root cause.** Could be noise. Day-of-week, holiday timing, conversion-window lag, exogenous variance. A 20% drop in a metric that varies 10 to 15% naturally is below the signal threshold.
+
+**Fix.** Pre-commit a test window before acting on weekly variance. For most campaigns, two consecutive weeks of decline below the threshold is the signal. Single-week swings are usually noise.
+
+**Prevention.** Establish baseline variance for each campaign before declaring "improvement" or "decline." Without the baseline, every weekly chart looks alarming.
+
+---
+
+## 2. Meta says 500 conversions, my warehouse says 200, who is right
+
+**Symptom.** Platform-reported numbers do not match warehouse numbers. The team picks the more flattering one.
+
+**Root cause.** Both are wrong; warehouse is closer to truth. Meta self-attributes (claims credit for conversions other channels also touched). View-through and modeled conversions inflate Meta's count.
+
+**Fix.** Reconcile, do not pick a winner. Report the warehouse number as canonical for board metrics. Use Meta's number only for in-flight optimization within Meta.
+
+**Prevention.** Make the reconciliation cadence explicit. Weekly check, monthly deep dive, quarterly attribution review. The team that runs the reconciliation never has to "pick a winner."
+
+---
+
+## 3. Turned off Google PMax, conversions did not drop
+
+**Symptom.** Paused PMax. Total account conversions held steady.
+
+**Root cause.** PMax was harvesting branded search conversions you would have gotten free from organic. The platform was claiming credit for traffic that was not incremental.
+
+**Fix.** Audit branded queries inside PMax. Add account-level negative keywords for branded queries. Restart PMax with branded excluded; the incremental contribution from non-branded inventory is the real value.
+
+**Prevention.** At PMax setup, exclude branded queries from the start. Audit PMax's spend distribution monthly to catch the cannibalization pattern early.
+
+---
+
+## 4. New campaign hit 5x ROAS in week 1
+
+**Symptom.** A fresh campaign's first-week ROAS is 5x. Team wants to scale immediately.
+
+**Root cause.** Likely retargeting hot leads or running on a small audience of warm prospects who would have converted anyway. The first week is unrepresentative.
+
+**Fix.** Check the audience composition. If retargeting or warm-list, the 5x is not the steady-state. Wait two to four weeks before scaling.
+
+**Prevention.** Define the success metric and the test window before launch. Do not let a strong first week change the plan; pre-commit to the four-week measurement.
+
+---
+
+## 5. A/B tested and one creative wins by 12%
+
+**Symptom.** Two creatives tested. One wins by 12%. Team wants to ship the winner.
+
+**Root cause.** 12% is within margin of platform noise for a typical creative test. Variants compete with each other inside the platform's optimization; the platform's own decisions confound the test.
+
+**Fix.** Re-run the test with more volume, or accept that the difference is within noise and pick based on production cost or refresh ease.
+
+**Prevention.** Set the minimum detectable effect (MDE) before testing. A 12% threshold requires a specific volume; if you cannot reach it, the test cannot detect that effect cleanly.
+
+---
+
+## 6. LTV calculation says this channel is profitable
+
+**Symptom.** A team's LTV-CAC analysis shows a channel as profitable. Spend is increased.
+
+**Root cause.** The "LTV" in the calculation may be a 60-day cumulative revenue projected forward, not actual lifetime value. Recent cohorts have not aged enough to confirm the LTV.
+
+**Fix.** Confirm the cohort age. If projecting forward, document the assumption and stress-test (what happens if actual LTV is 80% of projected).
+
+**Prevention.** Always pair LTV calculations with cohort age. A 30-day cohort has 30-day revenue, not LTV. Naming clearly prevents the substitution error.
+
+---
+
+## 7. High frequency is fine because conversions are still happening
+
+**Symptom.** Frequency at 6 to 8 per week. Conversions on the platform are stable. Team concludes fatigue is not an issue.
+
+**Root cause.** Fatigue masked by conversions that would have happened anyway from organic, retargeting overlap, or recurring customers. The platform is taking credit for traffic the high frequency did not actually drive.
+
+**Fix.** Run an incrementality test on the high-frequency campaign. The likely finding is that incremental rate dropped substantially even as raw conversions held.
+
+**Prevention.** Watch frequency as a leading indicator. Above 4 to 5 per week is the alarm regardless of conversion levels. Refresh creative.
+
+---
+
+## 8. Last-click attribution shows Meta at 60% credit
+
+**Symptom.** Last-click view of paid media shows Meta dominant. Team allocates budget accordingly.
+
+**Root cause.** Last-click bias. Meta may also be the closer because users who searched for the brand on Google clicked through, then later saw a Meta retargeting ad and converted. Last-click credits Meta; the conversion would have happened anyway.
+
+**Fix.** Read the same data under first-click and a multi-touch model. The picture changes. Allocate based on a balanced view, not the last-click view alone.
+
+**Prevention.** Always compare attribution under at least two models for budget decisions. The single-model view is reliable for in-flight only.
+
+---
+
+## 9. Scaled spend 5x, conversions only doubled
+
+**Symptom.** Budget went from $20K to $100K per month. Conversions went from 800 to 1,600.
+
+**Root cause.** Saturation. The channel found its ceiling; the marginal CAC at the new spend level is much higher than the average CAC the team was reporting.
+
+**Fix.** Calculate the marginal CAC, not just average CAC. The marginal CAC at the higher spend tier tells you whether more spend will produce more conversions or just spend more for the same conversions.
+
+**Prevention.** Project the saturation curve before scaling. If a 1.5x spend increase produced a 1.2x conversion increase, expect the next 1.5x to produce 1.0x or less.
+
+---
+
+## 10. Brand campaigns underperform on direct ROAS
+
+**Symptom.** A brand campaign reports 0.8x ROAS. Team wants to cut it.
+
+**Root cause.** Brand campaigns affect downstream channel efficiency, not direct conversion. The direct ROAS is the wrong measurement for brand impact.
+
+**Fix.** Measure brand against brand-search lift, organic traffic growth, or direct-traffic growth. The brand campaign's effect shows up in cheaper performance acquisition over the next 60 to 90 days.
+
+**Prevention.** At brand campaign setup, define the success metric explicitly (brand search lift target, organic traffic target, awareness lift). Do not let direct ROAS become the unintended grading metric.
+
+---
+
+## 11. ROAS held steady but profit dropped
+
+**Symptom.** Channel-level ROAS at 3x, stable. Profit on the same channel dropped 20% over the quarter.
+
+**Root cause.** The mix shifted toward lower-margin products. ROAS is a revenue metric; it does not see margin. The channel attracted bargain hunters at lower margin, holding ROAS but cutting profit.
+
+**Fix.** Track contribution-margin ROAS, not gross-revenue ROAS. The contribution-margin view catches the mix shift the gross view hides.
+
+**Prevention.** Build margin-aware reporting from the start. Most teams default to gross revenue; the move to contribution margin pays for itself within a quarter.
+
+---
+
+## 12. Agency reported a 4x ROAS month
+
+**Symptom.** External agency claims a 4x ROAS for the month. Team accepts the number.
+
+**Root cause.** Whose number? Platform-reported, warehouse-attributed, or model-adjusted? Agencies often report the most generous number (their incentive). Without specifying the attribution methodology, the 4x ROAS is unreadable.
+
+**Fix.** Demand the attribution methodology in every agency report. Reconcile against the warehouse before presenting to leadership.
+
+**Prevention.** Build attribution-methodology specification into the agency contract. Reports must include the model, the window, and the source of conversion data. The contract that does not specify produces reports that cannot be evaluated.
+
+---
+
+## The pattern across all twelve
+
+Most paid media interpretation failures share one root cause: optimizing one number without checking what the optimization did to the system. Scale ROAS at the cost of LTV. Pause an underperformer at the cost of total volume. Trust platform-reported attribution at the cost of incremental truth.
+
+The fix at the meta level. Decide on the success metric (warehouse-attributed CAC, LTV-CAC ratio, contribution-margin ROAS) and the guardrails (volume, frequency, customer-cohort quality, brand metrics) before reading any dashboard. Pull back the moment a guardrail breaks, even if the success metric still looks fine. The dashboard is a tool, not the truth; the warehouse plus quarterly incrementality testing is closer to truth.

--- a/skills/ads-performance-analytics/references/dashboard-reconciliation-patterns.md
+++ b/skills/ads-performance-analytics/references/dashboard-reconciliation-patterns.md
@@ -1,0 +1,114 @@
+# Dashboard reconciliation patterns
+
+The single-source-of-truth pattern for paid media reporting. Warehouse as canonical; platforms as in-flight signals.
+
+The principle. Sum-of-platform-reports is always greater than reality because every platform claims credit for conversions other platforms also touched. Reporting platform-summed numbers as fact in board decks is the most expensive error in paid media analytics.
+
+---
+
+## The three-layer reporting model
+
+**Layer 1: platform metrics.** Use for in-flight optimization only. Ad-set-level CAC, creative-level CTR, audience-level frequency. The platform's view of its own performance is fine for optimizing the platform's own levers.
+
+**Layer 2: warehouse multi-touch attribution.** Use for cross-platform comparison and channel-level decisions. Each conversion gets attributed across all platforms that touched the path. Pick one model (last-click, first-click, linear, U-shaped, DDA) and standardize across the team.
+
+**Layer 3: marketing-mix modeling (MMM) at scale.** Use for budget allocation across channels. MMM treats spend as input and revenue as output; it does not rely on platform-reported attribution at all. The strongest defense against platform self-attribution bias.
+
+The cadence. Layer 1 in real time. Layer 2 weekly. Layer 3 quarterly.
+
+---
+
+## Blended CAC
+
+The board-deck number. Resistant to attribution debates because it does not require choosing an attribution model.
+
+**Formula.**
+
+```
+Blended CAC = (total ad spend across platforms) / (total new customers from warehouse)
+```
+
+**Worked example.**
+
+In Q4, the team spent $200K total: $80K on Google Ads, $70K on Meta, $30K on LinkedIn, $20K on TikTok. The warehouse shows 1,250 new customers in Q4 from all sources (paid, organic, direct, referral).
+
+But the team needs to attribute the new customers to paid specifically. Two ways to do this:
+
+1. **Approximate.** Assume the proportion of paid-attributed customers in the warehouse roughly equals the proportion that paid contributed to traffic. If 60% of traffic in Q4 was paid-attributed, then 60% of 1,250 equals 750 paid-acquired customers. Blended paid CAC: $200K / 750 = $267.
+2. **Precise.** Use the warehouse's multi-touch attribution to credit paid channels with a fraction of each conversion. Sum the paid-attributed share across all conversions; that becomes the denominator.
+
+The precise version is better when available. The approximate version works when the warehouse data is incomplete. Both produce a number that does not double-count across platforms.
+
+---
+
+## The board-deck pattern
+
+Three rules for reporting paid media numbers to leadership.
+
+1. **Lead with blended CAC, not channel CAC.** Channel CAC depends on attribution model; blended CAC does not. Stakeholders not in the weeds on attribution find blended CAC easier to compare across quarters.
+2. **Show the range.** Report the conservative view (last-click) and the generous view (linear or DDA) for any high-stakes channel decision. The range tells stakeholders what they are not learning.
+3. **Always label the source.** "Meta drove 800 conversions" is unreadable. "Meta drove 800 conversions per Meta's 7-day-click attribution; warehouse-attributed: 540" is honest.
+
+A worked example board slide.
+
+```
+Q4 paid media performance
+
+Total spend: $200K (vs $185K Q3, +8%)
+New customers from paid (warehouse-attributed): 750 (vs 680 Q3, +10%)
+Blended paid CAC: $267 (vs $272 Q3, -2%)
+
+Channel CAC (warehouse-attributed, last-click):
+  Google: $240 (40% of new customers)
+  Meta: $290 (35% of new customers)
+  LinkedIn: $480 (15% of new customers)
+  TikTok: $180 (10% of new customers)
+
+Platform-reported CAC (for in-flight context, not board decision):
+  Google: $190 (Google reports 26% more attributed conversions than warehouse)
+  Meta: $210 (Meta reports 38% more)
+  LinkedIn: $475 (roughly aligned)
+  TikTok: $135 (TikTok reports 33% more)
+
+Quarterly incrementality test result (geo holdout, October):
+  Brand search: 12% incremental (95% CI: 6-18%). Reduced spend 30%; CAC dropped.
+  Meta retargeting: 31% incremental (95% CI: 22-40%). Maintained spend; CAC view adjusted.
+```
+
+The slide tells the truth: the warehouse number is the canonical CAC, the platform numbers are inflated, the incrementality test confirms which channels are real.
+
+---
+
+## Reconciliation cadence
+
+**Weekly.** Pull platform-reported numbers and warehouse numbers. Confirm the sum-of-platforms vs warehouse ratio is in the expected range. A sudden divergence means a tracking break, an attribution-model change, or a platform reporting bug. Investigate.
+
+**Monthly.** Deeper reconciliation. Compare channel-level attribution across last-click, first-click, and the team's chosen model. Identify channels whose ranking changes by model.
+
+**Quarterly.** Run an incrementality test on the highest-spend channel. Update the channel-level CAC adjustment factor based on the test result.
+
+---
+
+## Common reconciliation mistakes
+
+**Reporting platform-summed conversions to the board.** The most common error. The board sees "1,600 conversions across paid channels" when the warehouse says 950. The team gets caught when someone divides revenue by 1,600 and gets a CAC that does not match the P&L.
+
+**Comparing platforms on platform-reported CAC.** Each platform's CAC is computed against a different attribution window and a different set of self-attribution biases. Compare on warehouse-attributed CAC instead.
+
+**Treating "lift" as incrementality without a controlled test.** A campaign that ran during a period of overall conversion growth gets credit for "lift" that was actually seasonality or organic momentum. Lift requires a control group; otherwise it is correlation reported as causation.
+
+**Updating attribution models mid-quarter.** Switching from last-click to DDA mid-quarter makes the quarter's data uninterpretable. Pick a model for the quarter; switch only at quarter boundaries with a documented changelog.
+
+**Reporting blended CAC without naming the time window.** "$267 blended CAC" depends on whether you measured over 30, 60, or 90 days. Pin the window.
+
+---
+
+## When the platforms agree more than usual
+
+A useful diagnostic. If platform-reported sums match warehouse total within 10%, something has changed. Possibilities:
+
+- The team set up Conversions API on Meta or server-side tagging on Google, which improved tracking precision.
+- The mix shifted toward branded search, where attribution overlap is lower.
+- One platform's conversion volume dropped significantly (saturation, fatigue, or campaign issue).
+
+Investigate any sudden alignment. The platforms diverging is the normal state; alignment usually has a cause worth understanding.

--- a/skills/ads-performance-analytics/references/incrementality-testing-playbook.md
+++ b/skills/ads-performance-analytics/references/incrementality-testing-playbook.md
@@ -1,0 +1,139 @@
+# Incrementality testing playbook
+
+The honest test in paid media analytics. If we had not run this ad, would we still have gotten the conversion? The answer above zero is the incremental contribution.
+
+The principle. Most paid media is not 100% incremental. Branded search bidding is often 5 to 20% incremental. Retargeting is often 20 to 40% incremental. Prospecting is often 50 to 90% incremental. The number that matters for spend decisions is the incremental rate, not the platform-reported attribution rate.
+
+---
+
+## Method 1: Geo holdout
+
+The cleanest causal test for paid media at scale.
+
+**Setup.** Pick two regions with similar baseline conversion rates and demographic profiles (matched markets). Run the campaign in one region (test); turn it off in the other (holdout).
+
+**Duration.** Two to four weeks minimum. Statistical power calculation upfront determines the right length given the spend scale and expected lift.
+
+**Analysis.** Compare conversions in test vs holdout, normalized by population. The difference is the incremental contribution.
+
+**Expected incremental rate ranges.**
+
+| Channel | Typical incremental rate |
+|---|---|
+| Branded search | 5 to 20% |
+| Retargeting | 20 to 40% |
+| Lookalike audiences | 40 to 70% |
+| Cold prospecting | 50 to 90% |
+| Awareness video | 30 to 60% |
+
+**Common pitfalls.**
+
+- Picking holdout regions with confounding factors (different competitive presence, weather event, retail launch). Confounded results are worse than no test.
+- Stopping the test early when the data looks good. Pre-commit the duration and stick to it.
+- Holding out for too long. A 6-week holdout in a small region is expensive in lost conversions; 2 to 4 weeks is usually enough at scale.
+
+---
+
+## Method 2: Ghost bidding (Google)
+
+Google's own incrementality tool. The platform bids on a holdout share of impressions but does not actually serve the ad. The reported delta between served and ghost is incremental.
+
+**Setup.** Configure within Google Ads. Choose the campaigns and the holdout share (typically 5 to 20%).
+
+**Duration.** Two to four weeks.
+
+**Analysis.** Google reports incremental conversions directly. Cross-validate against your own warehouse measurement.
+
+**Pitfalls.**
+
+- The math is opaque to many teams. The output is a single incremental number; the underlying methodology is Google's. Trust but verify with a manual geo test on the same campaign.
+- Only available within Google Ads, not cross-channel.
+
+---
+
+## Method 3: Conversion lift studies (Meta)
+
+Meta's incrementality tool. Splits audiences into test (sees the ad) and control (does not). Measures lift.
+
+**Setup.** Configure within Meta Ads Manager. Specify the campaign and the test-control split.
+
+**Duration.** Three to four weeks. Meta requires a minimum spend per study.
+
+**Analysis.** Meta reports incremental lift. The reporting includes statistical significance bands.
+
+**Pitfalls.**
+
+- The minimum spend requirement makes it expensive for small accounts.
+- Only available within Meta, not cross-channel.
+- Meta's interpretation tilts toward generous (their incentive). Cross-validate with geo holdout when possible.
+
+---
+
+## Method 4: PSA tests
+
+Serve some users a public service announcement instead of your ad. Compare conversion rates.
+
+**Setup.** Run two parallel campaigns: one with your ad, one with a PSA (typically a charity or public-interest message). Match audiences.
+
+**Duration.** Three to six weeks.
+
+**Analysis.** Compare conversion rate of the PSA-exposed audience against the ad-exposed audience. The difference is incremental.
+
+**Pitfalls.**
+
+- Ethically and brand-wise, choose PSAs that align with brand values.
+- Setup overhead is high. Reserved for legacy brands with deep budgets and serious incrementality questions.
+
+---
+
+## Method 5: Switchback designs
+
+Alternate weeks of campaign on and off. Compare on-weeks to off-weeks.
+
+**Setup.** Run for at least 8 weeks. Alternate weekly: on, off, on, off. Or alternate by audience segment.
+
+**Duration.** Eight to twelve weeks. Shorter switchbacks have low statistical power.
+
+**Analysis.** Difference in conversions between on-weeks and off-weeks, normalized for week-of-year and external variance.
+
+**Pitfalls.**
+
+- Confounded by exogenous factors (news, competitor activity, seasonality). Best for steady-state campaigns where the external context is stable.
+- Audience contamination: users who saw the ad in week 1 may convert in week 2 even when the campaign is off. The contamination dilutes the measured incremental rate.
+
+---
+
+## Choosing the right method
+
+| Constraint | Recommended method |
+|---|---|
+| Single platform, want quick answer | Platform-native (ghost bidding for Google, conversion lift for Meta) |
+| Cross-platform incremental test | Geo holdout |
+| Small account, limited budget | Geo holdout in two small matched markets |
+| Long campaign cycle, steady-state | Switchback |
+| Brand or awareness channel | PSA test or geo holdout |
+| Regulated industry, ethics concern | Geo holdout (no PSA) |
+
+The default. Geo holdout. It is the most honest causal test, works cross-channel, and produces results that are interpretable without trusting the platform's methodology.
+
+---
+
+## How to run a geo holdout step by step
+
+1. **Pick matched markets.** Use designated market areas (DMAs) or postal-code-level regions with similar baseline conversion rates and demographic profiles. Aim for at least three test and three holdout regions for statistical power.
+2. **Calculate statistical power.** Given the expected lift and the regional conversion volume, can the test detect the effect? If the regions are too small, the test is underpowered and inconclusive results are likely.
+3. **Pre-commit the analysis window.** Define the start date and end date before the test begins. Do not adjust based on early results.
+4. **Run the test.** Campaign on in test regions; off in holdout. No mid-test changes.
+5. **Wait for the full window.** Analyzing early produces noise.
+6. **Compute the delta.** Conversions in test minus conversions in holdout, normalized by population. The delta divided by spend is the incremental CPA. Compare against the platform-reported CPA; the gap is the over-attribution.
+7. **Report incremental contribution.** Do not report platform-reported CAC alongside warehouse CAC and incremental CAC without labeling. The unit of measurement matters as much as the number.
+
+---
+
+## Cadence
+
+For accounts spending $25K+ per month, run incrementality tests at least quarterly on the highest-spend channels. The cost of the test is small relative to the cost of running un-incremental spend at scale.
+
+For accounts under $25K per month, annual or semi-annual tests are typically enough. The test cost vs the spend savings does not pencil out as often.
+
+The discipline. Schedule the tests. Do not wait for a "we should test this" moment; the moment never comes voluntarily.

--- a/skills/ads-performance-analytics/references/metric-definitions-glossary.md
+++ b/skills/ads-performance-analytics/references/metric-definitions-glossary.md
@@ -1,0 +1,83 @@
+# Metric definitions glossary
+
+The paid media metrics that show up on every dashboard, with explicit definitions, formulas, and the common pitfalls in usage.
+
+The point of an explicit glossary. Two teams using the same metric name often compute different numbers. "Conversion rate" might mean clicks-to-conversion or impressions-to-conversion or unique-users-to-conversion. The team that does not pin definitions ends up arguing about numbers that are not the same number.
+
+---
+
+## Volume metrics
+
+**Impressions.** Count of times an ad was displayed. Includes the same user seeing the ad multiple times.
+
+**Reach.** Count of unique users who saw the ad. Always less than or equal to impressions.
+
+**Frequency.** Impressions divided by reach. The average number of times a unique user saw the ad. Above 4 to 5 per week is the fatigue alarm.
+
+**Clicks.** Count of clicks on the ad. Some platforms count "outbound clicks" (which leave the platform) separately from "all clicks" (which include in-platform interactions like saves and shares). Use outbound for direct response.
+
+---
+
+## Cost metrics
+
+**CPC (cost per click).** Spend divided by clicks. Formula: `spend / clicks`. The cost of one click; not the cost of one conversion. Conflating them is the most common reporting error.
+
+**CPM (cost per thousand impressions).** Spend divided by (impressions / 1000). Formula: `spend / (impressions / 1000)`. The cost of reach. Useful for comparing platforms on awareness efficiency.
+
+**CPA (cost per acquisition).** Spend divided by conversions. Formula: `spend / conversions`. The variant where "conversion" is defined matters; the same campaign reports different CPAs depending on whether the conversion is a click, a lead form submission, a purchase, or a paid customer.
+
+**ROAS (return on ad spend).** Revenue from ad-attributed conversions divided by spend. Formula: `attributed revenue / spend`. NOT profit-divided-by-spend. ROAS is a revenue metric, not a profit metric. A 3x ROAS at 30% margin is a 0.9x return on cost; the ROAS reading on its own is misleading.
+
+**MER (marketing efficiency ratio).** Total revenue divided by total marketing spend, across all channels. Formula: `total revenue / total marketing spend`. The most honest top-line number; resistant to per-channel attribution debates.
+
+**Blended CAC.** Total ad spend divided by total new customers from warehouse. Formula: `total ad spend / new customers from warehouse`. The board-deck number. Channel-level CAC depends on attribution; blended CAC does not.
+
+---
+
+## Conversion metrics
+
+**Conversion.** The event the campaign optimizes for. Definition varies. Always document: which event, what window, which attribution model. Without these three, "conversions = 800" is unreadable.
+
+**Conversion rate.** Conversions divided by something. The denominator changes the meaning. Click-through conversion rate (`conversions / clicks`) is different from impression conversion rate (`conversions / impressions`) which is different from unique-user conversion rate (`conversions / reach`). Pin the denominator at every report.
+
+**Conversion window.** The maximum time between the ad event (click or view) and the conversion for which the platform takes credit. Meta default: 7-day click plus 1-day view. Google default: 30-day click plus 1-day view. Different windows mean different reported counts from the same activity.
+
+**View-through conversion.** A conversion attributed to an ad the user saw but did not click. Counted by Meta and Google. Often half the platform-reported conversions are view-through. Treat as a soft signal of awareness contribution, not as direct response measurement.
+
+**Modeled conversion.** A statistically estimated conversion when actual tracking is blocked (most commonly iOS users on Meta after ATT). The platform models what the conversion would have been based on aggregated data. Modeled is an estimate, not a measurement; precision is low.
+
+---
+
+## Customer-value metrics
+
+**LTV (lifetime value).** Total revenue from a customer over their relationship with the brand. Many definitions; the right one for paid media analytics is gross revenue or contribution margin, not unit count. Pair with CAC for the LTV:CAC ratio.
+
+**LTV:CAC ratio.** LTV divided by CAC. Formula: `LTV / CAC`. The unit-economics test. 3:1 is the venture-capital benchmark; the right number for any specific business depends on payback period and gross margin.
+
+**Payback period.** Months until cumulative revenue from a customer equals the CAC to acquire them. The cash-flow companion to LTV:CAC. Investors care about payback; operators care about both.
+
+**AOV (average order value).** Revenue divided by order count. Formula: `revenue / orders`. Useful for e-commerce; less for subscription. The number that turns "increased conversion rate" into "increased revenue."
+
+---
+
+## Engagement metrics (less direct)
+
+**CTR (click-through rate).** Clicks divided by impressions. Formula: `clicks / impressions`. Useful for hook quality. Less useful for conversion quality; high CTR with low conversion rate means the hook is too aggressive for the offer.
+
+**Hide ratio (negative feedback).** Count of users who explicitly hid or marked the ad as not-interested, divided by impressions. Above 1.5% is the alarm; the platform algorithm will throttle delivery to that audience.
+
+**Engagement rate.** Likes plus comments plus shares plus saves divided by impressions. Useful for organic-style content; less directly tied to performance for paid.
+
+---
+
+## Common pitfalls
+
+**Treating ROAS as profit.** ROAS is revenue-divided-by-spend. Profit-divided-by-spend is "return on ad investment" or "ROI." Confusing the two leads to greenlit campaigns that lose money on every conversion.
+
+**Ignoring conversion window in cross-platform comparisons.** Meta's 7-day-click count is not comparable to Google's 30-day-click count without normalization.
+
+**Treating frequency as a vanity number.** Frequency above 4 to 5 per week is a fatigue signal. Many teams celebrate high frequency as proof of "audience saturation"; it is the inverse.
+
+**Using CPA when conversion definitions differ across campaigns.** A search campaign with a "lead-form-submission" conversion has a CPA in different units from a display campaign with a "purchase" conversion. Compare campaign-level CPA only when the conversion event matches.
+
+**Confusing modeled conversions with measured conversions.** Modeled is an estimate; measured is a count. Treating the two as interchangeable produces false confidence in the size of the effect.

--- a/skills/ads-performance-analytics/references/platform-reporting-quirks.md
+++ b/skills/ads-performance-analytics/references/platform-reporting-quirks.md
@@ -1,0 +1,108 @@
+# Platform reporting quirks
+
+Per-platform reporting behaviors that affect how to read the numbers. The platforms do not agree on what counts as a conversion or how to credit it; reading their dashboards as truth is the most expensive error in paid media analytics.
+
+---
+
+## Google Ads
+
+**Default attribution model.** Data-driven attribution (DDA) is the default. DDA distributes credit across multiple touchpoints based on machine learning. Single-touch attribution (last-click) is available but no longer the default.
+
+**Conversion windows.** Default 30-day click attribution and 1-day view-through. Both adjustable. The 30-day click window is wider than what GA4 reports by default; this produces the typical 1.3 to 1.5x conversion overcount versus GA4 for the "Google Ads" channel.
+
+**Modeled conversions.** Google models conversions for users with consent restrictions or cross-device gaps. Modeled volume can be material in iOS-heavy traffic. Modeled is an estimate; do not treat with the precision you would treat directly observed conversions.
+
+**Performance Max black box.** PMax does not expose keyword-level, placement-level, or audience-level performance directly. The platform manages allocation across Search, Shopping, Display, YouTube, Discover, and Gmail. Levers you have: budget, asset groups (creative quality), audience signals (Customer Match seeds), and exclusions (account-level negatives).
+
+**Branded search cannibalization in PMax.** PMax includes Search by default. It will harvest branded queries you would have ranked for organically. Add account-level negative keywords for branded queries to prevent paid cannibalization.
+
+**Lost Impression Share metrics.** Search exposes "Lost IS (rank)" and "Lost IS (budget)" to indicate why your ad did not show. Lost IS rising is the leading indicator that competition increased or budget became constrained.
+
+**Search-term reports.** The list of actual queries that triggered your ad, vs your keyword targeting. Underused. Audit monthly to find irrelevant queries (negative keyword candidates) and high-performing queries you might want to add as exact-match keywords.
+
+---
+
+## Meta (Facebook and Instagram)
+
+**Default attribution.** 7-day click and 1-day view-through. Adjustable to 7-day click only or 1-day click only.
+
+**iOS 14.5+ impact.** App Tracking Transparency (ATT) reduced Meta's ability to track iOS conversions. Meta filled the gap with modeled conversions (statistically estimated) and Conversions API (CAPI, server-side event tracking). Both help, neither fully restores pre-ATT visibility.
+
+**Conversions API necessity.** CAPI sends server-side events directly from your backend to Meta, bypassing the browser-pixel restrictions. Setting up CAPI is one of the highest-impact technical investments for a Meta-heavy account. Without CAPI, the platform's optimization signal degrades significantly on iOS-heavy audiences.
+
+**View-through attribution overcount.** View-through counts impressions even when the user did not click. Often half the reported conversions on Meta are view-through. Useful as awareness signal; misleading for performance optimization.
+
+**Modeled conversions in iOS reports.** Meta reports modeled conversions inline with directly observed ones unless you filter explicitly. Use the breakdown view to disaggregate by attribution type (1-day click, 7-day click, 1-day view, modeled).
+
+**Frequency reporting at the ad set level.** Meta exposes frequency in the Ads Manager. Use it as the primary fatigue signal; CTR decay is downstream of frequency rising.
+
+**Negative feedback rate.** Meta exposes "negative feedback rate" as a customizable column. Above 1.5% is the alarm; the algorithm penalizes high-feedback creatives by reducing reach.
+
+---
+
+## LinkedIn
+
+**Default attribution.** 30-day click and 7-day view-through.
+
+**Why the longer windows.** B2B buying cycles are longer than B2C. The 30-day-click window matches the typical B2B consideration cycle. Comparing LinkedIn's reported numbers against Meta's 7-day-click numbers without normalizing is comparing different definitions.
+
+**Cross-device gaps.** LinkedIn reporting tends to under-credit cross-device journeys (work computer click, personal phone visit). Pair LinkedIn paid reports with self-reported attribution surveys when the offer is high-consideration B2B.
+
+**Lead Gen Forms reporting.** Form submissions count as conversions regardless of downstream lead qualification. Filter at CRM ingestion before treating LinkedIn-reported lead counts as the truth. Many leads are accidental or low-quality.
+
+**Demographic insights.** LinkedIn's demographic reporting (industry, job seniority, company size, function) is unique to the platform. Use it for audience refinement; the data is not available cleanly on other platforms.
+
+**Cost insights.** LinkedIn's CPM tends to be 3 to 10x higher than B2C platforms because of the audience precision premium. The justification is B2B LTV; lower-LTV offers cannot make LinkedIn math work.
+
+---
+
+## TikTok
+
+**Default attribution.** 7-day click and 1-day view-through, similar to Meta.
+
+**Video-completion-based attribution.** TikTok counts conversions even when the user did not click but watched the full video. This is unique among the platforms covered here. The signal is real for awareness; it inflates direct-response numbers.
+
+**iOS impact, less mature modeling.** TikTok faces similar ATT-driven tracking gaps as Meta. The modeling is less mature, which means iOS-heavy audiences see more under-reporting on TikTok than on Meta.
+
+**Spark Ads attribution overlap.** Spark Ads boost organic posts. Engagement on the boosted version shows up in both organic and paid surfaces. Be careful not to double-count when reconciling against organic engagement reports.
+
+**Spark Ads vs paid creative differential.** Spark Ads consistently outperform pure paid creative on TikTok because they retain organic engagement signals. A team comparing CPMs of Spark vs paid will see Spark consistently lower; the difference is real, not a reporting artifact.
+
+**Trend-based volatility.** TikTok performance is more sensitive to trending sounds and formats than other platforms. Reporting comparisons across long time periods are less reliable because the platform itself shifted.
+
+---
+
+## Programmatic and Display
+
+**Viewability gates.** Programmatic display sells impressions, but only "viewable" impressions count toward billed performance. The Media Rating Council (MRC) standard is 50% of pixels in view for 1 second (display) or 2 seconds (video). Below this threshold, the impression should not be billed.
+
+**Fraud filters.** Programmatic exposes fraud-detection metrics. Without fraud filtering, 10 to 30% of programmatic impressions are bot or fraudulent traffic. Use vendors like DoubleVerify or IAS for filtering.
+
+**Attribution decay.** Programmatic display's incremental rate is usually 5 to 20%. Most clicks come from users who would have converted from other channels anyway. Treat programmatic as awareness; do not optimize for direct response unless the incrementality test confirms it.
+
+---
+
+## Cross-platform interference
+
+A specific quirk worth a dedicated callout.
+
+**The mechanism.** Two platforms claim the same conversion. A user sees a Meta ad, then later searches for the brand on Google, clicks a brand keyword, and converts. Meta claims the conversion (view-through). Google Ads claims the conversion (last-click on the brand search). The same revenue event shows up twice in the platform totals.
+
+**The detection.** Sum-of-platforms exceeds total conversions in the warehouse. If platform-reported sum is 1.5 to 3x the warehouse total, you have heavy cross-platform double-counting.
+
+**The defense.** Warehouse as canonical for board reporting. Platform reports for in-flight tuning of the platform's own levers. MMM at scale to estimate true cross-channel contribution.
+
+---
+
+## Reporting differences in numbers
+
+A typical mid-stage account has the following attribution gap pattern across platforms.
+
+- Google Ads reports: 1.3 to 1.5x what GA4 reports for the "Google Ads" channel.
+- Meta reports: 1.5 to 2.5x what GA4 reports for the "Facebook" channel (more on iOS-heavy audiences).
+- LinkedIn reports: roughly equal to GA4 for click-based conversions.
+- TikTok reports: 1.5 to 3.0x what GA4 reports (high view-through component).
+
+If you sum all platforms' reported conversions and compare to actual revenue, the sum is typically 2 to 4x actual. The "extra" conversions are attribution overlap, view-through credit, and platform self-attribution.
+
+The discipline. Trust the warehouse number for incrementality decisions. Use platform numbers for in-flight tuning. Do not optimize one platform's CAC against another platform's CAC; you are comparing different definitions of the same word.


### PR DESCRIPTION
## Summary

Third skill in the marketing suite. **Completes the trio.** Pairs with the 5 paid media platforms in /integrations as the result-interpretation companion to paid-media-strategy and ads-creative-development.

15-section SKILL.md (~3375 words) plus 7 reference files. Voice: data-team-mentor to marketer. Conceptual cousin of \`experimentation-analytics\`; reuses some statistical patterns but applies to paid media, not experiments.

## Files

- \`SKILL.md\` (275 lines, 3375 words across 15 sections)
- 7 reference files:
  - \`metric-definitions-glossary.md\` (CTR, CPC, CPM, CPA, ROAS, LTV, AOV, frequency, reach, conversion window, view-through, modeled conversion, blended CAC, MER)
  - \`attribution-model-comparison.md\` (last-click, first-click, linear, time-decay, U-shaped, DDA, MMM with worked example showing same path under each model)
  - \`platform-reporting-quirks.md\` (Google PMax black box, Meta iOS / CAPI, LinkedIn 30-day defaults, TikTok video-completion attribution, programmatic viewability)
  - \`incrementality-testing-playbook.md\` (geo holdout, ghost bidding, conversion lift, PSA tests, switchback designs with expected incremental rate ranges)
  - \`dashboard-reconciliation-patterns.md\` (3-layer reporting model, blended CAC formula, board-deck pattern with worked slide example, reconciliation cadence)
  - \`cohort-analysis-templates.md\` (3 cohort cuts: by month, channel, campaign; retention curves; action triggers)
  - \`common-interpretation-failures.md\` (12 failure patterns with symptom, root cause, fix, prevention)

## Generator output

\`\`\`
Updated 6 sections in README.md, 69 skills, 160 reference files
\`\`\`

Skill count 68 to 69. Reference files 153 to 160. Marketing section now has 3 entries with \`ads-performance-analytics\` at catalog index 56, completing the marketing trio.

## Quality gates

- Lint passes 69 skills with both \`check_readme_catalog_count\` and \`check_readme_catalog_generated\` rules green
- Generator idempotent (running --write twice produces no diff)
- Em-dash audit zero on new content
- Forbidden-phrase audit zero on new content
- Real-firm scrub clean

## Test plan

- [ ] CI lint passes
- [ ] Catalog row 56 renders correctly in the GitHub Files changed view
- [ ] Marketing section header now reads \"Marketing (3)\" with all three skills

Companion landing page lands in \`rampstackco-app\` in a follow-up dispatch.