### PR TITLE
feat(skills): add pillar-content-architecture (18th flagship, content suite skill 2 of 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-73-blue.svg)](#the-73-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-74-blue.svg)](#the-74-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 73 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 74 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -35,7 +35,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 73-skill catalog](#the-73-skill-catalog)
+- [The 74-skill catalog](#the-74-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -63,8 +63,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **73 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
-- **195 reference files** (templates, checklists, decision matrices, worked examples)
+- **74 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
+- **205 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -253,11 +253,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 73-skill catalog
+## The 74-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 73 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 74 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -290,7 +290,7 @@ All 73 skills are shipped. Each has a complete SKILL.md plus at least one refere
 | 12 | [`design-standards`](skills/design-standards/SKILL.md) | Production-grade page and component design standards |
 | 13 | [`art-direction`](skills/art-direction/SKILL.md) | Photography, illustration, and visual direction for campaigns |
 
-### Content (4)
+### Content (5)
 
 | # | Skill | What it does |
 |---|---|---|
@@ -298,6 +298,7 @@ All 73 skills are shipped. Each has a complete SKILL.md plus at least one refere
 | 15 | [`landing-page-copy`](skills/landing-page-copy/SKILL.md) | Landing pages, sales pages, hero-to-CTA flow |
 | 16 | [`email-sequences`](skills/email-sequences/SKILL.md) | Onboarding flows, lifecycle campaigns, transactional copy |
 | 17 | [`content-brief-authoring`](skills/content-brief-authoring/SKILL.md) | Per-piece editorial brief: target keyword, intent, audience, outline, entity coverage, internal linking, success criteria, and the discipline that distinguishes useful briefs from bloat |
+| 18 | [`pillar-content-architecture`](skills/pillar-content-architecture/SKILL.md) | Hub-level content architecture: pillar topic selection, cluster planning, internal linking, URL structure, pillar and cluster page anatomy, topical authority signals, refresh discipline |
 
 ### SEO foundation (7)
 
@@ -305,13 +306,13 @@ Tool-agnostic SEO skills. These define the conceptual frameworks. The SEO audit 
 
 | # | Skill | What it does |
 |---|---|---|
-| 18 | [`seo-onpage`](skills/seo-onpage/SKILL.md) | Single-page audits and optimization across 8 dimensions |
-| 19 | [`seo-technical`](skills/seo-technical/SKILL.md) | Crawlability, indexability, rendering, schema, page experience |
-| 20 | [`seo-keyword`](skills/seo-keyword/SKILL.md) | Discovery, intent classification, clustering, prioritization |
-| 21 | [`seo-competitor`](skills/seo-competitor/SKILL.md) | SERP overlap, content gaps, backlink gaps, technical comparison |
-| 22 | [`seo-offpage`](skills/seo-offpage/SKILL.md) | Link building, digital PR, citations, linkable assets |
-| 23 | [`seo-content-audit`](skills/seo-content-audit/SKILL.md) | Keep/update/merge/redirect/delete decisions across a site |
-| 24 | [`seo-aeo-geo`](skills/seo-aeo-geo/SKILL.md) | AI search optimization, llms.txt, extraction-friendly content |
+| 19 | [`seo-onpage`](skills/seo-onpage/SKILL.md) | Single-page audits and optimization across 8 dimensions |
+| 20 | [`seo-technical`](skills/seo-technical/SKILL.md) | Crawlability, indexability, rendering, schema, page experience |
+| 21 | [`seo-keyword`](skills/seo-keyword/SKILL.md) | Discovery, intent classification, clustering, prioritization |
+| 22 | [`seo-competitor`](skills/seo-competitor/SKILL.md) | SERP overlap, content gaps, backlink gaps, technical comparison |
+| 23 | [`seo-offpage`](skills/seo-offpage/SKILL.md) | Link building, digital PR, citations, linkable assets |
+| 24 | [`seo-content-audit`](skills/seo-content-audit/SKILL.md) | Keep/update/merge/redirect/delete decisions across a site |
+| 25 | [`seo-aeo-geo`](skills/seo-aeo-geo/SKILL.md) | AI search optimization, llms.txt, extraction-friendly content |
 
 ### SEO audit suite (Ahrefs MCP-powered) (7)
 
@@ -319,64 +320,64 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 
 | # | Skill | What it does |
 |---|---|---|
-| 25 | [`seo-audit-orchestration`](skills/seo-audit-orchestration/SKILL.md) | Master orchestrator: sequences the suite, produces a rollup report |
-| 26 | [`seo-backlink-audit`](skills/seo-backlink-audit/SKILL.md) | Profile health, anchor mix, toxic links, reclamation, gap analysis |
-| 27 | [`seo-keyword-gap-audit`](skills/seo-keyword-gap-audit/SKILL.md) | Competitor keyword gaps with opportunity scoring and clustering |
-| 28 | [`seo-content-gap-audit`](skills/seo-content-gap-audit/SKILL.md) | Missing topics, thin coverage, outdated content, decay diagnosis |
-| 29 | [`seo-traffic-diagnosis`](skills/seo-traffic-diagnosis/SKILL.md) | Diagnose drops, stalls, or wins via 5-layer root cause analysis |
-| 30 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
-| 31 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
+| 26 | [`seo-audit-orchestration`](skills/seo-audit-orchestration/SKILL.md) | Master orchestrator: sequences the suite, produces a rollup report |
+| 27 | [`seo-backlink-audit`](skills/seo-backlink-audit/SKILL.md) | Profile health, anchor mix, toxic links, reclamation, gap analysis |
+| 28 | [`seo-keyword-gap-audit`](skills/seo-keyword-gap-audit/SKILL.md) | Competitor keyword gaps with opportunity scoring and clustering |
+| 29 | [`seo-content-gap-audit`](skills/seo-content-gap-audit/SKILL.md) | Missing topics, thin coverage, outdated content, decay diagnosis |
+| 30 | [`seo-traffic-diagnosis`](skills/seo-traffic-diagnosis/SKILL.md) | Diagnose drops, stalls, or wins via 5-layer root cause analysis |
+| 31 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
+| 32 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
 ### Product (10)
 
 | # | Skill | What it does |
 |---|---|---|
-| 32 | [`pm-spec-writing`](skills/pm-spec-writing/SKILL.md) | PRDs, user stories, acceptance criteria, dev briefs |
-| 33 | [`roadmap-planning`](skills/roadmap-planning/SKILL.md) | Quarterly planning, prioritization, dependency mapping |
-| 34 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
-| 35 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
-| 36 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
-| 37 | [`experimentation-analytics`](skills/experimentation-analytics/SKILL.md) | Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation |
-| 38 | [`experimentation-platform-orchestrator`](skills/experimentation-platform-orchestrator/SKILL.md) | Pick the right experimentation platform, migrate when wrong, coordinate when multi-platform: a decision framework for Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon |
-| 39 | [`product-analytics-setup`](skills/product-analytics-setup/SKILL.md) | Instrument product analytics correctly: event taxonomy, properties, naming conventions, schema versioning, funnels, retention cohorts, North Star selection, and the instrumentation debt that compounds without discipline |
-| 40 | [`data-warehouse-experimentation`](skills/data-warehouse-experimentation/SKILL.md) | Run experiments out of the warehouse: SQL assignment, exposure logs, dbt metric definitions, statistical analysis, variance reduction with CUPED, sequential testing, and the operational tradeoffs vs platforms |
-| 41 | [`feature-launch-playbook`](skills/feature-launch-playbook/SKILL.md) | The operational discipline of launching a feature well: positioning, internal alignment, customer comms, sales enablement, support readiness, rollout strategy, monitoring, and post-launch measurement |
+| 33 | [`pm-spec-writing`](skills/pm-spec-writing/SKILL.md) | PRDs, user stories, acceptance criteria, dev briefs |
+| 34 | [`roadmap-planning`](skills/roadmap-planning/SKILL.md) | Quarterly planning, prioritization, dependency mapping |
+| 35 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
+| 36 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
+| 37 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
+| 38 | [`experimentation-analytics`](skills/experimentation-analytics/SKILL.md) | Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation |
+| 39 | [`experimentation-platform-orchestrator`](skills/experimentation-platform-orchestrator/SKILL.md) | Pick the right experimentation platform, migrate when wrong, coordinate when multi-platform: a decision framework for Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon |
+| 40 | [`product-analytics-setup`](skills/product-analytics-setup/SKILL.md) | Instrument product analytics correctly: event taxonomy, properties, naming conventions, schema versioning, funnels, retention cohorts, North Star selection, and the instrumentation debt that compounds without discipline |
+| 41 | [`data-warehouse-experimentation`](skills/data-warehouse-experimentation/SKILL.md) | Run experiments out of the warehouse: SQL assignment, exposure logs, dbt metric definitions, statistical analysis, variance reduction with CUPED, sequential testing, and the operational tradeoffs vs platforms |
+| 42 | [`feature-launch-playbook`](skills/feature-launch-playbook/SKILL.md) | The operational discipline of launching a feature well: positioning, internal alignment, customer comms, sales enablement, support readiness, rollout strategy, monitoring, and post-launch measurement |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 42 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 43 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 44 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 45 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 43 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 44 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 45 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 46 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 46 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 47 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 47 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 48 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 49 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 50 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 51 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 52 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 53 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 54 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 55 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 48 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 49 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 50 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 51 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 52 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 53 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 54 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 55 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 56 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 56 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 57 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 57 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 58 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Marketing (3)
 
@@ -384,37 +385,37 @@ Paid media discipline: strategy, creative, and performance analytics. Pairs with
 
 | # | Skill | What it does |
 |---|---|---|
-| 58 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
-| 59 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
-| 60 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
+| 59 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
+| 60 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
+| 61 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 61 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 62 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 63 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 62 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 63 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 64 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 64 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 65 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 66 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 67 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 68 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 65 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 66 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 67 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 68 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 69 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 69 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 70 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 71 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 72 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 73 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 70 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 71 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 72 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 73 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 74 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/skills/pillar-content-architecture/SKILL.md
+++ b/skills/pillar-content-architecture/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: pillar-content-architecture
+description: "How to design a content hub that earns topical authority. Pillar topic selection, cluster planning, internal linking architecture, URL structure, pillar and cluster page anatomy, topical authority signals for SEO and AEO/GEO, and the maintenance discipline that distinguishes intentional hubs from accidental orphans. Triggers on pillar content, content hub, topic cluster, topical authority, content architecture, hub and spoke, pillar page, cluster page, content silo, internal linking strategy. Also triggers when a content set is not ranking despite individual piece quality, when a pillar was launched without a cluster, or when content has accumulated without an architecture."
+category: content
+catalog_summary: "Hub-level content architecture: pillar topic selection, cluster planning, internal linking, URL structure, pillar and cluster page anatomy, topical authority signals, refresh discipline"
+display_order: 5
+---
+
+# Pillar Content Architecture
+
+A senior content architect's playbook for designing content hubs that earn topical authority.
+
+Most content programs accumulate accidentally. Pieces ship one at a time, internal linking happens (or does not) in editing, similar topics get covered by multiple pieces with no coordination, and six months later the team has a content set that looks like a sitemap but feels like a yard sale. Search engines see disconnected pages; AI engines see scattered citations; readers cannot tell which piece is the entry point and which is the reference.
+
+This skill is the discipline of intentional hub architecture. It assumes you have decided which topic areas to invest in (see `content-strategy`) and have keyword data (see `seo-keyword`). It does not write any individual piece (see `content-brief-authoring` for per-piece work and `content-and-copy` for execution). What it does is design the structure: which topic gets a pillar, which subtopics get cluster pieces, how the pieces link to each other, where they live in the URL hierarchy, and what topical authority signals the architecture is engineered to produce.
+
+When to use this skill: launching a new content hub, restructuring an existing content set into a hub, deciding whether a piece should be a pillar or a cluster, or auditing why a content area is not ranking despite individual piece quality.
+
+---
+
+## What this skill is for
+
+This skill spans hub-level content architecture. It composes with five sister and adjacent skills, and the distinction between them is what keeps each one sharp.
+
+- `content-strategy` is program-scope: multiple topic pillars, editorial calendar, governance, formats. Decides what topic areas to invest in across a quarter or year.
+- `seo-keyword` is upstream-input: keyword research that surfaces candidate pillar topics with volume, difficulty, and intent data.
+- This skill is hub-scope: one pillar plus its cluster, the architecture that ties them together. The structural decisions, not the per-piece content.
+- `content-brief-authoring` is per-piece scope: brief for one content artifact. Each cluster piece (and the pillar itself) gets briefed via that skill.
+- `content-and-copy` is execution scope: writing the piece itself.
+- `seo-content-gap-audit` is audit-side: finds missing pieces in an existing content set after the fact. This skill prevents the gaps; that skill catches the ones that emerge.
+
+The clean composition: `content-strategy` decides which topics, `seo-keyword` surfaces opportunities, this skill designs the hub, `content-brief-authoring` briefs each piece, `content-and-copy` writes each piece, `seo-content-gap-audit` later catches what slipped. Six skills, sequential.
+
+The audience: SEO content strategists, content architects, in-house teams designing content hubs, agencies running topical authority programs. The voice is senior content architect to junior content marketer. Concrete, opinionated, honest about what makes a hub earn authority versus decorate the sitemap.
+
+---
+
+## Pillar vs cluster vs orphan content
+
+The keystone distinction. Three categories of content in any program.
+
+**Pillar.** Comprehensive piece covering a major topic area. 2,500 to 5,000 words plus. Anchors the topical authority claim for the topic. Receives links from cluster pieces; links out to cluster pieces selectively, not as a footer dump. The pillar is the entry point for the topic and the reference the cluster orbits.
+
+**Cluster.** Narrower piece covering a specific facet of the pillar topic. 800 to 2,000 words. Links up to pillar; may link sideways to other clusters in the same hub when a connection is natural. Each cluster answers one specific question within the pillar's scope.
+
+**Orphan.** Piece that does not connect to a pillar or cluster. May rank or convert on its own merits, but does not compound into topical authority. Some orphans are fine by design (release-note pages, customer stories, one-off campaigns); most orphans are accidents.
+
+The pathology. Most content programs are 80% orphans, 15% accidental clusters, 5% accidental pillars. The discipline is moving toward 70% intentional clusters, 20% intentional pillars, 10% standalone-by-design. Same total content volume; different architectural outcome.
+
+The reading model. Search engines and AI engines both read internal-link graphs to infer topical authority. A pillar with 12 well-linked cluster pieces signals depth on a topic. 12 orphans on the same topic signal scattered, less-authoritative coverage. The architecture is the signal.
+
+Detail and decision tree in `references/pillar-cluster-decision.md`.
+
+---
+
+## Topic selection for pillar pages
+
+Not every topic deserves a pillar. The five-criterion selection framework:
+
+1. **Search volume justifies the investment.** Pillar topic has enough monthly volume to support a 3,000 to 5,000-word effort plus 8 to 15 cluster pieces. Sub-100 monthly searches usually does not.
+2. **Topic has natural facets.** You can identify 8 to 15 distinct subtopics that could each be their own piece. If you can only think of 3, it is probably a cluster, not a pillar.
+3. **Commercial relevance.** The topic connects to your business model. A pillar without commercial signal is content marketing for content marketing's sake.
+4. **Competitive feasibility.** Top 10 SERP for the pillar keyword is achievable. If the SERP is dominated by Wikipedia, government sites, and Fortune 500 brands, your pillar will rank position 47 no matter how good it is.
+5. **Editorial commitment.** The team will maintain the pillar (refresh annually, add new clusters, update statistics). Pillars are not ship-and-forget; they are 5-year commitments.
+
+The "everything is a pillar" anti-pattern. Teams call any 3,000-word piece a pillar. Length does not make a pillar. The architecture does. Pillar is the role a piece plays in the hub structure, not the word count.
+
+Detail in `references/topic-selection-criteria.md`.
+
+---
+
+## Cluster planning
+
+Once a pillar is selected, plan its cluster:
+
+1. **Cluster size.** Typically 8 to 15 pieces for a strong hub. Below 5 reads thin; above 25 becomes unmanageable; sweet spot is 10 to 12.
+2. **Cluster facets.** Each cluster piece covers one facet of the pillar topic. Facets are surfaced from keyword research (long-tail variations of pillar keyword), "people also ask" data, sub-headings in top-ranking pillar pages on the SERP, competitor cluster maps, and first-party customer questions (sales calls, support tickets).
+3. **No facet duplication.** Two cluster pieces should not target overlapping queries. If they do, consolidate to one piece.
+4. **Cluster heterogeneity.** Clusters should cover the topic from multiple angles (definition, how-to, comparison, examples, common mistakes, costs, alternatives, case studies) rather than 12 variations of "what is X."
+5. **Sequence.** Ship pillar first (or alongside the first 3 to 5 clusters). The link graph will not form without the pillar in place; clusters that link to a non-existent pillar are orphans-in-waiting.
+
+Detail in `references/cluster-planning-patterns.md`.
+
+---
+
+## Internal linking architecture
+
+The hub's internal-link graph is what actually produces topical authority signals. The architecture has three directions:
+
+**Pillar to cluster (top-down).** Pillar links out to each cluster piece via contextual anchors, typically once per cluster from within the pillar's body. Do not bury cluster links in a "related reading" footer; weave them into the relevant section of the pillar where the reader's curiosity peaks.
+
+**Cluster to pillar (bottom-up).** Every cluster piece links up to the pillar at least once, typically in the first 200 words and again in the closing section. Bottom-up is the discipline that makes the pillar compound; without it the pillar is just a long article.
+
+**Cluster to cluster (lateral).** Selective lateral linking when one cluster naturally references another. Do not force lateral links; an "everyone links to everyone" cluster is messy and dilutes anchor text relevance.
+
+**Anchor text discipline.** Vary the anchor text. "Click here" is dead; exact-match keyword stuffing is dead; descriptive natural-language anchors are alive. The brief for each piece (see `content-brief-authoring`) specifies anchor text per outbound link.
+
+The "linking inventory" pattern. Maintain a sheet (or database row, or dbt model) tracking every link in the hub, who links to whom, and the anchor text used. Audit quarterly to catch broken links, anchor-text drift, and missing connections that should exist.
+
+Detail in `references/internal-linking-architecture.md`.
+
+---
+
+## URL structure and information architecture
+
+URL patterns matter for both crawl clarity and reader navigation. Decision factors:
+
+**Subfolder vs subdomain.** Subfolder is the default (`example.com/hub-topic/cluster-piece`) for SEO consolidation; both pillar and cluster live on the same domain authority. Subdomain is appropriate only for genuinely distinct properties (`docs.example.com`, `community.example.com`).
+
+**Hub URL pattern.** `/hub-topic/` for the pillar, `/hub-topic/cluster-piece/` for clusters. Avoid `/blog/cluster-piece/` if the goal is hub authority; the URL itself signals topical grouping to crawlers and readers.
+
+**Slug conventions.** Short, descriptive, keyword-aware but not stuffed. `/seo-content-strategy/keyword-research-for-pillars/` not `/the-ultimate-guide-to-seo-content-strategy-keyword-research-for-pillar-pages-2026/`.
+
+**Breadcrumbs.** Surface the hub structure in breadcrumb navigation. Helps readers see where they are; helps crawlers see the hierarchy.
+
+The "/blog/ trap." Teams put pillar and clusters under `/blog/` because that is where the CMS folder is. This works structurally but loses the URL signal that says "these pieces belong together as a topical hub."
+
+Detail in `references/url-structure-patterns.md`.
+
+---
+
+## Pillar page anatomy
+
+A pillar page does specific work. The standard sections:
+
+- **Hero.** Defines the topic, signals scope ("The complete guide to X for Y audience"), establishes authority quickly.
+- **TL;DR or executive summary.** 150 to 250 words at the top. AI engines often cite this section verbatim. Treat it as the citation-ready summary, not as a marketing intro.
+- **Comprehensive body.** Covers the topic's major facets, with internal-link callouts to cluster pieces for deep dives. The body is not a comprehensive treatment of every facet; it is a guided tour with depth links.
+- **Use cases or examples.** Anchor the abstract topic to concrete instances.
+- **Common mistakes / FAQ.** AI-citation friendly section with structured Q&A. Pair with FAQ schema markup.
+- **Closing or next steps.** Directs reader into the cluster (which piece to read next based on intent).
+- **Schema markup.** Article or HowTo schema depending on intent; FAQPage schema for the FAQ section.
+
+Pillar length. 3,000 to 5,000 words is the typical range. Pillar quality is comprehensiveness AND depth, not just word count. A 6,000-word pillar that covers 3 facets is worse than a 4,000-word pillar that covers 12 facets.
+
+Detail in `references/pillar-page-anatomy.md`.
+
+---
+
+## Cluster piece anatomy
+
+Cluster pieces have a different shape:
+
+- **Hero.** Focused on one specific question or task, not broad.
+- **Pillar callout.** Link up to pillar in the first 200 words. Typical phrasing: "This piece covers X. For the broader context on Y, see our guide to [pillar topic]."
+- **Focused body.** Answers the specific question with depth, but does not expand into adjacent facets (those have their own cluster pieces).
+- **Lateral callouts (selective).** When relevant, link to 1 or 2 sibling cluster pieces.
+- **Closing.** Link back to pillar OR to the next logical cluster piece in a reader journey.
+
+Cluster length. 800 to 2,000 words typical. A cluster piece longer than 2,500 words is probably a mini-pillar that should either get promoted to its own pillar or be split into two cluster pieces.
+
+Detail in `references/cluster-piece-anatomy.md`.
+
+---
+
+## Topical authority signals
+
+Signals that make hub architecture compound into authority. The two-engine view: pillars and clusters serve search engines and answer engines together, not as competing optimizations.
+
+**SEO signals:**
+
+- Internal-link graph density on the topic (PageRank flow within the hub)
+- Comprehensive entity coverage across pillar plus clusters (mentioned entities, statistics, citations)
+- URL structure clarity
+- Breadcrumb hierarchy
+- Schema markup (Article, HowTo, FAQPage as appropriate)
+- E-E-A-T signals: author credentials, expertise demonstrated, trust signals on every piece
+
+**AEO and GEO signals:**
+
+- Answer-paragraph format directly under H2 headings (40 to 60 words, citation-ready)
+- TL;DR section on pillars (highly citable; AI engines extract it verbatim)
+- FAQ schema (still cited heavily by AI engines including Perplexity and ChatGPT)
+- Specific statistics with cited sources
+- Named experts and named methods (entities AI engines weight heavily for citation)
+- Distinctive POV that AI engines can attribute to your brand
+
+The two-engine optimization is complementary, not competing. Both reward depth, structure, and entity coverage. The hub architecture creates more surface area for both signal types than scattered orphan content can.
+
+Detail in `references/topical-authority-signals.md` and the `seo-aeo-geo` skill for AEO/GEO strategy at the program level.
+
+---
+
+## Maintenance and refresh patterns
+
+Hubs decay if not maintained. The discipline:
+
+- **Annual pillar refresh.** Every 12 months, audit the pillar against current SERP, update statistics, add new sections for emerged facets, prune sections that no longer matter, refresh internal-link callouts to cluster pieces (since the cluster has likely grown).
+- **Cluster refresh as triggered.** Clusters refresh when keyword performance drops, when a new sub-topic emerges, or when a cluster's links go stale.
+- **Cluster expansion.** Add new cluster pieces as the topic surfaces new facets. A hub at year 1 might have 8 clusters; year 3 could have 18.
+- **Cluster pruning.** Kill cluster pieces that fail to rank or get cited after 12 months. Redirect to the most-relevant remaining cluster or to the pillar. Pruning is not failure; it is hygiene.
+- **Hub lifecycle.** Hubs themselves have a lifespan. After 5 to 7 years, even mature hubs may need wholesale restructuring as the topic landscape shifts.
+
+The "set and forget" failure. Hub launches, ranks, drives traffic for 2 years, then decays without anyone noticing because nobody owns the hub long-term. Hub ownership is durable: single owner across 3 to 5 year horizons, not "the team that launched it."
+
+Detail in `references/content-refresh-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-pillar-failures.md`.
+
+- "We have 80 blog posts but no rankings." Orphan content; no hub architecture.
+- "Our 8,000-word pillar does not rank." Comprehensive but no cluster support; pillar without a hub is just a long article.
+- "We launched the pillar, never built the cluster." Architecture half-built signals nothing.
+- "Cluster pieces do not link to the pillar." Top-down link graph but no bottom-up; the pillar does not compound.
+- "Two cluster pieces target the same keyword." Self-cannibalization; consolidate.
+- "Pillar URL is /blog/the-ultimate-guide-to..." Losing the URL hub signal.
+- "Our pillar is 12 sections of 'what is X'." Facet homogeneity; covers one angle 12 ways.
+- "We cannot tell which piece to refresh first." No maintenance ownership; no signals being tracked.
+- "Pillar ranks but does not get cited by AI engines." Missing AEO/GEO signals (no TL;DR, no answer paragraphs, no FAQ schema).
+- "Hub launched 3 years ago; nobody owns it now." Lifecycle ownership gap.
+- "We have 25 clusters and it is chaos." Over-built; sweet spot was 12.
+
+---
+
+## The framework: 12 considerations for hub architecture
+
+When designing or auditing a content hub, walk these 12 considerations.
+
+1. **Topic earns the pillar.** Search volume, facet count, commercial relevance, competitive feasibility, editorial commitment.
+2. **Cluster size targets 10 to 12.** Sweet spot, not the maximum.
+3. **Facet heterogeneity.** Definition, how-to, comparison, examples, mistakes, costs, alternatives. Not 12 variations of "what is X."
+4. **No facet duplication.** Clusters cover distinct queries; consolidate when they overlap.
+5. **Pillar to cluster to pillar link graph.** Top-down plus bottom-up plus selective lateral.
+6. **Anchor text discipline.** Varied, descriptive, natural-language. No stuffing, no "click here."
+7. **URL structure signals the hub.** `/topic/` not `/blog/`.
+8. **Pillar anatomy includes TL;DR and FAQ.** Citation-ready sections for AI engines.
+9. **Cluster anatomy links UP to pillar early.** First 200 words and closing.
+10. **AEO/GEO and SEO together.** Two-engine optimization, complementary not competing.
+11. **Annual pillar refresh plus triggered cluster refresh.** Maintenance is part of the architecture.
+12. **Hub ownership is durable.** Single owner across 3 to 5 year horizons; not "the team that launched it."
+
+The output of the framework is an architecture document the team can reference at every stage: pillar selected, cluster planned, links specified, URLs chosen, page anatomies templated, refresh cadence set, owner named.
+
+---
+
+## Reference files
+
+- [`references/pillar-cluster-decision.md`](references/pillar-cluster-decision.md) - Pillar vs cluster vs orphan decision tree with worked examples and the "everything is a pillar" anti-pattern.
+- [`references/topic-selection-criteria.md`](references/topic-selection-criteria.md) - Five-criterion framework expanded with B2B SaaS, ecommerce, services, and media examples.
+- [`references/cluster-planning-patterns.md`](references/cluster-planning-patterns.md) - Facet sourcing methods, sequencing patterns, heterogeneity check.
+- [`references/internal-linking-architecture.md`](references/internal-linking-architecture.md) - Top-down, bottom-up, lateral patterns; anchor text discipline; linking inventory; quarterly audit checklist.
+- [`references/url-structure-patterns.md`](references/url-structure-patterns.md) - Subfolder vs subdomain decision; slug conventions; breadcrumbs; the /blog/ trap.
+- [`references/pillar-page-anatomy.md`](references/pillar-page-anatomy.md) - Section-by-section anatomy; TL;DR placement; FAQ schema; internal-link callouts; schema choices; length calibration.
+- [`references/cluster-piece-anatomy.md`](references/cluster-piece-anatomy.md) - Focused-question framing; pillar callout placement; lateral linking judgment.
+- [`references/topical-authority-signals.md`](references/topical-authority-signals.md) - SEO and AEO/GEO signals at hub level; two-engine optimization framing.
+- [`references/content-refresh-patterns.md`](references/content-refresh-patterns.md) - Annual pillar refresh; triggered cluster refresh; cluster expansion and pruning; hub lifecycle.
+- [`references/common-pillar-failures.md`](references/common-pillar-failures.md) - Eleven-plus failure patterns with diagnoses and fixes.
+
+---
+
+## Closing: architecture is the moat
+
+Comprehensive content can be replicated. Authoritative sources can be cited. Individual pieces can be matched in quality by competitors with similar resources. What is harder to replicate is the compounding of an intentional hub built and maintained over years: the link graph, the entity coverage, the maintenance discipline, the topical depth signals that build over a 3 to 5 year horizon.
+
+That is the moat. Architecture is the only part of content marketing that compounds reliably; everything else is execution that can be matched.
+
+When in doubt about whether a hub is ready, ask: is the pillar selected against the five criteria, are the 10 to 12 clusters planned with facet heterogeneity, is the link graph specified top-down and bottom-up, is the URL structure clean, is the pillar anatomy templated with TL;DR and FAQ, is the refresh cadence set, and is the durable owner named? If yes to all of those, ship the hub plan and let the per-piece briefs and writers work.

--- a/skills/pillar-content-architecture/references/cluster-piece-anatomy.md
+++ b/skills/pillar-content-architecture/references/cluster-piece-anatomy.md
@@ -1,0 +1,120 @@
+# Cluster piece anatomy
+
+Focused-question framing. Pillar callout placement. Lateral linking judgment.
+
+---
+
+## The shape of a cluster piece
+
+A cluster piece is not a mini-pillar. Different shape, different work.
+
+### Hero (first 100 to 150 words)
+
+Focused on one specific question or task. The hero does not introduce the broader topic; the pillar does that. The hero introduces the cluster piece's specific facet.
+
+- **Title.** Includes the cluster's primary keyword. Often question-form ("What is a feature flag kill switch?") or task-form ("How to design a feature flag kill switch").
+- **Subhead.** One sentence promising the specific answer.
+
+### Pillar callout (within first 200 words)
+
+The bottom-up link to the pillar. Required.
+
+**Pattern.** "This piece covers feature flag kill switches in depth. For the broader context on rollout strategies that include kill switches as one safety mechanism, see our guide to [feature flag rollout strategies](/feature-flag-rollout/)."
+
+**Why required.** The pillar callout is the structural signal that this cluster belongs to the hub. Without it, the piece reads as a standalone article and the hub does not compound.
+
+**Why early.** Crawlers and AI engines weight links higher when they appear near the top of the page. The first 200 words is the citation-prime real estate; the pillar callout there has more impact than the same callout in the closing.
+
+### Focused body (the bulk of the cluster)
+
+Answers the specific question with depth. Does not expand into adjacent facets.
+
+**The discipline.** When the writer notices an interesting tangent into an adjacent facet, they note it as a candidate for another cluster piece and stay on topic. The cluster piece does one thing well; expansion belongs in a different piece.
+
+**Section structure.** 4 to 6 H2 sections covering the cluster's question from different angles. Each H2 has a featured-snippet-bait answer paragraph (40 to 60 words) followed by 200 to 400 words of development.
+
+### Lateral callouts (selective)
+
+When the cluster's body naturally references a sibling cluster, link to it.
+
+**Pattern.** A cluster on percentage rollouts naturally references kill switches in the section on "what happens when the rollout shows problems." A 1-sentence aside with a contextual link to the kill switches cluster.
+
+**Frequency.** 0 to 3 lateral links per cluster piece. Some clusters need none; some clusters at the topic's center connect to several siblings.
+
+**Anti-pattern.** Forced lateral linking. If the connection is not natural to the body's flow, the link is decorative and dilutes anchor signal.
+
+### Closing
+
+Two equally valid closing patterns.
+
+**Pattern A: link back to pillar.** "Kill switches are one part of a complete rollout strategy. Continue reading our [feature flag rollout strategies guide](/feature-flag-rollout/) for the rest of the patterns."
+
+**Pattern B: link to next cluster in a journey.** "If you have your kill switches designed and want to think about progressive rollouts, read our [percentage rollout guide](/feature-flag-rollout/percentage-rollouts/) next."
+
+The choice. Pattern A is the safe default; it reinforces the pillar and works for most cluster pieces. Pattern B is appropriate when the cluster has a clear "next step" in a reader journey (foundational concept → next concept).
+
+---
+
+## Length calibration
+
+800 to 2,000 words is the typical cluster range. Calibrate to:
+
+- **The SERP for the cluster's specific keyword.** Top 10 word counts tell you the band.
+- **The cluster's place in the hub.** Foundational clusters (definitions, intros) often run shorter; advanced clusters (deep how-tos, comparisons) often run longer.
+
+**The 2,500-word cluster trap.** A cluster piece longer than 2,500 words is probably a mini-pillar. Two diagnostic questions:
+
+1. Does it cover 2+ distinct facets? If yes, split into two cluster pieces.
+2. Does it have 8+ H2 sections? If yes, it is structurally a pillar; either promote it (with cluster support) or trim.
+
+**The 600-word cluster trap.** A cluster piece shorter than 800 words is often too thin to rank for its target keyword. Either:
+
+- Expand to 1,000+ words with deeper coverage of the question.
+- Merge with a sibling cluster if the topic does not have enough depth.
+- Demote to a non-hub blog post if the piece is just a brief observation.
+
+---
+
+## Featured snippet bait at H2 level
+
+Cluster pieces benefit from featured-snippet-bait answer paragraphs at every H2, not just at the top.
+
+**Pattern.**
+
+> ## What is a feature flag kill switch?
+>
+> A feature flag kill switch is a one-toggle mechanism that disables a feature instantly across all users. It exists as the final safety net when a rollout shows critical problems and per-user gradual rollback is too slow.
+
+The 40 to 60 word answer paragraph is self-contained and citation-ready. AI engines extract these paragraphs as the canonical answers.
+
+**Frequency.** Every H2 should have a snippet-bait paragraph. The pattern repeats throughout the piece; it is a structural discipline.
+
+---
+
+## Schema markup for clusters
+
+Cluster pieces typically use Article schema (or HowTo if the cluster is a step-by-step guide). FAQPage schema applies if the cluster has a real FAQ section.
+
+BreadcrumbList schema is required for cluster pieces; it tells crawlers the cluster is part of the hub.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://example.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Feature flag rollout", "item": "https://example.com/feature-flag-rollout/" },
+    { "@type": "ListItem", "position": 3, "name": "Kill switches" }
+  ]
+}
+```
+
+---
+
+## When the cluster piece is also useful as a standalone
+
+Some cluster pieces will rank for queries unrelated to the pillar's topic. A cluster on "kill switches" might also rank for queries about software safety patterns generally.
+
+The decision: keep the cluster piece in the hub even when it ranks for non-hub queries. The pillar callout costs nothing for the standalone-query reader; the hub-traffic reader benefits from the link. Both audiences are served.
+
+The exception: when the cluster piece's standalone ranking dominates and the pillar context is misleading to the standalone-query reader, consider splitting into two pieces. Rare; usually the pillar callout works fine for both audiences.

--- a/skills/pillar-content-architecture/references/cluster-planning-patterns.md
+++ b/skills/pillar-content-architecture/references/cluster-planning-patterns.md
@@ -1,0 +1,108 @@
+# Cluster planning patterns
+
+Facet sourcing methods, sequencing patterns, heterogeneity check.
+
+---
+
+## Facet sourcing methods
+
+A pillar's cluster is built from 8 to 15 facets. Source them deliberately rather than from the writer's imagination.
+
+### Method 1: keyword research expansion
+
+Start with the pillar keyword. Pull the long-tail variations from keyword tools (Ahrefs, Semrush, GSC, dataForSEO). Filter by intent: each cluster facet should have its own SERP intent and dominant format. Variations that share intent with the pillar are not separate facets; they belong inside the pillar itself.
+
+### Method 2: "people also ask" extraction
+
+Pull the PAA box for the pillar keyword and 3 to 5 supporting keywords. Each unique question is a candidate cluster facet. PAA is the cleanest signal of what readers actually ask in this topic space.
+
+### Method 3: top-ranking competitor outline mining
+
+Pull the top 5 SERP results for the pillar keyword. Extract H2 sections from each. Cluster the H2s across the 5 competitors; sections that appear in 3+ competitors are facets the topic objectively requires. Sections unique to 1 or 2 competitors may be differentiation opportunities.
+
+### Method 4: first-party customer questions
+
+Sales calls, support tickets, customer success notes, sales enablement Q&A. The questions customers actually ask are facets the pillar needs to address even if SERP signal is weak. First-party questions also produce differentiation: questions your customers ask but that competitor content does not address.
+
+### Method 5: Frase or AirOps SERP analysis
+
+Frase's entity gap analysis and AirOps' workflow builder both run versions of methods 1 to 3 in software. The output is a candidate facet list with SERP coverage scores. Use the tool output as the starting point; refine with first-party questions (method 4) for differentiation.
+
+---
+
+## Sequencing patterns
+
+How to ship the hub over time.
+
+### Pattern A: pillar first, cluster follows
+
+Ship the pillar as a 3,000 to 5,000 word piece. Over the next 6 to 12 weeks, ship 1 to 2 cluster pieces per week. By month 3, the hub has the pillar plus 8 to 12 clusters and starts compounding.
+
+**When this works.** Strong editorial team that can ship a pillar quickly. The pillar drives initial rankings; clusters fill in topical depth as they ship.
+
+**The risk.** Pillar ranks for 6 weeks before the cluster is complete; AI engines see a thin hub and may not return to crawl when clusters land. Mitigated by including cluster placeholders in the pillar with "coming soon" or by pre-publishing cluster stubs.
+
+### Pattern B: pillar plus first 5 clusters concurrent
+
+Ship the pillar and the first 5 clusters within the same 4-week window. The hub launches with the link graph already partially formed; rankings start with depth signals already in place.
+
+**When this works.** Larger team or agency support. The launch produces a more credible hub on day 1.
+
+**The cost.** Higher up-front investment. The first 5 clusters lock the team's editorial capacity for the launch window.
+
+### Pattern C: prove with 3 clusters, then commit to pillar
+
+Ship 3 cluster pieces under a planned-but-not-yet-shipped pillar slot. Measure performance over 8 to 12 weeks. If the clusters draw traffic and the topic shows commercial signal, commit to the pillar. If not, pivot to a different pillar topic without the sunk cost.
+
+**When this works.** Uncertain topic where the commercial signal needs validation before the pillar investment. Common in agencies running pillars for clients without strong upfront conviction.
+
+**The discipline.** The 3 clusters must be writeable as standalones during the validation window; they cannot reference the pillar by name yet because it does not exist. Once the pillar ships, retrofit the cluster pieces with pillar callouts and bottom-up links.
+
+---
+
+## Heterogeneity check
+
+A cluster passes heterogeneity if its facets cover the topic from multiple distinct angles. The check:
+
+**Categorize each facet** by primary angle:
+
+- Definition (what is X)
+- How-to (how to do X)
+- Comparison (X vs Y)
+- Examples (5 examples of X, X case studies)
+- Mistakes (common X mistakes)
+- Costs (how much X costs, X pricing models)
+- Alternatives (alternatives to X)
+- Best-of (best X tools, top X providers)
+- Use cases (when to use X)
+- Niche variants (X for [specific audience])
+- Foundational (related concept Y that supports X)
+- Advanced (advanced X techniques)
+
+**The rule.** A 12-cluster hub should have facets across 6+ distinct angles. If 10 of 12 are "how-to," the cluster is homogeneous and the pillar will look like a how-to series rather than a topical authority hub.
+
+**The fix.** When facet brainstorming over-indexes on one angle, deliberately add 2 to 3 facets from different angles. The "5 examples of X" cluster piece is often the most under-served angle; teams forget to add concrete-example pieces and over-invest in abstract how-tos.
+
+---
+
+## No facet duplication
+
+Two cluster pieces should not target overlapping queries. The check:
+
+- For each cluster piece, list the 3 to 5 keywords it would target.
+- For each pair of cluster pieces, check whether their keyword lists overlap by more than 30%.
+- Overlapping clusters compete for the same SERP and self-cannibalize. Consolidate to one piece.
+
+**The most common duplication.** "What is X" and "X explained" and "X definition" are the same facet. Pick one slug and one focus; do not split the foundational definition across three pieces.
+
+---
+
+## When the cluster is too big
+
+A planned cluster with 25+ pieces is over-built. The hub becomes unmanageable: maintenance burden too high, link graph too dense to audit, reader navigation confusing.
+
+**Fix 1.** Split into two pillars under a parent pillar. The original pillar covers the broadest topic; sub-pillars cover major sub-territories with their own clusters. Three-level hierarchy is rare but valid for very broad topics.
+
+**Fix 2.** Trim to the 12 most-impactful facets. Rank facets by combined search volume + commercial relevance + heterogeneity contribution; keep the top 12; archive the rest as future-cluster candidates.
+
+The 12-cluster sweet spot is empirical. Below 8, the hub looks thin; above 15, maintenance overhead kicks in; 10 to 12 is the band where most healthy hubs sit.

--- a/skills/pillar-content-architecture/references/common-pillar-failures.md
+++ b/skills/pillar-content-architecture/references/common-pillar-failures.md
@@ -1,0 +1,150 @@
+# Common pillar failures
+
+Eleven-plus failure patterns with diagnoses and fixes. Cross-references to other reference files where applicable.
+
+---
+
+## "We have 80 blog posts but no rankings"
+
+**Symptom.** The team has been publishing for 2+ years; 80 pieces shipped; organic traffic is flat or declining.
+
+**Diagnosis.** Orphan content; no hub architecture. 80 disconnected pieces produce no topical authority signal regardless of individual quality.
+
+**Fix.** Audit the 80 pieces. Group by topic. For each major topic group, identify or build a pillar; refactor the existing pieces into clusters by adding pillar callouts and bottom-up links. Some pieces will not fit and become standalone-by-design; some will need consolidation.
+
+The expected outcome: 4 to 6 hubs, each with a pillar plus 8 to 12 clusters; 15 to 20 standalones; the rest pruned. See `pillar-cluster-decision.md`.
+
+---
+
+## "Our 8,000-word pillar does not rank"
+
+**Symptom.** Team invested in a long, comprehensive pillar; 6 months in, position 23 on the primary keyword.
+
+**Diagnosis.** Comprehensive but no cluster support; the pillar is a long article without a hub. Length without architectural support does not signal authority.
+
+**Fix.** Build the cluster. Plan 10 to 12 cluster pieces under the pillar; ship 3 to 5 in the next 8 weeks; complete the cluster within 6 months. Update the pillar with internal-link callouts to each cluster as they ship. See `cluster-planning-patterns.md`.
+
+The expected outcome: ranking improves over 3 to 6 months as the cluster matures. The pillar that did not rank standalone will rank as the hub forms.
+
+---
+
+## "We launched the pillar, never built the cluster"
+
+**Symptom.** Pillar shipped 8 months ago; team's editorial focus shifted; the planned cluster never landed. Pillar has 2 supporting pieces shipped haphazardly.
+
+**Diagnosis.** Architecture half-built. The 2 supporting pieces are functioning as orphans because the hub is not formed; the pillar gets minimal compounding.
+
+**Fix.** Either commit to completing the cluster (8 to 10 more pieces over 4 to 6 months) or prune the hub. Half-built hubs are worse than no hub; commit or unwind. If completing, prioritize facets the team can ship within 12 weeks.
+
+---
+
+## "Cluster pieces do not link to the pillar"
+
+**Symptom.** Hub has pillar plus 12 clusters; pillar links to all clusters; only 4 of 12 clusters link back to the pillar.
+
+**Diagnosis.** Top-down link graph but no bottom-up. The pillar does not compound. Cluster pieces have not been required to include pillar callouts.
+
+**Fix.** Audit each cluster; add pillar callouts in the first 200 words and the closing of any cluster that lacks them. Update the brief template to require both pillar callouts on every future cluster piece. See `internal-linking-architecture.md`.
+
+---
+
+## "Two cluster pieces target the same keyword"
+
+**Symptom.** Cluster includes "what is a feature flag" and "feature flags explained." Both rank position 8 to 12 alternately; neither breaks into the top 5.
+
+**Diagnosis.** Self-cannibalization. Two pieces competing for the same SERP; PageRank splits across two URLs; neither piece gets enough authority to rank top 5.
+
+**Fix.** Consolidate. Pick the stronger piece (higher current rank, more inbound links, longer URL history). 301 redirect the weaker piece to the stronger one. Merge any unique content from the weaker into the stronger. Update the linking inventory.
+
+---
+
+## "Pillar URL is /blog/the-ultimate-guide-to..."
+
+**Symptom.** The pillar lives at `/blog/the-ultimate-guide-to-feature-flag-rollout-strategies/` because the CMS routes everything under `/blog/`.
+
+**Diagnosis.** Losing the URL hub signal. Crawlers cannot infer hub topology from the URL; readers cannot tell from the URL that this is a pillar.
+
+**Fix.** Migrate to `/feature-flag-rollout/` for the pillar; cluster pieces to `/feature-flag-rollout/[slug]/`. 301 redirect old URLs. Take a short-term ranking hit; gain long-term hub-signal clarity. See `url-structure-patterns.md`.
+
+The migration is not always worth it. If the pillar is small or the brand's overall content investment is modest, the cost may exceed the benefit. Score against the hub's commercial value.
+
+---
+
+## "Our pillar is 12 sections of 'what is X'"
+
+**Symptom.** Pillar covers the topic comprehensively in length but every H2 is a definitional question. "What is X." "What does X do." "What are the parts of X." 12 variations of the same angle.
+
+**Diagnosis.** Facet homogeneity. The pillar covers one angle 12 ways instead of 12 distinct angles.
+
+**Fix.** Rewrite the pillar's outline using the heterogeneity check (definition, how-to, comparison, examples, mistakes, costs, alternatives, etc.). Replace 8 of the 12 definitional sections with sections covering different angles. See `cluster-planning-patterns.md`.
+
+---
+
+## "We cannot tell which piece to refresh first"
+
+**Symptom.** Hub has 14 pieces; team knows refresh is needed; cannot prioritize where to start.
+
+**Diagnosis.** No maintenance ownership; no signals being tracked. Without per-piece performance data, refresh prioritization is guesswork.
+
+**Fix.** Assign a hub owner (see `content-refresh-patterns.md`). Track 4 metrics per piece: organic traffic, primary-keyword rank, AI citation count if measurable, last-updated date. Prioritize refresh on pieces with declining traffic, slipping ranks, or oldest update dates. The metrics make the prioritization mechanical.
+
+---
+
+## "Pillar ranks but does not get cited by AI engines"
+
+**Symptom.** Pillar ranks position 4 on Google; brand mention rate from Profound is unchanged after the pillar shipped.
+
+**Diagnosis.** Missing AEO/GEO signals. Pillar may have no TL;DR, no answer paragraphs under H2s, no FAQ schema, vague statistics, no named experts.
+
+**Fix.** Audit the pillar against the AEO/GEO signals checklist (see `topical-authority-signals.md`). Add a 150 to 250 word TL;DR at the top. Add 40 to 60 word answer paragraphs under each H2. Mark FAQ section with FAQPage schema. Replace vague statistics with specific numbers and cited sources. Add named experts where the topic supports them.
+
+The AEO/GEO refresh is faster than the SEO refresh; expect citation improvement within 4 to 8 weeks of changes propagating.
+
+---
+
+## "Hub launched 3 years ago; nobody owns it now"
+
+**Symptom.** Hub built by a content lead who left 18 months ago. No formal owner since. Performance has degraded; nobody noticed.
+
+**Diagnosis.** Lifecycle ownership gap. The "set and forget" failure mode.
+
+**Fix.** Assign a new owner. Allocate 1 to 2 weeks of editorial time for an emergency refresh: re-validate the SERP, update statistics, prune dead sections, refresh internal links. Set the annual refresh cadence going forward; track ownership renewal in the hub's planning doc. See `content-refresh-patterns.md`.
+
+Some hubs at this stage are unrecoverable. If the SERP has shifted enough that the original architecture no longer fits, restructure rather than refresh; treat as a year-5+ lifecycle event.
+
+---
+
+## "We have 25 clusters and it is chaos"
+
+**Symptom.** Hub started at 12 clusters; expanded over 3 years to 25; the linking inventory is unmanageable; new pieces tangle with old pieces; readers cannot find what they need.
+
+**Diagnosis.** Over-built. The cluster expanded beyond the manageable sweet spot.
+
+**Fix.** Prune. Apply the cluster pruning criteria (see `content-refresh-patterns.md`): clusters that have not ranked in top 30 after 12 months, clusters with zero search volume, clusters that duplicate other clusters. Aim to trim back to 12 to 15 active clusters; archive the rest with redirects.
+
+Alternative: split into two pillars under a parent topic. Rare; valid only for genuinely broad topics.
+
+---
+
+## "We did all the SEO work but the AI engines do not cite us"
+
+**Symptom.** Pillar ranks well; clusters rank well; brand mention rate from Profound is flat. AI engines cite competitors instead.
+
+**Diagnosis.** Could be either:
+
+- The hub is structurally fine for SEO but missing AEO/GEO signals (see "pillar ranks but does not get cited" above).
+- The hub is missing distinctive POV. AI engines preferentially cite content with attributable claims; content that reads as SEO consensus does not get cited even when it ranks.
+
+**Fix.** Audit each pillar and high-traffic cluster for distinctive claims. Add at least one strong POV per piece: a position the team is willing to defend, a recommendation that is not "it depends," a specific claim with named experts and statistics behind it. Bland comprehensive content does not get cited; opinionated comprehensive content does.
+
+---
+
+## "We have a hub but conversions are flat"
+
+**Symptom.** Hub drives traffic, ranks well, gets cited; trial signups attributable to the hub are flat.
+
+**Diagnosis.** Topical authority is working; commercial conversion is not. The hub's content does not connect cleanly to the buyer journey.
+
+**Fix.** Audit the pillar and clusters for commercial CTAs. Each cluster should have a clear next step that is NOT just "read another cluster." Trial signup, demo request, content download, newsletter subscription. The hub is producing the audience; the conversion path needs separate design work.
+
+This failure is outside this skill's scope to fully solve; pair with `landing-page-copy` for conversion-focused next-step pages and `content-strategy` for funnel-aware content planning.

--- a/skills/pillar-content-architecture/references/content-refresh-patterns.md
+++ b/skills/pillar-content-architecture/references/content-refresh-patterns.md
@@ -1,0 +1,164 @@
+# Content refresh patterns
+
+Annual pillar refresh checklist. Triggered cluster refresh signals. Cluster expansion patterns. Cluster pruning criteria. Hub lifecycle (5 to 7 year horizon).
+
+---
+
+## Why refresh matters
+
+Hubs decay. Statistics go stale; SERPs shift; new facets emerge; existing pieces drift from current best practice. A hub that ranks at year 1 often falls to position 12 by year 3 if nobody refreshes it.
+
+The discipline is built into the architecture: refresh is not an afterthought; it is a budgeted activity.
+
+---
+
+## Annual pillar refresh checklist
+
+Run every 12 months on each pillar. Allocate 1 to 2 weeks of editorial time per pillar.
+
+### Step 1: re-validate the SERP
+
+Pull the current SERP top 10 for the pillar's primary keyword. Compare to the last refresh's top 10.
+
+- Are new competitors in the top 10? What are they covering that you are not?
+- Have existing competitors updated their pillars? What new sections did they add?
+- Has the SERP intent shifted (e.g., from informational to commercial-investigation)?
+
+### Step 2: update statistics
+
+Find every numeric claim in the pillar. Verify each is still accurate; replace stale numbers with current ones; cite the new source.
+
+**Common stale numbers.** Industry statistics that were "as of 2023" and now are 2 years old. Pricing references that have shifted. Tool capabilities that have evolved.
+
+### Step 3: add new sections for emerged facets
+
+Did the topic surface new facets in the last 12 months? Add H2 sections covering them. Each new section should be 300 to 500 words; if it grows beyond 700, promote it to a new cluster piece and reduce the pillar section to a callout.
+
+### Step 4: prune sections that no longer matter
+
+Did old sections become irrelevant? Maybe a tool you covered shut down; maybe a method you described was deprecated. Cut or significantly trim those sections. Pillar bloat from un-pruned content is the most common pillar-decay symptom.
+
+### Step 5: refresh internal-link callouts to clusters
+
+The cluster has likely grown since last refresh. Add callouts to any new cluster pieces that did not exist before. Verify all existing callouts still link to live cluster URLs.
+
+### Step 6: update the TL;DR
+
+The TL;DR captures the pillar's argument as of the refresh date. Revise to reflect any structural changes: new facets, removed sections, shifted POV.
+
+### Step 7: bump the last-updated date
+
+Set the publish-modified date to the refresh completion date. The freshness signal matters; do not skip it.
+
+### Step 8: re-submit to search engines
+
+Submit the updated pillar URL to Google Search Console for re-crawl. Some teams also ping AI engine indexing endpoints (Perplexity, Bing for Copilot) where available.
+
+---
+
+## Triggered cluster refresh signals
+
+Clusters do not need annual refresh; they need triggered refresh when specific signals appear.
+
+### Trigger 1: keyword performance drops
+
+The cluster's primary keyword falls 5+ positions in 30 days. The drop is the signal; pull the SERP, identify what is now ranking ahead, and update the cluster to compete.
+
+### Trigger 2: new sub-topic emerges
+
+Within the cluster's facet, a new sub-topic appeared (new tool launched, new technique published, new regulation issued). Update the cluster to reference the new sub-topic.
+
+### Trigger 3: cluster's links go stale
+
+The quarterly link audit (see `internal-linking-architecture.md`) finds broken outbound links from the cluster. Update the cluster with new links.
+
+### Trigger 4: AI citation drops
+
+The cluster was being cited by AI engines and the citation count drops. Check whether content drifted, whether new entities should be added, whether the answer paragraphs need tightening. AI citation drops are slower-moving than ranking drops; act on month-over-month trends, not week-over-week.
+
+### Trigger 5: customer feedback surfaces a gap
+
+A sales rep, support agent, or customer success manager flags that the cluster does not cover a question customers actually ask. Add the section.
+
+---
+
+## Cluster expansion patterns
+
+A hub at year 1 might have 8 clusters. Year 3 could have 18. Expansion happens deliberately, not opportunistically.
+
+### When to expand
+
+- A new facet emerges and customer questions confirm demand.
+- Competitor analysis shows a facet your hub does not cover.
+- Keyword research surfaces new long-tail variations with traffic.
+- AI citation patterns show queries your hub does not address.
+
+### When not to expand
+
+- Tempting facet but no customer demand. Adds maintenance burden without driving traffic.
+- Facet already covered by another piece on the site outside the hub. Either move that piece into the hub or update its links.
+- Facet is too narrow (sub-100 monthly searches with no commercial signal). Add as a section to an existing cluster, not as its own cluster.
+
+### Expansion cap
+
+Max 20 clusters per pillar. Above that, the hub becomes unmanageable. If the topic genuinely supports 25+ facets, split into two pillars under a parent topic (rare; valid for very broad topics).
+
+---
+
+## Cluster pruning criteria
+
+Some clusters should die. Pruning is hygiene, not failure.
+
+### Prune when
+
+- Cluster has not ranked in top 30 after 12 months despite refresh attempts.
+- Cluster's keyword has gone to zero search volume.
+- Cluster duplicates another cluster (consolidate).
+- Cluster covers a tool, technique, or topic that no longer exists.
+
+### How to prune
+
+- 301 redirect the URL to the most-relevant remaining cluster, or to the pillar.
+- Remove links from the pillar and other clusters to the pruned URL.
+- Update the linking inventory.
+
+### What not to do
+
+- Do not delete the URL without redirecting; 404s waste any acquired authority.
+- Do not redirect to the homepage; redirect to the most topically-relevant alternative.
+
+---
+
+## Hub lifecycle (5 to 7 year horizon)
+
+Hubs themselves have lifespans. After 5 to 7 years, the topic landscape often shifts enough that wholesale restructuring becomes appropriate.
+
+### Signs the hub needs restructuring (vs annual refresh)
+
+- The pillar's primary keyword has shifted intent (the SERP is now showing a different content type).
+- Competitors have rebuilt their hubs around a different angle that better matches current reader needs.
+- The cluster has grown unwieldy (25+ pieces) and the topical organization no longer makes sense.
+- AI citation patterns suggest readers are asking questions the original hub structure cannot answer.
+
+### Restructuring approach
+
+- Treat the restructuring as a new hub launch. Plan the new pillar and cluster shape first.
+- 301 redirect old pillar and cluster URLs to new equivalents where possible.
+- Archive content that does not fit the new structure rather than force-fitting.
+- Communicate the change in a release-note-style post linked from both old and new URLs during the transition.
+
+The 5-to-7 year cycle is empirical. Some hubs last longer (foundational topics like "what is SEO"); some need restructuring sooner (fast-moving topics like "AI search"). Ownership tracks the lifecycle; the durable hub owner is the one who decides when to restructure.
+
+---
+
+## Maintenance ownership
+
+The pillar owner is named and durable. Common patterns:
+
+- **Single editor.** One person owns the hub for a 12-month commitment. Renewed annually.
+- **Editor + SEO partner.** Editor owns content; SEO partner owns rankings and link audits.
+- **Cross-functional team.** Editor, SEO, product marketing rotate quarterly reviews. Works for large teams; falls apart in small teams (rotation diffuses ownership).
+
+The "set and forget" failure mode happens when ownership dissolves. The team that launched the hub disbanded, was reorganized, or moved on; nobody picks up maintenance. Six quarters later, the hub has decayed and recovery costs more than the original launch.
+
+The fix. Assign a durable owner before the hub launches. Renew the assignment annually. Track the owner's continued ownership in the hub's planning doc; surface in quarterly reviews.

--- a/skills/pillar-content-architecture/references/internal-linking-architecture.md
+++ b/skills/pillar-content-architecture/references/internal-linking-architecture.md
@@ -1,0 +1,100 @@
+# Internal linking architecture
+
+Top-down, bottom-up, lateral linking patterns. Anchor text discipline. The linking inventory pattern. Quarterly link audit checklist.
+
+---
+
+## The three link directions
+
+A hub's link graph has three directions; all three need discipline.
+
+### Top-down: pillar to cluster
+
+The pillar links out to each cluster piece via contextual anchors woven into the pillar's body. The reader is reading the section on, for example, "kill switches"; that section includes a contextual link to the cluster piece on kill switches.
+
+**Pattern.** "Most rollouts include a kill switch as a final safety net. For the full pattern including code-level implementations, see [our guide on kill switch design](/feature-flag-rollout/kill-switches/)."
+
+**Anti-pattern.** A "Related reading" footer at the bottom of the pillar listing 12 cluster links. Footer links pass less topical signal and read as decorative; contextual body links read as load-bearing.
+
+**Frequency.** One link per cluster from within the pillar. Two links to the same cluster from the pillar is fine if the cluster covers two distinct sections; three links to the same cluster suggests the pillar should reference the cluster more selectively.
+
+### Bottom-up: cluster to pillar
+
+Every cluster piece links up to the pillar at least twice. First in the introduction (within the first 200 words); second in the closing.
+
+**Pattern in introduction.** "This piece covers kill switches in feature flag rollouts. For the broader context on rollout strategies, see our guide to [feature flag rollout strategies](/feature-flag-rollout/)."
+
+**Pattern in closing.** "Kill switches are one part of a complete rollout strategy. Continue reading our [feature flag rollout strategies guide](/feature-flag-rollout/) for the rest of the patterns, or jump to [percentage rollouts](/feature-flag-rollout/percentage-rollouts/)."
+
+**Why two.** First link tells crawlers and readers the topical context immediately. Second link captures readers who got value from the cluster piece and want to dig deeper into the hub.
+
+### Lateral: cluster to cluster
+
+Selective. When one cluster piece naturally references another, link with descriptive anchor text. Do not force lateral links.
+
+**Pattern.** A cluster on "percentage rollouts" naturally references "kill switches" when discussing what to do if the rollout shows problems. The lateral link is contextual; the reader is at a moment where the related cluster is actually useful.
+
+**Anti-pattern.** Every cluster piece links to every other cluster piece. The link graph becomes complete-graph-shaped; anchor text relevance dilutes; PageRank flow is undirected and weaker.
+
+**Frequency.** 1 to 3 lateral links per cluster piece is typical. Some clusters need zero lateral links; some clusters that sit at the center of a topic naturally connect to 5 sibling clusters.
+
+---
+
+## Anchor text discipline
+
+Anchor text is the signal that tells search engines what the linked-to page is about. The discipline:
+
+**Vary the anchor text.** Do not link to the pillar with the exact same phrase every time. Use the pillar's primary keyword, secondary keywords, and natural-language phrases that describe the linked page.
+
+**Descriptive natural-language anchors.** "See our guide to feature flag rollout strategies" beats "click here to read more." The anchor text should make sense if it is the only thing the reader reads.
+
+**No over-optimization.** Do not stuff every link with exact-match keywords. Anchor text that varies naturally is what a real authority cluster looks like; uniform exact-match anchors signal manipulation to ranking systems.
+
+**Brand-mention anchors.** Sometimes the right anchor is the brand name or product name when linking to a product page. "RampStack's experimentation skill" is a brand anchor; "experimentation skills documentation" is a descriptive anchor. Mix both.
+
+**Common dead anchors.** "Click here," "this article," "read more," "more info." All dead. They pass minimal topical signal and waste the link's potential.
+
+---
+
+## The linking inventory pattern
+
+Maintain an inventory of every link in the hub. The format depends on the team's tooling.
+
+**Spreadsheet.** Columns: source page slug, target page slug, anchor text, link section (intro / body / closing / sidebar), link direction (top-down / bottom-up / lateral / external).
+
+**Notion database.** Same columns as relations, queryable per page or per direction.
+
+**dbt model with content metadata.** For warehouse-native content tracking; the link graph becomes a queryable table that compounds with other content metrics (rank, citation count, conversion).
+
+**CMS audit fields.** Some CMSs (Contentful, Sanity, custom WordPress) allow per-page metadata fields. Track outbound links per piece; aggregate at the hub level.
+
+The inventory enables the quarterly audit; without it, the audit becomes a manual scan that misses things.
+
+---
+
+## Quarterly link audit checklist
+
+Run every 90 days. Catches the failures that compound silently.
+
+1. **Broken outbound links.** Crawl every cluster piece for 404s on outbound links. Common cause: cluster piece was renamed or moved without redirect.
+2. **Missing bottom-up links.** Every cluster should link to the pillar in intro and closing. Audit checks both.
+3. **Missing top-down links.** Pillar should link to every cluster from within the body. Audit checks each cluster has at least one body link from the pillar.
+4. **Anchor text drift.** Same anchor text used by 5+ links to the same target reads as over-optimized. Vary by editing 2 to 3 of them.
+5. **Dead anchors.** "Click here" or "read more" anchors that crept in during writing. Replace with descriptive anchors.
+6. **Lateral over-linking.** Cluster pieces linking to 5+ siblings reads as complete-graph noise. Trim to 2 to 3 most-relevant siblings.
+7. **Orphan clusters.** Cluster piece that no other piece links to (besides the pillar). The pillar's top-down link is required; ideally 1 to 2 sibling lateral links also exist.
+8. **Stale references.** Cluster pieces that reference statistics, products, or pages that no longer exist. Update the references; refresh the piece if the underlying topic shifted.
+9. **New cluster integration.** When a new cluster piece ships, audit confirms it received its top-down link from the pillar AND its bottom-up plus lateral links. New clusters often miss the inbound updates that would prevent orphan status.
+10. **Anchor diversity.** Pull the inventory; group anchor texts by target page. If 8 of 10 links to a page use the same anchor, edit 3 to 5 to vary.
+
+The audit takes 1 to 3 hours per hub. The cost is real but smaller than the cost of letting the link graph decay.
+
+---
+
+## When the link graph is too dense
+
+Some teams over-link. Every cluster piece has 8 outbound contextual links plus 5 lateral plus 3 external. The reader is bombarded; the anchor text relevance dilutes.
+
+**Heuristic.** A cluster piece with more than 6 outbound internal links per 1,000 words is over-linked. Trim to the 4 to 6 highest-relevance links.
+
+The trim improves both reader experience and PageRank concentration. Each remaining link gets more weight; the link graph becomes more legible to crawlers.

--- a/skills/pillar-content-architecture/references/pillar-cluster-decision.md
+++ b/skills/pillar-content-architecture/references/pillar-cluster-decision.md
@@ -1,0 +1,98 @@
+# Pillar vs cluster vs orphan decision
+
+The decision tree, worked examples, and the "everything is a pillar" anti-pattern.
+
+---
+
+## The decision tree
+
+When a new piece is being planned, walk these questions in order.
+
+**Question 1.** Does this topic have 8 to 15 distinct facets that could each be a separate piece?
+
+- Yes: this might be a pillar. Continue to question 2.
+- No: this is not a pillar. Continue to question 4 to test cluster fit.
+
+**Question 2.** Is the topic competitive enough to require comprehensive coverage to rank?
+
+- Yes (top 10 SERP shows long-form pillars from authoritative sources): pillar candidate confirmed. Continue to question 3.
+- No (top 10 SERP shows short articles or tools): the topic does not need a pillar. A cluster piece probably suffices.
+
+**Question 3.** Is the team committed to maintaining this pillar for 3 to 5 years (annual refresh, cluster expansion, ownership)?
+
+- Yes: ship as pillar. Plan the cluster.
+- No: do not start. A pillar without maintenance is worse than no pillar; it ranks for a year, then decays.
+
+**Question 4.** Is there an existing pillar this piece could connect to as a cluster?
+
+- Yes: ship as cluster. Specify the pillar callout and the bottom-up link in the brief.
+- No: continue to question 5.
+
+**Question 5.** Is this piece intentionally standalone (release note, customer story, one-off campaign, executive announcement)?
+
+- Yes: ship as standalone. Standalone-by-design is fine.
+- No: this is an accidental orphan. Either build the pillar first, or postpone the piece until a pillar exists, or rescope the piece to fit an existing pillar's cluster.
+
+---
+
+## Worked examples
+
+### Example 1: "Feature flag rollout strategies"
+
+A B2B SaaS team is planning a piece on feature flag rollout strategies.
+
+- 8 to 15 facets? Yes: percentage rollout, ring deployment, canary, blue-green, kill switches, automatic rollbacks, rollout per cohort, rollout by geography, rollout by plan tier, etc. ✓
+- Competitive SERP? Top 10 are long-form articles from LaunchDarkly, Statsig, Optimizely. Pillar candidate confirmed. ✓
+- 3 to 5 year commitment? The team plans to expand the cluster as new patterns emerge. ✓
+
+Decision: pillar. Plan 10 to 12 cluster pieces around it.
+
+### Example 2: "How to set up a Statsig experiment"
+
+The same team is planning a how-to on Statsig experiment setup.
+
+- 8 to 15 facets? No. The topic is one task with maybe 5 sub-steps. ✗
+- Existing pillar to connect to? Yes: the team has an "experimentation" pillar.
+
+Decision: cluster. Pillar callout to "experimentation" pillar; link up in first 200 words and closing.
+
+### Example 3: "Q3 2026 product release notes"
+
+The marketing team is planning a quarterly release-notes post.
+
+- 8 to 15 facets? No. ✗
+- Existing pillar to connect to? Not a topical fit; release notes are a different content type.
+- Standalone-by-design? Yes; release notes serve customers tracking the product, not topical authority.
+
+Decision: standalone. Do not force into a hub; serve the customer tracking purpose.
+
+### Example 4: "What is a feature flag?"
+
+A piece on the basic definition.
+
+- 8 to 15 facets? No. The topic is one definition. ✗
+- Existing pillar to connect to? Yes: the "feature flag rollout strategies" pillar from example 1 needs a "what is a feature flag" cluster piece for the foundational facet.
+
+Decision: cluster under the feature flag rollout pillar. The pillar gets the cluster it needs; the piece gets the topical context it needs.
+
+---
+
+## The "everything is a pillar" anti-pattern
+
+The symptom. Every 3,000-word piece on the team's site is called a pillar. The marketing team uses the word loosely; the SEO team uses it strictly; nobody agrees on what makes a pillar.
+
+The diagnosis. Length is being treated as the pillar criterion. Length does not make a pillar. The architectural role does. A 3,000-word piece with no cluster supporting it is a long article, not a pillar. A 1,500-word piece with 12 cluster pieces linking up to it is closer to a pillar than the 3,000-word standalone, even though the word counts are reversed.
+
+The fix. Use the word "pillar" precisely. Pillar is a piece that anchors a hub. If there is no hub, there is no pillar. Long articles that are not anchoring hubs are just long articles, and that is fine; they do not need to be promoted to "pillar" to justify the investment.
+
+The diagnostic question. "What pieces link up to this pillar?" If the answer is "none yet" or "we are planning to add some," the pillar is not yet a pillar. It is a planned pillar that becomes a real pillar when the cluster ships.
+
+---
+
+## When the decision is hard
+
+**The "almost a cluster" case.** A piece is 1,800 words, covers a specific facet of an existing pillar, and would link up to the pillar. Sounds like a cluster. But the piece also stands alone for non-hub queries. Decision: ship as cluster. The pillar callout is cheap; the topical compounding is real. The "standalone-by-design" exception is for pieces that have a different purpose (release notes, customer stories), not for pieces that happen to be readable alone.
+
+**The "almost a pillar" case.** A piece is 3,500 words, covers a topic with 6 facets (not 8 to 15), and the SERP for the topic is moderately competitive. Decision: ship as a long cluster piece under a broader pillar, or postpone until the topic surfaces more facets. Forcing 3,500 words into a 6-facet topic creates the "pillar with 12 sections of 'what is X'" failure mode.
+
+**The "we already have 5 standalone pieces on this topic" case.** No pillar exists; 5 orphans cover related facets. Decision: build the pillar, then refactor the 5 orphans into clusters by adding pillar callouts and bottom-up links. The hub is being created from existing content rather than from scratch; this is faster than starting over and works well when the orphans are already decent.

--- a/skills/pillar-content-architecture/references/pillar-page-anatomy.md
+++ b/skills/pillar-content-architecture/references/pillar-page-anatomy.md
@@ -1,0 +1,144 @@
+# Pillar page anatomy
+
+Section-by-section anatomy. TL;DR placement and length. FAQ schema. Internal-link callout placement. Schema markup choices. Length calibration.
+
+---
+
+## Section-by-section structure
+
+A pillar page does specific work across a recognizable set of sections.
+
+### Hero (first 200 words)
+
+Defines the topic, signals scope, establishes authority quickly.
+
+- **Title.** Includes the primary keyword. Reads as comprehensive ("The complete guide to feature flag rollout strategies").
+- **Subhead.** One sentence promising specific value to a specific audience.
+- **Author / publish / update line.** Author name with link to bio (E-E-A-T signal); last-updated date (freshness signal).
+
+### TL;DR or executive summary (150 to 250 words)
+
+The most important section for AI citation. AI engines extract this verbatim and use it as the canonical answer when users ask the topic question.
+
+**What goes in.** A self-contained summary of the pillar's argument. Read alone, it answers the topic. Read in context, it sets up the comprehensive body.
+
+**What does not go in.** Marketing fluff. Throat-clearing meta-commentary that announces what the page is about to do instead of doing it. Cut it.
+
+**Format.** Either a single dense paragraph (150 to 250 words) or 5 to 7 bullet points. Both work; bullets often extract more cleanly to AI engines.
+
+### Table of contents
+
+Auto-generated from H2 and H3 structure. Anchors to each section. Helps readers scan; helps crawlers see structure.
+
+### Comprehensive body (the bulk of the pillar)
+
+12 to 20 H2 sections covering the topic's major facets. The body is a guided tour with depth links, not a comprehensive treatment of every facet.
+
+**Per H2 section.**
+
+- **Featured snippet bait.** A 40 to 60 word answer paragraph immediately following the H2 question. AI engines often quote this as the citation.
+- **Body of the section.** 200 to 600 words developing the answer with examples, formulas, edge cases.
+- **Cluster link callout.** When the section maps to a cluster piece, link to the cluster contextually within the body. "For the full pattern including [specific facet], see our [cluster piece guide]."
+
+### Use cases or examples
+
+Anchor the abstract topic to concrete instances. 3 to 5 worked examples. Each example named, scoped, and referenced in the body.
+
+### Common mistakes / FAQ
+
+Structured Q&A. Each Q is a real question; each A is a 40 to 80 word answer.
+
+**Pair with FAQPage schema.** Mark the Q&A section with FAQPage structured data. AI engines (Perplexity especially) cite FAQPage content heavily.
+
+**Anti-pattern.** "Frequently asked questions" that nobody actually asks. The FAQ should source from real customer questions, sales-call transcripts, support tickets. Fabricated FAQs are obvious to readers and to AI engines.
+
+### Closing or next steps
+
+Directs the reader into the cluster. "If you are starting fresh, read [intro cluster piece]. If you have rollouts running and need to harden them, read [advanced cluster piece]."
+
+The closing is also where the second bottom-up pillar reinforcement lands for cluster pieces; for the pillar itself, the closing names the next-best clusters by reader intent.
+
+---
+
+## TL;DR placement and length
+
+Place immediately after the hero, before the table of contents. The reader sees TL;DR within the first scroll. AI engines scrape from the top of the page; TL;DR placed early gets prioritized.
+
+**150 words minimum.** Below 150, the TL;DR is too thin to serve as a citation candidate.
+
+**250 words maximum.** Above 250, the TL;DR loses its punch and starts duplicating the body.
+
+**Self-contained.** A reader who reads only the TL;DR should walk away with the topic's core. No throat-clearing or hedging; the TL;DR IS the answer.
+
+---
+
+## FAQ schema
+
+The FAQ section gets FAQPage schema. The format:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is a feature flag kill switch?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A feature flag kill switch is a one-toggle mechanism that disables a feature instantly across all users. It exists as the final safety net when a rollout shows critical problems and per-user gradual rollback is too slow. Kill switches are configured at deploy time and remain available throughout the feature's lifecycle."
+      }
+    }
+  ]
+}
+```
+
+**Common mistake.** FAQPage schema on questions that are not real FAQs. Schema markup that misrepresents page content can trigger manual penalties; mark only genuine FAQ sections.
+
+---
+
+## Internal-link callout placement
+
+The pillar links to cluster pieces from within the body, not from a "related reading" footer.
+
+**Pattern.** Inside the H2 section that maps to a cluster, place one contextual link to the cluster piece. Position the link at the moment in the section where the reader's curiosity peaks: typically after the section has set up the question and before the answer goes deep.
+
+**Example.** In the H2 "What is a kill switch?" section, after the 40 to 60 word answer paragraph, link to the cluster piece on kill switches with the phrase "For the full pattern including code-level implementations, see our [kill switch design guide]."
+
+**Frequency.** One link per cluster from the pillar. Two if the cluster maps to two distinct sections of the pillar. Avoid more than two; the second link is the reinforcement, not a third or fourth.
+
+---
+
+## Schema markup choices
+
+The pillar's primary schema depends on intent.
+
+**Article schema.** Default for most pillars. Marks the page as long-form editorial content.
+
+**HowTo schema.** When the pillar is a step-by-step guide ("how to launch a feature flag rollout"). HowTo gives Google more structured data to render in SERPs.
+
+**FAQPage schema.** Always pair with the FAQ section, not the pillar overall.
+
+**BreadcrumbList schema.** Always include for hub navigation context.
+
+**Author schema.** Embed Person schema for the author with credentials, bio link, and same-as references to LinkedIn or X. E-E-A-T signal.
+
+---
+
+## Length calibration
+
+3,000 to 5,000 words is the typical pillar range. Calibrate to the SERP, not to a quota.
+
+**SERP top 10 average word count tells you the band.** Pull the top 10; tag word counts; aim for the top 3 average. If the top 3 average 4,200 words, your pillar should target 4,000 to 4,500.
+
+**The depth-vs-length tradeoff.** Pillar quality is comprehensiveness AND depth, not just length. A 6,000-word pillar that covers 3 facets in massive depth is worse than a 4,000-word pillar that covers 12 facets at appropriate depth. Length without breadth is not a pillar; it is a long article.
+
+**The cluster offload.** Each cluster piece reduces the depth required in the pillar's corresponding section. If kill switches has its own cluster piece, the pillar's kill-switches section can be 300 words pointing to the cluster, not 1,200 words duplicating the cluster. The cluster offload is what keeps the pillar at the right length.
+
+---
+
+## Updates and freshness signals
+
+The pillar's "last updated" date is a freshness signal. Update it whenever you make material changes (statistics refreshed, new section added, cluster expanded). Do not update it for cosmetic edits; spurious freshness signals are noticed by ranking systems.
+
+The annual pillar refresh (see `content-refresh-patterns.md`) is the discipline that produces honest freshness signals.

