### PR TITLE
feat(skills): add editorial-qa (20th flagship, content suite skill 4 of 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-75-blue.svg)](#the-75-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-76-blue.svg)](#the-76-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 75 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 76 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -35,7 +35,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 75-skill catalog](#the-75-skill-catalog)
+- [The 76-skill catalog](#the-76-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -63,8 +63,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **75 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
-- **216 reference files** (templates, checklists, decision matrices, worked examples)
+- **76 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
+- **226 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -253,11 +253,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 75-skill catalog
+## The 76-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 75 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 76 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -290,7 +290,7 @@ All 75 skills are shipped. Each has a complete SKILL.md plus at least one refere
 | 12 | [`design-standards`](skills/design-standards/SKILL.md) | Production-grade page and component design standards |
 | 13 | [`art-direction`](skills/art-direction/SKILL.md) | Photography, illustration, and visual direction for campaigns |
 
-### Content (6)
+### Content (7)
 
 | # | Skill | What it does |
 |---|---|---|
@@ -300,6 +300,7 @@ All 75 skills are shipped. Each has a complete SKILL.md plus at least one refere
 | 17 | [`content-brief-authoring`](skills/content-brief-authoring/SKILL.md) | Per-piece editorial brief: target keyword, intent, audience, outline, entity coverage, internal linking, success criteria, and the discipline that distinguishes useful briefs from bloat |
 | 18 | [`pillar-content-architecture`](skills/pillar-content-architecture/SKILL.md) | Hub-level content architecture: pillar topic selection, cluster planning, internal linking, URL structure, pillar and cluster page anatomy, topical authority signals, refresh discipline |
 | 19 | [`programmatic-seo`](skills/programmatic-seo/SKILL.md) | Designing pSEO programs that work: data sources, template design, quality control at scale, internal linking, crawl budget, AEO/GEO patterns, refresh discipline, and when pSEO is and is not the right answer |
+| 20 | [`editorial-qa`](skills/editorial-qa/SKILL.md) | Pre-publish QA framework: brief adherence, voice consistency, fact accuracy, AI-content audit, AEO/SEO compliance, sampling at scale, and the workflow that distinguishes catch-problems QA from process theater |
 
 ### SEO foundation (7)
 
@@ -307,13 +308,13 @@ Tool-agnostic SEO skills. These define the conceptual frameworks. The SEO audit 
 
 | # | Skill | What it does |
 |---|---|---|
-| 20 | [`seo-onpage`](skills/seo-onpage/SKILL.md) | Single-page audits and optimization across 8 dimensions |
-| 21 | [`seo-technical`](skills/seo-technical/SKILL.md) | Crawlability, indexability, rendering, schema, page experience |
-| 22 | [`seo-keyword`](skills/seo-keyword/SKILL.md) | Discovery, intent classification, clustering, prioritization |
-| 23 | [`seo-competitor`](skills/seo-competitor/SKILL.md) | SERP overlap, content gaps, backlink gaps, technical comparison |
-| 24 | [`seo-offpage`](skills/seo-offpage/SKILL.md) | Link building, digital PR, citations, linkable assets |
-| 25 | [`seo-content-audit`](skills/seo-content-audit/SKILL.md) | Keep/update/merge/redirect/delete decisions across a site |
-| 26 | [`seo-aeo-geo`](skills/seo-aeo-geo/SKILL.md) | AI search optimization, llms.txt, extraction-friendly content |
+| 21 | [`seo-onpage`](skills/seo-onpage/SKILL.md) | Single-page audits and optimization across 8 dimensions |
+| 22 | [`seo-technical`](skills/seo-technical/SKILL.md) | Crawlability, indexability, rendering, schema, page experience |
+| 23 | [`seo-keyword`](skills/seo-keyword/SKILL.md) | Discovery, intent classification, clustering, prioritization |
+| 24 | [`seo-competitor`](skills/seo-competitor/SKILL.md) | SERP overlap, content gaps, backlink gaps, technical comparison |
+| 25 | [`seo-offpage`](skills/seo-offpage/SKILL.md) | Link building, digital PR, citations, linkable assets |
+| 26 | [`seo-content-audit`](skills/seo-content-audit/SKILL.md) | Keep/update/merge/redirect/delete decisions across a site |
+| 27 | [`seo-aeo-geo`](skills/seo-aeo-geo/SKILL.md) | AI search optimization, llms.txt, extraction-friendly content |
 
 ### SEO audit suite (Ahrefs MCP-powered) (7)
 
@@ -321,64 +322,64 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 
 | # | Skill | What it does |
 |---|---|---|
-| 27 | [`seo-audit-orchestration`](skills/seo-audit-orchestration/SKILL.md) | Master orchestrator: sequences the suite, produces a rollup report |
-| 28 | [`seo-backlink-audit`](skills/seo-backlink-audit/SKILL.md) | Profile health, anchor mix, toxic links, reclamation, gap analysis |
-| 29 | [`seo-keyword-gap-audit`](skills/seo-keyword-gap-audit/SKILL.md) | Competitor keyword gaps with opportunity scoring and clustering |
-| 30 | [`seo-content-gap-audit`](skills/seo-content-gap-audit/SKILL.md) | Missing topics, thin coverage, outdated content, decay diagnosis |
-| 31 | [`seo-traffic-diagnosis`](skills/seo-traffic-diagnosis/SKILL.md) | Diagnose drops, stalls, or wins via 5-layer root cause analysis |
-| 32 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
-| 33 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
+| 28 | [`seo-audit-orchestration`](skills/seo-audit-orchestration/SKILL.md) | Master orchestrator: sequences the suite, produces a rollup report |
+| 29 | [`seo-backlink-audit`](skills/seo-backlink-audit/SKILL.md) | Profile health, anchor mix, toxic links, reclamation, gap analysis |
+| 30 | [`seo-keyword-gap-audit`](skills/seo-keyword-gap-audit/SKILL.md) | Competitor keyword gaps with opportunity scoring and clustering |
+| 31 | [`seo-content-gap-audit`](skills/seo-content-gap-audit/SKILL.md) | Missing topics, thin coverage, outdated content, decay diagnosis |
+| 32 | [`seo-traffic-diagnosis`](skills/seo-traffic-diagnosis/SKILL.md) | Diagnose drops, stalls, or wins via 5-layer root cause analysis |
+| 33 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
+| 34 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
 ### Product (10)
 
 | # | Skill | What it does |
 |---|---|---|
-| 34 | [`pm-spec-writing`](skills/pm-spec-writing/SKILL.md) | PRDs, user stories, acceptance criteria, dev briefs |
-| 35 | [`roadmap-planning`](skills/roadmap-planning/SKILL.md) | Quarterly planning, prioritization, dependency mapping |
-| 36 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
-| 37 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
-| 38 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
-| 39 | [`experimentation-analytics`](skills/experimentation-analytics/SKILL.md) | Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation |
-| 40 | [`experimentation-platform-orchestrator`](skills/experimentation-platform-orchestrator/SKILL.md) | Pick the right experimentation platform, migrate when wrong, coordinate when multi-platform: a decision framework for Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon |
-| 41 | [`product-analytics-setup`](skills/product-analytics-setup/SKILL.md) | Instrument product analytics correctly: event taxonomy, properties, naming conventions, schema versioning, funnels, retention cohorts, North Star selection, and the instrumentation debt that compounds without discipline |
-| 42 | [`data-warehouse-experimentation`](skills/data-warehouse-experimentation/SKILL.md) | Run experiments out of the warehouse: SQL assignment, exposure logs, dbt metric definitions, statistical analysis, variance reduction with CUPED, sequential testing, and the operational tradeoffs vs platforms |
-| 43 | [`feature-launch-playbook`](skills/feature-launch-playbook/SKILL.md) | The operational discipline of launching a feature well: positioning, internal alignment, customer comms, sales enablement, support readiness, rollout strategy, monitoring, and post-launch measurement |
+| 35 | [`pm-spec-writing`](skills/pm-spec-writing/SKILL.md) | PRDs, user stories, acceptance criteria, dev briefs |
+| 36 | [`roadmap-planning`](skills/roadmap-planning/SKILL.md) | Quarterly planning, prioritization, dependency mapping |
+| 37 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
+| 38 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
+| 39 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
+| 40 | [`experimentation-analytics`](skills/experimentation-analytics/SKILL.md) | Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation |
+| 41 | [`experimentation-platform-orchestrator`](skills/experimentation-platform-orchestrator/SKILL.md) | Pick the right experimentation platform, migrate when wrong, coordinate when multi-platform: a decision framework for Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon |
+| 42 | [`product-analytics-setup`](skills/product-analytics-setup/SKILL.md) | Instrument product analytics correctly: event taxonomy, properties, naming conventions, schema versioning, funnels, retention cohorts, North Star selection, and the instrumentation debt that compounds without discipline |
+| 43 | [`data-warehouse-experimentation`](skills/data-warehouse-experimentation/SKILL.md) | Run experiments out of the warehouse: SQL assignment, exposure logs, dbt metric definitions, statistical analysis, variance reduction with CUPED, sequential testing, and the operational tradeoffs vs platforms |
+| 44 | [`feature-launch-playbook`](skills/feature-launch-playbook/SKILL.md) | The operational discipline of launching a feature well: positioning, internal alignment, customer comms, sales enablement, support readiness, rollout strategy, monitoring, and post-launch measurement |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 44 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 45 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 46 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 47 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 45 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 46 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 47 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 48 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 48 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 49 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 49 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 50 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 51 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 52 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 53 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 54 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 55 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 56 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 57 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 50 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 51 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 52 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 53 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 54 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 55 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 56 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 57 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 58 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 58 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 59 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 59 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 60 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Marketing (3)
 
@@ -386,37 +387,37 @@ Paid media discipline: strategy, creative, and performance analytics. Pairs with
 
 | # | Skill | What it does |
 |---|---|---|
-| 60 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
-| 61 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
-| 62 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
+| 61 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
+| 62 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
+| 63 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 63 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 64 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 65 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 64 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 65 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 66 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 66 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 67 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 68 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 69 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 70 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 67 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 68 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 69 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 70 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 71 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 71 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 72 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 73 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 74 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 75 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 72 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 73 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 74 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 75 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 76 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/skills/editorial-qa/SKILL.md
+++ b/skills/editorial-qa/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: editorial-qa
+description: "Pre-publish QA framework for content. Brief adherence, voice consistency, fact accuracy, structure and clarity, AI-content audit, SEO and AEO compliance, internal linking and schema validation, QA at scale via sampling, the QA workflow, and the discipline that distinguishes catch-problems QA from checkbox QA. Triggers on editorial QA, content review, pre-publish review, content audit, content QA process, AI-content audit, hallucination check, content sampling, programmatic QA, voice consistency check, brief adherence check. Also triggers when a content team is shipping sloppy work, when AI-co-authored content is reaching publish unaudited, when a QA process burns reviewers out, or when a programmatic SEO set needs sampling discipline."
+category: content
+catalog_summary: "Pre-publish QA framework: brief adherence, voice consistency, fact accuracy, AI-content audit, AEO/SEO compliance, sampling at scale, and the workflow that distinguishes catch-problems QA from process theater"
+display_order: 7
+---
+
+# Editorial QA
+
+A senior editor's playbook for pre-publish content QA. The discipline that catches problems BEFORE content ships, not after.
+
+Most content QA is broken in one of two directions. The thin version is "did I read it once and is the spelling OK," which catches typos but misses brief drift, voice inconsistency, hallucinated facts, AI tells, and structural problems that reach readers as "this is fine but not memorable." The thick version is a 47-item checklist that nobody completes honestly because it is process theater: checkboxes nobody actually believes catch problems.
+
+This skill is the discipline of catch-problems QA. Each check earns its keep by catching a specific class of failure that would reach readers if missed. Checks that do not catch anything get cut. Checks the production volume cannot sustain get redesigned (sampling instead of full audit, automated instead of manual). The QA framework is what is left when you remove the theater.
+
+The skill covers three production shapes: single editorial pieces (one at a time, full QA), AI-generated drafts (with the AI-content audit that did not exist as prominently 2 years ago), and programmatic SEO sets at scale (sampling discipline, threshold gating). Each needs its own QA shape; the underlying methodology composes across all three.
+
+When to use this skill: building a content QA process from scratch, auditing an existing QA process that ships sloppy work or burns out the team, designing QA gates for an AI-assisted workflow, or building sampling discipline for programmatic SEO sets.
+
+---
+
+## What this skill is for
+
+This skill spans pre-publish quality control. It plugs in at the END of every other content skill's output. The six-skill content suite distinction:
+
+- `content-strategy` is program scope: what to produce.
+- `pillar-content-architecture` is hub scope: how the topical hub fits together.
+- `content-brief-authoring` is per-piece scope: briefs each piece.
+- `content-and-copy` is execution scope: writes each piece.
+- `programmatic-seo` is scaled scope: generates many pages from data.
+- This skill is gate scope: verifies before publish.
+
+Every skill above produces a draft. This skill is what gets drafts to publishable. It is the gate where quality is actually enforced.
+
+The audience: editorial leads, content directors, in-house content QA, agencies with production lines, content ops managers, anyone running a writer (human or AI) and accountable for what ships. The voice is senior editor to junior editor or content marketer. Specific, opinionated, honest about where QA earns its keep versus where it becomes process theater.
+
+---
+
+## Catch-problems QA vs checkbox QA
+
+The keystone distinction. Two failure modes plus the discipline.
+
+**Thin QA (typo-checking dressed as quality control).** "I read it once, it is fine." Catches obvious mistakes; misses brief drift, voice inconsistency, hallucinated facts, structural problems, AI tells. Output: shipped content that is "fine but not memorable." Cost: invisible until a brand misstep, a hallucinated statistic, or a competitor's content compounds and the thin set falls behind.
+
+**Thick QA (47-item checklist nobody completes honestly).** Every conceivable check listed; no triage. Reviewers either skim and check boxes (theater) or burn out under the cognitive load. Output: shipped content slightly more polished than thin QA produces, but the team's review velocity collapses. Cost: throughput drops; reviewers leave; the checklist atrophies into a few checks that actually run.
+
+**Catch-problems QA (the discipline).** Each check earns its keep by catching a specific class of failure that would reach readers if missed. Checks that do not catch anything get cut. Production volume drives sampling versus full-audit decisions. Reviewers are accountable for what they caught, not for box-completion.
+
+The litmus test. If the team can name the last 3 problems each QA check caught, the check earns its keep. If a check has not caught anything in 6 months, it is theater. Cut it; reallocate the attention to checks that catch real problems.
+
+---
+
+## Brief adherence check
+
+Did the writer execute the brief? The check is straightforward when the brief is well-authored (see `content-brief-authoring`).
+
+The brief-adherence checks:
+
+- **Target keyword and cluster.** Present in title, first paragraph, headings.
+- **Search intent and SERP format.** Piece matches the dominant SERP format (article when SERP wants article, listicle when SERP wants listicle).
+- **Target audience.** Piece reads as written FOR the named audience, not for a generic reader.
+- **Heading structure.** Piece follows the H2 / H3 outline in the brief, or has a documented reason for deviation.
+- **Required entities.** Every entity flagged in the brief appears in the piece.
+- **Internal links.** Outbound links specified in the brief are present with the right anchor text.
+- **Anti-patterns.** Piece avoids the off-limits language and structures named in the brief.
+- **Success criteria acknowledged.** Piece is shaped to MEASURE against the success criteria.
+
+The brief-adherence check is the cheapest, fastest, highest-value QA gate. It runs first in the QA sequence because catching a brief-adherence failure early saves the editor from spending time on voice and structure on a piece that will need to restart.
+
+If briefs are vague, this check is impossible. Fix briefs first; the QA process cannot enforce a contract that does not exist.
+
+Detail in `references/brief-adherence-checklist.md`.
+
+---
+
+## Voice consistency check
+
+Does the piece sound like the brand?
+
+- **Vocabulary.** Brand-specific terms used correctly; off-brand terms absent.
+- **Sentence rhythm.** Matches brand voice (short and punchy versus measured and layered versus colloquial).
+- **Stance.** The piece takes positions consistent with brand POV.
+- **Register.** Formal or casual matches the surface (blog versus whitepaper versus help doc).
+- **Voice drift in long pieces.** 3,000-word pieces often start in brand voice and drift to generic by section 4. Sample paragraphs from start, middle, end.
+
+For AI-co-authored pieces, voice drift is the dominant failure mode. AI assistants regress to a model-default voice unless the writer actively pulls them back. The QA check needs to read for the brand voice as much as for the words.
+
+Detail in `references/voice-consistency-patterns.md`.
+
+---
+
+## Fact accuracy and citation discipline
+
+Every claim in the piece needs to be true. The check:
+
+- **Statistics.** Every number sourced or removed if no source.
+- **Quotes.** Every quote attributed to a real person who actually said it.
+- **Case studies.** Every example refers to a real company or scenario, or labeled clearly as hypothetical.
+- **Dates and timelines.** Verified, not approximate.
+- **Named experts.** Real people who consented to attribution.
+- **Product claims.** Matches actual product behavior, not future-tense roadmap or marketing aspiration.
+
+Hallucination is the dominant failure mode in AI-assisted writing. AI assistants generate plausible statistics, plausible quotes, plausible case studies, none of which are real. The fact-accuracy check is the gate that catches them. If you skip this gate on AI-generated content, you ship hallucinations.
+
+Citation discipline:
+
+- Inline citations link to authoritative sources (academic papers, industry reports, primary sources).
+- Avoid citing other content marketing pages (citation laundering).
+- Date the source; sources older than 3 years for fast-moving topics need refresh.
+
+Detail in `references/fact-accuracy-and-citation-discipline.md`.
+
+---
+
+## Structure and clarity check
+
+Does the piece work as a piece?
+
+- **Lede.** First 200 words answer the user's likely query (for SEO/AEO pieces) OR establish the thesis (for thought leadership).
+- **Sectioning.** H2s map to user mental model, not writer enthusiasm.
+- **Section length.** Even-ish across H2s. One massive section plus four 80-word sections signals broken structure.
+- **Reading flow.** Paragraphs connect, sentences vary in length.
+- **Specificity vs abstraction.** Claims are concrete, not vague.
+- **Endings.** Piece concludes with something specific (action, question, idea), not throat-clearing filler.
+
+Detail in `references/structure-and-clarity-review.md`.
+
+---
+
+## AI-content audit
+
+The QA check that did not exist as prominently 2 years ago. AI-co-authored content has detectable patterns even when written by a competent human editor.
+
+**AI tells (pattern recognition).**
+
+- Excessive em-dashes (model-default punctuation)
+- Predictable opening phrasings (throat-clearing openers that announce what the piece is about to do; the fast-paced-world opener, the importance-noting opener, the whether-you-are-X-or-Y opener)
+- Predictable concluding paragraphs (throat-clearing wrap-ups, "By following these steps")
+- Bullet-list overuse where prose would serve
+- "On the other hand" / "However" overuse
+- Forced bilateral framing (always "two sides" even when one side is right)
+- Sentence-end filler ("...and more.", "...among other things.", "...for example.")
+- Repetitive sentence-rhythm (every paragraph 2-3 sentences, similar lengths)
+- Generic openings (descriptive paragraphs that could open any article on the topic)
+- Bridging fluff ("That said", "With that in mind", "Moving on")
+- Hedge stacking ("typically", "generally", "often") on claims that should be specific
+
+**Hallucination patterns (factual errors).**
+
+- Statistics that look authoritative (specific decimal places, named source) but the source does not exist or does not say that
+- Quotes attributed to real people who did not say it
+- Case studies about companies that do not exist
+- Citations to URLs that 404 or never existed
+- "Studies show" claims with no actual study behind them
+- Made-up product features
+
+**Voice drift.**
+
+- Piece starts in brand voice, drifts to generic by section 4
+- Vocabulary regresses to model defaults
+- Stance becomes diplomatic ("there are good arguments on all sides") when brand stance was clear
+
+The audit shape. Read with these patterns top-of-mind. Flag any match. The bar is not "AI was used" (it almost always is now); the bar is "would a careful human editor have shipped this." If the patterns above are present, the piece needs another revision pass with the patterns called out.
+
+Detail in `references/ai-content-audit-patterns.md`.
+
+---
+
+## SEO and AEO compliance check
+
+Does the piece serve search engines AND answer engines?
+
+**SEO checks.**
+
+- Target keyword in title, H1, first paragraph, slug
+- Heading hierarchy clean (no orphan H3s, no H4 without H3)
+- Image alt text descriptive
+- Meta description compelling and keyword-aware
+- Internal links specified in brief are present
+- External links open in new tab (typically) and have rel attributes appropriate
+- URL slug short and descriptive
+
+**AEO checks.**
+
+- 40 to 60 word answer paragraph immediately following each H2 question
+- TL;DR section present (for pillar pieces)
+- FAQ section with FAQPage schema (for pieces where Q and A format applies)
+- Specific statistics with cited sources (AI engines weight statistics with sources)
+- Named entities (experts, methods, tools) consistently mentioned (entity coverage signals)
+- Distinctive POV that is attributable to the brand
+
+Detail in `references/seo-aeo-compliance-checklist.md`.
+
+---
+
+## Internal linking and schema validation
+
+**Internal linking.**
+
+- Outbound links specified in brief are present with correct anchor text
+- Anchor text varies (avoid every link being "click here" or every link being the exact-match target keyword)
+- Link targets are live (no 404s, no links to deprecated pages)
+- Internal link count appropriate to length (3 to 7 for typical 1,500-word piece, 8 to 15 for pillars)
+- Self-cannibalization check: piece does not compete with existing pieces for same target keyword
+
+**Schema validation.**
+
+- Article schema present on most pieces; HowTo schema on instructional pieces; FAQPage schema where Q and A applies
+- Schema validates against schema.org definitions (no missing required fields, no malformed JSON-LD)
+- Schema is consistent with on-page content (do not claim 5-star rating in schema if no rating on page)
+
+Detail in `references/internal-linking-and-schema-validation.md`.
+
+---
+
+## QA at scale
+
+For pieces shipping at programmatic-SEO scale (100s to 100,000s of pages), full-audit QA is infeasible. Sampling discipline replaces it.
+
+**Sampling strategy.**
+
+- Random sample 50 to 200 pages per audit cycle
+- Balance the sample across data shape (sparse versus dense records, recent versus old generation, popular versus niche categories)
+- Fixed sample percentage as set grows; absolute count plateaus around 200 once the set is large
+
+**Automated checks at scale.**
+
+- Heading structure validation
+- Schema markup validation
+- Word count (flag pages below the floor, e.g. 600 words)
+- Duplicate content check (compare each page against the rest of the set)
+- Broken-link check
+- Image-presence check (where templates expect images)
+
+**Manual checks on sampled pages.**
+
+- Brief-adherence equivalent (template-adherence check: does the page execute the template?)
+- Top-200-word answer quality
+- Whether the page would satisfy a human user's likely query
+- Whether the page reads as distinctive versus templated
+- Spot-check for AI hallucination if AI was in the loop
+
+**Threshold gating.**
+
+- If more than 5% of sampled pages fail the manual review, halt new generation
+- Fix the template OR data quality issue before resuming
+- Document the threshold breach in the QA log so patterns become visible
+
+Detail in `references/qa-at-scale-patterns.md`.
+
+---
+
+## The QA workflow
+
+Ownership and sequencing.
+
+**Single QA owner per piece**, not a committee. The owner is accountable for what shipped. Committees diffuse accountability; nobody owns a problem that reaches readers.
+
+**Sequencing.** Brief-adherence, then fact-accuracy, then structure, then AI-content audit, then voice, then SEO/AEO, then internal linking, then schema. Brief-adherence first because it is the cheapest gate; SEO/AEO checks last because they are easiest to fix and rarely halt-conditions.
+
+**Halt vs flag vs auto-fix.**
+
+- Brief-adherence and fact-accuracy can HALT (return to writer).
+- Voice and structure FLAG with suggestions; editor judgment decides whether to halt or revise inline.
+- SEO/AEO and schema typically auto-fix (slug, meta description, schema markup are mechanical edits the editor or a script can ship without writer involvement).
+
+**Escalation.** When QA finds a pattern (multiple pieces failing the same check), escalate to the brief author, the writer, or the editorial process owner. Pattern signals process problem, not just per-piece problem.
+
+Detail in `references/qa-workflow-templates.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-qa-failures.md`.
+
+- "Our QA process is a 47-item checklist nobody completes." Checkbox theater; cut to the checks that earned their keep.
+- "We caught zero problems in QA last quarter." Either the process is broken or the writers are extraordinary; investigate.
+- "Editor and writer disagree on voice." Voice guidelines are vague; document brand voice with concrete examples.
+- "AI hallucinations made it to publish." Fact-accuracy gate skipped or rushed; reinstate as halt-condition.
+- "Our pSEO set is shipping thin pages." Sampling discipline missing or thresholds not honored.
+- "QA takes longer than the writing." Wrong sequencing; brief-adherence early catches problems before voice/structure investment.
+- "Reviewers burn out." Checks that do not catch problems are taxing reviewer attention; cut them.
+- "Voice drifts halfway through long pieces." Sample mid-piece paragraphs, not just open and close.
+- "We never go back to evaluate." QA log archives feed pattern detection; quarterly review.
+- "Different editors apply different standards." Calibration sessions where editors review the same piece independently and reconcile.
+- "We ship and discover problems on social." QA was not catching the problem class that is reaching readers; add a check for that class.
+
+---
+
+## The framework: 12 considerations for editorial QA
+
+When designing or auditing a QA process, walk these 12 considerations.
+
+1. **Catch-problems vs checkbox.** Every check earns its keep by catching a class of failure.
+2. **Brief-adherence first.** Cheapest, fastest, highest-value gate.
+3. **Fact-accuracy as halt-condition.** AI hallucinations do not ship to readers.
+4. **Voice consistency including mid-piece sampling.** Long pieces drift; sample throughout.
+5. **AI-content audit.** Pattern recognition for AI tells, hallucinations, voice drift.
+6. **Structure and clarity.** Lede, sectioning, even-ish length, specific endings.
+7. **SEO and AEO compliance.** Answer paragraphs, schema, entity coverage.
+8. **Internal linking and schema validation.** Outbound links live, anchor text varies, schema validates.
+9. **Sampling at scale.** Programmatic and high-volume sets need sampling, not full-audit.
+10. **Threshold gating.** Failure rate above threshold halts generation; document breaches.
+11. **Single QA owner per piece.** Accountability not diffused across committee.
+12. **Sequencing.** Brief-adherence to fact-accuracy to structure to AI-audit to voice to SEO/AEO to linking to schema.
+
+The output of the framework is a QA process the team can run repeatably: each check named, each owner named, each halt-condition documented, each sampling rule specified for programmatic surfaces.
+
+---
+
+## Reference files
+
+- [`references/brief-adherence-checklist.md`](references/brief-adherence-checklist.md) - Every brief field as a QA check, with how to verify and what failure looks like.
+- [`references/voice-consistency-patterns.md`](references/voice-consistency-patterns.md) - Vocabulary, rhythm, stance, register, mid-piece sampling discipline for long pieces.
+- [`references/fact-accuracy-and-citation-discipline.md`](references/fact-accuracy-and-citation-discipline.md) - Verification methodology, hallucination detection, citation rules, source-age guidelines.
+- [`references/structure-and-clarity-review.md`](references/structure-and-clarity-review.md) - Lede patterns, sectioning principles, endings, structural anti-patterns.
+- [`references/ai-content-audit-patterns.md`](references/ai-content-audit-patterns.md) - 11 AI tells, 6 hallucination patterns, voice drift detection, worked example with revision.
+- [`references/seo-aeo-compliance-checklist.md`](references/seo-aeo-compliance-checklist.md) - SEO and AEO checks combined into one workflow.
+- [`references/internal-linking-and-schema-validation.md`](references/internal-linking-and-schema-validation.md) - Link discipline, anchor text variation, schema patterns and validation.
+- [`references/qa-at-scale-patterns.md`](references/qa-at-scale-patterns.md) - Sampling strategy, automated checks, manual review at scale, threshold gating.
+- [`references/qa-workflow-templates.md`](references/qa-workflow-templates.md) - Ownership, sequencing, halt versus flag versus auto-fix, escalation patterns.
+- [`references/common-qa-failures.md`](references/common-qa-failures.md) - 11+ failure patterns with diagnoses and fixes.
+
+---
+
+## Closing: QA is where quality gets enforced
+
+Every other skill in the content suite produces drafts. QA is the discipline that turns drafts into publishable work. It is also where every previous decision (brief shape, voice guidelines, hub architecture, programmatic template) gets tested against actual output. Skipping QA is not "moving fast"; it is shipping the failure modes of every upstream decision unfiltered.
+
+The QA process is the immune system of the content program: invisible when it is working, catastrophic in its absence.
+
+When in doubt about whether a QA process is ready, ask: does each check name a class of failure it catches, has each check actually caught something in the last 6 months, is brief-adherence first in the sequence, is fact-accuracy a halt-condition, is the AI-content audit included, does sampling discipline apply to scaled surfaces? If yes to all of those, the process is real. If no to any, the gap is where readers will encounter the failure that QA did not catch.

--- a/skills/editorial-qa/references/ai-content-audit-patterns.md
+++ b/skills/editorial-qa/references/ai-content-audit-patterns.md
@@ -1,0 +1,119 @@
+# AI-content audit patterns
+
+The 11 AI tells, the 6 hallucination patterns, voice drift detection, a worked example. The QA check that did not exist as prominently 2 years ago and is now load-bearing for any program with AI in the loop.
+
+---
+
+## The 11 AI tells
+
+Pattern recognition. Read with these top-of-mind; flag any match.
+
+**1. Excessive em-dashes.** Model-default punctuation. A piece with 8 em-dashes per 1,000 words is almost certainly AI-drafted. The fix: replace with periods, semicolons, or rephrase the sentence.
+
+**2. Predictable opening phrasings.** Throat-clearing openers that announce what the piece is about to do (the fast-paced-world opener, the importance-noting opener, the whether-you-are-X-or-Y opener). These openings appear in AI output across topics; pattern-match against the team's curated do-not-use list and cut.
+
+**3. Predictable concluding paragraphs.** Throat-clearing wrap-ups. "By following these steps." "By implementing these strategies." "Now you have a comprehensive understanding of." All cut.
+
+**4. Bullet-list overuse.** AI defaults to bullets when prose would serve. Bullets fragment reading flow and signal AI drafting. Convert to prose where prose makes the connection between items clearer.
+
+**5. "On the other hand" / "However" overuse.** Forced bilateral framing pattern. Used 4+ times in 1,500 words is the AI tell.
+
+**6. Forced bilateral framing.** "While X has its advantages, Y also has merits." Always two sides given equal weight even when one side is right. The fix: pick a position; defend it; let the contrary view get one short acknowledgment.
+
+**7. Sentence-end filler.** "...and more." "...among other things." "...for example." All padding. Cut.
+
+**8. Repetitive sentence-rhythm.** Every paragraph 2 or 3 sentences of similar length. Read aloud: monotonous. The fix: deliberate variation in sentence length and paragraph shape.
+
+**9. Generic openings.** Descriptive paragraphs that could open any article on the topic. "Customer experience is more important than ever in today's competitive landscape." Cut; replace with a specific opening tied to the piece's thesis or the reader's specific query.
+
+**10. Bridging fluff.** "That said." "With that in mind." "Moving on." Throat-clearing transitions; cut.
+
+**11. Hedge stacking.** "Typically," "generally," "often" stacked on claims that should be specific. AI hedges to avoid being wrong; the result is content that says nothing definite. Replace hedges with specifics or cut the hedge.
+
+---
+
+## The 6 hallucination patterns
+
+Factual errors that AI assistants generate and how to detect each.
+
+**1. Specific decimal places, named source, source does not exist.** "According to a 2024 Forrester report, 67.3% of B2B buyers..." The decimal place plus named source is the AI tell. Detection: search the source. If it does not exist or does not say that, cut the claim.
+
+**2. Quotes attributed to real people the person did not say.** "As Marc Benioff said in his 2024 keynote..." Plausible because Benioff gives keynotes. Detection: search for the quote in actual transcripts; verify against original source. If the quote does not match a real source, cut.
+
+**3. Case studies about companies that do not exist.** "Acme Innovations reduced their cycle time 40% using..." Detection: search the company name. If it does not appear in business directories, news coverage, or LinkedIn, the case study is fake.
+
+**4. Citations to URLs that 404 or never existed.** Detection: click every external link. 404s and dead links are signals; multiple dead links signal multiple unverified claims.
+
+**5. "Studies show" claims with no actual study.** "Studies show that 45% of marketers..." with no link, no journal, no year. Detection: ask for the study. If the writer cannot produce it, cut the claim.
+
+**6. Made-up product features.** "Product X now supports automatic Y" when the product does not. Detection: verify against the product's current documentation, not against marketing copy that might be aspirational.
+
+---
+
+## Voice drift detection
+
+The mid-piece drift pattern in AI-co-authored content.
+
+**The pattern.** Piece starts in brand voice (because the writer set up the opening prompt with brand voice cues). By section 4, the voice has drifted to model-default. The drift is gradual; the start and end pass voice review while the middle fails.
+
+**Detection methodology.**
+
+1. Sample paragraphs from start, middle (2 paragraphs from middle 60%), and end.
+2. Compare each sample to the brand voice doc's vocabulary, rhythm, stance, register.
+3. If start and end match brand voice while middle samples regress to generic, the piece has voice drift.
+
+**The fix.** Send back with the drifted sections highlighted. Specific note: "Sections 3 and 4 read as model-default. Revise with the voice doc's vocabulary, rhythm, and stance. Specifically: [3 specific fixes from the voice doc]."
+
+---
+
+## Worked example: AI tells in a 4-paragraph excerpt
+
+Original AI-drafted excerpt (with AI tells in bold for the audit):
+
+> **In today's fast-paced digital landscape**, content marketing has become more important than ever. **Whether you're a small business owner or a Fortune 500 executive**, understanding the nuances of effective content strategy is crucial for success.
+>
+> There are many factors to consider when developing a content strategy. **On one hand**, you need to focus on creating high-quality content that resonates with your audience. **On the other hand**, you also need to ensure that your content is optimized for search engines, social media platforms, **and more**.
+>
+> **It's important to note** that successful content marketing requires a balance between creativity and analytics. **Studies show** that companies that prioritize data-driven decision-making see significant improvements in their content performance metrics.
+>
+> **By following these steps**, you'll be well on your way to creating a content strategy that drives results. Remember that consistency is key, and that great content takes time to produce.
+
+The audit tags 9 AI tells in 4 paragraphs (more than 2 per paragraph).
+
+Revised excerpt (AI tells removed, voice tightened, specifics added):
+
+> Content marketing produces results when the strategy answers two questions: who are we writing for, and what do they need to do after reading. The B2B SaaS team writing for senior data engineers asks different questions than the consumer brand writing for first-time buyers. Both work; conflating them does not.
+>
+> The trade-off most teams get wrong is craft against measurement. Pieces optimized for search rankings often read as templated; pieces optimized for craft often miss the structural patterns that earn rankings. The fix is not balance; it is sequencing. Brief the structural patterns first; write to craft within them.
+>
+> Companies that ship measurable content programs share three patterns: a brief discipline that survives writer changes, a voice doc specific enough to enforce, and a fact-check gate that does not compromise under deadline pressure. Companies that miss any of the three produce inconsistent output regardless of writer talent.
+>
+> The next step is auditing your current process against those three patterns. If the brief is vague, fix the brief. If the voice doc is aspirational, tighten it with concrete examples. If the fact-check gate is optional, make it a halt-condition.
+
+The revision removed AI tells, added specifics (the two audience examples, the three patterns), and replaced the closing throat-clearing with a concrete next-step.
+
+---
+
+## The audit checklist
+
+For each AI-co-authored draft, walk this checklist.
+
+1. Read the first 200 words. Does the opening match any of the 11 AI tells? Flag.
+2. Sample 2 paragraphs from the middle. Does either match AI tells? Does the voice match the brand voice doc? Flag.
+3. Read the last 200 words. Does the closing match any of the 11 AI tells? Flag.
+4. Search the piece for em-dashes; count. More than 5 in a 1,500-word piece is suspicious.
+5. Search for forced bilateral framing patterns. Count.
+6. Verify every statistic, quote, case study, citation, and product claim per the fact-accuracy methodology.
+7. Sample 3 to 5 internal links; verify they go where the brief specified and the targets exist.
+
+If 3+ items flag, halt the piece and return for revision with the specific items called out.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The 11 AI tells, the 6 hallucination patterns, voice drift detection methodology, the worked example revision pattern, the 7-step audit checklist.
+
+## Implementation choices that stay internal
+
+The specific tooling for automated AI-tell detection (regex patterns, classifier models, prompt-based audits). The specific brand voice doc that drives voice-drift comparison. The specific archive of past AI-tell catches that informs ongoing pattern recognition. The specific revision workflow when AI tells are detected (writer's editing tool, AI assistant configured for revision-not-drafting, human-only revision). These vary by team and tooling preferences.

--- a/skills/editorial-qa/references/brief-adherence-checklist.md
+++ b/skills/editorial-qa/references/brief-adherence-checklist.md
@@ -1,0 +1,137 @@
+# Brief adherence checklist
+
+Every brief field as a QA check, with how to verify and what failure looks like.
+
+The brief-adherence check is the first QA gate in sequence. It is the cheapest gate to run and the highest-value gate to pass: catching a brief-adherence failure early saves the editor from spending review time on voice, structure, and fact-accuracy on a piece that will need to restart.
+
+This check assumes the brief was authored under the discipline of `content-brief-authoring`. If briefs are vague or thin, fix briefs first; the brief-adherence check enforces a contract that has to exist.
+
+---
+
+## The checklist
+
+For each piece, walk these 8 fields.
+
+### 1. Target keyword and cluster
+
+**Verify.** Pull the brief's primary keyword and 3 to 5 supporting cluster keywords. Search the piece for each.
+
+**Pass.** Primary keyword appears in title, H1 (if separate), first paragraph, and at least one H2. Supporting keywords appear naturally across the piece without stuffing.
+
+**Fail patterns.**
+
+- Primary keyword missing from title or first paragraph
+- Cluster keywords absent (piece read like a generic article on the topic)
+- Keyword stuffing: same exact-match phrase repeated 8+ times in 1,500 words
+
+### 2. Search intent and SERP format
+
+**Verify.** Pull the brief's intent classification and dominant SERP format. Compare to the piece's shape.
+
+**Pass.** Piece shape matches the format the brief specified: long-form article when SERP wants long-form, listicle when SERP wants listicle, comparison when SERP wants comparison.
+
+**Fail patterns.**
+
+- Brief specified listicle; piece is long-form prose
+- Brief specified commercial-investigation intent; piece reads as informational with no purchase decision support
+- Brief flagged the SERP intent override; piece ignored the override
+
+### 3. Target audience
+
+**Verify.** Read the first 200 words and the closing 200 words with the brief's audience description in mind.
+
+**Pass.** Piece reads as written FOR the named audience: vocabulary, examples, and assumed knowledge match the audience's level.
+
+**Fail patterns.**
+
+- Brief specified senior data engineers; piece explains "what is a database" in the introduction
+- Brief specified non-technical CMOs; piece uses unexplained jargon
+- Piece reads as written for a generic reader rather than the named audience
+
+### 4. Heading structure
+
+**Verify.** Compare the piece's H2 / H3 outline to the brief's specified outline.
+
+**Pass.** Piece follows the brief's outline. Where the writer deviated, the brief's deviation note explains why or the writer's first-draft note flags the deviation for editor review.
+
+**Fail patterns.**
+
+- Brief specified 6 H2s; piece has 4 or 9 with no documented reason
+- H2 order changed without explanation
+- Sections from the outline missing entirely
+
+### 5. Required entities
+
+**Verify.** Pull the brief's required-entity list. Search the piece for each.
+
+**Pass.** Every required entity appears in the piece, ideally in the section the brief specified. Standard entities are covered. Gap entities (the differentiation opportunity) are present where the brief committed to them.
+
+**Fail patterns.**
+
+- Brief required mentioning CUPED in the methodology section; CUPED is not in the piece
+- Required entities mentioned in passing once each; depth-of-coverage requirements not met
+- Gap entities skipped because they were "optional" (they were not; the brief committed to them)
+
+### 6. Internal links
+
+**Verify.** Pull the brief's outbound internal-link list with anchor text. Check the piece for each link.
+
+**Pass.** Every required outbound link is present with the specified anchor text. Optional outbound links are either present or noted as skipped with reason.
+
+**Fail patterns.**
+
+- Brief specified 4 required outbound links; piece has 2
+- Anchor text differs from the specified anchor text without reason
+- Links to deprecated pages (the writer copied old anchor links from a stale draft)
+
+### 7. Anti-patterns
+
+**Verify.** Pull the brief's anti-pattern list. Read the piece looking for each pattern.
+
+**Pass.** Piece avoids every named anti-pattern. The do-not-use word list, off-brand voice, off-topic tangents, AI clichés, and structural patterns the brief explicitly forbade are absent.
+
+**Fail patterns.**
+
+- Anti-pattern words from the do-not-use list present (e.g., the writer slipped into corporate-speak adjectives)
+- Off-topic tangents the brief warned against (the writer wandered into adjacent facets the cluster covers separately)
+- Voice drifted toward a register the brief excluded
+
+### 8. Success criteria acknowledged
+
+**Verify.** Read the piece with the brief's success criteria in mind. Does the piece's shape support the criteria?
+
+**Pass.** Piece is shaped to MEASURE against the success criteria: ranking-targeted pieces have keyword-aware structure, citation-targeted pieces have answer paragraphs and statistics, conversion-targeted pieces have CTAs and decision-support content.
+
+**Fail patterns.**
+
+- Brief said "rank top 10 for [keyword]"; piece misses the structural patterns that earn ranking (no answer paragraphs, no entity coverage, no internal-link plan)
+- Brief said "drive 50 trial signups in 30 days"; piece has no clear CTA path to signup
+- Success criteria treated as an afterthought rather than a design parameter
+
+---
+
+## What halt-condition looks like
+
+Brief-adherence failures are halt-conditions: return the piece to the writer with the specific failures named.
+
+The return note is short. "This piece misses the brief in 3 places: [field 1], [field 2], [field 3]. The brief specified [X]; the piece does [Y]. Please revise and return for round 2."
+
+Editors who try to fix brief-adherence failures themselves end up rewriting the piece. Better to halt cleanly, return to the writer, and let the writer execute the contract that already existed in the brief.
+
+---
+
+## When briefs are too vague to enforce
+
+Sometimes the brief itself is the problem. The brief specified "engineers" without naming the seniority level. The brief specified "informational intent" without checking the SERP. The brief specified entities without depth-of-coverage requirements.
+
+When the brief is too vague, brief-adherence cannot enforce anything. The fix is upstream: tighten brief authoring discipline (see `content-brief-authoring`). The brief is the contract; vague contracts produce vague output regardless of writer skill.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The 8-field checklist, the halt-condition discipline, the upstream-fix observation when briefs are vague.
+
+## Implementation choices that stay internal
+
+The specific format the team uses for return notes (Slack message template, Notion row, ticketing system field structure). The specific tooling that stores brief metadata for diff-checking against pieces. The specific automation (if any) that surfaces brief-adherence failures before manual review. These vary by team and stack.

--- a/skills/editorial-qa/references/common-qa-failures.md
+++ b/skills/editorial-qa/references/common-qa-failures.md
@@ -1,0 +1,168 @@
+# Common QA failures
+
+11+ failure patterns with diagnoses and fixes. Cross-references to other reference files where applicable.
+
+The pattern across most failures: QA either drifted into theater (checks that do not catch problems but cost reviewer attention) or skipped the gates that catch the problems readers actually encounter. The fix is upstream: cut theater checks, reinstate gates that actually catch problems.
+
+---
+
+## "Our QA process is a 47-item checklist nobody completes"
+
+**Symptom.** The checklist exists. Nobody completes it honestly. Reviewers either skim and check boxes or burn out under the cognitive load.
+
+**Diagnosis.** Checkbox theater. The checklist accumulated over time as new failures appeared and got added; nothing was ever removed. The list grew past what reviewer attention can sustain.
+
+**Fix.** Audit the checklist. For each item, ask: when did this last catch a problem? If the answer is "never" or "more than 6 months ago," cut it. The remaining items are the catch-problems checks; the cut items were theater.
+
+**Prevention.** Quarterly review of the checklist. Each new check earns its keep by catching at least one problem within 90 days; checks that do not catch problems get cut.
+
+---
+
+## "We caught zero problems in QA last quarter"
+
+**Symptom.** No QA returns. No halt-conditions. No revision rounds. Pieces ship clean every time.
+
+**Diagnosis.** Either the writers are extraordinary or the process is broken. Almost always the latter.
+
+**Fix.** Audit recently-shipped pieces independently of the original QA. Find the problems QA missed: hallucinated statistics, voice drift in long pieces, broken links, schema validation failures. Document each. Reinstate the QA gate that should have caught the failure.
+
+**The pattern.** When QA catches nothing for a quarter, reviewers have stopped reading carefully. The fix is not "trust the writers"; it is reinstating the discipline that was nominally still running.
+
+---
+
+## "Editor and writer disagree on voice"
+
+**Symptom.** Editor returns the piece with voice notes; writer pushes back; edits go back and forth without convergence.
+
+**Diagnosis.** Voice guidelines are vague. Both editor and writer are interpreting the brand voice doc differently because the doc does not specify enough.
+
+**Fix.** Update the voice doc with concrete examples of the disputed dimension. If the dispute was about sentence rhythm, add 5 paired examples (the rhythm we want, the rhythm we do not want). The voice doc gets sharper; future disputes resolve by reference to the examples.
+
+**Prevention.** Quarterly voice calibration sessions (see `voice-consistency-patterns.md`) where editors review the same piece independently and reconcile.
+
+---
+
+## "AI hallucinations made it to publish"
+
+**Symptom.** A statistic, quote, citation, or product claim in a published piece turns out to be invented. Reader (or competitor) flags it.
+
+**Diagnosis.** The fact-accuracy gate was skipped or rushed.
+
+**Fix.** Two parts.
+
+- Immediate: correct the published piece, document the failure in the QA log.
+- Process: reinstate fact-accuracy as a halt-condition. AI hallucinations do not progress past this gate. If the gate is too slow, automate the easy parts (named-entity extraction, statistic detection) so manual verification focuses on the hard parts.
+
+**Prevention.** Fact-accuracy gate runs second in the QA sequence (after brief-adherence). Detail in `fact-accuracy-and-citation-discipline.md`.
+
+---
+
+## "Our pSEO set is shipping thin pages"
+
+**Symptom.** Programmatic pSEO set is producing pages with insufficient data; pages render at 200 to 400 words of templated boilerplate; algorithm risk compounds.
+
+**Diagnosis.** Sampling discipline missing or thresholds not honored. The set was generating pages without QC checking the quality at the data-shape level.
+
+**Fix.** Implement the sampling discipline (see `qa-at-scale-patterns.md`). Set the 5% failure threshold; halt new generation when breached. Audit the existing set; noindex or remove pages below the data depth threshold.
+
+**Prevention.** Sampling and threshold gating built into the program at design time, not retrofitted.
+
+---
+
+## "QA takes longer than the writing"
+
+**Symptom.** The team's writers ship drafts in 4 hours; QA cycle takes 6 hours. The bottleneck is review.
+
+**Diagnosis.** Wrong sequencing. The team is running expensive checks (voice, structure) before cheap checks (brief-adherence, fact-accuracy). When a piece fails at gate 1, the time spent on gates 5 to 8 is wasted.
+
+**Fix.** Reorder the sequence. Brief-adherence first; fact-accuracy second; halt-conditions short-circuit the rest of the gates. Voice and SEO checks last because they are easiest to fix and rarely halt-conditions.
+
+**Prevention.** The sequencing discipline is documented in `qa-workflow-templates.md`; new editors get the sequence in their onboarding.
+
+---
+
+## "Reviewers burn out"
+
+**Symptom.** Editors who used to review carefully now skim. The catch rate drops. Editors leave the team.
+
+**Diagnosis.** The QA load exceeds reviewer capacity. Often because checks that do not catch problems are taxing reviewer attention.
+
+**Fix.** Cut theater checks (the same fix as the 47-item checklist failure). Burn-out reduces with the cognitive load.
+
+**Also.** Verify that production volume matches reviewer capacity. If the team is shipping 30 pieces a week with 1 editor, the volume is wrong. Either reduce volume, add reviewers, or accept lower quality with eyes open.
+
+---
+
+## "Voice drifts halfway through long pieces"
+
+**Symptom.** 3,000-word pillar pieces start in brand voice; by section 4 they read generic.
+
+**Diagnosis.** Voice review only sampled the start and end. Mid-piece drift went undetected.
+
+**Fix.** Mid-piece sampling discipline (see `voice-consistency-patterns.md`). Sample paragraphs from start, middle (2 paragraphs from middle 60%), and end. AI-co-authored pieces especially need this.
+
+**Prevention.** Voice review template explicitly requires mid-piece sampling.
+
+---
+
+## "We never go back to evaluate"
+
+**Symptom.** QA process exists. QA log accumulates. Nobody reviews the log.
+
+**Diagnosis.** The log is an artifact, not a feedback mechanism. Patterns the log surfaces never reach the editorial process owner.
+
+**Fix.** Quarterly QA log review. The owner reads the log; pattern observations get translated into process changes (brief tweaks, writer feedback, workflow adjustments, automation additions).
+
+**Prevention.** The quarterly review is calendar-anchored. Skipping it is the failure mode.
+
+---
+
+## "Different editors apply different standards"
+
+**Symptom.** A piece shipped under editor A would be returned under editor B (or vice versa). Writers receive inconsistent feedback. Quality varies by which editor caught the piece.
+
+**Diagnosis.** Voice and structural standards have drifted between editors. Without calibration, individual editors apply individual taste.
+
+**Fix.** Calibration sessions. Three editors review the same piece independently; the team reads the three assessments together and reconciles. The consensus updates the voice doc and the QA process; future reviews stay consistent.
+
+**Prevention.** Calibration sessions quarterly minimum. Onboarding new editors includes a calibration round before they review live pieces solo.
+
+---
+
+## "We ship and discover problems on social"
+
+**Symptom.** Readers (or competitors, or critics on social) flag problems that QA did not catch.
+
+**Diagnosis.** QA was not catching the problem class that is reaching readers. The class might be hallucinations, voice drift, structural problems, factual errors, or off-brand tone.
+
+**Fix.** Identify the class of failure that reached readers. Add a QA check that catches that class. Document the addition in the QA log so the pattern becomes visible.
+
+**Prevention.** The QA process evolves with feedback from shipped pieces. New failure classes that reach readers feed new QA checks.
+
+---
+
+## "AI tells slipped through"
+
+**Symptom.** Published piece reads as AI-generated despite a human editor reviewing it. Readers or AI-detection tools flag it.
+
+**Diagnosis.** The AI-content audit either was not run or ran without the pattern recognition the editor needed.
+
+**Fix.** Add the AI-content audit as a named gate in the QA sequence (see `ai-content-audit-patterns.md`). Train the editor on the 11 AI tells; provide the worked example as reference. The audit becomes a 5-minute discipline rather than an unstructured "does this read OK" check.
+
+**Prevention.** Every AI-co-authored piece runs through the audit. The audit is a named gate, not an implicit step.
+
+---
+
+## The pattern across most failures
+
+Most QA failures are designed-in. The process either drifted into theater (cuts needed) or skipped gates that should have been there (gates needed). The discipline is upstream: design the QA process around catch-problems, not around process appearance, and the operational discipline at scale becomes manageable.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The 12 failure patterns above, the diagnosis-and-fix structure, the prevention guidance, the upstream-discipline observation.
+
+## Implementation choices that stay internal
+
+The specific QA log format and tooling. The specific calibration session cadence and team composition. The specific automation that supports each gate (statistic detection, hallucination flagging, schema validation, link audit). The specific escalation pathways within the team's structure. These vary by team and tooling.

--- a/skills/editorial-qa/references/fact-accuracy-and-citation-discipline.md
+++ b/skills/editorial-qa/references/fact-accuracy-and-citation-discipline.md
@@ -1,0 +1,113 @@
+# Fact accuracy and citation discipline
+
+Verification methodology, hallucination detection, citation rules, source-age guidelines.
+
+Fact accuracy is a halt-condition QA gate. Hallucinations from AI-assisted writing reach readers if the gate is skipped or rushed. The discipline below is what makes the gate work at production speed without becoming the bottleneck.
+
+---
+
+## What gets fact-checked
+
+Every claim that could be wrong. The categories.
+
+**Statistics.** Every number in the piece needs a source. "23% of feature flag rollouts include a kill switch" needs a source link to the survey, report, or dataset that produced the 23%. Without a source, the number is either removed or replaced with sourced equivalent.
+
+**Quotes.** Every quote attributed to a real person needs verification: the person said it, the quote is verbatim or correctly paraphrased, the attribution is accurate, the person consents to attribution.
+
+**Case studies.** Every example refers to a real company or scenario, OR is labeled clearly as hypothetical. "Acme Corp reduced churn by 40% using this method" needs verification that Acme exists, the method was used, the 40% is real. If the example is hypothetical, the piece labels it: "Imagine a SaaS company..."
+
+**Dates and timelines.** Verified, not approximate. "Google launched feature X in March 2025" needs verification of the exact month and year.
+
+**Named experts.** Real people who consented to being attributed. The piece should not attribute claims to "Ronny Kohavi" without verifying the attribution traces to actual published work or direct consent.
+
+**Product claims.** Match actual product behavior. The product does what the piece says it does, in the way the piece says it does, today, in production. Future-tense roadmap items get clearly labeled as roadmap; marketing aspirations get cut.
+
+---
+
+## The verification methodology
+
+For each claim in the piece, the editor follows one of three paths.
+
+**Path 1: in-line citation present.** Click through the citation. Does the source exist? Does the source actually say the claimed thing? Is the source the original (not a citation-of-citation)?
+
+**Path 2: claim has no citation but is a known fact.** Editor verifies via authoritative source (academic paper, primary government data, official company announcement). Add the citation; do not let the piece ship with uncited claims.
+
+**Path 3: claim has no citation and is not a known fact.** Halt. Return to writer with the claim flagged. Either the writer adds verification, or the claim gets removed.
+
+The discipline. No claim ships without verification. "I'm pretty sure I read this somewhere" is not verification.
+
+---
+
+## Hallucination detection
+
+AI-assisted writing produces plausible-but-fake claims at scale. The patterns to recognize.
+
+**Pattern 1: specific decimal places, named source, source does not exist.** "According to a 2024 Forrester report, 67.3% of B2B buyers prefer..." Sounds authoritative. The Forrester report does not exist, or exists but does not say that. The decimal place is the AI tell; AI assistants generate false precision to sound credible.
+
+**Pattern 2: quotes attributed to real people the person did not say.** "As Marc Benioff said in his keynote..." Plausible because Benioff gives keynotes. The specific quote is fabricated. Verify quotes against the actual recording, transcript, or primary source.
+
+**Pattern 3: case studies about companies that do not exist.** "Acme Innovations reduced their cycle time 40% using..." The company does not appear in any business directory; the case study is invented. Search the company name; if it does not surface in legitimate sources, the case study is fake.
+
+**Pattern 4: citations to URLs that 404 or never existed.** Click every external link. 404s and dead links are signals; a piece with multiple dead links has multiple unverified claims.
+
+**Pattern 5: "Studies show" claims with no actual study.** "Studies show that..." with no link, no journal, no year. Either the writer provides the study or the claim gets cut.
+
+**Pattern 6: made-up product features.** "[Product] now supports automatic X" when the product does not. Verify against the product's current documentation, not against marketing copy that might be aspirational.
+
+---
+
+## Citation discipline
+
+When citations are present, they need to be the right kind.
+
+**Authoritative sources.**
+
+- Academic papers (peer-reviewed journals)
+- Industry reports from established research firms (Forrester, Gartner, McKinsey, IDC) when verified
+- Primary government data (BLS, Census, SEC filings)
+- Original company announcements (the company's own blog, press release, official documentation)
+- First-party data the brand owns and has published
+
+**Avoid citation laundering.**
+
+Citing another content marketing page that itself cites a primary source is laundering. The chain of attribution gets murky; the claim's accuracy degrades through each hop. Cite the primary source directly.
+
+**Date the source.**
+
+Sources older than 3 years for fast-moving topics need refresh. "According to a 2018 Gartner report" is a yellow flag for content about a 2026 topic; the data might still be true but probably is not. Either find a more recent source or note the date and explain why the older source still applies.
+
+---
+
+## When the writer disputes the fact-check
+
+Sometimes the editor flags a claim and the writer pushes back. "I read it in the original source; here's the link." Two outcomes.
+
+**Outcome 1: writer's source verifies the claim.** Add the citation; ship the piece. The QA process worked.
+
+**Outcome 2: writer's source does not verify the claim.** This is where the conversation gets uncomfortable. The writer thought they had a source; the source does not say what they thought. The fix is the same: cut the claim or find a verifying source. Do not ship the unverified claim because the writer is sure it is true.
+
+---
+
+## Fact-check log
+
+Maintain a log of fact-check failures across pieces. Patterns surface over time.
+
+**Log fields.** Piece, claim, failure type (hallucination / wrong citation / outdated source / unverifiable), writer (if naming patterns), resolution (cut / re-sourced / verified).
+
+**Patterns the log surfaces.**
+
+- One writer repeatedly produces hallucinations: writer needs feedback or different work
+- One topic area produces frequent hallucinations: that topic needs more verification time built in
+- AI-co-authored pieces fail at higher rates than human-authored: AI workflow needs additional guardrails
+
+The log is process improvement input. Quarterly review; act on patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The verification methodology, the 6 hallucination patterns, the citation discipline rules, the fact-check log methodology.
+
+## Implementation choices that stay internal
+
+The specific tooling for storing the fact-check log (spreadsheet, database, Notion). The specific automation (if any) for surfacing claims that need verification (named-entity extractors, statistic detectors). The specific verification workflow when the editor does not have the bandwidth to fact-check personally (assistant-powered verification, fact-checking service integration). These vary by team scale and tooling preferences.

--- a/skills/editorial-qa/references/internal-linking-and-schema-validation.md
+++ b/skills/editorial-qa/references/internal-linking-and-schema-validation.md
@@ -1,0 +1,125 @@
+# Internal linking and schema validation
+
+Link discipline, anchor text variation, schema patterns and validation.
+
+The internal-linking and schema layer is where SEO compounds. Each piece's link contribution and schema contribution feeds the program's overall ranking and citation signal. QA enforces the discipline so individual pieces do not drift from the program's link graph and schema standards.
+
+---
+
+## Internal linking
+
+### Outbound links specified in brief
+
+- **The brief named X outbound links.** Verify each is present in the piece.
+- **Anchor text matches the brief's specification.** "Click here" is dead anchor text; the brief should specify keyword-aware anchor text per link.
+- **Links go where the brief said.** The link target is the page the brief specified, not a deprecated alternate or a different page that happens to share the topic.
+
+### Anchor text variation
+
+The "every link has the same anchor text" anti-pattern.
+
+**Pattern.** A piece links to the pillar 3 times. All 3 links use the exact-match keyword as anchor. This signals manipulation to ranking systems and dilutes the anchor's signal.
+
+**Fix.** Vary the anchor across the 3 links. One uses the exact-match keyword; one uses a descriptive natural-language phrase; one uses a brand-mention anchor or a context-driven phrase.
+
+**The audit.** For each piece, count the outbound links to the same target. If multiple links to the same target use identical anchor text, vary at least one.
+
+### Link-target liveness
+
+- **Every internal link target exists.** No 404s. The link goes to a live page on the site.
+- **No links to deprecated pages.** If a target page was retired, the link should redirect (via 301) or the link itself should be replaced.
+- **External links work.** Click them; verify they resolve and lead to the intended source.
+
+The external-link audit catches hallucinated citations (see `fact-accuracy-and-citation-discipline.md`) and link rot.
+
+### Internal link count
+
+- **3 to 7 internal links for a typical 1,500-word piece.** Below 3 signals under-linked (orphan-shaped). Above 10 signals link-stuffing.
+- **8 to 15 for a pillar piece.** Pillars carry more outbound links to their cluster.
+- **The link count should be by design, not by accident.** The brief specifies the link count; the writer should hit it; QA verifies.
+
+### Self-cannibalization check
+
+- **The piece does not compete with an existing piece for the same target keyword.** Search the site for the primary keyword. If an existing piece is in the top 5 internal results, flag the new piece.
+
+The flag triggers a decision: consolidate, differentiate, or kill one. Detail in `pillar-content-architecture/references/internal-linking-architecture.md` for the broader internal linking discipline.
+
+---
+
+## Schema validation
+
+### Schema type matches content
+
+- **Article schema for editorial pieces.** Default for blog posts, long-form articles, thought leadership.
+- **HowTo schema for instructional pieces.** Step-by-step guides with explicit steps that the schema can structure.
+- **Product schema for product pages.** Programmatic pSEO pages rendering products usually use Product schema.
+- **LocalBusiness schema for location-based pages.** Programmatic pSEO for geographic categories.
+- **FAQPage schema for genuine FAQ sections.** As an embedded schema within the page, not as the page's primary schema (unless the page is FAQ-shaped throughout).
+- **BreadcrumbList schema for navigation context.** Most pages benefit; pillar pages especially.
+
+### Schema validates
+
+- **Schema validates against schema.org definitions.** No missing required fields. No malformed JSON-LD. No invalid field types.
+- **Validation method.** Run the schema through a validator (Google's Structured Data Testing Tool, schema.org's validator, or equivalent). Failures appear as errors with field-specific messages.
+
+### Schema is consistent with on-page content
+
+- **Schema reflects what the page actually shows.** Do not claim 5-star rating in schema if there is no rating on the page. Do not claim a HowTo with 7 steps if the page only walks through 4. Mismatch between schema and content can trigger manual penalties.
+
+### Optional schema fields earn their keep
+
+- **Populated optional schema fields signal depth.** Programmatic pages with comprehensive schema (`aggregateRating`, `additionalProperty`, `areaServed`, etc.) score higher with AI engines than pages with bare-minimum schema.
+- **The trade-off.** Filling optional fields requires data. If the data does not exist, do not fabricate it; either populate genuinely or leave the field absent.
+
+---
+
+## The link audit pattern
+
+For each piece in QA:
+
+1. **Outbound links present.** Match against brief.
+2. **Anchor text variation.** Same-target links use varied anchor text.
+3. **Targets live.** No 404s, no deprecated pages.
+4. **Link count in band.** 3 to 7 for typical, 8 to 15 for pillar.
+5. **Self-cannibalization.** No competition with existing pieces.
+6. **Inbound links queued for post-publish update.** The brief queued 1 to 3 existing pages that should add links to this piece after publish; the QA log queues those updates.
+
+The 6-step audit takes 5 minutes per piece. Worth the time; under-linked or stuffed pieces fail to compound.
+
+---
+
+## The schema audit pattern
+
+For each piece in QA:
+
+1. **Schema type appropriate.** Article, HowTo, Product, LocalBusiness, FAQPage, or BreadcrumbList per content shape.
+2. **Schema validates.** Run through a validator; resolve errors before publish.
+3. **Schema matches content.** No false claims (false ratings, false step counts).
+4. **Optional fields populated.** Where data exists, fields populate; the page signals depth.
+5. **Multiple schema types when appropriate.** Article + FAQPage + BreadcrumbList is common for pillar pieces with FAQ sections.
+
+The schema audit takes 3 to 5 minutes per piece (less with automation; more on first-pass for new content types).
+
+---
+
+## Common failures
+
+**Brief specified link, writer skipped it.** Halt and return; brief-adherence catches this earlier in the QA sequence.
+
+**Anchor text identical across links.** Auto-fix in the editor pass; vary the anchor on at least 2 of every 3 same-target links.
+
+**Schema fails validation.** Auto-fix; the editor or a script ships the corrected schema.
+
+**Schema claims rating that is not on the page.** Halt and return; this is the manual-penalty risk.
+
+**Internal link count below brief.** Flag and return for the writer to add the missing links per the brief's specification.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The 6-step link audit, the 5-step schema audit, the anchor variation rule, the schema-content consistency rule, the optional-field discipline.
+
+## Implementation choices that stay internal
+
+The specific schema validation tooling (Google's tool, schema.org's tool, custom CI integration). The specific link checker (Screaming Frog, custom Puppeteer script, headless browser audit). The specific CMS integration that auto-populates schema from page metadata. The specific deployment pipeline that runs schema validation on every publish. These vary by stack and team.

--- a/skills/editorial-qa/references/qa-at-scale-patterns.md
+++ b/skills/editorial-qa/references/qa-at-scale-patterns.md
@@ -1,0 +1,184 @@
+# QA at scale patterns
+
+Sampling strategy, automated checks, manual review at scale, threshold gating.
+
+For pieces shipping at programmatic-SEO scale (100s to 100,000s of pages), full-audit QA is infeasible. The discipline below is sampling plus automated checks plus threshold gating. It is the same shape as the QA section in `programmatic-seo` but applied to the editorial QA gate specifically.
+
+---
+
+## Sampling strategy
+
+Random sample 50 to 200 pages per audit cycle. The sample is stratified.
+
+**Stratification dimensions.**
+
+- **Sparse vs dense data.** Sample some records with minimum-required fields; sample some with most-fields-populated. Sparse pages fail differently from dense pages; the sample needs both.
+- **Recent vs old.** Sample some pages generated in the last 30 days; sample some generated 12+ months ago. Recent pages catch template drift; old pages catch data drift.
+- **Popular vs niche categories.** Sample some pages from high-traffic parent categories; sample some from low-traffic ones. The popular categories carry the program's traffic; the niche ones surface long-tail-specific failures.
+- **Different cohort versions.** If the template has shipped revisions, sample some pages from each cohort. Cohort-specific failures only surface if the sample includes the cohort.
+
+**Sample size by set size.**
+
+- Set under 1,000 pages: sample 50 pages per cycle.
+- Set 1,000 to 10,000 pages: sample 100 pages per cycle.
+- Set 10,000 to 100,000 pages: sample 150 pages per cycle.
+- Set 100,000+ pages: sample 200 pages per cycle.
+
+**Cycle frequency.** Monthly for active sets (new pages generating, data refreshing). Quarterly for stable sets (mature programs in maintenance mode).
+
+---
+
+## Automated checks at scale
+
+Run on every page on a cadence; surface failures as a queue.
+
+### Heading-structure validation
+
+- One H1 per page, in the right place
+- H2 sequence reasonable (not orphan H3s, not H4 without H3)
+- Heading text length within bounds (no 200-character H2s)
+
+### Schema markup validation
+
+- Schema type present and matches the page's content type
+- Required fields populated
+- JSON-LD parses without errors
+- Schema does not claim things absent from the page
+
+### Word count
+
+- Pages below the floor (typically 600 words for editorial; varies for programmatic templates) get flagged
+- Pages above an upper bound (typically 8,000+ words on programmatic templates) get flagged for review
+
+### Duplicate content
+
+- Hash-similarity comparison across the set
+- Pages with >80% content overlap with another page in the set get flagged
+- Common cause: comparison-pivot pages (X vs Y inverse) without canonicalization
+
+### Broken links
+
+- Crawl outbound and internal links
+- 404s and 5xx responses get flagged
+- Both internal links to deleted pages and external links to dead URLs surface
+
+### Image presence
+
+- Pages where the template expects images but the image slot is empty
+- Programmatic pages with missing image fields render visibly broken
+
+---
+
+## Manual checks on sampled pages
+
+For sampled pages, the human review covers what automation misses.
+
+### Brief or template adherence
+
+- For editorial pages: did the writer execute the brief?
+- For programmatic pages: did the page execute the template?
+
+### Top-200-word answer quality
+
+- Read the first 200 words. Does the page answer the user's likely query?
+- Is the answer self-contained (could be cited as the canonical answer to the query)?
+
+### Distinctive vs templated
+
+- Compare the sampled page to two siblings in the same template cohort. Could you tell them apart on substance, not just on identifiers?
+- Templated pages that look identical signal weak data depth or weak template variable density.
+
+### User-intent satisfaction
+
+- If a real user landed on this page from the target SERP, would they stay or bounce?
+- The bounce-shaped pages are the failure mode; staying-shaped pages are the goal.
+
+### AI hallucination spot-check
+
+- For pages that involved AI in drafting or generation, spot-check 3 to 5 statistics, citations, or factual claims per sampled page.
+- Hallucination patterns surface in patterns; one bad page often signals a template-level or pipeline-level issue.
+
+### AI-tell pattern check
+
+- Sample a paragraph from the middle of the sampled page.
+- Does it match the AI tells from `ai-content-audit-patterns.md`?
+- Mid-page drift in programmatic pages signals the generation pipeline's output drifted; investigate.
+
+---
+
+## Threshold gating
+
+If more than 5% of sampled pages fail the manual review, halt new generation. Fix the template OR data quality issue before resuming.
+
+**The 5% threshold is empirical.** Programs that hold under 5% sample failure tend to maintain quality at scale; programs that drift above 5% tend to compound the failure into algorithm-update territory.
+
+**What "halt" means.**
+
+- New page generation stops.
+- The template or data fix is shipped.
+- The next sample audit confirms the fix improved the failure rate before generation resumes.
+
+**Why halt instead of "fix as you go."** Continuing to generate while quality degrades produces more pages that need to be fixed retroactively. Halting prevents the problem from compounding.
+
+**The threshold is not negotiable.** "Just ship the next batch and we will fix later" is the failure mode. The pattern produces sets that look fine at month 6 and get penalized at month 18.
+
+---
+
+## Cohort tracking
+
+Pages generated in one period rank differently from pages generated in another. That signals a template change or data quality drift; investigate.
+
+**Cohort cuts.**
+
+- Pages from a given month
+- Pages from a given template version
+- Pages from a given data-source version
+
+**Drift signals.**
+
+- **Cohort A pages rank top 10; cohort B pages rank position 30.** Template or data changed between cohorts; identify the change.
+- **Cohort A pages get cited; cohort B pages do not.** Template's above-the-fold answer changed shape; cohort B may have lost the citation pattern.
+- **Cohort A pages have stable engagement; cohort B pages have decaying engagement.** Cohort B may have a data freshness problem.
+
+Aggregate metrics hide problems. The set's overall rank looks fine if 80% of pages are stable and 20% are decaying. Cohort tracking surfaces the decaying 20% specifically.
+
+---
+
+## QA log
+
+Document each cycle's audit. The log compounds into pattern detection.
+
+**Log fields.** Cycle date, sample size, failure count, failure types, cohort distribution, threshold breach if any, halt action if triggered, fix shipped if applicable.
+
+**The patterns the log surfaces over time.**
+
+- Recurrent failure types (always the answer paragraph; always the schema; always the data freshness)
+- Cohort-specific patterns (cohort B always fails harder than cohort A)
+- Template versions that solved one problem and introduced another
+- Data sources that drift faster than expected
+
+The log is process improvement input. Quarterly review; act on patterns.
+
+---
+
+## When the sample reveals the program is broken
+
+Sometimes QC at scale reveals the underlying program is wrong, not just that individual pages need fixes.
+
+**Signals.**
+
+- 30%+ of sampled pages fail the manual review (data is too thin to support the template)
+- Failures cluster around a specific category (the dataset has a hole there; pSEO is generating pages from missing data)
+- Cohort decay is universal (the underlying competitive dynamics have shifted; the program's value proposition is decaying)
+
+The right response is not "fix individual pages." The right response is to revisit the program's design: data depth, template scope, cohort coverage. Sometimes the answer is to prune the program back to its strong segments and walk away from the weak ones.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The stratified sampling strategy, the 5% threshold, the automated check categories, the manual review checklist, the cohort tracking discipline, the QA log methodology.
+
+## Implementation choices that stay internal
+
+The specific tooling for storing and querying the QA log (database table, Notion, dbt model, BI tool). The specific automated check pipeline (CI integration, scheduled crawls, data warehouse queries). The specific sampling implementation (random ID selection script, weighted sampling logic). The specific dashboard or visualization for surfacing cohort patterns. These vary per team scale and tooling.

--- a/skills/editorial-qa/references/qa-workflow-templates.md
+++ b/skills/editorial-qa/references/qa-workflow-templates.md
@@ -1,0 +1,153 @@
+# QA workflow templates
+
+Ownership, sequencing, halt vs flag vs auto-fix, escalation patterns.
+
+The QA workflow is the operational shape of how QA actually runs. Templates below name the patterns; teams adapt the implementation to their own tooling.
+
+---
+
+## Ownership: single QA owner per piece
+
+The principle. One person is accountable for what shipped. Committees diffuse accountability; nobody owns a problem that reaches readers.
+
+**Common ownership models.**
+
+- **Editor-owns-piece.** The editor who reviews the piece is also accountable for what shipped. The same person sees the brief, reads the draft, runs QA checks, ships.
+- **Editor + dedicated QA.** Editor reviews voice and structure; dedicated QA runs fact-checks, link audits, schema validation. The editor is still the single point of accountability for ship-decision.
+- **Rotating editor pool.** Larger teams have multiple editors; each piece gets one named owner from the pool. The pool is calibrated quarterly so individual editors apply consistent standards.
+
+**Anti-pattern.** Committee review where 4 reviewers comment, nobody decides, the writer revises against contradictory feedback. The fix: name the decision-maker; treat other input as advisory.
+
+---
+
+## The sequencing template
+
+Run QA gates in this order. Each gate is cheaper than the next; running them in order saves the editor's time on pieces that should restart.
+
+1. **Brief-adherence.** First. Cheapest to run. Catches the largest class of failures.
+2. **Fact-accuracy.** Second. Halt-condition; AI hallucinations do not progress past this gate.
+3. **Structure and clarity.** Third. Identifies pieces that need structural revision before voice and SEO checks make sense.
+4. **AI-content audit.** Fourth. Catches AI tells, hallucinations not caught at gate 2, voice drift.
+5. **Voice consistency.** Fifth. Mid-piece sampling for long pieces.
+6. **SEO and AEO compliance.** Sixth. Most failures here are auto-fixable; rarely halt-conditions.
+7. **Internal linking and schema validation.** Seventh. Mostly auto-fix or flag.
+8. **Final read.** The last full read before publish. Catches anything the gate-by-gate review missed.
+
+The early gates (brief, fact, structure) save the most time; running them first means a piece that fails brief-adherence does not consume voice/SEO review time.
+
+---
+
+## Halt vs flag vs auto-fix taxonomy
+
+Each QA gate has a default action when failures appear.
+
+**Halt-conditions (return to writer).**
+
+- Brief-adherence failures. The contract was not executed.
+- Fact-accuracy failures (hallucinations, unverifiable claims). Cannot ship false claims.
+- Structural failures that require rewriting (buried lede, mismatched intent, missing facets). Cannot fix in editor pass.
+- Voice drift that requires rewriting sections. Cannot fix inline.
+
+**Flag-and-revise (editor flags; writer or editor revises).**
+
+- Voice consistency issues that are correctable inline.
+- Structural issues that need paragraph-level revision (sentence variety, transition smoothing).
+- AI tells that need targeted rewriting.
+- Specificity gaps where the writer needs to add the missing concrete claim.
+
+**Auto-fix (editor or script ships the correction without writer involvement).**
+
+- Slug, meta description, image alt text.
+- Schema markup formatting issues.
+- Anchor text variation when same-target links share identical anchors.
+- Heading structure mechanical fixes (closing orphan H3s).
+- Typos and minor grammar.
+
+The discipline. Most pieces have a mix: some auto-fix items, some flag-and-revise items, sometimes a halt-condition. The editor processes them in the right order: handle auto-fixes inline, batch flag-and-revise items into one return note, halt early if a halt-condition appears.
+
+---
+
+## Escalation patterns
+
+When QA finds a pattern (multiple pieces failing the same check), escalate to the brief author, the writer, or the editorial process owner. Pattern signals process problem, not just per-piece problem.
+
+### Brief-level patterns
+
+- Multiple writers fail brief-adherence on the same brief field. The brief is unclear about that field; tighten the brief template.
+- Multiple briefs surface the same gap (always missing the audience specification, always missing the success criteria). The brief authoring process needs feedback.
+
+### Writer-level patterns
+
+- One writer repeatedly produces pieces that fail at the same gate. The writer needs targeted feedback or different work.
+- One writer's pieces consistently need substantial revision. Either the briefs the writer receives need to be tighter, or the writer-fit is wrong for the work.
+
+### Process-level patterns
+
+- AI-content audit catches similar tells across pieces. The AI workflow needs additional guardrails.
+- Fact-accuracy gates catch repeated hallucinations on the same topic. The verification step for that topic needs more time.
+- Schema validation fails consistently on the same content type. The CMS template for that type needs updating.
+
+The escalation. Pattern goes to the editorial process owner with a short summary: "Across the last 12 pieces, 5 failed at [gate] for [reason]. Recommend [action]." The owner decides whether to update the brief template, retrain a writer, change the workflow, or document the pattern as known and accepted.
+
+---
+
+## QA review templates
+
+Common formats for capturing QA findings.
+
+### Halt-condition return note
+
+Short. The note specifies what failed and what needs to change.
+
+> "This piece needs revision before round 2. Three failures: [field 1] missing the brief specification of [X], [field 2] contains an unverified statistic on line [N], [field 3] reads as model-default voice in section 4. Revise per the brief and the voice doc."
+
+### Flag-and-revise inline review
+
+Inline comments in the editing tool. Each comment is short and actionable.
+
+- "[Brief required] Add internal link to [X] with anchor '[Y]' here."
+- "[Voice drift] This paragraph reads generic; pull back to brand voice."
+- "[Specificity] 'Many companies' is vague; add the source or remove the claim."
+
+### Auto-fix log entry
+
+The editor logs what was auto-fixed for the writer's awareness without requiring writer action.
+
+> "Auto-fixed during review: meta description tightened, schema markup field [X] added, anchor text varied on 2 links to [target]. No writer action required."
+
+### Escalation note
+
+Short summary to the editorial process owner.
+
+> "Pattern: 5 of 12 recent pieces have failed AI-content audit on em-dash count. The writer using AI assistance is shipping mid-stage drafts without final em-dash cleanup. Recommend a final-pass revision guideline added to the AI-co-author workflow doc."
+
+---
+
+## QA cycle time
+
+The discipline keeps QA cycle time tractable.
+
+**Typical times for a 1,500-word piece.**
+
+- Brief-adherence: 5 minutes
+- Fact-accuracy: 10 to 30 minutes (depending on claim density)
+- Structure and clarity: 10 minutes
+- AI-content audit: 5 minutes
+- Voice consistency: 5 minutes
+- SEO and AEO compliance: 10 minutes
+- Internal linking and schema: 5 minutes
+- Final read: 5 minutes
+
+**Total.** 55 to 75 minutes for a healthy piece. Pieces that halt at gate 1 or gate 2 take less editor time because the early gates short-circuit the rest.
+
+**The "QA takes longer than the writing" failure.** Usually means the wrong sequencing (running expensive checks before cheap ones). Fix the sequence; the cycle time drops.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The single-owner principle, the gate sequencing, the halt/flag/auto-fix taxonomy, the escalation patterns, the review templates, the cycle-time targets.
+
+## Implementation choices that stay internal
+
+The specific editing tool the team uses (Google Docs, Notion, Markdown PRs, headless CMS draft mode). The specific commenting and review workflow within that tool. The specific tracking system for QA logs and escalations (Notion, Linear, Jira, custom database). The specific reporting cadence and format for editorial process owners. These vary per team and tooling.

--- a/skills/editorial-qa/references/seo-aeo-compliance-checklist.md
+++ b/skills/editorial-qa/references/seo-aeo-compliance-checklist.md
@@ -1,0 +1,113 @@
+# SEO and AEO compliance checklist
+
+SEO and AEO checks combined into one workflow. The two-engine optimization principle holds: pieces that earn search rankings are largely the same pieces that earn AI citations.
+
+This checklist runs late in the QA sequence (after brief-adherence, fact-accuracy, structure, AI-content audit, voice). SEO and AEO failures are mostly auto-fixable; halting on them is rarely the right call.
+
+---
+
+## SEO checks
+
+### Title and headings
+
+- **Target keyword in title.** The brief's primary keyword appears in the page title; the title is 50 to 65 characters; the title reads naturally rather than keyword-stuffed.
+- **H1 present and matches title intent.** Some CMSs use the title as H1; some have separate H1. Either way, one H1 per page that establishes the topic.
+- **Heading hierarchy clean.** No orphan H3s (every H3 sits under an H2). No H4 without H3. The hierarchy is tree-shaped, not arbitrary.
+- **H2 keyword variation.** Supporting cluster keywords appear naturally across H2s without forcing.
+
+### Meta and URL
+
+- **Meta description compelling and keyword-aware.** 140 to 160 characters; includes the primary keyword without stuffing; reads as a benefit-statement that earns the click from SERP.
+- **URL slug short and descriptive.** Hyphens, lowercase, keyword-aware, date-free, under 60 characters. Generic example: `/feature-flag-rollout/kill-switches/`.
+- **Canonical URL set.** The piece has a canonical URL pointing to itself (or to the canonical version if this piece is a duplicate-by-design like an X vs Y comparison page).
+
+### On-page
+
+- **Image alt text descriptive.** Every image has alt text that describes the image's content, not "image of [thing]" or generic placeholders.
+- **External links open appropriately.** Most external links open in a new tab; rel attributes (`noopener`, `noreferrer`, `sponsored`, `nofollow`) match the link's purpose.
+- **Internal link count appropriate.** 3 to 7 internal links for a 1,500-word piece; 8 to 15 for a pillar piece. Below the floor signals under-linked; well above signals link-stuffing.
+
+---
+
+## AEO checks
+
+The AEO surface complements the SEO surface. AI engines weight different patterns; the checks below catch what AI engines specifically reward.
+
+### Answer paragraphs at H2 level
+
+- **40 to 60 word answer paragraph immediately following each H2 question.** AI engines extract these as citation candidates. The paragraph is self-contained: read alone, it answers the H2's specific question completely.
+- **Snippet-bait pattern repeats throughout.** Not just the top of the piece. Every H2 gets one.
+
+### TL;DR section
+
+- **Pillar pieces include a TL;DR section near the top.** 150 to 250 words. Self-contained. The most-cited section by AI engines for pillar-shaped content.
+- **TL;DR placement.** After the hero, before the table of contents. The reader sees TL;DR within the first scroll.
+
+### FAQ schema
+
+- **FAQ section with FAQPage schema.** Pieces that contain FAQ-shaped content (genuine reader questions with answers) mark the FAQ section with FAQPage structured data. Perplexity especially cites FAQPage content heavily.
+- **Genuine FAQs only.** Do not mark fake FAQs (questions nobody actually asks) with FAQPage schema. Search engines and AI engines detect fabricated FAQs and deprioritize.
+
+### Statistics with sources
+
+- **Specific statistics with cited sources.** AI engines weight statistics with sources higher than vague qualifiers. "23% of B2B buyers cite [specific source]" beats "many B2B buyers."
+- **The numbers are real.** Verify in the fact-accuracy gate; do not let hallucinated statistics ship just because they would help SEO/AEO.
+
+### Named entities
+
+- **Entity coverage matches brief.** The required entities from the brief are present; the standard entities are present where relevant; the gap entities are present where the brief committed to them.
+- **Entities mentioned with weight.** Pass the brief's depth-of-coverage requirement: not just "CUPED is mentioned in passing" but "CUPED is developed in the methodology H2 with the formula and an example."
+
+### Distinctive POV
+
+- **The piece takes a position.** AI engines preferentially cite content with attributable claims. "Kill switches should be the first safety mechanism designed, not the last" is a POV. "Kill switches are important" is not.
+- **The POV is consistent with brand stance.** Voice doc specified the brand stance; the piece's POV aligns.
+
+---
+
+## Auto-fix vs flag vs halt
+
+Most SEO/AEO failures are auto-fixable: the editor or a script can fix slug, meta description, image alt text, schema markup without writer involvement.
+
+Some require flag-and-revise: heading structure, internal link count, answer paragraph patterns. The editor flags; the writer revises.
+
+Halt-conditions are rare for SEO/AEO. The typical case where halt makes sense: the piece is structurally wrong for the target SERP (brief specified listicle; piece is long-form prose). That is a brief-adherence failure that surfaced late; route back to the brief-adherence gate.
+
+---
+
+## The combined SEO/AEO audit
+
+Run as one pass. The checks overlap (both reward heading structure, both reward depth, both reward freshness). Treating SEO and AEO as separate workflows doubles the audit time without doubling the catch rate.
+
+The discipline. One audit, one checklist, two-engine optimization mindset. The piece serves both surfaces or it serves neither well.
+
+---
+
+## Pillar-specific extensions
+
+Pillar pieces have additional SEO/AEO requirements.
+
+- **TL;DR section** (covered above)
+- **Comprehensive entity coverage.** Pillar pieces should mention 15 to 25 entities across the topic; cluster pieces have lower bars.
+- **Internal links to cluster pieces.** Pillar links out to each cluster piece via contextual anchors, not via a footer dump.
+- **Schema includes BreadcrumbList.** Tells crawlers and AI engines that this is the hub of a topical cluster.
+
+---
+
+## Programmatic-page-specific extensions
+
+For programmatic SEO pages, SEO/AEO checks adapt.
+
+- **Top-200-word answer.** First 200 words answer the user's specific query directly. AI engines cite programmatic data pages for factual queries primarily.
+- **Schema population at scale.** Every page has Article, Product, LocalBusiness, or other type-appropriate schema; schema fields populate from the same data that renders the visible page.
+- **Sampling discipline.** Full-audit SEO/AEO checks are infeasible at scale; sample 50 to 200 pages per cycle (see `qa-at-scale-patterns.md`).
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The combined SEO/AEO check sequence, the auto-fix/flag/halt taxonomy, the pillar-specific extensions, the programmatic-specific extensions.
+
+## Implementation choices that stay internal
+
+The specific tooling for automated SEO/AEO checks (Lighthouse audits, schema validators, headless-CMS-specific plugins). The specific schema-validation library or service. The specific staging environment where pre-publish checks run. The specific deployment pipeline that gates publish on SEO/AEO compliance. These vary by stack and team.

--- a/skills/editorial-qa/references/structure-and-clarity-review.md
+++ b/skills/editorial-qa/references/structure-and-clarity-review.md
@@ -1,0 +1,128 @@
+# Structure and clarity review
+
+Lede patterns, sectioning principles, endings, structural anti-patterns.
+
+Structure determines whether the piece works as a piece. The discipline below is about making structure visible enough to QA repeatably without becoming process theater.
+
+---
+
+## The lede
+
+The first 200 words. Two valid patterns depending on intent.
+
+**For SEO/AEO pieces.** The lede answers the user's likely query directly. The reader landed from a SERP looking for a specific answer; the lede provides it within the first 200 words. The rest of the piece develops the answer with depth.
+
+**For thought leadership.** The lede establishes the thesis. The reader is investing attention; the lede tells them the argument the piece will defend. The rest of the piece builds the case.
+
+**Lede failure patterns.**
+
+- **Welcome-to-our-blog throat-clearing.** The lede announces what the piece is about to do instead of doing it.
+- **Buried lede.** The actual answer or thesis appears in section 4. The reader bounced at section 2.
+- **Vague opening.** Generic descriptive paragraph that could open any article on the topic.
+- **History dump.** "Since the dawn of [topic]..." Cuts the throat-clearing; ledes do not need a history.
+
+---
+
+## Sectioning
+
+**The check.** H2s map to user mental model, not writer enthusiasm.
+
+**User mental model.** What questions does the reader bring? What questions follow naturally from the first answer? What does the reader want to know next? The H2 sequence answers these in order.
+
+**Writer enthusiasm.** What does the writer find interesting? Where does the writer want to dig deep? Writer enthusiasm produces sections that are well-written but mistargeted; the reader did not come for that section and skips it.
+
+**The audit.** Read the H2 list as a sequence of questions or topics. Does the sequence match what the reader's mind would ask in order? If H2 #4 has the answer the reader landed for, the structure has buried lede; promote H2 #4 to H2 #1.
+
+---
+
+## Section length
+
+**The check.** Even-ish across H2s.
+
+**Why even-ish matters.** One massive section followed by four 80-word sections signals broken structure. The massive section is doing real work; the 80-word sections are placeholders or filler.
+
+**The fix.**
+
+- If the 80-word sections are placeholders: cut them or expand them to the section's natural depth.
+- If the massive section is two facets bundled: split it into two H2s.
+- If the structure is genuinely uneven (one section needs to be twice as long for substantive reasons): document the rationale; ship with the imbalance acknowledged rather than hidden.
+
+---
+
+## Reading flow
+
+**The check.** Paragraphs connect; sentences vary in length.
+
+**Paragraph flow.** Each paragraph extends the previous one or pivots intentionally. Disconnected paragraphs read as bullet-points-pretending-to-be-prose. The fix: explicit connective tissue between paragraphs (the connection is implicit in the sequence, or the writer adds a one-sentence transition that does the work).
+
+**Sentence variety.** Reading aloud is the audit. Do all the sentences run the same length? That is a tell of AI-assisted writing or rushed drafting. Vary sentence length across the paragraph; mix short declarative sentences with longer ones that build through clauses.
+
+---
+
+## Specificity vs abstraction
+
+**The check.** Claims are concrete, not vague.
+
+**Concrete.** Named tools, named methods, named statistics with sources, named experts, named scenarios. Concrete claims earn citations from AI engines and trust from readers.
+
+**Abstract.** "Many companies struggle with X." "Studies show Y." "Industry leaders agree Z." Vague claims read as content marketing filler; AI engines and readers both deprioritize.
+
+**The fix.** Replace each abstract claim with a specific one. "Many companies struggle with X" becomes "73% of B2B SaaS companies surveyed by [source] report struggling with X." If the specific version requires research the writer did not do, halt and request the research before shipping.
+
+---
+
+## Endings
+
+**The check.** Piece concludes with something specific.
+
+**Specific endings.**
+
+- An action the reader can take now
+- A specific question that frames the next step
+- A concrete idea that lands as the takeaway
+- A direct call to action with a specific destination
+
+**Filler endings to cut.**
+
+- Wrap-up paragraphs that summarize what the piece just said
+- Wrap-up frames that announce the ending instead of arriving at it (the conclusion should land as a conclusion, not declare itself)
+- Vague "join us as we explore" closings
+- Marketing-tone CTAs that do not match the piece's voice
+
+The ending is the last thing the reader reads; it is the moment of conversion or memory. Filler endings waste the moment.
+
+---
+
+## Structural anti-patterns
+
+The patterns that surface in QA, with the fix for each.
+
+**Bullet-list overuse.** When prose would serve, the writer used bullets. Bullets fragment the reading flow and signal AI-assisted drafting. Convert bullets to prose where prose makes the connection between items clearer.
+
+**Subheading-fest.** Every paragraph has its own H3 subheading. Reads as outline-converted-to-content rather than written content. Cut subheadings to the structural ones; let prose carry between subheadings.
+
+**Repetitive paragraph structure.** Every paragraph is 2 or 3 sentences of similar length. Vary the structure: some paragraphs are one long sentence; some are 4 short sentences; some are a sentence and a fragment.
+
+**Forced bilateral framing.** "On one hand X, on the other hand Y" pattern repeated throughout. AI-tell. Pick a position; defend it; let the contrary position get one sentence rather than equal weight when the position is genuinely strong.
+
+**Throat-clearing transitions.** "That said," "With that in mind," "Moving on," "Now let us look at..." All filler. Cut them; the section heading does the transition work.
+
+---
+
+## The read-aloud audit
+
+The fastest structure check. Read the piece aloud (or silently with attention to rhythm).
+
+**Signals.** Where does the rhythm break? Where do you stumble? Where does the reading energy drop? Each break is a structural signal. Sometimes the fix is sentence-level; sometimes it is structural.
+
+**The discipline.** The read-aloud audit takes 10 minutes for a 1,500-word piece. It catches problems that line-by-line review misses. Build it into the QA workflow.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The lede patterns, the sectioning principles, the section-length discipline, the reading-flow audit, the specificity rule, the endings discipline, the structural anti-patterns, the read-aloud audit.
+
+## Implementation choices that stay internal
+
+The specific format the team uses for structural feedback (inline comments versus written summary versus structural diff). The specific tooling for documenting structural decisions on a piece (CMS metadata, brief addendum, separate review doc). The specific surface conventions per content type (the team's own blog vs help doc vs landing page structural patterns). These vary by team and stack.

--- a/skills/editorial-qa/references/voice-consistency-patterns.md
+++ b/skills/editorial-qa/references/voice-consistency-patterns.md
@@ -1,0 +1,108 @@
+# Voice consistency patterns
+
+Vocabulary, rhythm, stance, register. Mid-piece sampling discipline for long pieces. The voice-drift failure mode in AI-co-authored content.
+
+Voice is the most subjective QA dimension and often the easiest one to skip. The discipline below makes voice-consistency checking concrete enough to run repeatably.
+
+---
+
+## Vocabulary
+
+**The check.** Brand-specific vocabulary used correctly; off-brand vocabulary absent.
+
+**Brand vocabulary.** Each brand has a set of terms it uses (or refuses) consistently. Apple says "Mac," not "PC." Stripe says "developers," not "engineers." A B2B SaaS company might say "customers," not "users." A consumer brand might say "members," not "subscribers."
+
+**The audit.** Pull the brand voice doc's vocabulary section. Check the piece for each preferred term and each forbidden term. Failures: off-brand terms slipped in (the writer or AI assistant defaulted to industry-standard vocabulary instead of brand-specific).
+
+**Forbidden terms list.** Every brand has a list. Common patterns: corporate-speak adjectives, throat-clearing phrases, generic descriptors that flatten distinctive voice. The list is short (10 to 30 terms typically); reviewers should know it cold.
+
+---
+
+## Sentence rhythm
+
+**The check.** Sentence rhythm matches brand voice.
+
+**Three common rhythms.**
+
+- **Short and punchy.** Short sentences. Frequent paragraph breaks. Dramatic emphasis through structural choices.
+- **Measured and layered.** Longer sentences with subordinate clauses. Paragraphs build through accumulation. Conversational but considered.
+- **Colloquial.** Conversational rhythm with mid-sentence asides, contractions, and direct reader address. Reads like a smart person talking.
+
+**The audit.** Read 3 paragraphs aloud. Does the rhythm match the brand's voice doc? Common drift: AI-assisted pieces regress to a uniform medium-length sentence rhythm regardless of the brand's specified rhythm.
+
+---
+
+## Stance
+
+**The check.** The piece takes positions consistent with brand POV.
+
+**Brand stance varies.** Some brands are diplomatic and surface multiple sides without endorsing one. Others are opinionated and take clear positions. Others are coach-style and challenge the reader directly.
+
+**The audit.** Pick 3 to 5 places in the piece where the writer made a stance choice (a recommendation, a warning, an evaluation). Does each match the brand's stance pattern?
+
+**Voice drift signal.** AI-assisted pieces regress toward "diplomatic" stance even when the brand stance is opinionated. "There are good arguments on all sides" is the AI default; opinionated brands need to push the AI back toward conviction explicitly.
+
+---
+
+## Register
+
+**The check.** Formal versus casual matches the surface.
+
+**Surface determines register.** A whitepaper takes one register; a blog post takes another; a help doc takes a third. The brand voice doc usually specifies registers per surface type.
+
+**The audit.** Identify the surface this piece will publish on (blog, knowledge base, whitepaper, marketing page, product help). Check the piece's register against the surface-appropriate register.
+
+**Common drift.** Blog pieces drift formal (they read like watered-down whitepapers). Whitepapers drift casual (they read like long blog posts). Help docs drift either direction. The brand voice doc establishes register expectations; the QA check enforces them.
+
+---
+
+## Mid-piece sampling
+
+**The discipline.** Long pieces drift; sample throughout, not just at start and end.
+
+**Why drift happens.** Writers (human or AI) start in brand voice because that is what the brief, the opening prompt, and the recent context established. By section 4 of a 3,000-word piece, the writer's working memory has shifted to the topic at hand and the voice has drifted toward a generic baseline. AI-assisted pieces drift faster because the model's defaults reassert without continuous reinforcement.
+
+**The sampling pattern.**
+
+- **Start sample.** First 200 words. Voice should be strongest here.
+- **Middle samples.** Two paragraphs from the middle 60% of the piece. Voice should hold.
+- **End sample.** Last 200 words. Voice should match the start.
+
+If the start and end samples show brand voice and the middle samples show generic voice, the piece has voice drift. Send it back with the drifted sections highlighted.
+
+---
+
+## The voice-drift signal in AI-co-authored content
+
+Voice drift is the dominant voice failure in 2025-2026 content. AI assistants produce drafts that pass the start-and-end check (because the writer set up the opening prompt with brand voice cues) but fail the mid-piece check (because the model defaults reasserted in the middle).
+
+**The detection pattern.**
+
+- Mid-piece paragraphs use vocabulary not in the brand voice doc
+- Mid-piece sentence rhythm regresses to medium-length uniformity
+- Mid-piece stance becomes diplomatic where brand stance was opinionated
+- Mid-piece register drifts toward "professional neutral" regardless of the surface's intended register
+
+**The fix.** When mid-piece drift is detected, the revision pass needs to explicitly pull the voice back. The editor's note: "Sections 3 and 4 read as model-default. Revise with the voice doc's vocabulary, rhythm, and stance. Specifically: [3 specific fixes]."
+
+---
+
+## Voice calibration sessions
+
+Different editors apply voice judgment differently. Quarterly calibration sessions reduce the drift between editors.
+
+**The session.** Three editors review the same piece independently. Each writes a one-paragraph voice assessment. The team reads the three assessments together; differences in interpretation surface; the team reconciles to a shared standard.
+
+**The output.** A short addendum to the brand voice doc capturing the calibration consensus on whatever was contested. Over time the addenda accumulate into a sharper, more specific voice doc.
+
+**Why calibration matters.** Without it, voice judgment varies by editor; writers receive inconsistent feedback; voice drift compounds across the program. The calibration session is preventative; once the team is calibrated, individual reviews stay consistent.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The 4-dimension voice check (vocabulary, rhythm, stance, register), the mid-piece sampling discipline, the AI voice-drift detection pattern, the calibration session methodology.
+
+## Implementation choices that stay internal
+
+The specific brand voice doc format (Notion page, Markdown file, internal wiki page). The specific vocabulary list and the specific forbidden-term list (these are brand-specific and live in the brand's own documentation). The specific calibration session cadence and team composition. The specific tooling for archiving voice assessments. These vary per brand and team.


### PR DESCRIPTION
Fourth skill in Direction 6b content suite. Pre-publish QA framework with the AI-content audit as the load-bearing 2025-2026 addition.

## What

- 15-section SKILL.md (334 lines, ~3,000 words)
- 10 reference files (~10,500 words total)
- Each reference closes with the 'Methodology-level choices / Implementation choices' pattern established in skill 19

## Distinction (called out in Section 1)

6-skill content distinction matrix:
- `content-strategy` → program scope
- `pillar-content-architecture` → hub scope
- `content-brief-authoring` → per-piece scope
- `content-and-copy` → execution scope
- `programmatic-seo` → scaled scope
- this skill → **gate scope** (verifies before publish)

## Keystone framing

Catch-problems QA vs checkbox QA. Every check earns its keep by catching a class of failure that would reach readers if missed. The litmus test: if the team can name the last 3 problems each QA check caught, the check earns its keep. If a check has not caught anything in 6 months, it is theater.

## The AI-content audit (load-bearing novel content)

The QA check that did not exist as prominently 2 years ago. Section 7 of SKILL.md plus `references/ai-content-audit-patterns.md` (119 lines) cover:

- 11 AI tells (excessive em-dashes, predictable openings, bullet-list overuse, forced bilateral framing, hedge stacking, etc.)
- 6 hallucination patterns (specific decimals with named-source-that-does-not-exist, fabricated quotes, fake case studies, dead URLs, "studies show" with no study, made-up product features)
- Voice drift detection with mid-piece sampling
- A worked 4-paragraph AI-drafted excerpt with AI tells highlighted, then a revised version
- 7-step audit checklist

## display_order

`display_order: 7` (appended). Per the systemic-re-order pattern.

## Catalog

- 75 → 76 skills
- 216 → 226 reference files
- Content category 6 → 7 entries

## Quality gates

- Em-dash audit clean
- Forbidden phrase audit clean (3 initial matches in anti-pattern call-outs were rephrased to avoid the literal forbidden strings)
- Illumine scrub clean
- Methodology/implementation discipline check clean: zero `generateStaticParams`, `className=`, `tailwind`, `next/image`, `rampstack.co` matches
- All 10 reference files include the 'Methodology-level choices / Implementation choices' closing section
- `lint_skills.py`: 76 skills validated, 1 expected warning (documentation-strategy outlier preserved)
- Generator idempotent

Companion landing page in rampstackco-app PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)