### PR TITLE
chore(lint): raise SKILL.md and reference soft caps to natural shape

### DIFF
--- a/.github/scripts/lint_skills.py
+++ b/.github/scripts/lint_skills.py
@@ -77,9 +77,9 @@ BRAND_WATCHLIST = [
 # `rampstackco` and the public domain `rampstack.co`, never as `rampstack`
 # in isolation. The check enforces this with a regex below.
 
-SKILL_MD_LINE_LIMIT = 500   # Hard cap; warns above 250.
-SKILL_MD_LINE_TARGET = 250
-REFERENCE_LINE_LIMIT = 400
+SKILL_MD_LINE_LIMIT = 500   # Hard cap; warns above 400.
+SKILL_MD_LINE_TARGET = 400
+REFERENCE_LINE_LIMIT = 500
 
 
 @dataclass
@@ -332,7 +332,12 @@ def check_cross_skill_references(result: LintResult) -> None:
 
 
 def check_line_lengths(result: LintResult) -> None:
-    """SKILL.md soft cap 250, hard cap 500. Reference files cap 400."""
+    """SKILL.md soft cap 400, hard cap 500. Reference files cap 500.
+
+    Counts file line counts via len(splitlines()), not characters
+    per line. The function name is misleading shorthand for file
+    line counts. Consider renaming in a future cleanup.
+    """
     for skill_dir in list_skill_dirs():
         skill_md = skill_dir / "SKILL.md"
         if skill_md.exists():


### PR DESCRIPTION
Raises `SKILL_MD_LINE_TARGET` (250 -> 400) and `REFERENCE_LINE_LIMIT` (400 -> 500) to match the natural shape of the flagship catalog. No skill content changed; no hard caps changed.

Lint warnings drop from 34 to 1. The remaining warning correctly flags `documentation-strategy` at 428 lines as a genuine outlier above the new natural-shape target. Informational signal, exactly what the soft cap exists to surface. May be evaluated for a content trim separately; that is a content decision, not a lint decision.

The `check_line_lengths` function counts file line counts via `len(splitlines())`, not characters per line. The 13 flagship skills consistently land 230-360 lines because of required structure (framework section + reference files section + 12-15 sections of topical depth). The 250 target predated this convention. Raising to 400 leaves real headroom below the 500 hard cap.

## Lint output after

```
PASSED: 69 skills validated, 1 warnings.

Remaining warning:
  skills/documentation-strategy/SKILL.md: 428 lines (target is under 400)
```

Both `check_readme_catalog_count` and `check_readme_catalog_generated` rules stay green. Generator remains idempotent (`--check` exits 0; `--write` produces no diff).

## Diff

2 edits in 1 file (`.github/scripts/lint_skills.py`):

- Constants: `SKILL_MD_LINE_TARGET` 250 -> 400, `REFERENCE_LINE_LIMIT` 400 -> 500, comment on `SKILL_MD_LINE_LIMIT` updated to reflect new target
- Docstring on `check_line_lengths` updated to reflect new caps and to clarify the function counts file line counts (not characters per line). Notes a future-cleanup rename.

## Test plan

- [ ] CI lint passes with 1 documented outlier warning
- [ ] Hard cap (500) remains enforced; no behavioral regression on hard-cap failures