### PR TITLE
feat(skills): add product-analytics-setup (14th flagship, PM gap closing skill 1 of 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-69-blue.svg)](#the-69-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-70-blue.svg)](#the-70-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 69 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 70 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -35,7 +35,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 69-skill catalog](#the-69-skill-catalog)
+- [The 70-skill catalog](#the-70-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -63,8 +63,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **69 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
-- **160 reference files** (templates, checklists, decision matrices, worked examples)
+- **70 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
+- **169 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -253,11 +253,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 69-skill catalog
+## The 70-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 69 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 70 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -326,7 +326,7 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 29 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
 | 30 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
-### Product (7)
+### Product (8)
 
 | # | Skill | What it does |
 |---|---|---|
@@ -337,42 +337,43 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 35 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
 | 36 | [`experimentation-analytics`](skills/experimentation-analytics/SKILL.md) | Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation |
 | 37 | [`experimentation-platform-orchestrator`](skills/experimentation-platform-orchestrator/SKILL.md) | Pick the right experimentation platform, migrate when wrong, coordinate when multi-platform: a decision framework for Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon |
+| 38 | [`product-analytics-setup`](skills/product-analytics-setup/SKILL.md) | Instrument product analytics correctly: event taxonomy, properties, naming conventions, schema versioning, funnels, retention cohorts, North Star selection, and the instrumentation debt that compounds without discipline |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 38 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 39 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 40 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 41 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 39 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 40 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 41 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 42 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 42 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 43 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 43 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 44 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 45 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 46 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 47 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 48 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 49 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 50 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 51 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 44 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 45 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 46 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 47 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 48 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 49 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 50 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 51 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 52 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 52 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 53 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 53 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 54 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Marketing (3)
 
@@ -380,37 +381,37 @@ Paid media discipline: strategy, creative, and performance analytics. Pairs with
 
 | # | Skill | What it does |
 |---|---|---|
-| 54 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
-| 55 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
-| 56 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
+| 55 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
+| 56 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
+| 57 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 57 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 58 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 59 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 58 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 59 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 60 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 60 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 61 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 62 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 63 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 64 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 61 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 62 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 63 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 64 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 65 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 65 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 66 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 67 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 68 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 69 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 66 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 67 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 68 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 69 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 70 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/skills/product-analytics-setup/SKILL.md
+++ b/skills/product-analytics-setup/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: product-analytics-setup
+description: "How to actually instrument product analytics correctly. Event taxonomy, property design, naming conventions, schema versioning, identity stitching, funnel design, retention cohorts, North Star metric selection, dashboard hygiene, instrumentation debt, and the failure modes that produce data nobody trusts. Triggers on product analytics setup, event taxonomy, tracking plan, instrumentation, schema versioning, North Star metric, retention cohorts, funnel design, naming conventions, instrument new feature, audit existing analytics, dashboard reconciliation, instrumentation debt, Mixpanel setup, Amplitude setup, PostHog setup, warehouse-native analytics. Also triggers when the team has data but cannot trust it, or when designing instrumentation for a new feature, or when auditing an existing setup that has drifted."
+category: product
+catalog_summary: "Instrument product analytics correctly: event taxonomy, properties, naming conventions, schema versioning, funnels, retention cohorts, North Star selection, and the instrumentation debt that compounds without discipline"
+display_order: 8
+---
+
+# Product Analytics Setup
+
+A senior PM and analyst's playbook for instrumenting product analytics correctly the first time.
+
+Most product analytics setups are some combination of inherited mistakes, dashboard sprawl, and events nobody trusts. The team launches a new feature; instrumentation gets bolted on under deadline pressure; naming drifts; properties are inconsistent; six months later nobody can answer simple questions because the answer depends on which event you trust.
+
+This skill is the discipline that prevents that. It assumes you have answered the strategic questions about what to measure (see `analytics-strategy`). It assumes you have a tool connected (Mixpanel, Heap, PostHog, Amplitude, or warehouse-native via BigQuery, Snowflake, or dbt). The hard part is the systematic execution: naming conventions, property design, schema versioning, funnel construction, cohort definitions, retention measurement.
+
+When to use this skill: setting up product analytics from scratch, auditing an existing instrumentation, fixing a "we have data but cannot trust it" problem, or designing instrumentation for a new feature.
+
+---
+
+## What this skill is for
+
+This skill spans instrumentation execution. It does not cover measurement strategy (use `analytics-strategy`), experimentation result interpretation (use `experimentation-analytics`), paid media analytics (use `ads-performance-analytics`), or platform decisions (use `experimentation-platform-orchestrator`). Pair this skill with the relevant integrations microsite for your specific tool.
+
+The clean distinction from analytics-strategy. That skill (Growth category) is strategic: what to measure and why, KPI hierarchy, dashboard architecture, attribution models. This skill (Product category) is execution: how to actually instrument the product correctly. The two compose. Read analytics-strategy first to decide what matters; read this skill to instrument it.
+
+---
+
+## The instrumentation hierarchy
+
+The mental model. Every analytics setup is a stack of layers. Each layer depends on the one below it being correct.
+
+- **Events** are the atomic facts: `user_signed_up`, `checkout_completed`, `feature_x_used`.
+- **Properties** describe events: who, what, where, when, with what context.
+- **Identities** map events to people: `anonymous_id`, `user_id`, `account_id`.
+- **Cohorts** are filters across events: "users acquired via paid in March."
+- **Funnels** are sequences of events: signup, then activated, then first paid action.
+- **Retention** measures repeat behavior: signups still active at week N.
+
+You cannot construct higher levels without correct lower levels. Garbage events produce garbage funnels. The discipline is bottom-up. Most "we have data but cannot trust it" problems trace back to the bottom two layers.
+
+---
+
+## Event taxonomy design
+
+Three rules for event design.
+
+1. **Past tense, action-oriented.** `checkout_completed`, not `checkout_complete` or `completing_checkout`. Past tense reads as "this happened" rather than as a state.
+2. **Object-action format.** Noun then verb. `video_played`, `form_submitted`, `email_opened`. Reading the event name aloud should describe what happened.
+3. **Granular but not redundant.** Track distinct user actions, not button clicks. Fire `checkout_completed` once at the moment of completion, not `submit_button_clicked` plus `checkout_completed`. UI events are noise; semantic events are signal.
+
+The verbs vs states trap.
+
+- Verbs ARE events. `checkout_completed`, `subscription_canceled`, `account_upgraded`.
+- States are NOT events; they are properties. `user_status: active` is a property on the user, not an event. Setting state via events ("status_changed_to_active") is a code smell that produces double-counting.
+
+How many events to design. Thirty to fifty events is the sweet spot for a typical SaaS product. Below twenty means under-instrumented; above one hundred almost always means tracking UI noise or duplicating events in different formats.
+
+Detail and a canonical event spec in `references/event-taxonomy-template.md`.
+
+---
+
+## Property design: event-level vs user-level
+
+Two property types, treated separately.
+
+**Event-level properties** describe THIS event. The `checkout_completed` event has properties like `cart_value`, `item_count`, `payment_method`, `discount_code`. They live on the event payload and are immutable once fired.
+
+**User-level properties** describe the USER over time. `subscription_tier`, `lifetime_value`, `acquisition_channel`. Set them once on the user profile; the analytics tool joins them onto every event the user fires. They update over time as the user changes.
+
+The trap. Putting user-level properties on every event. Do not track `subscription_tier` on every event payload; set it once on the user profile and rely on the join. Putting it on the event creates payload bloat, schema drift when the value changes, and reporting confusion when a user upgrades mid-session.
+
+Data type discipline.
+
+- **Strings** for enums: status, tier, channel, region. Enumerable values where the set is bounded.
+- **Numbers** only for actual numbers: count, value, duration, score. Never use strings for numeric data ("free trial day 7" should be `trial_day: 7`).
+- **Booleans** for actual booleans: `is_admin`, `has_trial`, `is_new_user`. Two values; nothing else.
+- **Timestamps** in ISO 8601, always. Always. The number of bugs caused by inconsistent date formats is uncountable.
+- **Arrays** rarely. An array property is usually a sign you should split into multiple events with one item per event.
+
+Worked example in `references/property-design-patterns.md` showing right and wrong design for a `product_viewed` event.
+
+---
+
+## Naming conventions
+
+Pick ONE convention and enforce it. Three conventions worth picking.
+
+- **snake_case** for events and properties: `user_signed_up`, `cart_value`. Most platforms default to this; pushback is rarely worth it.
+- **Object-action format** for events: `user_signed_up`, `video_played`. Reading the name should describe what happened.
+- **Verb-noun for user properties** (or just nouns): `subscription_tier`, `is_admin`, `last_active_at`.
+
+What NOT to do.
+
+- Mixed case across events. `user_signedUp`, `User Signed Up`, `userSignedUp` all coexisting in the same project. Pick one and migrate.
+- Spaces in event or property names. "Sign Up Completed" breaks every URL-encoding scenario and confuses every tool.
+- Inconsistent verbs. `user_signed_up` plus `completedCheckout` plus `VIEW_PRODUCT` in the same project means nobody can predict an event name without looking it up.
+- Brand names in event names. `mailchimp_email_opened` ages badly when you switch to Customer.io.
+
+The naming convention reference file provides a complete style guide. Cite it in your team's data contract.
+
+Detail in `references/naming-convention-reference.md`.
+
+---
+
+## Schema versioning
+
+Schema changes are inevitable. The pattern.
+
+**Additive changes** are safe. New event, new property on an existing event, new value in an enum. Just ship. Existing dashboards continue to work.
+
+**Breaking changes** require migration. Renamed event, removed property, changed property type, narrowed enum. These break dashboards downstream; the migration plan is part of the change.
+
+Versioning patterns.
+
+- Append `_v2` to events when semantics change. `checkout_completed_v2` fires alongside `checkout_completed` during a transition.
+- Keep old events firing during the transition (90 days is typical). Both versions fire; analytics queries gradually migrate to v2.
+- Migrate dashboards to v2 before retiring v1. Then deprecate v1 explicitly with a documentation note.
+
+The data contract idea.
+
+- Document the canonical schema in code: TypeScript interface, JSON Schema, or Protobuf definition.
+- Code review every schema change. Schema is product, not afterthought.
+- CI lint rejects schema violations before they hit production. The deploy that adds an event with the wrong type fails the build.
+
+Detail in `references/schema-versioning-patterns.md`.
+
+---
+
+## Funnel design
+
+Funnels measure progression through a sequence. Four rules.
+
+1. **Order matters.** A then B then C is a different funnel from B then A then C. The platform will compute different conversion rates depending on order.
+2. **Time windows matter.** Most funnels use a 1 to 30 day window from the first event. Document the window explicitly; "users who completed signup AND activated" is meaningless without "within 14 days."
+3. **Drop-off interpretation is hard.** Eighty percent of users dropping at step 2 might be the funnel design (audience is wrong), might be the audience (timing is wrong), or might be the product (genuine drop-off). Investigate before declaring.
+4. **The anchor event pattern.** Every funnel starts with a high-intent action: signup, trial start, key feature use. Not a vanity event like `page_view` or `session_start`. Vanity-event-anchored funnels show 99% drop-off and tell you nothing.
+
+Common funnel mistakes.
+
+- Funnels that include events firing automatically. `session_started` happens for every visit; using it as a step inflates the denominator and makes the rest of the funnel meaningless.
+- Funnels too long (10+ steps). Break into two or three shorter funnels. A 10-step funnel produces near-zero end-to-end conversion that is hard to interpret.
+- Funnels with the same event in multiple positions. The platform handles this poorly; the analyst handles it worse.
+- Mixing different time windows in one funnel. "Users who signed up within 7 days AND converted within 30 days" is two different cohort definitions glued together.
+
+Common funnel shapes and time-window guidance in `references/funnel-design-templates.md`.
+
+---
+
+## Cohort definitions
+
+A cohort is a group of users sharing an attribute or behavior. Useful patterns.
+
+- **Acquisition cohorts.** Users acquired in month X. The standard for retention analysis.
+- **Behavioral cohorts.** Users who completed action Y. Useful for activation analysis ("users who sent first message in week 1").
+- **Property cohorts.** Users with `subscription_tier: pro`. Useful for segment-level analysis.
+- **Combined cohorts.** Signup in March AND completed onboarding AND in EU. The most common in real analytics work.
+
+Cohort discipline.
+
+- Define cohorts in code (or in your tool's saved-cohort feature) so they are reusable.
+- Version them when criteria change. Compare apples-to-apples.
+- Do not compare a 30-day-old cohort to a 365-day-old cohort on retention; the older cohort has had more time to retain by definition.
+
+Detail in `references/cohort-definition-patterns.md`.
+
+---
+
+## Retention measurement
+
+Retention is repeat behavior over time. Three flavors.
+
+- **N-day retention.** Did user X come back on day 7, day 14, day 30 specifically. High noise on any single day; useful for short-cycle products.
+- **Bracket retention.** Did user X come back at any point during the week 7 to 13 window. More stable than N-day; reads cleaner on retention curves.
+- **Unbounded (rolling) retention.** Did user X come back any time after signup. Useful for longer-cycle products where weekly cadence is misleading.
+
+For most SaaS products, bracket retention is the right default. Day-7 is high-noise; week-2 (bracket) is more stable. Day-1 retention is almost always over-indexed to onboarding effects rather than product-market-fit signal.
+
+Retention curve interpretation.
+
+- Steep early drop, then plateau. The product has core users; the rest churn fast. Typical for most SaaS products.
+- Gradual decay across weeks with no plateau. No one is sticking. Usually a value-prop or onboarding problem; the product is not delivering recurring value.
+- Flat line at low percentage. A power-user product with a small but engaged base. Not a problem; just a different shape.
+
+Detail in `references/retention-measurement-patterns.md`.
+
+---
+
+## North Star and supporting metrics
+
+North Star metric (NSM) selection rules.
+
+- Reflects user value, not company value alone.
+- Captures the core action that, if it grows, the business grows.
+- Measurable consistently across time.
+- Hard to game.
+
+Bad NSMs. Signups (vanity; many signups never activate). Revenue (lagging; not action-oriented; varies by mix). DAU (only useful for engagement-driven products; misleads on monthly-cadence products).
+
+Better NSMs. Weekly active editors (Figma). Nights booked (Airbnb). Messages sent per day (Slack). Products created per workspace per week (Linear). Each names a user-value action that maps to business growth.
+
+Supporting metrics framework.
+
+- One NSM.
+- Three to five input metrics that drive the NSM. For "weekly active editors" these might be: signups per week, signup-to-active conversion rate, week-over-week active retention.
+- Five to ten health metrics that warn of problems. Monthly churn rate, account-level concentration, support ticket volume.
+
+Detail and product-type-specific examples in `references/north-star-metric-selection.md`.
+
+---
+
+## The trustable dashboard principle
+
+A dashboard is trustable when four things are true.
+
+1. **Each metric has a clear definition** documented inline. Not "active users" but "users who fired any event in the last 7 days, deduplicated by user_id, excluding employees."
+2. **Each metric has a known data source.** Not "from the warehouse" but "from `fct_orders`, last 30 days, joined to `dim_customers`."
+3. **Each metric has known caveats.** Modeled iOS conversions excluded. Internal employees excluded. Test users in QA accounts excluded.
+4. **Each metric is reproducible.** The same query, run tomorrow, produces the same number for the same time period.
+
+The stale dashboard failure mode. A dashboard built two years ago is still in use. The underlying schema changed; the dashboard's query points at columns that no longer exist or now mean something different. The team makes decisions on broken numbers and does not realize until something breaks loudly.
+
+Prevention. Every dashboard has an owner, a refresh cadence, and a quarterly audit. Dashboards without an owner get deprecated. Dashboards that have not been refreshed in 90 days get deprecated. The half-life of a dashboard is shorter than the half-life of the product.
+
+---
+
+## Instrumentation debt
+
+The compounding cost of cutting corners.
+
+- New feature ships without instrumentation: 1 hour saved.
+- Six months later: nobody can answer "is feature X working?"
+- Cost to retroactively instrument: 20 hours (re-deploy, backfill, validate).
+- Cost in lost decisions during the gap: untrackable but real. Decisions get made on intuition rather than data; sometimes the intuition is wrong.
+
+Instrumentation debt is real and compounds like technical debt. The discipline.
+
+- Every PR for new functionality includes instrumentation. The PR template asks "what events does this fire?" and rejects the PR if the answer is none.
+- Quarterly schema audits. Identify orphan events (firing but not used in any dashboard or query) and deprecate them. Identify gaps (features without events) and fill them.
+- "If we cannot measure it, we do not ship it" with explicit exceptions for genuinely experimental features where the cost of instrumentation exceeds the value of the data.
+
+Detail in `references/instrumentation-audit-checklist.md`.
+
+---
+
+## Common failure modes
+
+Twelve patterns recur across product analytics setups. The short version.
+
+- "We have data but cannot trust it." Naming and schema drift. Fix is a schema audit plus naming convention enforcement.
+- "Our funnel says 80% drop-off but real conversion is fine." Wrong anchor event or wrong window. Fix the funnel definition.
+- "Retention curve is flat at 5%." Often not a problem. Power-user products genuinely have small engaged bases. Compare against business reality before treating as a fix-it.
+- "Mixpanel says 1000 conversions, warehouse says 800." Attribution plus identity stitching mismatch. Reconcile against warehouse for canonical numbers.
+- "Dashboards take 30 seconds to load." Over-broad queries, unindexed properties, or schema bloat. Profile and refactor.
+- "Everyone has their own definition of MAU." No canonical metric document. Ship one; force everyone to use the same definition.
+- "We track every button click." UI noise. Audit and remove events that are not used by any dashboard or query.
+- "Our event names changed three times." No versioning. Migrate to a versioning pattern; freeze further renames.
+- "Analytics tool says iOS users converted 3% but warehouse says 5%." iOS Intelligent Tracking Prevention plus modeled conversions. Treat platform iOS data with extra skepticism.
+- "We cannot answer simple questions." Under-instrumented or wrong abstraction layer. Audit the events list against the questions the team is asking; fill the gaps.
+- "Two analysts compute different MAU." Different identity stitching. Pick one canonical identity layer and make everyone query from it.
+- "Numbers are different than last quarter for no reason." Underlying schema changed without versioning. The dashboard quietly broke; nobody noticed until the gap got large.
+
+Detail in `references/common-failures.md`.
+
+---
+
+## The framework: 12 considerations for trustable product analytics
+
+When designing or auditing product analytics, walk these 12 considerations. Skipping any of them is how the team ends up with data nobody trusts.
+
+1. **Event taxonomy.** Past tense, object-action, granular but not redundant. Verbs are events; states are properties.
+2. **Property design.** Event-level vs user-level. Type discipline. ISO 8601 timestamps everywhere.
+3. **Naming conventions.** Pick one and enforce it. snake_case wins by default.
+4. **Schema versioning.** Additive vs breaking. `_v2` suffix during transitions. Data contract in code.
+5. **Identity stitching.** Anonymous to authenticated, cross-device, cross-tool. One canonical identity layer.
+6. **Funnel design.** Anchor on high-intent events. Document time windows. No auto-firing events as steps.
+7. **Cohort definitions.** Reusable, versioned, apples-to-apples. Defined in code or saved in the tool.
+8. **Retention measurement.** Bracket over N-day for stability. Compare cohorts at matched ages.
+9. **North Star.** Captures user value. Hard to game. One NSM, three to five inputs, five to ten health metrics.
+10. **Dashboard hygiene.** Definitions, sources, owners, refresh cadence. Stale dashboards get deprecated.
+11. **Instrumentation debt.** Every PR includes instrumentation. Quarterly audits.
+12. **Single source of truth.** Warehouse for board metrics. Tool for in-flight optimization. Reconcile when they disagree.
+
+The output of the framework is a tracking plan. A list of events with their properties, the canonical user identity, the named cohorts, the named funnels, the retention measurement choice, the named NSM, the dashboard owners. The plan lives in code and gets reviewed like any other product spec.
+
+---
+
+## Reference files
+
+- [`references/event-taxonomy-template.md`](references/event-taxonomy-template.md) - Canonical event spec for typical SaaS: account, user, activation, engagement, conversion, retention events with required properties.
+- [`references/property-design-patterns.md`](references/property-design-patterns.md) - Event-level vs user-level patterns. Type discipline. Worked example: `product_viewed` right vs wrong.
+- [`references/naming-convention-reference.md`](references/naming-convention-reference.md) - Complete style guide. snake_case, past tense, object-action. Boolean prefixes. Money in cents. Timestamps with `_at` suffix. Do/don't side-by-side.
+- [`references/schema-versioning-patterns.md`](references/schema-versioning-patterns.md) - Additive vs breaking changes. `_v2` suffix pattern. Data contract in TypeScript. CI lint patterns.
+- [`references/funnel-design-templates.md`](references/funnel-design-templates.md) - Activation, conversion, engagement, feature adoption funnels. Time windows, anchor events, drop-off interpretation.
+- [`references/cohort-definition-patterns.md`](references/cohort-definition-patterns.md) - Acquisition, behavioral, property, combined cohorts. SQL examples plus tool-specific examples.
+- [`references/north-star-metric-selection.md`](references/north-star-metric-selection.md) - NSM rules with examples by product type. Anti-patterns. Migration patterns when changing NSM.
+- [`references/instrumentation-audit-checklist.md`](references/instrumentation-audit-checklist.md) - Quarterly audit playbook: schema review, volume sanity checks, dashboard freshness, owner audit, deprecation candidates.
+- [`references/common-failures.md`](references/common-failures.md) - Twelve failure patterns with symptom, root cause, fix, prevention.
+
+---
+
+## Closing: when in doubt, instrument less
+
+Most product analytics setups are over-instrumented, not under-instrumented. Tracking every button click produces noise that drowns the signal. The discipline of saying "we do not need to track that" is harder than "let us track that just in case." Default to less.
+
+The data you do not have can be added later. The data you over-collected costs you forever, in dashboard performance, in schema complexity, in signal-to-noise. The team that ships with thirty well-designed events and a small set of named cohorts outperforms the team that ships with two hundred events and no cohort discipline.
+
+When the team disagrees on whether to add an event, the question is not "could this be useful?" but "what specific decision will this event inform, and is the decision worth the instrumentation cost?" If the answer is "we might want to know" the answer to the question is no.

--- a/skills/product-analytics-setup/references/cohort-definition-patterns.md
+++ b/skills/product-analytics-setup/references/cohort-definition-patterns.md
@@ -1,0 +1,202 @@
+# Cohort definition patterns
+
+Four cohort patterns: acquisition, behavioral, property, combined. With SQL examples for warehouse-native and tool-specific examples for Mixpanel, Amplitude, and PostHog.
+
+---
+
+## Pattern 1: acquisition cohort
+
+Users acquired in a specific time window. The standard for retention analysis.
+
+### Definition
+
+```sql
+-- Warehouse-native (BigQuery / Snowflake / Postgres)
+SELECT user_id
+FROM dim_users
+WHERE first_seen_at >= '2026-04-01'
+  AND first_seen_at <  '2026-05-01';
+```
+
+### Tool-specific
+
+**Mixpanel.** Cohort builder, condition: "First time the user did `user_signed_up` was between April 1 and April 30, 2026."
+
+**Amplitude.** User segment, condition: "First event date between April 1 and April 30, 2026."
+
+**PostHog.** Cohort, condition: "Person property `first_seen` is between April 1 and April 30, 2026."
+
+### Use cases
+
+- Retention analysis. Compare retention curves across acquisition cohorts to detect product or onboarding regressions.
+- Onboarding A/B test results. The treatment cohort and control cohort are both acquisition cohorts.
+- Cohort revenue tracking. How much did April's signups generate over the next 12 months?
+
+### Common mistakes
+
+- Comparing cohorts at different ages. A 30-day-old cohort has lower retention than a 90-day-old cohort by definition.
+- Using "user created" vs "first event" inconsistently. Pick one and document it.
+
+---
+
+## Pattern 2: behavioral cohort
+
+Users who completed a specific action. The standard for activation and engagement analysis.
+
+### Definition
+
+```sql
+-- Users who fired first_value_action_completed within 14 days of signup
+SELECT u.user_id
+FROM dim_users u
+JOIN fct_events e ON e.user_id = u.user_id
+WHERE e.event_name = 'first_value_action_completed'
+  AND e.event_timestamp <= u.first_seen_at + INTERVAL '14 days';
+```
+
+### Tool-specific
+
+**Mixpanel.** Cohort builder, condition: "User did `first_value_action_completed` at least once where event time was within 14 days of `user_signed_up`."
+
+**Amplitude.** Behavioral cohort, "Performed event `first_value_action_completed` within 14 days after first event."
+
+**PostHog.** Cohort, condition: "Person performed event `first_value_action_completed` and the event happened within 14 days of person creation."
+
+### Use cases
+
+- Activation funnel: activated users vs non-activated users.
+- Feature adopters: users who used feature X. How does their retention compare to non-adopters?
+- Power users: users who fired a specific high-value event 5 or more times.
+
+### Common mistakes
+
+- Using behavioral cohorts for retention without a time anchor. "Users who completed onboarding" includes users from January and users from October; their retention curves are at different ages.
+- Confusing "users who ever did X" with "users who did X recently." Specify the time window.
+
+---
+
+## Pattern 3: property cohort
+
+Users with a specific property value. The standard for segment-level analysis.
+
+### Definition
+
+```sql
+SELECT user_id
+FROM dim_users
+WHERE subscription_tier = 'pro'
+  AND region = 'us'
+  AND is_admin = false;
+```
+
+### Tool-specific
+
+**Mixpanel.** Cohort, condition: "User properties: `subscription_tier = pro` AND `region = us`."
+
+**Amplitude.** User segment, condition: "User properties match: `subscription_tier = pro` AND `region = us`."
+
+**PostHog.** Cohort, condition: "Person properties: `subscription_tier = pro` AND `region = us`."
+
+### Use cases
+
+- Segment performance: how does the Pro tier behave differently from the Free tier?
+- Geographic analysis: do EU users convert at a different rate than US users?
+- Role-based analysis: do admins use the product differently than members?
+
+### Common mistakes
+
+- Using event-level properties as if they were user-level. "Users who fired any event with `cart_value > 100`" returns events, not users; use a behavioral cohort for "users who fired a high-value event."
+- Snapshot vs current property values. "Users who were Pro in March" vs "users who are Pro now" are different cohorts; some platforms default to current values without warning.
+
+---
+
+## Pattern 4: combined cohort
+
+Combinations of the above. The most common in real analytics work.
+
+### Definition
+
+```sql
+-- Users who signed up in March, completed onboarding within 7 days,
+-- are in EU, and are on the Pro tier
+SELECT u.user_id
+FROM dim_users u
+WHERE u.first_seen_at >= '2026-03-01'
+  AND u.first_seen_at <  '2026-04-01'
+  AND u.region = 'eu'
+  AND u.subscription_tier = 'pro'
+  AND EXISTS (
+    SELECT 1 FROM fct_events e
+    WHERE e.user_id = u.user_id
+      AND e.event_name = 'onboarding_completed'
+      AND e.event_timestamp <= u.first_seen_at + INTERVAL '7 days'
+  );
+```
+
+### Tool-specific
+
+All three platforms support combined cohorts via boolean composition (AND, OR, NOT). The composition gets unwieldy past 4 or 5 conditions; consider whether the cohort is genuinely useful or whether the team is over-segmenting.
+
+### Use cases
+
+- Activation analysis by acquisition channel: "Paid Meta users who signed up in March and activated within 7 days."
+- Quality cohorts: "Pro tier users acquired via organic search who reached aha_moment within 14 days."
+- Test cohorts: "Treatment group users who completed the onboarding A/B test within 7 days."
+
+### Common mistakes
+
+- Cohorts so narrow that the population is too small for analysis. A cohort of 50 users has high variance on every metric.
+- Combining conditions that contradict each other. "Pro tier free users" returns nothing.
+- Forgetting to time-box. A combined cohort without acquisition or behavioral time bounds drifts as users join and leave.
+
+---
+
+## Cohort discipline
+
+Three rules that apply across all four patterns.
+
+### Rule 1: define cohorts in code (or saved in the tool)
+
+Re-querying the same cohort definition by hand each time produces inconsistencies. Define the cohort once; reuse the definition across analyses.
+
+In SQL: a `WITH` clause or a saved view.
+
+```sql
+WITH march_cohort AS (
+  SELECT user_id
+  FROM dim_users
+  WHERE first_seen_at >= '2026-03-01'
+    AND first_seen_at <  '2026-04-01'
+)
+SELECT COUNT(*) FROM march_cohort;
+```
+
+In analytics tools: saved cohorts. Every analysis references the saved cohort by name.
+
+### Rule 2: version when criteria change
+
+A cohort definition that evolves over time produces non-comparable results. If you change the activation definition, the new cohort is a different cohort.
+
+Pattern. Append `_v2` to the cohort name when criteria change. Keep the old definition queryable for historical comparison.
+
+### Rule 3: compare apples-to-apples
+
+Two cohorts compared at different ages produce misleading conclusions. Always compare at matched ages.
+
+If comparing March cohort retention against November cohort retention, both should be measured at the same number of days post-acquisition. November cohort at 30 days vs March cohort at 60 days is not a fair comparison.
+
+---
+
+## When to introduce a cohort
+
+The team has a question that filters on a user attribute or behavior. The question repeats across analyses. The team is computing the same filter 5+ times by hand.
+
+That is the trigger. Define the cohort once; reuse it.
+
+---
+
+## When to deprecate a cohort
+
+The cohort has not been queried in 90 days. The cohort criteria no longer match a real product question (e.g., the feature it tracked was deprecated). The team has built a more precise replacement cohort.
+
+Stale cohorts in the analytics tool produce dropdown clutter and tempt analysts to use them when newer cohorts are appropriate. Deprecate explicitly.

--- a/skills/product-analytics-setup/references/common-failures.md
+++ b/skills/product-analytics-setup/references/common-failures.md
@@ -1,0 +1,155 @@
+# Common failures
+
+Twelve patterns that recur across product analytics setups. For each: name, symptom, root cause, fix, prevention.
+
+---
+
+## 1. We have data but cannot trust it
+
+**Symptom.** The team has years of events. Two analysts run the same query and get different numbers. Stakeholders ask for "the real number" and the answer is "it depends."
+
+**Root cause.** Naming and schema drift over time. Same event name has slightly different semantics in different code paths. Properties have inconsistent types or values.
+
+**Fix.** Schema audit. Identify the canonical events; deprecate the duplicates and aliases. Standardize property types. Document the canonical definitions.
+
+**Prevention.** Schema in code (TypeScript interface or JSON Schema). CI lint that rejects schema violations. Naming convention enforcement.
+
+---
+
+## 2. Funnel says 80% drop-off but real conversion is fine
+
+**Symptom.** The activation funnel shows 20% conversion. The team knows from revenue numbers that real activation is 60%.
+
+**Root cause.** Wrong anchor event (using a too-broad event like `page_view` as the start) or wrong time window (asking for activation within 24 hours when the real cycle is 14 days).
+
+**Fix.** Audit the funnel definition. Anchor on a high-intent event (signup, trial start). Set the time window to match the actual activation cycle.
+
+**Prevention.** Document the funnel anchor and window in the funnel definition itself, not implicit in dashboard text. Review funnels at each quarterly audit.
+
+---
+
+## 3. Retention curve is flat at 5%
+
+**Symptom.** Retention curve drops fast then plateaus at 5%. The team panics; only 5% of users are active.
+
+**Root cause.** Not always a problem. Some products are power-user products with small but engaged bases (developer tools, niche B2B software). The 5% may be the natural shape.
+
+**Fix.** Compare against business reality. If 5% retention with strong unit economics, the curve is healthy. If 5% retention and the business model assumes 20% retention, then it is a problem and the cohort needs investigation.
+
+**Prevention.** Set retention targets based on business model assumptions, not industry benchmarks. The right retention for a niche tool is different from the right retention for a consumer app.
+
+---
+
+## 4. Mixpanel says 1000 conversions, warehouse says 800
+
+**Symptom.** Two systems report different conversion counts for the same event.
+
+**Root cause.** Identity stitching mismatch. Mixpanel may stitch anonymous-to-authenticated differently than the warehouse. Server-side and client-side fires of the same event may not deduplicate correctly. Time-window differences (Mixpanel using event time, warehouse using ingest time).
+
+**Fix.** Pick one source as canonical (warehouse for board metrics, tool for in-flight). Reconcile the gap by understanding the cause. Document the expected gap so stakeholders are not surprised.
+
+**Prevention.** Identity stitching pattern documented and consistent. Server-side and client-side firing for the same event handled with explicit deduplication. Use a single time field consistently.
+
+---
+
+## 5. Dashboards take 30 seconds to load
+
+**Symptom.** The team's main dashboard takes 30+ seconds to refresh. Reviewing a metric becomes a coffee break.
+
+**Root cause.** Over-broad queries (scanning years of data for a 30-day metric). Unindexed properties used as filters. Schema bloat from too many events or too many properties on each event.
+
+**Fix.** Profile the slow queries. Add date filters. Index the filter properties. Pre-aggregate metrics into a daily summary table; query the summary, not the raw events.
+
+**Prevention.** Set query budgets per dashboard (target: under 5 seconds). Audit performance during the quarterly audit. Cap the data volume per query.
+
+---
+
+## 6. Everyone has their own definition of MAU
+
+**Symptom.** Three people compute MAU; three different numbers.
+
+**Root cause.** No canonical definition. One person counts unique user_ids firing any event. Another counts users who fired a specific qualifying event. Another counts authenticated users only.
+
+**Fix.** Write a canonical metric document. "MAU is unique user_ids firing any event in the last 30 days, deduplicated, excluding employee accounts (employees identified by email domain) and excluding test accounts (account_type = 'test')." Force everyone to use this definition.
+
+**Prevention.** Canonical metric document maintained as living documentation. Every dashboard's metric definitions reference the canonical document. Disagreements get resolved by updating the document, not by recomputing on the fly.
+
+---
+
+## 7. We track every button click
+
+**Symptom.** The event list has 800 events. Many are individual button clicks. Dashboards are slow; analyses produce noise.
+
+**Root cause.** Tracking UI events (clicks, hovers, page views) rather than semantic events (created, completed, shared). Each button gets its own event "for completeness."
+
+**Fix.** Audit the event list. Deprecate UI events. Replace with semantic events that capture user intent.
+
+**Prevention.** Naming convention enforcement (verbs are events; UI states are properties). Code review on new events asks "is this a semantic event or a UI event?" UI events get rejected unless there is a specific use case.
+
+---
+
+## 8. Our event names changed three times
+
+**Symptom.** `signup_complete`, then `signupCompleted`, then `user_signed_up`. Dashboards reference all three; nobody knows which is current.
+
+**Root cause.** No versioning. Each rename happened without coordination, leaving old events in the warehouse and old queries in the dashboards.
+
+**Fix.** Migrate to a single canonical version. Use the `_v2` pattern if semantics changed. Deprecate old versions explicitly. Update all dashboards.
+
+**Prevention.** Versioning pattern in the schema documentation. Schema review on every PR that adds or modifies an event. CI lint on event names.
+
+---
+
+## 9. Analytics tool says iOS users converted 3% but warehouse says 5%
+
+**Symptom.** iOS conversion rate looks bad in the analytics tool but fine in the warehouse.
+
+**Root cause.** iOS Intelligent Tracking Prevention (ITP) blocks third-party cookies, breaking attribution for iOS users. The analytics tool models the missing data; the warehouse uses server-side conversion tracking that is unaffected.
+
+**Fix.** Treat iOS analytics-tool data with extra skepticism. Use the warehouse for canonical iOS metrics. Set up server-side event tracking (Conversions API for Meta, server-side GA4) where possible.
+
+**Prevention.** Document the iOS measurement gap. Pair every iOS-specific metric with a note on the data source.
+
+---
+
+## 10. We cannot answer simple questions
+
+**Symptom.** Stakeholder asks: "How many users came back this week?" Three days of analyst time later, still no clean answer.
+
+**Root cause.** Under-instrumented or wrong abstraction layer. The events list does not include the right event. The user identity layer does not stitch correctly. The cohort definition is too narrow or too broad.
+
+**Fix.** Audit the event list against the questions the team actually asks. Fill gaps with new events; fix identity stitching; create canonical cohorts for the most common questions.
+
+**Prevention.** Quarterly review of the question backlog. Map questions to events; identify gaps. Fill gaps proactively, not after the question goes unanswered.
+
+---
+
+## 11. Two analysts compute different MAU on the same data
+
+**Symptom.** Same query, same data, different numbers. The discrepancy is not because of a definition disagreement; it is because the queries silently return different rows.
+
+**Root cause.** Different identity stitching layers. One query uses user_id; another uses anonymous_id with stitching applied at query time. Edge cases (users who logged out and back in, users on multiple devices) get counted differently.
+
+**Fix.** Pick one canonical identity layer. Build a `dim_users` table in the warehouse that resolves identity once. Force all queries to join through this table.
+
+**Prevention.** Identity-stitching pattern documented. New queries use the canonical table. Code review rejects queries that bypass the layer.
+
+---
+
+## 12. Numbers different than last quarter for no reason
+
+**Symptom.** A dashboard's metrics shifted between Q1 and Q2 by 30%. No product change, no instrumentation change... or so it seems.
+
+**Root cause.** Underlying schema changed without versioning. An event was renamed; the dashboard's query points at the old name and now silently returns nothing or returns a different cohort. Often discovered weeks after the fact.
+
+**Fix.** Audit the dashboard's query against the current schema. Update to current event names. Check for similar drift in other dashboards.
+
+**Prevention.** Versioning pattern enforced. CI lint catches event renames before they ship. Quarterly dashboard audit catches drift early.
+
+---
+
+## The pattern across all twelve
+
+Most product analytics failures share one root cause: cutting corners during instrumentation produces compounded debt that surfaces months later as untrustworthy data. The team that ships without a tracking plan saves an hour at instrumentation time and pays 20+ hours at audit time.
+
+The fix at the meta level. Treat instrumentation as a first-class engineering concern. Schema in code. Naming convention enforced. Quarterly audits. Single source of truth for canonical metrics. Instrumentation debt is real; the discipline of paying it down regularly is the only thing that keeps the data trustworthy.

--- a/skills/product-analytics-setup/references/event-taxonomy-template.md
+++ b/skills/product-analytics-setup/references/event-taxonomy-template.md
@@ -1,0 +1,114 @@
+# Event taxonomy template
+
+A canonical event spec for typical SaaS. Six event categories with the events that belong in each, when they fire, who fires them (client or server), required properties, and common pitfalls.
+
+The principle. Thirty to fifty events covers most SaaS products. Below twenty is under-instrumented; above one hundred is usually UI noise. The categories below are the durable shape; the specific event names map to your product.
+
+---
+
+## Account events
+
+Account-level lifecycle. Server-side firing typical because billing is server-side.
+
+| Event | Fires when | Required properties | Notes |
+|---|---|---|---|
+| `account_created` | A new account (workspace, organization) is provisioned. | `account_id`, `plan_tier`, `seat_count` | Distinct from `user_signed_up` (a user can join an existing account). |
+| `account_upgraded` | The account moves to a higher plan tier. | `account_id`, `from_tier`, `to_tier`, `change_reason` | Fires server-side from the billing webhook. |
+| `account_downgraded` | The account moves to a lower plan tier. | `account_id`, `from_tier`, `to_tier`, `change_reason` | Same source as upgrade. |
+| `account_canceled` | The account cancels and stops renewing. | `account_id`, `cancellation_reason`, `final_term_end_at` | Cancellation reason is critical; capture it from the cancellation flow. |
+| `seat_added` | A new seat is provisioned on the account. | `account_id`, `seat_count_after`, `added_by_user_id` | Useful for net-revenue-retention analysis. |
+| `seat_removed` | A seat is released from the account. | `account_id`, `seat_count_after`, `removed_by_user_id`, `removal_reason` | |
+
+Common pitfall. Firing account events client-side from the admin UI. The admin's browser may not be open during the cancellation; server-side from the billing webhook is the right source.
+
+---
+
+## User events
+
+User-level lifecycle.
+
+| Event | Fires when | Required properties | Notes |
+|---|---|---|---|
+| `user_signed_up` | A user creates an account or joins an existing account. | `user_id`, `account_id`, `signup_source`, `referrer_source` | Distinct from `account_created`; one account, many users. |
+| `user_invited` | An existing user invites a new user. | `inviter_user_id`, `invited_email`, `account_id`, `invitation_role` | The invitation event; `user_signed_up` fires later when the invite is accepted. |
+| `user_role_changed` | A user's role within the account changes. | `user_id`, `account_id`, `from_role`, `to_role`, `changed_by_user_id` | |
+| `user_logged_in` | A user authenticates after a logged-out state. | `user_id`, `auth_method`, `device_type` | Different from session start. Logged-in across multiple sessions. |
+| `user_logged_out` | A user explicitly signs out. | `user_id`, `logout_reason` | Often missed; explicit signout vs session timeout. |
+| `user_deactivated` | A user's account is deactivated. | `user_id`, `account_id`, `deactivation_reason` | Soft delete pattern. |
+
+---
+
+## Activation events
+
+The first-value moment. Critical for activation analysis.
+
+| Event | Fires when | Required properties | Notes |
+|---|---|---|---|
+| `onboarding_step_completed` | The user completes a step in the onboarding flow. | `user_id`, `step_name`, `step_number`, `time_in_step_s` | Step name is canonical; do not change it without versioning. |
+| `onboarding_completed` | The user finishes all onboarding steps. | `user_id`, `total_time_s`, `steps_completed_count` | Distinct from activation; onboarding completion does not equal activation. |
+| `first_value_action_completed` | The user does the thing that delivers product value for the first time. | `user_id`, `action_name`, `time_since_signup_s` | Define this carefully per product. For Slack, first message sent. For Figma, first frame created. |
+| `aha_moment_reached` | The user crosses the activation threshold. | `user_id`, `threshold_metric`, `threshold_value` | Tied to the activation definition (e.g., "5 messages in week 1"). |
+
+---
+
+## Engagement events
+
+Recurring product use. The bulk of event volume.
+
+| Event | Fires when | Required properties | Notes |
+|---|---|---|---|
+| `feature_x_used` | The user invokes feature X. Replace x with the actual feature name. | `user_id`, `feature_name`, `entry_point` | Granularity guidance: one event per feature, not one event per button. |
+| `content_y_created` | The user creates a new asset (document, project, message, etc.). | `user_id`, `content_type`, `content_id`, `creation_source` | |
+| `content_y_edited` | The user modifies an existing asset. | `user_id`, `content_type`, `content_id`, `edit_type` | High volume; consider sampling if storage is a concern. |
+| `content_y_shared` | The user shares an asset externally. | `user_id`, `content_type`, `content_id`, `share_method`, `recipient_count` | Sharing is often the strongest engagement signal. |
+| `search_executed` | The user runs an in-product search. | `user_id`, `query_length`, `result_count`, `clicked_result_position` | Capture click-through rates. |
+
+---
+
+## Conversion events
+
+Money moves. Server-side firing required.
+
+| Event | Fires when | Required properties | Notes |
+|---|---|---|---|
+| `trial_started` | The user starts a free trial. | `user_id`, `account_id`, `trial_plan`, `trial_length_days` | Server-side from the billing system. |
+| `trial_converted` | The trial converts to paid. | `user_id`, `account_id`, `from_plan`, `to_plan`, `mrr_added` | Server-side. The MRR property feeds revenue analysis. |
+| `trial_expired_no_conversion` | The trial ends without converting. | `user_id`, `account_id`, `trial_plan`, `usage_during_trial` | Useful for win-back campaigns. |
+| `subscription_purchased` | A subscription begins (any path). | `user_id`, `account_id`, `plan_tier`, `mrr_added`, `purchase_source` | Includes trial conversions and direct purchases. |
+| `subscription_renewed` | A subscription renews for the next term. | `account_id`, `plan_tier`, `mrr_at_renewal` | |
+| `payment_failed` | A payment attempt fails. | `account_id`, `failure_reason`, `attempt_number` | Critical for involuntary churn analysis. |
+
+---
+
+## Retention events
+
+Repeat behavior markers. Useful for retention curve construction.
+
+| Event | Fires when | Required properties | Notes |
+|---|---|---|---|
+| `weekly_active_marker` | The user fires any qualifying event in a given week. | `user_id`, `week_of_year`, `qualifying_event_count` | Some teams compute this in the warehouse rather than fire it as an event; either pattern works. |
+| `returned_after_n_days` | The user returns after N days of inactivity. | `user_id`, `inactive_days_count`, `last_active_at` | Useful for resurrection-flow analytics. |
+
+---
+
+## Property requirements across all events
+
+Every event payload should include:
+
+- `user_id` (or `anonymous_id` for pre-auth events)
+- `account_id` (where applicable; for B2B SaaS especially)
+- `timestamp` (ISO 8601, server-stamped)
+- `device_type` and `platform` (mobile, web, desktop)
+- `app_version` (for change-tracking)
+- `session_id` (for path analysis)
+
+Some platforms inject these automatically. Verify; do not assume.
+
+---
+
+## Common pitfalls in event taxonomy
+
+- **Tracking page views as the primary engagement signal.** Page views are noise. Track semantic events (created, edited, shared) instead.
+- **Treating onboarding completion as activation.** Many users complete onboarding without ever returning. Define activation as a recurring-value action, not as flow completion.
+- **Inconsistent fire timing across the funnel.** Some events fire client-side, some server-side. Reconcile by picking one source per event and documenting it.
+- **Adding new events without checking existing ones.** Six months in, the event list has three versions of "subscription started." Audit before adding.

--- a/skills/product-analytics-setup/references/funnel-design-templates.md
+++ b/skills/product-analytics-setup/references/funnel-design-templates.md
@@ -1,0 +1,174 @@
+# Funnel design templates
+
+Common funnel shapes with anchor events, time windows, and drop-off interpretation guidance.
+
+The principle. Every funnel measures progression through a sequence. The shape of the funnel must match the shape of the user behavior; mismatch produces conversion rates that are uninterpretable.
+
+---
+
+## Activation funnel
+
+Signup to first value. The most important funnel for product-led growth.
+
+### Standard shape
+
+| Step | Event | Notes |
+|---|---|---|
+| 1 | `user_signed_up` | The anchor. High intent. |
+| 2 | `onboarding_started` | The user begins the guided onboarding. |
+| 3 | `onboarding_completed` | The user finishes onboarding. Note: this is not activation. |
+| 4 | `first_value_action_completed` | The user does the action that delivers product value. THIS is activation. |
+| 5 | `aha_moment_reached` | Optional. The threshold beyond which retention curves stabilize. |
+
+### Time window
+
+7 to 14 days from signup. Longer windows include users who activated after a long delay; shorter windows undercount slow adopters.
+
+### Anchor selection
+
+`user_signed_up` is the standard anchor. Avoid `landing_page_viewed` (too noisy) and `email_collected` (too low-intent).
+
+### Drop-off interpretation
+
+- 70%+ drop between signup and onboarding_started: the post-signup experience is the problem. Often a friction issue (email verification, account setup steps).
+- 30%+ drop between onboarding_completed and first_value_action_completed: onboarding is teaching the wrong thing. Users complete the tour but do not understand the product.
+- High drop at first_value_action_completed: the value action is too hard or too far from the user's natural path. Move it earlier in the experience.
+
+---
+
+## Conversion funnel
+
+Trial to paid. The most important funnel for SaaS subscription businesses.
+
+### Standard shape
+
+| Step | Event | Notes |
+|---|---|---|
+| 1 | `trial_started` | The anchor. High intent and ready to evaluate. |
+| 2 | `aha_moment_reached` | The user experiences product value. Critical predictor of conversion. |
+| 3 | `paywall_viewed` | The user sees the upgrade prompt. |
+| 4 | `checkout_started` | The user begins the payment flow. |
+| 5 | `subscription_purchased` | The conversion. |
+
+### Time window
+
+The trial length plus a 7-day grace period. A 14-day trial uses a 21-day funnel window. Shorter windows undercount last-day conversions.
+
+### Anchor selection
+
+`trial_started` is the standard anchor. Funnels that start at signup (rather than trial start) include users who never engaged with the trial; the conversion rate looks lower than it actually is for engaged users.
+
+### Drop-off interpretation
+
+- High drop between aha_moment_reached and paywall_viewed: users got value but the paywall did not appear (timing issue) or did not feel relevant. Audit the paywall trigger logic.
+- High drop between paywall_viewed and checkout_started: pricing or feature gating is the friction. Often a positioning issue rather than a UX issue.
+- High drop between checkout_started and subscription_purchased: payment flow friction. UX audit the checkout pages; check failed-payment rates.
+
+---
+
+## Engagement funnel
+
+Visit to action. Useful for understanding session-level conversion.
+
+### Standard shape
+
+| Step | Event | Notes |
+|---|---|---|
+| 1 | `feature_x_landing_page_viewed` | The anchor. Specific intent (feature page, not homepage). |
+| 2 | `feature_x_used` | The user performs the core action. |
+| 3 | `feature_x_completed_workflow` | The user finishes the workflow. |
+| 4 | `content_y_shared` or similar high-intent action | Optional. Strongest engagement signal. |
+
+### Time window
+
+Single session, typically 30 to 60 minutes from the first event.
+
+### Anchor selection
+
+A feature-specific landing or entry point. Avoid `homepage_viewed` (too broad) and `session_started` (auto-firing, not intent).
+
+### Drop-off interpretation
+
+- High drop from landing to use: the page promises something the feature does not deliver, or the activation friction is too high.
+- High drop from use to workflow completion: the workflow has too many steps, or a specific step has UX issues.
+
+---
+
+## Feature adoption funnel
+
+Awareness to repeat use. Tracks how a feature spreads through the user base.
+
+### Standard shape
+
+| Step | Event | Notes |
+|---|---|---|
+| 1 | `feature_x_announced_to_user` | The anchor. The user saw a notification, prompt, or in-app message about feature X. |
+| 2 | `feature_x_first_used` | The user tried feature X for the first time. |
+| 3 | `feature_x_used_in_week_2` | The user used feature X again in a different week. |
+| 4 | `feature_x_used_in_week_4` | Sustained adoption. |
+
+### Time window
+
+4 weeks from announcement.
+
+### Anchor selection
+
+The announcement event is the right anchor for measuring rollout effectiveness. For organic discovery (no announcement), use `feature_x_first_used` as the anchor and measure the feature's reach as a denominator.
+
+### Drop-off interpretation
+
+- High drop from announcement to first use: the announcement was missed, the announcement was unclear, or the feature was not relevant to the audience. Audit by user segment.
+- High drop from first use to repeat use in week 2: the feature did not deliver value on first use. Either the use case was wrong (user tried it for the wrong thing) or the value-prop is weak.
+- Adoption stalls at 5% of the user base: the feature is for a niche; this may be expected. Compare against the projected target audience size.
+
+---
+
+## Common funnel design mistakes
+
+### Mistake 1: vanity-event anchor
+
+Using `homepage_viewed` or `session_started` as the anchor. The denominator is huge; the conversion rate is tiny; the funnel says nothing about user behavior.
+
+Fix. Anchor on a high-intent action: signup, trial_started, feature-specific page view.
+
+### Mistake 2: too long
+
+Ten or more steps. The end-to-end conversion rate is near zero; the funnel is hard to interpret; small numerator changes look like dramatic shifts.
+
+Fix. Break into 2 or 3 shorter funnels. An activation funnel plus a conversion funnel beats one 10-step funnel.
+
+### Mistake 3: auto-firing events as steps
+
+Including `session_started`, `app_opened`, or any event that fires automatically. The denominator is the entire user base; the meaning of conversion rates is muddled.
+
+Fix. Use only intentional, semantic events as funnel steps.
+
+### Mistake 4: same event in multiple positions
+
+Using `feature_used` at step 2 and step 5. The platform double-counts; the analyst gets confused.
+
+Fix. Distinguish via different events (`feature_first_used` vs `feature_used_in_week_2`) or via a property filter.
+
+### Mistake 5: mixed time windows
+
+The funnel definition allows step 2 within 7 days but step 4 within 30 days. The math becomes interpretable only by the analyst who built it; everyone else gets it wrong.
+
+Fix. One time window for the entire funnel. Document it explicitly.
+
+### Mistake 6: forgetting the cohort
+
+Running the funnel against "all users ever" rather than a specific acquisition cohort. The cohort matters; January users behave differently from November users.
+
+Fix. Always specify the cohort. "Users who signed up in March, evaluated against the activation funnel within 14 days."
+
+---
+
+## Comparing funnels across cohorts
+
+The strongest analytical use of funnels is comparing how the funnel performs across cohorts.
+
+- This month's signup cohort vs last month's: is the funnel stable, or are recent users dropping more?
+- Paid acquisition cohort vs organic: are paid users converting at the same rate, or are paid users worse-quality?
+- Mobile vs web: is the experience parity issue real?
+
+Always compare cohorts at matched ages. A 30-day-old cohort vs a 60-day-old cohort has different conversion rates by definition.

--- a/skills/product-analytics-setup/references/instrumentation-audit-checklist.md
+++ b/skills/product-analytics-setup/references/instrumentation-audit-checklist.md
@@ -1,0 +1,119 @@
+# Instrumentation audit checklist
+
+The quarterly playbook for keeping product analytics trustworthy. Five categories: schema, volume, dashboard freshness, ownership, deprecation.
+
+The principle. Instrumentation decays without active maintenance. Quarterly audits catch decay early; without them, the team ends up with the "we have data but cannot trust it" problem.
+
+---
+
+## 1. Schema review
+
+Goal. Ensure the event taxonomy and property schema match the canonical contract.
+
+Steps.
+
+- **Pull the event list from the analytics tool.** Mixpanel: Lexicon. Amplitude: Govern. PostHog: Data Management. Or directly from the warehouse if warehouse-native.
+- **Compare against the schema definition in code.** Every event in the tool should appear in the schema; every event in the schema should appear in the tool.
+- **Flag drift.** Events firing without a schema entry. Schema entries with no events firing in the last 90 days. Property type mismatches between schema and observed values.
+- **Audit naming.** Events that do not match the naming convention (snake_case, past tense, object-action). Property names with inconsistent casing or typo variants.
+- **Action items.** For each drift item, decide: fix the schema, fix the tracking code, or deprecate the event. Document the decision.
+
+Cadence. Quarterly. More frequently if the team is shipping rapidly.
+
+---
+
+## 2. Volume sanity check
+
+Goal. Confirm event volumes match expectations.
+
+Steps.
+
+- **Pull weekly event counts** for the last 90 days. Group by event name.
+- **Identify volume anomalies.** Sudden drops (deployment broke instrumentation). Sudden spikes (a new code path is firing the event excessively or a bot is hitting the endpoint). Events whose volume drifts steadily down (the feature behind them was deprecated; instrumentation should follow).
+- **Check ratios.** If `signup_started` fires 10x more than `signup_completed`, signup completion is broken or the events fire under different conditions than expected. If `checkout_started` fires more than `add_to_cart`, the events are misordered or one fires automatically.
+- **Compare against business reality.** The dashboard says 50,000 weekly signups; the warehouse says 38,000 paying customers were acquired in the same period. The gap is fine if the business is in trial mode; alarming if the gap should be smaller.
+- **Action items.** For each anomaly, identify the cause. Either the instrumentation is broken (fix it), the business changed (update expectations), or the event semantics drifted (version it).
+
+Cadence. Quarterly minimum. Real-time alerts on the highest-volume events for major deviations.
+
+---
+
+## 3. Dashboard freshness review
+
+Goal. Identify dashboards that have rotted.
+
+Steps.
+
+- **Pull the dashboard inventory** from the analytics tool or BI platform.
+- **Check last-viewed dates.** Dashboards not viewed in the last 90 days are candidates for deprecation. Dashboards not viewed in the last 180 days are almost always stale.
+- **Check last-edited dates.** A dashboard last edited 18 months ago whose underlying schema changed is silently broken. Audit whether the dashboard's metrics still compute correctly.
+- **Check ownership.** Every dashboard should have a named owner. Dashboards with no owner or with an owner who has left the company need reassignment or deprecation.
+- **Spot-check key metrics.** Pick 5 to 10 dashboards. Compute the same metric directly from the warehouse. Compare. Drift over 5% needs investigation.
+- **Action items.** Reassign orphan dashboards. Deprecate stale dashboards. Fix or rewrite dashboards that have drifted from underlying truth.
+
+Cadence. Quarterly.
+
+---
+
+## 4. Owner assignment audit
+
+Goal. Every event, dashboard, cohort, and saved query has a named owner who can answer questions about it.
+
+Steps.
+
+- **Pull the ownership map** for events, dashboards, cohorts, saved queries. Most analytics tools support tagging or property fields for owner.
+- **Identify orphans.** Items with no owner. Items whose owner has left the company.
+- **Reassign.** For each orphan, assign a new owner or deprecate. Owner means "the person who can explain why this exists and what depends on it." It is not a vanity tag.
+- **Document the chain of custody.** If the original owner left and the new owner is unfamiliar with the history, write down what you know.
+- **Action items.** Update the ownership tags. Notify owners of items they are now responsible for. Set up a review cycle (every 6 months minimum) for owners to confirm or release ownership.
+
+Cadence. Quarterly minimum. Whenever someone leaves the team, immediately for their owned items.
+
+---
+
+## 5. Deprecation candidates
+
+Goal. Identify and remove instrumentation, cohorts, and dashboards that no longer serve a purpose.
+
+Steps.
+
+- **Identify candidate events.** Events whose volume is below 10 per week. Events not referenced in any active dashboard or query in the last 90 days. Events that are duplicate or near-duplicate of other events.
+- **Identify candidate cohorts and saved queries.** Items not used in the last 90 days. Items whose source data is now stale.
+- **Identify candidate dashboards.** Already covered in step 3; gather candidates here.
+- **Soft deprecation.** Tag items as deprecated; remove from default views. Wait 30 days. If anyone notices, reverse the deprecation; if nobody notices, hard delete.
+- **Communicate.** Post the deprecation list to the data channel. Anyone with a use case has 14 days to push back.
+- **Action items.** Soft deprecate. Wait. Hard delete on the next audit if no objections.
+
+Cadence. Quarterly. Hard deletion happens at the next audit, not the same one.
+
+---
+
+## The audit deliverable
+
+Each quarterly audit produces a written report with five sections matching the steps above. The report includes.
+
+- **What changed since the last audit.** Events added, removed, renamed. Schema migrations completed.
+- **Drift identified.** Events firing without schema entries. Property type mismatches. Volume anomalies.
+- **Decisions made.** What was fixed, what was deprecated, what was deferred.
+- **Open items.** Drift not yet resolved. Pending decisions. Owners reassigned but not yet confirmed.
+- **Forward planning.** Schema changes anticipated next quarter. Dashboards likely to be migrated. Events likely to be deprecated.
+
+The report goes to the data team and the eng leads. It does not need to go to the entire company; the value is in the discipline of writing it.
+
+---
+
+## When to skip an audit
+
+Never. The cost of skipping a quarter compounds. The team that audits twice a year ends up doing 3x the work each audit; the team that audits quarterly maintains a steady state.
+
+The exception. A team in a 30-day sprint to launch a major product version may defer one audit by 4 to 6 weeks. After that, the audit is overdue and the discipline is at risk.
+
+---
+
+## What the audit is not
+
+Three things to avoid.
+
+- **Not a witch hunt.** The audit identifies drift, not blame. Many drift items are produced by good-faith engineering decisions that did not include the analytics-debt cost.
+- **Not perfectionism.** Some drift is acceptable. Aim for 95% clean, not 100%. Spending the audit cycle chasing the last 5% leaves real problems unaddressed.
+- **Not silent.** The audit produces a deliverable. Without the deliverable, the audit happened in someone's head; it does not transfer to the next quarter or the next team.

--- a/skills/product-analytics-setup/references/naming-convention-reference.md
+++ b/skills/product-analytics-setup/references/naming-convention-reference.md
@@ -1,0 +1,125 @@
+# Naming convention reference
+
+A complete style guide. Pick one convention; enforce it via CI lint.
+
+---
+
+## The canonical conventions
+
+**snake_case** for events and properties. `user_signed_up`, `cart_value`, `trial_day`.
+
+**Past tense, action-oriented** for events. `checkout_completed`, not `complete_checkout` or `completing_checkout`.
+
+**Object-action format** for events. Noun then verb. `video_played`, `form_submitted`, `email_opened`.
+
+**Boolean prefix** for boolean properties. `is_`, `has_`, `can_`. `is_admin`, `has_trial`, `can_invite`.
+
+**Counting suffix** for count properties. `_count` or `_total`. `seat_count`, `total_purchases`, `signup_count`.
+
+**Money in smallest unit** with currency named. `price_cents` not `price` (and currency on `currency` property).
+
+**Timestamp suffix** for date-time properties. `_at` for absolute timestamps. `created_at`, `last_active_at`. `_s` or `_ms` for durations. `time_since_signup_s`.
+
+**Period suffix** for relative-time properties. `_days`, `_weeks`. `inactive_days_count`, `trial_length_days`.
+
+---
+
+## Do and don't
+
+| Don't | Do | Why |
+|---|---|---|
+| `Sign Up Completed` | `signup_completed` | snake_case, no spaces. URL-safe. |
+| `userSignedUp` | `user_signed_up` | snake_case wins by default; consistent across the platform. |
+| `signup` (event) | `user_signed_up` | Past tense, object-action. Reads as "this happened." |
+| `complete_checkout` | `checkout_completed` | Past tense for events. |
+| `completing_checkout` | `checkout_completed` | Past tense, not progressive. |
+| `Sign Up` | `signup` or `signed_up` | Pick one form for the same concept. Document it. |
+| `price: "$19.99"` | `price_cents: 1999` plus `currency: "USD"` | Money in smallest unit. Currency separate. |
+| `quantity: "5"` | `quantity: 5` | Numbers as numbers, not strings. |
+| `is_premium: "yes"` | `is_premium: true` | Booleans as booleans. |
+| `viewed: 1` | `is_viewed: true` | If it is yes/no, it is boolean, not 0/1. |
+| `created: "5/5/2026"` | `created_at: "2026-05-05T14:30:00Z"` | ISO 8601, always. UTC. |
+| `tags: "a,b,c"` | `tag_list: ["a", "b", "c"]` | Arrays for bounded lists, not delimiter-strings. |
+| `signup_source` (one event) plus `source` (another event) | `signup_source` plus `referral_source` | Disambiguate when the same name means different things. |
+| `User Signed Up` (event), `signupCompleted` (event), `SIGN_UP` (event) | `user_signed_up` (event), `signup_completed` (event) | Pick one casing, stick to it. |
+| `mailchimp_email_opened` | `email_opened` plus `provider: "mailchimp"` property | Brand-neutral event names; vendor as a property. |
+| `feature_x_clicked` | `feature_x_used` | Track usage, not button clicks. UI events are noise. |
+
+---
+
+## Boolean property prefixes
+
+The prefix should make the property read as a yes-or-no question.
+
+- `is_admin` reads as "is admin?" Yes or no.
+- `has_trial` reads as "has trial?" Yes or no.
+- `can_invite` reads as "can invite?" Yes or no.
+- `should_notify` reads as "should notify?" Yes or no.
+
+What NOT to do.
+
+- `admin: true`. Reads as "admin is true." Awkward in queries.
+- `premium: 1`. Reads as a count, not a yes-or-no.
+- `trial: "yes"`. String, not boolean.
+
+---
+
+## Time, date, and duration suffixes
+
+| Suffix | Meaning | Example |
+|---|---|---|
+| `_at` | Absolute timestamp (ISO 8601 UTC) | `created_at`, `last_active_at`, `event_timestamp` |
+| `_s` | Duration in seconds | `time_in_step_s`, `session_duration_s` |
+| `_ms` | Duration in milliseconds | `response_time_ms` |
+| `_days` | Duration in days (integer) | `inactive_days_count`, `trial_length_days` |
+| `_weeks` | Duration in weeks (integer) | `weeks_since_signup` |
+| `_months` | Duration in months (integer) | `months_active` |
+
+Mixing units across the schema produces bugs. Pick one unit per concept and document it.
+
+---
+
+## Money
+
+Two rules.
+
+1. **Smallest unit, integer.** `price_cents`, `mrr_cents`, `total_revenue_cents`. Float arithmetic on money produces rounding errors.
+2. **Currency named separately.** `currency: "USD"`. Do not assume USD; international users break the assumption.
+
+When the smallest unit varies (yen has no decimals; bitcoin has 8), pick a precision and document it. The integer math discipline still applies.
+
+---
+
+## Identifiers
+
+Three identifier patterns.
+
+- **Stable IDs** are immutable. `user_id`, `account_id`, `product_id`. Use UUIDs or a system-generated identifier.
+- **Human-readable names** are mutable. `product_name`, `account_name`. Useful for reporting; never use as a join key.
+- **Display IDs** are user-visible. `invoice_number`, `order_number`. Often distinct from the database primary key.
+
+Always include a stable ID in event payloads. Optionally include the human-readable name for reporting convenience.
+
+---
+
+## What NOT to encode in event names
+
+Three categories of detail belong on properties, not in event names.
+
+1. **State or status.** Not `user_active`, `user_inactive`. Use `user_signed_in` (event) plus `status` (user property).
+2. **Variant or treatment.** Not `signup_variant_a`. Use `user_signed_up` (event) plus `experiment_variant` (property).
+3. **Source or channel.** Not `signup_from_facebook`. Use `user_signed_up` (event) plus `acquisition_channel: "facebook"` (property).
+
+The principle. Event names answer "what happened?" Properties answer "with what context?"
+
+---
+
+## Enforcement
+
+A naming convention without enforcement decays. Two patterns.
+
+**CI lint.** A schema definition (TypeScript interface, JSON Schema) plus a CI step that rejects events whose payload does not match. The lint catches new violations before they hit production.
+
+**Code review checklist.** PRs that add or modify events include a snippet showing the event name, properties, and types. The reviewer compares against the naming convention reference and the existing taxonomy.
+
+Without enforcement, the convention becomes documentation that nobody reads. With enforcement, it becomes a constraint that the codebase respects.

--- a/skills/product-analytics-setup/references/north-star-metric-selection.md
+++ b/skills/product-analytics-setup/references/north-star-metric-selection.md
@@ -1,0 +1,159 @@
+# North Star metric selection
+
+Rules for picking a North Star metric (NSM), examples by product type, anti-patterns, and migration patterns when changing NSM.
+
+The principle. The NSM is the single number the team optimizes against. Picking the wrong number focuses the team on the wrong work for as long as the team uses it.
+
+---
+
+## NSM selection rules
+
+A trustworthy NSM passes four tests.
+
+1. **Reflects user value, not company value alone.** Revenue is company value; the NSM should track an action that delivers user value. Revenue can be the trailing measure; the NSM is the leading driver.
+2. **Captures the core action that, if it grows, the business grows.** The NSM should be cause-correlated with revenue growth, retention, and any other business goal. If you double the NSM and the business does not improve, the NSM is wrong.
+3. **Measurable consistently across time.** The definition should not drift. If the NSM definition changes every quarter, year-over-year comparison is impossible.
+4. **Hard to game.** The team should not be able to grow the NSM via shortcuts that do not deliver user value. A gameable NSM produces local maxima that the team optimizes toward at the expense of the actual mission.
+
+---
+
+## Examples by product type
+
+### Engagement-driven products
+
+The product creates ongoing value through repeated use.
+
+| Product | NSM | Why it works |
+|---|---|---|
+| Slack | Messages sent in workspaces of 3+ active users per week | Captures recurring value; harder to game than DAU; size threshold filters out trial-only users. |
+| Figma | Weekly active editors | The action that delivers value (creating in Figma); active editors filters out viewers who do not get full product value. |
+| Notion | Weekly content blocks created per workspace | Captures the core verb (creating); per-workspace normalizes for team size variance. |
+| Linear | Weekly issues created per workspace | The product use case is project tracking; issues created is the load-bearing action. |
+
+### Transaction-driven products
+
+The product makes money on each transaction.
+
+| Product | NSM | Why it works |
+|---|---|---|
+| Airbnb | Nights booked (not bookings) | Nights captures the value delivered to hosts and guests; bookings count is gameable via short stays. |
+| Uber | Rides completed (not requests) | Completion includes the driver-side fulfillment; requests alone misses the supply-side metric. |
+| Etsy | GMV per active buyer | GMV per buyer is more stable than total GMV; it tracks user value rather than top-line growth alone. |
+
+### Conversion-driven products (SaaS subscription)
+
+The product is sold via subscription; the NSM tracks recurring engagement that drives renewal.
+
+| Product | NSM | Why it works |
+|---|---|---|
+| HubSpot | Activated workspaces (defined as workspaces using 3+ products) | Multi-product use is the activation signal that drives expansion revenue. |
+| Stripe (developer-side) | Production payments processed per merchant per week | Captures the core transaction; per-merchant per-week filters for active integrations. |
+| Calendly | Meetings booked via Calendly per user per week | The exact value delivered (meetings booked) and the recurring cadence. |
+
+### Content-driven products (media, publishing)
+
+The product delivers value through content consumption.
+
+| Product | NSM | Why it works |
+|---|---|---|
+| Spotify | Hours listened per active user | Hours captures depth of engagement; per active user normalizes for catalog growth. |
+| YouTube (creator-side) | Watch time per video per audience cohort | Watch time is the core metric that drives ads and creator earnings. |
+| Substack (writer-side) | Paid subscribers added per month | The action that converts to revenue; not just total subscribers (which is lagging). |
+
+---
+
+## Anti-patterns
+
+Six NSMs that consistently produce the wrong incentives.
+
+### Bad NSM 1: signups
+
+Captures top-of-funnel volume, not value. A team optimizing for signups loosens activation criteria and chases low-quality acquisition channels. The NSM grows; the business does not.
+
+### Bad NSM 2: revenue
+
+Lagging, not action-oriented. The team can optimize against revenue only by changing pricing or sales tactics. Revenue is the trailing outcome; the NSM should be the leading action that produces revenue.
+
+### Bad NSM 3: DAU (daily active users)
+
+Useful for engagement-driven products with a daily cadence. Misleading for products with a longer cadence (weekly, monthly). DAU on a B2B SaaS often shows an unhealthy daily ritual the product does not actually need.
+
+### Bad NSM 4: page views or sessions
+
+Captures traffic, not value. A team optimizing for page views or sessions loosens content quality and adds engagement loops that do not deliver user value.
+
+### Bad NSM 5: feature usage
+
+The team optimizes for "feature X used" by promoting feature X aggressively. The feature usage grows; the underlying user value may not. NSM should capture cross-cutting value, not feature-specific use.
+
+### Bad NSM 6: reviews or NPS
+
+Captures sentiment, not value. NPS is useful as a health metric but a poor NSM because it is heavily influenced by survey design and customer-service interactions, neither of which the product team controls directly.
+
+---
+
+## Supporting metrics framework
+
+The NSM does not stand alone. Around it lives a framework of input metrics and health metrics.
+
+### One NSM
+
+The single number the team optimizes against.
+
+### Three to five input metrics
+
+The metrics that drive the NSM. If the input metrics improve, the NSM should follow.
+
+For "weekly active editors" (Figma's NSM):
+- Signups per week (the top of the funnel)
+- Signup-to-active conversion rate (the activation step)
+- Week-over-week active retention (the repeat-use step)
+
+For "messages sent in workspaces of 3+ active users per week" (Slack's NSM):
+- Workspaces created per week
+- Workspaces reaching 3+ active members
+- Messages per active workspace per week
+
+The team's roadmap should map every initiative to one or more input metrics.
+
+### Five to ten health metrics
+
+Metrics that warn of problems. They should not regress while the NSM grows.
+
+- Monthly churn rate
+- Account-level concentration (is growth coming from one big customer?)
+- Support ticket volume per active user
+- Latency or error rate
+- Activation rate (signup-to-NSM-action)
+
+If any health metric regresses while the NSM grows, the team should investigate before declaring success.
+
+---
+
+## Migration patterns when changing NSM
+
+The NSM should change rarely. When it does, the migration is high-risk.
+
+### Pattern 1: phased migration
+
+Run both NSMs in parallel for a quarter. Track team behavior; document where the new NSM produces different incentives. Decide based on real evidence, not speculation.
+
+### Pattern 2: shadow mode first
+
+The new NSM is tracked privately by the data team. The team continues to optimize against the old NSM. After 90 days, the data team reports on the divergence. Public switch happens only if the new NSM clearly aligns better with business outcomes.
+
+### Pattern 3: replace plus reinforce
+
+The new NSM replaces the old. The old metric becomes a health metric (still tracked, no longer the primary target). Over the next 6 months, ensure the old metric does not regress while the new NSM grows.
+
+---
+
+## When to refuse to change the NSM
+
+Three signs that a proposed NSM change is wrong.
+
+1. **The change is reactive to a single quarter's bad numbers.** "Our NSM went down so we should change the NSM" is not a reason to change the NSM.
+2. **The proposed new NSM is gameable.** A new NSM that the team can grow without delivering user value is worse than the existing NSM, even if the old one is imperfect.
+3. **The change has no concrete decision the team will make differently.** If switching from old NSM to new NSM does not change which initiatives the team prioritizes, the change is theater.
+
+The NSM should be stable for years. Change it when the business model changes substantively or when the existing NSM is producing demonstrably wrong incentives.

--- a/skills/product-analytics-setup/references/property-design-patterns.md
+++ b/skills/product-analytics-setup/references/property-design-patterns.md
@@ -1,0 +1,168 @@
+# Property design patterns
+
+Event-level vs user-level properties, with type discipline and a worked example.
+
+The principle. Event-level properties describe a specific event. User-level properties describe a user across all events. Mixing them up creates payload bloat, schema drift, and reporting confusion.
+
+---
+
+## Event-level vs user-level
+
+**Event-level properties** belong on the event payload. They describe the specific event, snapshot at the moment it fires.
+
+- `cart_value` on `checkout_completed`
+- `item_count` on `checkout_completed`
+- `payment_method` on `checkout_completed`
+- `discount_code` on `checkout_completed`
+- `referrer_source` on `user_signed_up`
+
+**User-level properties** belong on the user profile. They describe the user over time. Set them once; the analytics tool joins them onto every event the user fires.
+
+- `subscription_tier`
+- `acquisition_channel`
+- `lifetime_value`
+- `account_role`
+- `is_admin`
+- `last_active_at`
+
+The trap. Putting user-level properties on every event payload. Three problems.
+
+1. **Payload bloat.** Every event carries the same `subscription_tier` value. Multiplied across millions of events, the storage and bandwidth cost is real.
+2. **Schema drift when the value changes.** A user upgrades mid-session. Some events have `subscription_tier: free`; later events have `subscription_tier: pro`. Reporting becomes ambiguous about which value to use.
+3. **Reporting confusion.** Analyst writes "WHERE subscription_tier = 'pro'" thinking they are filtering users. The query actually filters events, returning a different cohort.
+
+The fix. Set user-level properties on the user profile via the platform's identify/track-user API. Let the analytics tool perform the join.
+
+---
+
+## Type discipline
+
+Property types matter. The analytics tool will accept any value, but the reporting breaks when types are inconsistent.
+
+**Strings** for enumerable values.
+
+- `status`, `tier`, `channel`, `region`, `category`
+- Bounded sets. Document the allowed values in the schema.
+- Wrong: storing numbers as strings. `quantity: "5"` breaks every numeric aggregation.
+
+**Numbers** for actual numbers.
+
+- `count`, `value`, `duration_s`, `score`
+- Cents (or smallest unit) for money. Never floats. `price_cents: 1999`, not `price: 19.99`.
+- Wrong: `trial_day: "day 7"`. Use `trial_day: 7`.
+
+**Booleans** for actual booleans.
+
+- `is_admin`, `has_trial`, `is_new_user`
+- Two values: `true` and `false`. Nothing else. Not "yes"/"no", not 1/0, not strings.
+- Prefix discipline: `is_`, `has_`, `can_`. Reading the property name should suggest a yes/no question.
+
+**Timestamps** in ISO 8601, always.
+
+- `created_at`, `last_active_at`, `event_timestamp`
+- Format: `2026-05-05T14:30:00Z` (UTC, with the Z suffix).
+- Wrong: Unix timestamps as strings, locale-specific formats, or any other variant. ISO 8601 across the entire schema.
+- Suffix discipline: `_at` for timestamps, `_s` or `_ms` for durations.
+
+**Arrays** rarely.
+
+- An array property usually means you should split into multiple events with one item per event.
+- Example: instead of `cart.items: [item_a, item_b, item_c]` on `checkout_completed`, fire one `item_purchased` event per item plus one `checkout_completed` event with the item count.
+- Exception: small bounded arrays where the use case is clear (e.g., `tag_list: ["urgent", "billing"]`).
+
+---
+
+## Worked example: product_viewed event
+
+A `product_viewed` event fires when a user views a product detail page in an e-commerce app.
+
+### Wrong design
+
+```json
+{
+  "event": "Product Viewed",
+  "user_id": "u_12345",
+  "product": "Premium Hoodie",
+  "price": "$49.99",
+  "category": "Apparel",
+  "user_subscription_tier": "Premium",
+  "user_lifetime_purchases": 8,
+  "user_acquisition_source": "Meta",
+  "is_premium_user": "true",
+  "viewed_at": "5/5/2026 2:30 PM",
+  "tags": "summer, hoodie, sale"
+}
+```
+
+Problems.
+
+- Event name uses spaces and mixed case. `Product Viewed` should be `product_viewed`.
+- `price` is a money string with currency symbol. Should be `price_cents: 4999`.
+- User-level properties on the event: `user_subscription_tier`, `user_lifetime_purchases`, `user_acquisition_source`, `is_premium_user`. These belong on the user profile.
+- `is_premium_user` is a string `"true"`, not a boolean.
+- `viewed_at` is a locale-specific date format. Should be ISO 8601: `2026-05-05T14:30:00Z`.
+- `tags` is a comma-delimited string. Should be an array of strings, or split into separate events.
+- `product` is the human-readable name; lacks the stable identifier. Should include `product_id`.
+
+### Right design
+
+User profile (set via `identify`):
+
+```json
+{
+  "user_id": "u_12345",
+  "subscription_tier": "premium",
+  "lifetime_purchase_count": 8,
+  "acquisition_channel": "meta",
+  "is_premium": true,
+  "last_active_at": "2026-05-05T14:30:00Z"
+}
+```
+
+Event payload (`product_viewed`):
+
+```json
+{
+  "event": "product_viewed",
+  "user_id": "u_12345",
+  "product_id": "p_premium_hoodie_v2",
+  "product_name": "Premium Hoodie",
+  "price_cents": 4999,
+  "currency": "USD",
+  "category": "apparel",
+  "tag_list": ["summer", "hoodie", "sale"],
+  "viewed_at": "2026-05-05T14:30:00Z"
+}
+```
+
+Differences.
+
+- Event name is `snake_case`.
+- Money in cents with currency named.
+- User-level properties live on the user profile, not the event. The analytics tool joins them.
+- Boolean is an actual boolean.
+- Timestamp is ISO 8601 UTC.
+- Tags are a bounded array (acceptable here because the use case is faceted filtering).
+- Stable identifier (`product_id`) included alongside the human-readable name.
+
+---
+
+## When to put a property on every event
+
+A small set of properties should appear on every event regardless of category.
+
+- `app_version` and `platform` (web, ios, android, desktop)
+- `device_type` and `device_id`
+- `session_id`
+- `experiment_assignments` if the user is in active experiments
+
+These are technically event-level (they describe the context of the event) but they are required across every event for path analysis and segmentation.
+
+---
+
+## Common property design mistakes
+
+- **Property names that are also event names.** `signup` as a property and `signup` as an event creates queries that depend on context. Disambiguate.
+- **Free-text properties for things that should be enums.** "Where did you hear about us?" with free-text answers produces 47 unique values that map to 5 actual channels. Force the enum at collection time.
+- **Storing PII in properties.** Email addresses, full names, phone numbers should not be in event properties. Use a hashed identifier and look up PII separately.
+- **Reusing property names across events with different meanings.** `source` on `user_signed_up` means acquisition source. `source` on `email_opened` means email campaign source. Same name, different meaning, breaks queries.

--- a/skills/product-analytics-setup/references/schema-versioning-patterns.md
+++ b/skills/product-analytics-setup/references/schema-versioning-patterns.md
@@ -1,0 +1,167 @@
+# Schema versioning patterns
+
+Schema changes are inevitable. The discipline is distinguishing safe changes from breaking ones, then versioning the breaking ones.
+
+---
+
+## Additive vs breaking changes
+
+**Additive changes** are safe. They preserve existing dashboards and queries.
+
+- New event. `feature_y_used` ships alongside existing events. Old dashboards continue to work.
+- New property on an existing event. `checkout_completed` gains a `discount_code` property. Old dashboards ignore it; new dashboards can use it.
+- New value in an enum. The `acquisition_channel` enum gains `"tiktok"`. Old dashboards may filter incorrectly if they hard-code values; usually low-risk.
+
+**Breaking changes** require migration.
+
+- Renamed event. `signup_complete` becomes `user_signed_up`. Every dashboard, query, and saved cohort referencing the old name breaks.
+- Removed property. `cart_value_cents` is removed because it was redundant with `total_value_cents`. Queries referencing the removed property fail.
+- Changed property type. `price` was a string; now it is a number. Existing queries cast or compare differently.
+- Narrowed enum. `acquisition_channel` previously had `"organic"` and `"paid"`; the new schema removes `"organic"` and replaces it with `"organic_search"` and `"organic_social"`. Old queries break.
+- Changed semantics. The same event name now fires under different conditions. The dashboard reading "weekly active users" silently gets a different number.
+
+The rule. If old code or old queries continue to work after the change, it is additive. Otherwise, it is breaking.
+
+---
+
+## The `_v2` suffix pattern
+
+Versioning in the event name makes the change visible at every layer.
+
+```
+checkout_completed   <- v1, fires alongside v2 during transition
+checkout_completed_v2 <- new semantics, new schema
+```
+
+The transition.
+
+1. **Phase 1: ship v2 alongside v1.** Both events fire. Dashboards continue to read v1. New queries can use v2.
+2. **Phase 2: migrate dashboards.** Update every saved query, dashboard tile, and downstream consumer to read v2. Document each migration.
+3. **Phase 3: deprecate v1.** Stop firing v1. Mark it deprecated in the schema. Remove from event tracking instrumentation.
+4. **Phase 4: cleanup.** Six months after deprecation, remove v1 from any historical reference documentation. Existing v1 data in the warehouse stays for historical analysis but is not used in current dashboards.
+
+Typical transition window. 90 days from v2 ship to v1 deprecation. Longer if the team is small or the dashboard inventory is large.
+
+---
+
+## The data contract idea
+
+The canonical schema lives in code, not in the analytics tool.
+
+### TypeScript interface
+
+```typescript
+// schema/events.ts
+
+export interface CheckoutCompletedEvent {
+  event: "checkout_completed";
+  user_id: string;
+  account_id: string;
+  cart_value_cents: number;
+  currency: string;
+  item_count: number;
+  payment_method: "card" | "paypal" | "apple_pay" | "google_pay";
+  discount_code?: string;
+  event_timestamp: string;  // ISO 8601 UTC
+}
+
+export interface UserSignedUpEvent {
+  event: "user_signed_up";
+  user_id: string;
+  account_id: string;
+  signup_source: "homepage" | "pricing_page" | "blog" | "invite" | "other";
+  referrer_source: string | null;
+  event_timestamp: string;
+}
+
+export type AnalyticsEvent =
+  | CheckoutCompletedEvent
+  | UserSignedUpEvent;
+  // ... etc.
+```
+
+The interface is the contract. TypeScript catches type mismatches at compile time. The CI pipeline runs the type check.
+
+### JSON Schema
+
+For non-TypeScript projects, JSON Schema serves the same role.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "checkout_completed",
+  "type": "object",
+  "required": ["event", "user_id", "account_id", "cart_value_cents", "currency", "item_count", "payment_method", "event_timestamp"],
+  "properties": {
+    "event": { "const": "checkout_completed" },
+    "user_id": { "type": "string" },
+    "account_id": { "type": "string" },
+    "cart_value_cents": { "type": "integer", "minimum": 0 },
+    "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
+    "item_count": { "type": "integer", "minimum": 1 },
+    "payment_method": { "enum": ["card", "paypal", "apple_pay", "google_pay"] },
+    "discount_code": { "type": "string" },
+    "event_timestamp": { "type": "string", "format": "date-time" }
+  }
+}
+```
+
+A CI step validates events against the schema before they ship.
+
+---
+
+## CI lint patterns
+
+Three lint rules catch most schema drift.
+
+1. **Type validation.** Every event payload validates against its declared type. Failed validations fail the build.
+2. **Naming convention check.** Event names match snake_case. Property names match snake_case. Boolean properties have `is_`, `has_`, or `can_` prefix.
+3. **Forbidden-event check.** Removed or deprecated events do not appear in the codebase. The deploy that adds a deprecated event back fails.
+
+Implementation. A pre-commit hook plus a GitHub Actions workflow plus a runtime sampling check (random 1% of events validated against the schema in production; failures alert).
+
+---
+
+## Migration patterns for breaking changes
+
+Three common migration patterns.
+
+### Pattern 1: rename
+
+The event name changes. The semantics are the same.
+
+1. Ship v2 with the new name; old name continues to fire.
+2. Migrate dashboards, queries, saved cohorts.
+3. Deprecate v1.
+
+### Pattern 2: split
+
+One event splits into two or more events with narrower meanings.
+
+1. Ship the new events; the old event continues to fire alongside.
+2. Update tracking code to fire the appropriate new event instead of the old one.
+3. Migrate dashboards.
+4. Deprecate the old event.
+
+Example. `subscription_changed` splits into `subscription_upgraded` and `subscription_downgraded`. Both new events provide more analytical power than the old single event.
+
+### Pattern 3: merge
+
+Two events merge into one event with a discriminating property.
+
+1. Ship the new event with the discriminating property.
+2. Update tracking code to fire the new event with the appropriate property value.
+3. Migrate dashboards (often: queries that filtered on event name now filter on property value).
+4. Deprecate the old events.
+
+Example. `signup_via_facebook` and `signup_via_google` merge into `user_signed_up` with `auth_method: "facebook" | "google"`.
+
+---
+
+## Common schema versioning mistakes
+
+- **Renaming events without versioning.** The dashboards break overnight; the team blames the analytics tool.
+- **Skipping the transition period.** v2 ships and v1 stops firing the same day. Historical analysis of v1 data is fine, but in-flight queries break.
+- **Versioning everything pre-emptively.** `event_v3_v2` is overkill. Version when semantics change, not at every iteration.
+- **Letting the analytics tool be the schema source of truth.** The tool's "events you have ever fired" list is a graveyard, not a contract. Maintain the schema in code; export to the tool.
+- **No CI enforcement.** The discipline becomes an etiquette that decays as the team grows. Enforcement is the only thing that scales.


### PR DESCRIPTION
## Summary

First skill in the PM gap-closing track. Companion to the existing \`analytics-strategy\` skill (Growth category). Pairs with the 5 data and analytics platforms in /integrations: BigQuery, Snowflake, Mixpanel, dbt, Hex.

16-section SKILL.md (~3163 words) plus 9 reference files. Voice: senior PM and analyst to junior PM and analyst.

## Distinction from analytics-strategy

\`analytics-strategy\` (Growth category) is strategic: what to measure and why, KPI hierarchy, dashboard architecture, attribution models. \`product-analytics-setup\` (Product category, this skill) is execution: how to actually instrument the product correctly. The two compose: read analytics-strategy first to decide what matters, then read this skill to instrument it. Section 1 names the distinction explicitly so users do not confuse them.

## Files

- \`SKILL.md\` (308 lines, 3163 words across 16 sections)
- 9 reference files:
  - \`event-taxonomy-template.md\` (canonical event spec for typical SaaS: account, user, activation, engagement, conversion, retention)
  - \`property-design-patterns.md\` (event-level vs user-level; type discipline; worked example)
  - \`naming-convention-reference.md\` (complete style guide with do/don't table)
  - \`schema-versioning-patterns.md\` (additive vs breaking; \`_v2\` pattern; data contract in TypeScript)
  - \`funnel-design-templates.md\` (activation, conversion, engagement, feature adoption funnels)
  - \`cohort-definition-patterns.md\` (acquisition / behavioral / property / combined; SQL + tool-specific)
  - \`north-star-metric-selection.md\` (rules + examples by product type + anti-patterns + migration patterns)
  - \`instrumentation-audit-checklist.md\` (5-category quarterly playbook)
  - \`common-failures.md\` (12 failure patterns with symptom, root cause, fix, prevention)

## Generator output

\`\`\`
Updated 6 sections in README.md, 70 skills, 169 reference files
\`\`\`

Skill count 69 to 70. Reference files 160 to 169. Product category grows to 8 entries with \`product-analytics-setup\` at catalog index 38.

## Quality gates

- Lint passes 70 skills with both \`check_readme_catalog_count\` and \`check_readme_catalog_generated\` rules green
- Generator idempotent (running --write twice produces no diff)
- Em-dash audit zero on new content
- Forbidden-phrase audit zero on new content
- Real-firm scrub clean

## Test plan

- [ ] CI lint passes
- [ ] Catalog row 38 renders correctly in the GitHub Files changed view
- [ ] Product section header now reads \"Product (8)\"

Companion landing page lands in \`rampstackco-app\` in a follow-up dispatch.