--- a/skills/pillar-content-architecture/references/topic-selection-criteria.md
+++ b/skills/pillar-content-architecture/references/topic-selection-criteria.md
@@ -1,0 +1,104 @@
+# Topic selection criteria
+
+The five-criterion framework for pillar topic selection, with worked examples across business types.
+
+---
+
+## The five criteria
+
+A topic earns pillar status only when all five hold. Failing one is a hard signal to stop.
+
+### 1. Search volume justifies the investment
+
+The pillar will cost 3 to 6 weeks of editorial effort and 8 to 15 cluster pieces. The topic needs enough monthly search demand to repay the investment over a 3 to 5 year horizon.
+
+**Heuristic.** Pillar topic with combined volume across the keyword cluster of 1,000+ monthly searches usually justifies a pillar. Below 500 combined monthly searches, the topic is probably a single cluster piece under a broader pillar, not its own pillar.
+
+**Exception.** High-commercial-value topics with low volume (enterprise B2B SaaS niches, expensive professional services) can justify pillars at lower volumes because each ranking visit is worth more.
+
+### 2. Topic has natural facets
+
+A pillar covers a topic with internal structure. The team should be able to brainstorm 8 to 15 distinct subtopics, each capable of being a standalone cluster piece.
+
+**The test.** Spend 30 minutes listing facets. If the list reaches 12 organically, the topic has the structure. If the list stalls at 5, the topic is a cluster, not a pillar.
+
+**Common false positive.** Listing 12 keyword variations of "what is X" is not 12 facets. It is one facet (definition) said 12 ways. True facets are dimensionally different (definition, how-to, comparison, mistakes, costs, alternatives, examples, case studies).
+
+### 3. Commercial relevance
+
+The topic connects to the business model. A pillar without commercial signal is content marketing for content marketing's sake.
+
+**The test.** Can you draw a line from "reader lands on this pillar" to "reader becomes customer or contributor of customer-related signal"? If yes, the topic is commercially relevant. If the line requires three hops and a leap of faith, the topic is too far from the business.
+
+### 4. Competitive feasibility
+
+Top 10 SERP for the pillar keyword is achievable for the brand at its current authority. If the SERP is dominated by Wikipedia, government sites, and global household-name brands, your pillar will rank position 47 no matter how good it is.
+
+**The test.** Pull the SERP top 10. Tag each result by domain authority and commercial profile. If the top 10 are all DR 80+ household names and your brand is DR 35, do not start the pillar. Either pick a less-competitive long-tail variant or build authority on adjacent topics first.
+
+### 5. Editorial commitment
+
+The team will maintain the pillar for 3 to 5 years: annual refresh, cluster expansion, ownership through team changes.
+
+**The test.** Name the durable owner. If the owner is "the marketing team" instead of a specific person with a 12-month commitment, the pillar will not get maintained. Pillars without owners decay; the decay is invisible until the traffic drop is unrecoverable.
+
+---
+
+## Worked example: B2B SaaS
+
+The brand is a feature-flag platform competitor (DR 45). Considering a pillar on "feature flag rollout strategies."
+
+- Volume: 2,400 combined monthly searches across the cluster. ✓
+- Facets: 14 listed (rollout strategies, naming conventions, lifecycle, governance, kill switches, technical debt, multi-environment, A/B testing integration, etc.). ✓
+- Commercial: pillar visitors are exactly the buyer audience. ✓
+- Competitive: top 10 includes LaunchDarkly (DR 78), Statsig (DR 65), and several DR 60+ blogs. Tight but not impossible at DR 45 with strong cluster support. ✓ (with effort)
+- Commitment: PM and content lead jointly own; renewal review every 12 months. ✓
+
+Decision: pillar candidate. Plan a 12-cluster hub.
+
+---
+
+## Worked example: ecommerce
+
+A direct-to-consumer skincare brand (DR 38). Considering a pillar on "retinol routine for beginners."
+
+- Volume: 8,500 combined monthly searches. ✓
+- Facets: 11 listed (intro, how to start, percentages, frequency, side effects, sun pairing, age considerations, mixing with other actives, sensitive-skin variant, pregnancy considerations, troubleshooting). ✓
+- Commercial: high; pillar visitors are exactly the buyer audience. ✓
+- Competitive: top 10 includes The Ordinary blog, Paula's Choice, Reddit threads, dermatology sites. Mixed authority; achievable at DR 38 with cluster depth and original photography. ✓
+- Commitment: brand educator owns; refresh every 12 months. ✓
+
+Decision: pillar. Plan a 10 to 12 cluster hub.
+
+---
+
+## Worked example: services business
+
+A regional accounting firm (DR 28). Considering a pillar on "small business tax preparation."
+
+- Volume: 1,200 combined monthly searches. ✓
+- Facets: 12 listed (deductions, quarterly estimates, software comparison, when to hire vs DIY, common mistakes, audit risk, retirement contributions, payroll tax, sales tax, state-specific notes, multi-state operations, business structure choice). ✓
+- Commercial: very high; readers are local prospective clients. ✓
+- Competitive: top 10 includes Intuit, H&R Block, IRS itself, AICPA. Hard at DR 28. ✗
+
+Decision: do not pursue this pillar. Instead, scope to a niche the brand can win: "small business tax preparation in [city]" with a pillar focused on the local-business audience and local SEO signals where DR matters less.
+
+---
+
+## Worked example: media or publishing
+
+A career-focused publication (DR 55). Considering a pillar on "remote work productivity."
+
+- Volume: high. ✓
+- Facets: easily 15+. ✓
+- Commercial: ad-driven; pillar traffic monetizes through display and email signups. Indirect but real. ✓
+- Competitive: top 10 is moderately authoritative; achievable. ✓
+- Commitment: senior editor owns. ✓
+
+Decision: pillar. Note the commercial-signal pattern is different from B2B SaaS or ecommerce; the funnel is impressions to audience growth rather than impressions to qualified lead. Same architecture, different success metrics.
+
+---
+
+## When to walk away
+
+If three or more criteria fail, walk away from the pillar idea. If exactly one criterion fails (usually competitive feasibility), see whether a long-tail variant of the topic resolves the failed criterion. The "long-tail variant pivot" is the most common save: instead of "feature flags" (DR 78 incumbents), pick "feature flags for [niche]" (DR 50 incumbents) where the brand can compete.

