### PR TITLE
feat(content): systemic display_order re-order for content category (Direction 6 wrap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,11 +294,11 @@ All 77 skills are shipped. Each has a complete SKILL.md plus at least one refere
 
 | # | Skill | What it does |
 |---|---|---|
-| 14 | [`content-and-copy`](skills/content-and-copy/SKILL.md) | Website copy, blog content, content production frameworks |
-| 15 | [`landing-page-copy`](skills/landing-page-copy/SKILL.md) | Landing pages, sales pages, hero-to-CTA flow |
-| 16 | [`email-sequences`](skills/email-sequences/SKILL.md) | Onboarding flows, lifecycle campaigns, transactional copy |
-| 17 | [`content-brief-authoring`](skills/content-brief-authoring/SKILL.md) | Per-piece editorial brief: target keyword, intent, audience, outline, entity coverage, internal linking, success criteria, and the discipline that distinguishes useful briefs from bloat |
-| 18 | [`pillar-content-architecture`](skills/pillar-content-architecture/SKILL.md) | Hub-level content architecture: pillar topic selection, cluster planning, internal linking, URL structure, pillar and cluster page anatomy, topical authority signals, refresh discipline |
+| 14 | [`pillar-content-architecture`](skills/pillar-content-architecture/SKILL.md) | Hub-level content architecture: pillar topic selection, cluster planning, internal linking, URL structure, pillar and cluster page anatomy, topical authority signals, refresh discipline |
+| 15 | [`content-brief-authoring`](skills/content-brief-authoring/SKILL.md) | Per-piece editorial brief: target keyword, intent, audience, outline, entity coverage, internal linking, success criteria, and the discipline that distinguishes useful briefs from bloat |
+| 16 | [`content-and-copy`](skills/content-and-copy/SKILL.md) | Website copy, blog content, content production frameworks |
+| 17 | [`landing-page-copy`](skills/landing-page-copy/SKILL.md) | Landing pages, sales pages, hero-to-CTA flow |
+| 18 | [`email-sequences`](skills/email-sequences/SKILL.md) | Onboarding flows, lifecycle campaigns, transactional copy |
 | 19 | [`programmatic-seo`](skills/programmatic-seo/SKILL.md) | Designing pSEO programs that work: data sources, template design, quality control at scale, internal linking, crawl budget, AEO/GEO patterns, refresh discipline, and when pSEO is and is not the right answer |
 | 20 | [`editorial-qa`](skills/editorial-qa/SKILL.md) | Pre-publish QA framework: brief adherence, voice consistency, fact accuracy, AI-content audit, AEO/SEO compliance, sampling at scale, and the workflow that distinguishes catch-problems QA from process theater |
 | 21 | [`ai-content-collaboration`](skills/ai-content-collaboration/SKILL.md) | How humans and AI compose in content workflows: participation boundaries, hybrid patterns, voice ownership, the AI slop problem, disclosure and transparency, team calibration, and the ethics of honest AI-assisted production |

--- a/skills/content-and-copy/SKILL.md
+++ b/skills/content-and-copy/SKILL.md
@@ -3,7 +3,7 @@ name: content-and-copy
 description: "Write or edit website copy, blog content, and editorial pieces with attention to voice, structure, and goal. Use this skill whenever the user wants to write an article, draft website copy, edit existing content for clarity or voice, write a blog post, or produce general editorial content. Triggers on write a blog post, draft an article, write copy for, edit this, rewrite this, write content, write a guide, draft a how-to, write web copy. Also triggers when content has been outlined and now needs to be written, or when existing content needs voice or clarity edits."
 category: content
 catalog_summary: "Website copy, blog content, content production frameworks"
-display_order: 1
+display_order: 3
 ---
 
 # Content and Copy

--- a/skills/content-brief-authoring/SKILL.md
+++ b/skills/content-brief-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: content-brief-authoring
 description: "How to author a content brief that actually guides a writer (human or AI) to produce a piece that ranks, converts, or both. Per-piece editorial brief: target keyword and cluster, search intent, audience and JTBD, heading structure, entity coverage for AEO/GEO, internal linking strategy, success criteria. The middle path between thin briefs (a keyword and a deadline) and thick briefs (a 4-page document nobody reads). Triggers on content brief, brief the writer, brief the article, brief authoring, content brief template, brief audit, per-piece brief, editorial brief, target keyword brief, search intent brief. Also triggers when briefing a human writer or an AI agent on a single content piece."
 category: content
 catalog_summary: "Per-piece editorial brief: target keyword, intent, audience, outline, entity coverage, internal linking, success criteria, and the discipline that distinguishes useful briefs from bloat"
-display_order: 4
+display_order: 2
 ---
 
 # Content Brief Authoring

--- a/skills/email-sequences/SKILL.md
+++ b/skills/email-sequences/SKILL.md
@@ -3,7 +3,7 @@ name: email-sequences
 description: "Design and write email campaigns and sequences including onboarding flows, lifecycle campaigns, transactional emails, newsletters, and broadcast sends. Use this skill whenever the user wants to write email copy, plan an email sequence, design an onboarding drip, or set up lifecycle email campaigns. Triggers on email sequence, drip campaign, onboarding email, lifecycle email, welcome email, transactional email, newsletter, email broadcast, nurture sequence, abandoned cart, re-engagement, win-back. Also triggers when planning email automation flows or writing email subject lines for campaigns."
 category: content
 catalog_summary: "Onboarding flows, lifecycle campaigns, transactional copy"
-display_order: 3
+display_order: 5
 ---
 
 # Email Sequences

--- a/skills/landing-page-copy/SKILL.md
+++ b/skills/landing-page-copy/SKILL.md
@@ -3,7 +3,7 @@ name: landing-page-copy
 description: "Write landing page copy with attention to the hero, value proposition, social proof, objection handling, and conversion-focused CTAs. Use this skill whenever the user wants to write a landing page, sales page, hero section, or any conversion-focused web copy. Triggers on landing page, sales page, hero copy, value proposition, headline, subheadline, hero section, CTA copy, conversion copy, opt-in page, squeeze page. Also triggers when the user has a marketing campaign or product launch needing dedicated conversion copy."
 category: content
 catalog_summary: "Landing pages, sales pages, hero-to-CTA flow"
-display_order: 2
+display_order: 4
 ---
 
 # Landing Page Copy

--- a/skills/pillar-content-architecture/SKILL.md
+++ b/skills/pillar-content-architecture/SKILL.md
@@ -3,7 +3,7 @@ name: pillar-content-architecture
 description: "How to design a content hub that earns topical authority. Pillar topic selection, cluster planning, internal linking architecture, URL structure, pillar and cluster page anatomy, topical authority signals for SEO and AEO/GEO, and the maintenance discipline that distinguishes intentional hubs from accidental orphans. Triggers on pillar content, content hub, topic cluster, topical authority, content architecture, hub and spoke, pillar page, cluster page, content silo, internal linking strategy. Also triggers when a content set is not ranking despite individual piece quality, when a pillar was launched without a cluster, or when content has accumulated without an architecture."
 category: content
 catalog_summary: "Hub-level content architecture: pillar topic selection, cluster planning, internal linking, URL structure, pillar and cluster page anatomy, topical authority signals, refresh discipline"
-display_order: 5
+display_order: 1
 ---
 
 # Pillar Content Architecture


### PR DESCRIPTION
**Direction 6 wrap, parallel to [rampstackco-app PR #52](https://github.com/rampstack/rampstackco-app/pull/52).**

Re-orders content-category display_order frontmatter to follow the pedagogical workflow order. Reading-order argument deferred across skills 17-21 per the agreed systemic-re-order pattern; this is that pass.

## Pre-existing state (chronological by ship date)

| Position | Skill |
|---|---|
| 1 | content-and-copy |
| 2 | landing-page-copy |
| 3 | email-sequences |
| 4 | content-brief-authoring |
| 5 | pillar-content-architecture |
| 6 | programmatic-seo |
| 7 | editorial-qa |
| 8 | ai-content-collaboration |

## New state (pedagogical workflow)

| Position | Skill | Role |
|---|---|---|
| 1 | pillar-content-architecture | Hub scope |
| 2 | content-brief-authoring | Per-piece brief |
| 3 | content-and-copy | Writing execution (general) |
| 4 | landing-page-copy | Specific writing format |
| 5 | email-sequences | Specific writing format |
| 6 | programmatic-seo | Scaled execution alternative |
| 7 | editorial-qa | Verification gate |
| 8 | ai-content-collaboration | Cross-cutting workflow |

5 SKILL.md files updated; 3 already at their target positions.

## Surfaced for awareness (out of scope to fix in this dispatch)

Three content-adjacent skills live in other categories upstream:

- `content-strategy` → `strategy-and-discovery` (display_order 5 there)
- `content-migration` → `cross-cutting` (display_order 2 there)
- `documentation-strategy` → `process-and-team` (display_order 2 there)

The rampstackco-app's local `content-and-copy` SkillCategoryId groups all of these together for UI presentation, but the upstream claude-skills uses different categories. Not wrong, just different mental models. Surfaced per the dispatch's instruction; out of scope to move them in this dispatch.

## Catalog

- **Skill count: 77 (unchanged)**
- **Reference file count: 235 (unchanged)**
- README content section re-ordered to pedagogical workflow

## Quality gates

- Em-dash audit clean across changed files
- Forbidden phrase audit unchanged from prior state (only display_order values modified)
- `lint_skills.py`: 77 skills validated, 1 expected warning (documentation-strategy 428-line outlier preserved)
- Generator idempotent (`--check` exit 0)
- README diff shows only the content category section re-ordered; no other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)