--- a/skills/pillar-content-architecture/references/topical-authority-signals.md
+++ b/skills/pillar-content-architecture/references/topical-authority-signals.md
@@ -1,0 +1,126 @@
+# Topical authority signals
+
+SEO and AEO/GEO signals at the hub level. Two-engine optimization framing.
+
+---
+
+## Why hubs produce stronger signals than orphans
+
+Search engines and AI engines both read internal-link graphs and content patterns to infer topical authority. A hub with 12 connected pieces produces signals an orphan set cannot match:
+
+- **Density of internal links on the topic.** PageRank flows within the hub; pages reinforce each other.
+- **Comprehensive entity coverage across pieces.** The hub mentions more named tools, methods, experts, and statistics than any single piece could.
+- **Repeated topical signal at scale.** Multiple pieces with overlapping topical vocabulary, distinct facets, consistent structure.
+- **Crawl-rate compounding.** Search engines crawl high-link-density clusters more frequently; AI engines re-index hubs more aggressively.
+
+Same total content volume; different architectural outcome. 12 orphans on the same topic produce scattered, weaker signals than a 12-piece hub.
+
+---
+
+## SEO signals at the hub level
+
+### Internal-link graph density
+
+Google's PageRank algorithm flows authority through internal links. A pillar with 12 cluster pieces linking back to it concentrates PageRank on the pillar; the pillar in turn passes authority to clusters via top-down links. The graph shape compounds.
+
+**Heuristic.** Compare PageRank on a pillar before and after the cluster ships. Most teams see ranking improvements on the pillar within 3 to 6 months as the cluster matures.
+
+### Comprehensive entity coverage
+
+The hub mentions more named entities than any single page could: tools, methods, experts, datasets, frameworks. Search engines extract entity graphs at crawl time; comprehensive coverage signals topical depth.
+
+**The discipline.** Each piece in the hub mentions the topic's required entities (entities the SERP top 10 share) and the gap entities (entities only 1 or 2 SERP results mention). The hub-level entity graph is the union across all pieces.
+
+### URL structure clarity
+
+The `/topic/cluster-piece/` pattern signals topical grouping. Crawlers follow the URL hierarchy and infer the hub structure even before parsing internal links.
+
+### Breadcrumb hierarchy
+
+BreadcrumbList schema tells crawlers the hub structure explicitly. Some SERPs surface breadcrumb URLs as rich-result enhancements.
+
+### Schema markup at scale
+
+Article, HowTo, FAQPage, BreadcrumbList schema across the hub. Each schema type passes additional structured data to crawlers. The hub is structured for extraction in a way that orphan content rarely is.
+
+### E-E-A-T signals
+
+Experience, Expertise, Authoritativeness, Trustworthiness. Google's quality framework. Hub-level E-E-A-T comes from:
+
+- Author credentials displayed on every piece (with Person schema)
+- Expertise demonstrated through depth and accuracy
+- Authoritativeness signaled by entity coverage and citations
+- Trustworthiness signaled by clear authorship, last-updated dates, and corrections to prior work when relevant
+
+E-E-A-T is not a discrete signal; it is the aggregate of many small signals. Hubs accumulate E-E-A-T faster than orphans because the signals compound across pieces.
+
+---
+
+## AEO and GEO signals at the hub level
+
+AI engines (ChatGPT, Perplexity, Claude, Gemini, Google AI Mode) cite content based on different patterns than traditional search ranking. Hubs serve AI engines as well as search engines if the right signals are present.
+
+### Answer-paragraph format under H2 headings
+
+40 to 60 word self-contained answers immediately following H2 questions. AI engines extract these as citation candidates. The pattern repeats across pillar and clusters; the hub becomes a structured set of citation-ready answers.
+
+### TL;DR section on pillars
+
+The pillar's TL;DR (150 to 250 words) is the most-cited section by AI engines. Place it at the top, make it self-contained, write it as the canonical summary.
+
+### FAQPage schema
+
+AI engines (Perplexity especially) heavily cite FAQPage-marked content. Pair every pillar's FAQ section with FAQPage schema. Cluster pieces with genuine FAQs also benefit.
+
+### Specific statistics with cited sources
+
+"23% of feature flag rollouts include a kill switch (Feature Flag Survey 2025, n=412)" cites better than "many feature flag rollouts include a kill switch." Specific numbers with sources are higher-citation signals; vague qualifiers are lower-citation.
+
+### Named experts and named methods
+
+"As Adam Kalai noted in the original CUPED paper" cites better than "experts have shown." Named attribution earns citation; anonymous attribution does not. The hub should mention 5+ named experts or methods across pillar and clusters.
+
+### Distinctive POV
+
+AI engines preferentially cite content with a clear, attributable position. "Kill switches should be the first safety mechanism designed, not the last" is a POV. "Kill switches are important" is not. The hub's POV is the brand's editorial position; consistency across pieces reinforces attribution.
+
+---
+
+## The two-engine optimization
+
+Pillars and clusters serve search engines and answer engines together, not as competing optimizations.
+
+**Both reward depth.** Search engines reward comprehensive treatment of a topic. AI engines reward citation-ready depth. Same content; different extraction.
+
+**Both reward structure.** Search engines parse heading hierarchy for ranking. AI engines parse heading hierarchy for citation extraction. Same structure; different use.
+
+**Both reward entity coverage.** Search engines use entities for topical relevance. AI engines use entities for retrieval and citation. Same entities; different scoring.
+
+**Both reward freshness.** Search engines reward recent updates. AI engines re-index recently-updated content more aggressively. Same updates; different cadence.
+
+The implication. Optimizing for AEO/GEO does not trade off against SEO. The hub architecture that earns search rankings is the same architecture that earns AI citations. Teams that treat them as separate optimizations under-invest in both.
+
+---
+
+## Measuring topical authority signals
+
+Hub-level metrics worth tracking:
+
+**Search-side:**
+
+- Aggregate organic traffic to all pieces in the hub
+- Average position for the pillar's primary keyword
+- Number of cluster pieces ranking in top 10 for their target keywords
+- Internal-link count per cluster piece (from inventory)
+- Crawl frequency (Google Search Console)
+
+**AI-side:**
+
+- Brand mention rate from Profound, Frase, AirOps, or similar tools
+- Citation share by engine (ChatGPT, Perplexity, Gemini, Claude)
+- Top-cited pieces (which clusters get cited most often)
+- AI crawler hit frequency (server logs, Profound Agent Analytics)
+
+The hub-level dashboard composes these metrics. Tracking at the hub level (not per piece) is what surfaces architecture-level patterns: which clusters drive traffic, which clusters drive citations, which clusters are dead weight.
+
+See the `seo-aeo-geo` skill for AEO/GEO program-level strategy.

--- a/skills/pillar-content-architecture/references/url-structure-patterns.md
+++ b/skills/pillar-content-architecture/references/url-structure-patterns.md
@@ -1,0 +1,105 @@
+# URL structure patterns
+
+Subfolder vs subdomain decision, slug conventions, breadcrumbs, the /blog/ trap.
+
+---
+
+## Subfolder vs subdomain
+
+The default for hubs is subfolder. Subdomain has narrow valid use cases.
+
+**Subfolder pattern.** `example.com/feature-flag-rollout/` for the pillar; `example.com/feature-flag-rollout/kill-switches/` for cluster pieces. Both pillar and cluster live on the same domain authority; PageRank flow is consolidated; the hub compounds within the brand's existing SEO equity.
+
+**Subdomain pattern.** `docs.example.com`, `community.example.com`, `support.example.com`. Used when the property is genuinely distinct (different audience, different content type, different team ownership). Subdomains receive less of the parent domain's authority signal in most analyses; do not split a hub across subdomains without a strong reason.
+
+**Decision rule.** Pillar plus cluster always on the same subdomain as the rest of the marketing content. If the brand's marketing content lives at `example.com`, the hub lives at `example.com/[hub]/`. Splitting the hub onto a subdomain treats the hub as a separate property, which is almost never correct.
+
+---
+
+## Hub URL pattern
+
+The pattern: `/hub-topic/` for the pillar, `/hub-topic/cluster-piece/` for clusters.
+
+**Why this pattern.** The URL itself signals topical grouping. Crawlers see the path structure and infer that pages under `/feature-flag-rollout/` belong to a topical hub. Readers see the breadcrumb in the URL and know where they are.
+
+**The /blog/ alternative.** `/blog/feature-flag-rollout/` and `/blog/kill-switches/`. This works structurally; the pieces still rank. But the hub signal is weaker because the URL groups by content type (blog) rather than by topic. Two unrelated blog posts share the `/blog/` path; nothing in the URL says "kill-switches is part of the feature-flag-rollout hub."
+
+**The fix when migrating off /blog/.** Change the URL pattern via 301 redirects from old to new. Lose some short-term ranking equity during the redirect; gain long-term hub-signal clarity. The migration is worth it for major hubs; not worth it for smaller content sets.
+
+---
+
+## Slug conventions
+
+**Short, descriptive, keyword-aware but not stuffed.**
+
+Good: `/feature-flag-rollout/kill-switches/`
+
+Bad: `/feature-flag-rollout/the-ultimate-guide-to-implementing-kill-switches-in-feature-flag-rollouts-2026/`
+
+**Why short.** Long slugs read as keyword-stuffed and break in social shares, email previews, and conversational mentions. Search engines do not need every keyword in the URL; they parse the page content.
+
+**Why descriptive.** The slug should make sense as a standalone string. `/feature-flag-rollout/kill-switches/` is self-describing; `/post-1247/` is not.
+
+**Keyword-aware.** Include the primary keyword for the cluster piece. Do not include the supporting cluster keywords (those go in the page content, not the URL).
+
+**Date-free.** Avoid dates in slugs (`/2026-rollout-guide/`). Dated slugs anchor the piece in time; refreshing the piece in 2027 is awkward. Pieces with date-relevant content (annual reports, year-in-review) are exceptions.
+
+**Hyphens, not underscores.** Search engines treat hyphens as word separators; underscores as part of one word. `kill-switches` reads as two words; `kill_switches` reads as one.
+
+**Lowercase.** Mixed-case URLs cause case-sensitivity confusion across servers and create duplicate-content issues.
+
+---
+
+## Breadcrumb structure
+
+Breadcrumbs surface the hub structure in the page UI and the page schema. The pattern:
+
+`Home > Hub topic > Cluster piece`
+
+In the UI, breadcrumbs typically render as a small horizontal nav above the title. In schema, BreadcrumbList markup tells crawlers the path.
+
+**Why breadcrumbs help.** Readers see they are in a hub and can navigate up. Crawlers parse the BreadcrumbList schema and reinforce the hub hierarchy. Some SERPs also surface breadcrumb URLs in rich results.
+
+**Breadcrumb anti-pattern.** Breadcrumbs that show URL segments instead of human-readable labels. `Home > /feature-flag-rollout > /kill-switches` is the wrong format. Use the hub's display name and the cluster piece's title, not the URL slug.
+
+**Schema example.**
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://example.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Feature flag rollout", "item": "https://example.com/feature-flag-rollout/" },
+    { "@type": "ListItem", "position": 3, "name": "Kill switches" }
+  ]
+}
+```
+
+The third item omits "item" because breadcrumbs typically do not link to the current page.
+
+---
+
+## The /blog/ trap
+
+The symptom. The team's content all lives at `/blog/[slug]/` because that is how the CMS is configured. Pillar and cluster live alongside unrelated blog posts in the same flat URL space.
+
+The diagnosis. The CMS folder defaulted to `/blog/`. Nobody changed it because changing CMS routing is non-trivial. Hub structure exists in the editorial team's head but not in the URL.
+
+The cost. Hub signal is weakened; PageRank flow is less topically concentrated; readers cannot tell from the URL that a piece is part of a hub.
+
+The fix. Change CMS routing to support topic-based subfolders. Migration via 301 redirects from old `/blog/` URLs to new `/[hub]/` URLs. Take a short-term ranking hit during redirect; gain long-term hub authority.
+
+The "do not migrate" exception. If the existing `/blog/` URL structure is generating significant traffic and the hub investment is small, the migration may not pay back. Score the migration cost against the hub's commercial value; migrate only when the hub justifies it.
+
+---
+
+## Multilingual or multi-region URL patterns
+
+Hubs that span languages or regions add another structural decision. The two main patterns:
+
+**Subfolder per locale.** `example.com/en/[hub]/`, `example.com/de/[hub]/`. Cleanest for SEO consolidation; clearest for crawlers.
+
+**ccTLD per region.** `example.de/[hub]/`, `example.fr/[hub]/`. Stronger for regional ranking but splits domain authority.
+
+The decision usually depends on the brand's existing internationalization choice; the hub follows the existing pattern. Do not use the hub launch as the moment to switch internationalization strategies.


### PR DESCRIPTION
Second skill in Direction 6b content suite. Hub-level content architecture covering pillar topic selection, cluster planning, internal linking, URL structure, page anatomy, topical authority signals (SEO + AEO/GEO), and refresh discipline.

## What

- 14-section SKILL.md (260 lines, ~3,000 words)
- 10 reference files (~10,800 words total): pillar-cluster-decision, topic-selection-criteria, cluster-planning-patterns, internal-linking-architecture, url-structure-patterns, pillar-page-anatomy, cluster-piece-anatomy, topical-authority-signals, content-refresh-patterns, common-pillar-failures

## Distinction (called out in Section 1)

- `content-strategy` → program scope (multiple pillars, calendar)
- `seo-keyword` → upstream input (keyword research)
- this skill → hub scope (one pillar + cluster, the architecture)
- `content-brief-authoring` → per-piece scope
- `content-and-copy` → execution scope
- `seo-content-gap-audit` → audit-side (catches missing pieces)

Six-skill composition matrix; this skill plugs in between strategy/research and per-piece briefing/writing.

## Keystone framing

Pillar vs cluster vs orphan content. Most content programs are 80% orphans; the discipline is intentional architecture that compounds across a 3–5 year horizon.

## display_order

`display_order: 5` (appended). Reading-order argument (strategy → architecture → brief → write) flagged for revisit when content suite is complete.

## Catalog

- 73 → 74 skills
- 195 → 205 reference files
- Content category 4 → 5 entries

## Quality gates

- Em-dash audit clean
- Forbidden phrase audit clean (rephrased "in this guide" anti-pattern call-outs to avoid the literal string; replaced "feature flag best practices" example topic with "feature flag rollout strategies")
- Illumine scrub clean
- `lint_skills.py`: 74 skills validated, 1 expected warning (documentation-strategy 428-line outlier preserved)
- Generator idempotent (`--check` exit 0)
- 6 cross-skill references all resolve: `content-strategy`, `content-brief-authoring`, `content-and-copy`, `seo-keyword`, `seo-content-gap-audit`, `seo-aeo-geo`

Companion landing page in rampstackco-app PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)