### PR TITLE
feat(skills): add Tier 2 content suite (4 skills, Direction 7 Dispatch A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-77-blue.svg)](#the-77-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-81-blue.svg)](#the-81-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 77 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 81 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -35,7 +35,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 77-skill catalog](#the-77-skill-catalog)
+- [The 81-skill catalog](#the-81-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -63,8 +63,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **77 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
-- **235 reference files** (templates, checklists, decision matrices, worked examples)
+- **81 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
+- **271 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -253,11 +253,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 77-skill catalog
+## The 81-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 77 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 81 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -290,7 +290,7 @@ All 77 skills are shipped. Each has a complete SKILL.md plus at least one refere
 | 12 | [`design-standards`](skills/design-standards/SKILL.md) | Production-grade page and component design standards |
 | 13 | [`art-direction`](skills/art-direction/SKILL.md) | Photography, illustration, and visual direction for campaigns |
 
-### Content (8)
+### Content (12)
 
 | # | Skill | What it does |
 |---|---|---|
@@ -302,6 +302,10 @@ All 77 skills are shipped. Each has a complete SKILL.md plus at least one refere
 | 19 | [`programmatic-seo`](skills/programmatic-seo/SKILL.md) | Designing pSEO programs that work: data sources, template design, quality control at scale, internal linking, crawl budget, AEO/GEO patterns, refresh discipline, and when pSEO is and is not the right answer |
 | 20 | [`editorial-qa`](skills/editorial-qa/SKILL.md) | Pre-publish QA framework: brief adherence, voice consistency, fact accuracy, AI-content audit, AEO/SEO compliance, sampling at scale, and the workflow that distinguishes catch-problems QA from process theater |
 | 21 | [`ai-content-collaboration`](skills/ai-content-collaboration/SKILL.md) | How humans and AI compose in content workflows: participation boundaries, hybrid patterns, voice ownership, the AI slop problem, disclosure and transparency, team calibration, and the ethics of honest AI-assisted production |
+| 22 | [`long-form-content-frameworks`](skills/long-form-content-frameworks/SKILL.md) | Structural patterns for individual long-form pieces (case studies, whitepapers, research reports, definitive guides, manifestos, ebooks, long-form tutorials) that distinguish publication-quality work from bloggy-long padding or academic bloat |
+| 23 | [`content-refresh-system`](skills/content-refresh-system/SKILL.md) | Systematic content refresh: quarterly audits, refresh prioritization, refresh-vs-merge-vs-delete decisions, the lifecycle discipline that distinguishes intentional programs from set-and-forget decay |
+| 24 | [`content-repurposing`](skills/content-repurposing/SKILL.md) | Cross-format content adaptation: one piece becomes many (blog series, email, social, webinar, podcast, video) with per-format adaptation rather than mass-blast that ignores medium constraints |
+| 25 | [`content-distribution`](skills/content-distribution/SKILL.md) | Content distribution discipline: owned, earned, and paid channels matched to audience and content type. Channel-fit decisions, distribution cadence, the strategic alternative to spam-everywhere or hope-and-pray |
 
 ### SEO foundation (7)
 
@@ -309,13 +313,13 @@ Tool-agnostic SEO skills. These define the conceptual frameworks. The SEO audit 
 
 | # | Skill | What it does |
 |---|---|---|
-| 22 | [`seo-onpage`](skills/seo-onpage/SKILL.md) | Single-page audits and optimization across 8 dimensions |
-| 23 | [`seo-technical`](skills/seo-technical/SKILL.md) | Crawlability, indexability, rendering, schema, page experience |
-| 24 | [`seo-keyword`](skills/seo-keyword/SKILL.md) | Discovery, intent classification, clustering, prioritization |
-| 25 | [`seo-competitor`](skills/seo-competitor/SKILL.md) | SERP overlap, content gaps, backlink gaps, technical comparison |
-| 26 | [`seo-offpage`](skills/seo-offpage/SKILL.md) | Link building, digital PR, citations, linkable assets |
-| 27 | [`seo-content-audit`](skills/seo-content-audit/SKILL.md) | Keep/update/merge/redirect/delete decisions across a site |
-| 28 | [`seo-aeo-geo`](skills/seo-aeo-geo/SKILL.md) | AI search optimization, llms.txt, extraction-friendly content |
+| 26 | [`seo-onpage`](skills/seo-onpage/SKILL.md) | Single-page audits and optimization across 8 dimensions |
+| 27 | [`seo-technical`](skills/seo-technical/SKILL.md) | Crawlability, indexability, rendering, schema, page experience |
+| 28 | [`seo-keyword`](skills/seo-keyword/SKILL.md) | Discovery, intent classification, clustering, prioritization |
+| 29 | [`seo-competitor`](skills/seo-competitor/SKILL.md) | SERP overlap, content gaps, backlink gaps, technical comparison |
+| 30 | [`seo-offpage`](skills/seo-offpage/SKILL.md) | Link building, digital PR, citations, linkable assets |
+| 31 | [`seo-content-audit`](skills/seo-content-audit/SKILL.md) | Keep/update/merge/redirect/delete decisions across a site |
+| 32 | [`seo-aeo-geo`](skills/seo-aeo-geo/SKILL.md) | AI search optimization, llms.txt, extraction-friendly content |
 
 ### SEO audit suite (Ahrefs MCP-powered) (7)
 
@@ -323,64 +327,64 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 
 | # | Skill | What it does |
 |---|---|---|
-| 29 | [`seo-audit-orchestration`](skills/seo-audit-orchestration/SKILL.md) | Master orchestrator: sequences the suite, produces a rollup report |
-| 30 | [`seo-backlink-audit`](skills/seo-backlink-audit/SKILL.md) | Profile health, anchor mix, toxic links, reclamation, gap analysis |
-| 31 | [`seo-keyword-gap-audit`](skills/seo-keyword-gap-audit/SKILL.md) | Competitor keyword gaps with opportunity scoring and clustering |
-| 32 | [`seo-content-gap-audit`](skills/seo-content-gap-audit/SKILL.md) | Missing topics, thin coverage, outdated content, decay diagnosis |
-| 33 | [`seo-traffic-diagnosis`](skills/seo-traffic-diagnosis/SKILL.md) | Diagnose drops, stalls, or wins via 5-layer root cause analysis |
-| 34 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
-| 35 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
+| 33 | [`seo-audit-orchestration`](skills/seo-audit-orchestration/SKILL.md) | Master orchestrator: sequences the suite, produces a rollup report |
+| 34 | [`seo-backlink-audit`](skills/seo-backlink-audit/SKILL.md) | Profile health, anchor mix, toxic links, reclamation, gap analysis |
+| 35 | [`seo-keyword-gap-audit`](skills/seo-keyword-gap-audit/SKILL.md) | Competitor keyword gaps with opportunity scoring and clustering |
+| 36 | [`seo-content-gap-audit`](skills/seo-content-gap-audit/SKILL.md) | Missing topics, thin coverage, outdated content, decay diagnosis |
+| 37 | [`seo-traffic-diagnosis`](skills/seo-traffic-diagnosis/SKILL.md) | Diagnose drops, stalls, or wins via 5-layer root cause analysis |
+| 38 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
+| 39 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
 ### Product (10)
 
 | # | Skill | What it does |
 |---|---|---|
-| 36 | [`pm-spec-writing`](skills/pm-spec-writing/SKILL.md) | PRDs, user stories, acceptance criteria, dev briefs |
-| 37 | [`roadmap-planning`](skills/roadmap-planning/SKILL.md) | Quarterly planning, prioritization, dependency mapping |
-| 38 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
-| 39 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
-| 40 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
-| 41 | [`experimentation-analytics`](skills/experimentation-analytics/SKILL.md) | Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation |
-| 42 | [`experimentation-platform-orchestrator`](skills/experimentation-platform-orchestrator/SKILL.md) | Pick the right experimentation platform, migrate when wrong, coordinate when multi-platform: a decision framework for Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon |
-| 43 | [`product-analytics-setup`](skills/product-analytics-setup/SKILL.md) | Instrument product analytics correctly: event taxonomy, properties, naming conventions, schema versioning, funnels, retention cohorts, North Star selection, and the instrumentation debt that compounds without discipline |
-| 44 | [`data-warehouse-experimentation`](skills/data-warehouse-experimentation/SKILL.md) | Run experiments out of the warehouse: SQL assignment, exposure logs, dbt metric definitions, statistical analysis, variance reduction with CUPED, sequential testing, and the operational tradeoffs vs platforms |
-| 45 | [`feature-launch-playbook`](skills/feature-launch-playbook/SKILL.md) | The operational discipline of launching a feature well: positioning, internal alignment, customer comms, sales enablement, support readiness, rollout strategy, monitoring, and post-launch measurement |
+| 40 | [`pm-spec-writing`](skills/pm-spec-writing/SKILL.md) | PRDs, user stories, acceptance criteria, dev briefs |
+| 41 | [`roadmap-planning`](skills/roadmap-planning/SKILL.md) | Quarterly planning, prioritization, dependency mapping |
+| 42 | [`integration-orchestrator`](skills/integration-orchestrator/SKILL.md) | Sequence creative-direction work across phases, gates, handoffs, and QA verification |
+| 43 | [`experiment-design`](skills/experiment-design/SKILL.md) | Hypothesis to decision: sample size, duration, segment analysis, interpretation, and the failure modes that produce wrong shipping calls |
+| 44 | [`feature-flagging`](skills/feature-flagging/SKILL.md) | Flags as production infrastructure: types, naming, lifecycle, targeting, rollout, stale flag cleanup, governance |
+| 45 | [`experimentation-analytics`](skills/experimentation-analytics/SKILL.md) | Read result panels without fooling yourself: confidence intervals, p-values, multiple testing, sequential testing, CUPED, ratio metrics, network effects, dashboard reconciliation |
+| 46 | [`experimentation-platform-orchestrator`](skills/experimentation-platform-orchestrator/SKILL.md) | Pick the right experimentation platform, migrate when wrong, coordinate when multi-platform: a decision framework for Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon |
+| 47 | [`product-analytics-setup`](skills/product-analytics-setup/SKILL.md) | Instrument product analytics correctly: event taxonomy, properties, naming conventions, schema versioning, funnels, retention cohorts, North Star selection, and the instrumentation debt that compounds without discipline |
+| 48 | [`data-warehouse-experimentation`](skills/data-warehouse-experimentation/SKILL.md) | Run experiments out of the warehouse: SQL assignment, exposure logs, dbt metric definitions, statistical analysis, variance reduction with CUPED, sequential testing, and the operational tradeoffs vs platforms |
+| 49 | [`feature-launch-playbook`](skills/feature-launch-playbook/SKILL.md) | The operational discipline of launching a feature well: positioning, internal alignment, customer comms, sales enablement, support readiness, rollout strategy, monitoring, and post-launch measurement |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 46 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 47 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 48 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 49 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 50 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 51 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 52 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 53 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 50 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 54 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 51 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 52 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 53 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 54 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 55 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 56 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 57 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 58 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 59 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 55 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 56 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 57 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 58 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 59 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 60 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 61 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 62 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 63 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 60 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 61 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 64 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 65 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Marketing (3)
 
@@ -388,37 +392,37 @@ Paid media discipline: strategy, creative, and performance analytics. Pairs with
 
 | # | Skill | What it does |
 |---|---|---|
-| 62 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
-| 63 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
-| 64 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
+| 66 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
+| 67 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
+| 68 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
 
 ### Research (3)
 
 | # | Skill | What it does |
 |---|---|---|
-| 65 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 66 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 67 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 69 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 70 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 71 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 68 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 69 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 70 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 71 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 72 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 72 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 73 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 74 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 75 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 76 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 73 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 74 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 75 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 76 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 77 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 77 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 78 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 79 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 80 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 81 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/skills/content-distribution/SKILL.md
+++ b/skills/content-distribution/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: content-distribution
+description: "Content distribution as a discipline. Owned channels (newsletter, blog, social), earned channels (PR, syndication, mentions), paid channels (boosted posts, syndication networks), and the channel-fit decisions that distinguish strategic distribution from spam-everywhere. Audience-channel matching, content-channel matching, distribution cadence. Triggers on content distribution, channel strategy for content, owned earned paid channels, content amplification, content promotion, audience-channel matching, content-channel matching, distribution cadence, syndication strategy, organic distribution. Also triggers when content is publishing but reach is low, when the team is distributing on every channel without strategy, or when the content program needs a distribution discipline rather than just publication."
+category: content
+catalog_summary: "Content distribution discipline: owned, earned, and paid channels matched to audience and content type. Channel-fit decisions, distribution cadence, the strategic alternative to spam-everywhere or hope-and-pray"
+display_order: 12
+---
+
+# Content Distribution
+
+A senior editorial leader's playbook for content distribution as a discipline. Owned, earned, and paid channels matched to audience and content type, with the channel-fit decisions that distinguish strategic distribution from spam-everywhere or hope-and-pray.
+
+Content distribution is half the work and gets a fraction of the attention. Most programs spend 90% of capacity on production and 10% on distribution; the resulting ratio of effort-to-reach is consistently poor. The teams producing content that reaches audiences are the ones who treat distribution as a real discipline: channels chosen for fit, cadence calibrated to audience attention, owned-earned-paid balance set by program strategy, and effectiveness measured per channel.
+
+This skill is the channel discipline. Different from `content-repurposing` (which turns one piece into many formats), this skill is about getting content TO audiences via the right channels. The two skills compose: repurpose first, then distribute the right format on the right channel.
+
+The voice is the senior editorial leader who has watched programs underperform because distribution was treated as posting-after-publishing rather than as the equal half of the work.
+
+When to use this skill: building a distribution discipline for a content program, auditing why content publishes consistently but reach is low, calibrating owned-earned-paid balance, designing channel-fit decisions for a multi-format program.
+
+---
+
+## What this skill is for
+
+This skill spans channel selection, audience-channel matching, content-channel matching, and distribution cadence. The content suite distinction:
+
+- `content-strategy` decides what to produce.
+- `pillar-content-architecture` designs the topical hub.
+- `content-brief-authoring` briefs each piece.
+- `content-and-copy` writes pieces.
+- `editorial-qa` verifies before publish.
+- `content-repurposing` turns one piece into many formats (transformation).
+- **`content-distribution` (this skill)** gets content TO audiences via channels (channel work).
+
+The distinction from `content-repurposing` is load-bearing. Repurposing is transformation work: turning one piece INTO many formats, each adapted for its medium. Distribution is channel work: getting content to audiences via the right channels. They compose: repurpose first, then distribute the right format on the right channel.
+
+The audience: editorial leads, content directors, content ops managers, in-house teams running content programs that need reach, agencies running distribution for clients.
+
+What is not in scope: paid acquisition for purposes other than content amplification (covered by `paid-media-strategy`), the specific email channel discipline (covered by `email-sequences`), the AI-search optimization layer that sits across distribution channels (covered partially by `seo-aeo-geo`).
+
+---
+
+## Hope-and-pray vs spam-everywhere vs channel-fit
+
+The keystone framing.
+
+**Hope-and-pray.** Publish and assume readers will find it. The piece goes live; the team links it on the blog homepage; maybe shares it once on social; assumes search and word of mouth will carry it. Output: most pieces reach a fraction of their potential audience because no deliberate distribution work was done. The program produces good content that nobody encounters.
+
+**Spam-everywhere.** Blast every piece on every channel regardless of fit. Every piece on LinkedIn, Twitter/X, Facebook, Threads, Mastodon, Bluesky, plus 5 emails to the full list, plus paid promotion on every platform. Audience tunes out; channels deprioritize the program; trust degrades. AI tooling has made spam-everywhere cheap and increasingly common, which makes the audience reaction sharper.
+
+**Channel-fit.** Distribute through channels matched to audience and content type. Specific channels chosen for specific pieces. Cadence calibrated to each channel's audience attention rhythm. Owned-earned-paid balance set by program strategy. Output: each distribution choice produces engagement from audiences who actually want the content; the program's distribution capacity is concentrated where it produces value.
+
+The litmus test. Ask of any distribution decision: which audience is this piece for, where does that audience consume content, does the piece's format fit that channel's conventions, and at what cadence does the channel reward presence? If the answers are specific, the distribution is channel-fit. If the answers are "everyone, everywhere, every channel, all the time," the distribution is spam-everywhere.
+
+---
+
+## Channel taxonomy
+
+Three categories with sub-types within each.
+
+**Owned channels.** Channels the program owns and controls.
+
+- **Newsletter and email.** Direct relationship with subscribers. High control over reach (every subscriber receives the email); lower scale than social.
+- **Blog and content site.** Owned property where pieces live. Search and direct traffic; the canonical version of pieces.
+- **Social channels owned by the program.** LinkedIn company page, X account, YouTube channel, podcast feed, Instagram account. Owned in the sense that the program runs the account; not owned in the sense that the platform controls reach.
+- **Communities and forums owned by the program.** Slack communities, Discord servers, dedicated discussion forums. Direct relationship with members.
+
+**Earned channels.** Channels where content reaches audiences via third-party amplification, not paid placement.
+
+- **PR and press coverage.** Journalists, podcasters, newsletter operators who cover the program's content because it is newsworthy or insightful.
+- **Syndication.** Other publications republishing or excerpting the program's content (with appropriate attribution and canonical signaling).
+- **Mentions and citations.** Other content marketing programs, industry analysts, AI search engines citing the program's content.
+- **Word of mouth and shares.** Audiences sharing pieces with their networks; the program's content becoming part of conversations.
+
+**Paid channels.** Channels where paid spending amplifies content.
+
+- **Boosted social posts.** Paying to extend reach of an organic post on LinkedIn, X, Facebook, Instagram.
+- **Promoted newsletter sends.** Sponsored placements in third-party newsletters.
+- **Syndication networks.** Outbrain, Taboola, native-content networks that distribute content via paid placement on third-party sites.
+- **Search advertising for content.** Paying for clicks on content pieces (less common; usually content is the organic side and paid is the conversion side).
+- **Sponsored podcast or content placements.** Pre-rolls, mid-rolls, sponsored segments in industry podcasts or newsletters.
+
+Detail in `references/channel-taxonomy.md`.
+
+---
+
+## Audience-channel matching
+
+Where the target audience actually consumes content. The distribution decision starts here.
+
+**The audit.**
+
+- Identify the audience for the program (or for the specific piece).
+- Map where that audience spends time in their professional or consumer life.
+- Identify the channels in that audience map where the audience is genuinely engaged (not just present).
+- Match content distribution to those channels.
+
+**Common audience-channel maps.**
+
+- **B2B technical audiences.** LinkedIn high engagement; X moderate engagement (specific communities); industry newsletters; specific industry forums; podcasts in their domain.
+- **B2B executive audiences.** LinkedIn high engagement; specific executive newsletters and podcasts; conferences and analyst-influence channels.
+- **Consumer mass audiences.** Instagram, TikTok, YouTube, Facebook depending on demographic; broad email if subscribed.
+- **Niche specialist audiences.** Specific subreddits, Discord servers, specialized newsletters, niche podcasts. Often higher engagement on smaller channels than on broad social.
+- **Developer audiences.** GitHub, Hacker News, specific subreddits, dev-focused podcasts and newsletters, Twitter/X for parts of the community.
+
+**The mismatch failure.** Distributing on channels where the audience is present but not engaged produces low reach and low engagement. A B2B technical program publishing TikToks may technically reach audiences on TikTok but engage few of them; the audience is on TikTok for entertainment, not for technical learning.
+
+Detail in `references/audience-channel-matching.md`.
+
+---
+
+## Content-channel matching
+
+Which formats fit which channels. Beyond audience match, the format must fit the channel's conventions.
+
+**Format-channel fit examples.**
+
+- Long-form analytical text fits blog, newsletter, LinkedIn long posts, X threads (for the right communities). Does not fit TikTok, Instagram Reels, or short-form video platforms.
+- Short-form video fits TikTok, Reels, Shorts, increasingly LinkedIn video. Does not fit newsletter (where text leads) or owned blog (where written long-form leads).
+- Statistic-driven content fits social with quote-graphics, AI search snippets, podcast mentions. Does not fit (as primary format) newsletter where context develops the stat.
+- Conversational expert content fits podcasts, video interviews, possibly long social threads. Does not fit short-form video or single-post-format social.
+
+**The mismatch failure.** Distributing a format on a channel where the format does not fit produces low engagement. A 5,000-word whitepaper on TikTok (even repurposed) may not fit the format expectations of TikTok audiences regardless of audience overlap.
+
+**The compose-with-repurposing pattern.** When the audience is on a channel but the format does not fit, the right answer is often to repurpose into a format that does fit (see `content-repurposing`), then distribute. The composition is "repurpose for fit, distribute on channel."
+
+Detail in `references/content-channel-matching.md`.
+
+---
+
+## Distribution cadence
+
+How often, what mix, sustaining vs campaign rhythm.
+
+**Cadence axes.**
+
+- **Frequency per channel.** How often the program posts to each channel.
+- **Mix.** What proportion of distribution is owned vs earned vs paid; what proportion is original vs derivative.
+- **Rhythm.** Sustaining baseline cadence vs campaign spikes around flagship launches.
+
+**Common cadence patterns.**
+
+- **B2B program with content-led demand generation.** Newsletter weekly. Blog 2-4 posts per week. LinkedIn 3-5 posts per week. X 5-10 posts per week. Quarterly campaign spikes for flagship launches.
+- **Consumer brand with broad-audience reach goals.** Daily Instagram content. Weekly newsletter. TikTok 2-4 posts per week. Owned blog 1-2 posts per week. Continuous paid amplification.
+- **Niche specialist program with concentrated audience.** Newsletter weekly or bi-weekly. Owned blog 1-2 posts per month. Social on specific platforms 2-3 posts per week. Earned channels prioritized over paid.
+
+**Sustaining vs campaign.**
+
+- **Sustaining cadence.** The baseline rhythm. Audiences expect this cadence; deviation (long pauses or sudden spikes) affects engagement.
+- **Campaign rhythm.** Spikes around flagship launches, major announcements, or significant events. Concentrated cross-format distribution that briefly exceeds the sustaining cadence.
+
+**The cadence audit.** Programs that publish in fits and starts (3 posts in one week, then nothing for 3 weeks) underperform programs with steady cadence. Audience attention rewards predictability.
+
+Detail in `references/distribution-cadence-patterns.md`.
+
+---
+
+## Owned-channel discipline
+
+Owned channels are the program's most reliable distribution. The discipline keeps them effective.
+
+**Newsletter.** Direct subscriber relationship; near-100% delivery to inboxes (modulo spam filtering). Cadence consistency matters: weekly is the most common cadence for B2B; bi-weekly works for higher-investment formats. Each send earns the next; sloppy sends lose subscribers.
+
+**Blog.** Canonical home for long-form content. SEO compounds over time; internal linking earns authority. The blog is where pieces persist; social and email send audiences to the blog.
+
+**Social channels owned by the program.** LinkedIn, X, Instagram, etc. Reach is platform-controlled (not the program's), but the program controls what publishes and when. Algorithmic favor varies; content that the platform's algorithm rewards gets reach beyond the follower base.
+
+**Podcast.** Owned distribution is the show feed; subscribers receive new episodes. Episodes also live on the blog with show notes; the show notes are an SEO asset.
+
+**Communities.** Slack, Discord, forums where the program facilitates discussion. The community is the audience the program is most directly engaged with; distribution to the community is the most reliable engagement signal.
+
+**The owned-channel anti-pattern: starvation.** Programs that under-invest in owned channels become dependent on third-party distribution. When platforms change algorithms, when paid costs rise, when earned channels go quiet, the program's reach collapses. Owned-channel investment is the durable foundation.
+
+Detail in `references/owned-channel-discipline.md`.
+
+---
+
+## Earned-channel work
+
+Earned channels reach audiences the program cannot reach directly. The work to earn the channel is real.
+
+**PR and press.** Pitching journalists, podcasters, newsletter operators on the program's content. Effective when the content is genuinely newsworthy or insightful; ineffective when pitches feel like blast emails.
+
+**Syndication.** Negotiating with other publications to republish or excerpt the program's content with appropriate attribution and canonical signaling. The syndication earns reach; the canonical link preserves SEO value.
+
+**Mentions and citations.** Earning mentions in other programs' content. Often happens when the program's pieces are genuinely useful as references; pieces that are generic or surface-level rarely get cited.
+
+**AI search citation.** Earning citations from AI search engines. Increasingly important as AI search grows; pieces designed for citation (see `content-repurposing`'s AEO extraction patterns) get cited at higher rates.
+
+**Word of mouth and shares.** Audiences sharing pieces with their networks. The hardest to earn deliberately; pieces that are genuinely valuable get shared.
+
+**The earned-channel investment.** Earned channels require relationship-building, pitch quality, and content quality. Programs that try to "do PR" with mass-blast pitches earn nothing; programs that invest in genuine relationships earn ongoing channel access.
+
+Detail in `references/earned-channel-work.md`.
+
+---
+
+## Paid promotion of organic content
+
+When boosting organic content earns its keep.
+
+**The pattern.** A piece publishes organically; some pieces show strong engagement signals; the program boosts those pieces with paid spend to extend reach. The paid spend is on content that the audience has already validated.
+
+**When boosting fits.**
+
+- The piece has demonstrated organic engagement (high CTR, high time-on-page, organic shares).
+- The audience addressable through paid amplification overlaps with the program's target audience.
+- The piece's value is clear enough that paid amplification produces engagement, not just impressions.
+
+**When boosting fails.**
+
+- Boosting low-engagement pieces because the calendar said so. Paid spend on content the audience does not engage with produces wasted budget.
+- Boosting pieces that drive volume but not value. Pieces that produce clicks but not engagement may be drawing the wrong audience; paid amplification compounds the wrong-audience problem.
+- Treating paid content amplification as a substitute for organic distribution. Paid amplifies what organic validated; paid alone produces transactional reach without the audience relationship organic builds.
+
+**The mix.** Most strong programs allocate 0-20% of distribution capacity to paid content amplification. Programs heavily dependent on paid promotion are usually programs that have not yet built owned and earned distribution.
+
+Detail in `references/paid-promotion-patterns.md`.
+
+---
+
+## Distribution measurement
+
+Which channels actually drive value. The discipline that prevents distribution-theater.
+
+**Per-channel metrics.**
+
+- **Reach.** How many people the channel surfaces the content to.
+- **Engagement.** Click-through, time-on-page, scroll depth, completion rate (varies by format).
+- **Conversion.** Newsletter signups, content downloads, qualified-lead actions, sales-cycle progression.
+- **Attribution.** Which channels drove the audience members who eventually converted.
+
+**Channel-level analysis.**
+
+- Which channels produce the highest engagement-per-distribution-effort? Some channels look impressive (high reach) but produce low engagement.
+- Which channels produce the highest conversion? Reach without conversion is vanity; conversion is value.
+- Which channels' performance is changing over time? Algorithm shifts, audience migrations, and competitive landscape changes affect channel effectiveness.
+
+**Cross-channel attribution.** The same audience member encounters the program on multiple channels before converting. Single-touch attribution misrepresents which channels matter; multi-touch attribution is more accurate but harder to implement.
+
+**The measurement-honest program.** Cuts channels that consistently underperform. Increases investment in channels that consistently produce. Adjusts cadence based on engagement patterns, not on arbitrary publishing schedules.
+
+Detail in `references/distribution-measurement.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-distribution-failures.md`.
+
+- "We publish but reach is low." Hope-and-pray pattern; no deliberate distribution work happening.
+- "We post on every channel and engagement is flat." Spam-everywhere pattern; distribution capacity diluted across channels where the audience is not engaged.
+- "Newsletter open rates are dropping." Cadence may be wrong, or list quality declining, or content not earning the open. Investigate.
+- "Our LinkedIn engagement keeps falling." Possible algorithm shift; possible content-channel mismatch; possible cadence issue.
+- "Our PR pitches are getting ignored." Mass-blast pitching; relationships not built; pitches not specific to recipient.
+- "We invest heavily in paid but engagement is low." Paid amplifying low-organic-engagement content; paid as substitute for owned development.
+- "We do not know which channels are working." Measurement absent; program operating on channel-presence rather than channel-effectiveness.
+- "Content publishes but audiences do not see it." Distribution treated as posting; cadence wrong; channels mismatched to audience.
+- "We launched campaign distribution but it landed quietly." Campaign rhythm not earned by sustaining cadence; audiences not primed to attention-spike.
+- "Our owned audience is small." Long-term investment in owned channels skipped; program dependent on third-party distribution.
+- "Earned channels are not producing." Treating earned as automatic; relationships not built; pitches not earning.
+- "Paid distribution costs are rising." Auction dynamics on paid platforms; programs heavily dependent on paid see costs rise without offsetting owned/earned investment.
+
+---
+
+## The framework: 12 considerations for content distribution
+
+When designing or auditing a distribution program, walk these 12 considerations.
+
+1. **Channel-fit, not hope-and-pray or spam-everywhere.** Specific channels for specific audiences and formats.
+2. **Channel taxonomy understood.** Owned, earned, paid; sub-types within each; which channels the program actually uses.
+3. **Audience-channel matching.** Where the target audience actually engages, not just where they are present.
+4. **Content-channel matching.** Format fits the channel's conventions and audience expectations.
+5. **Distribution cadence calibrated.** Per-channel frequency, owned-earned-paid mix, sustaining-vs-campaign rhythm.
+6. **Owned-channel discipline.** Newsletter, blog, social channels owned by the program, possibly podcast and community. Long-term investment.
+7. **Earned-channel work.** PR, syndication, mentions, AI-search citation. Relationship investment.
+8. **Paid promotion of organic content.** Boost pieces that have organic engagement; do not substitute paid for owned.
+9. **Cross-channel attribution.** How audiences encounter the program across channels before converting.
+10. **Per-channel measurement.** Reach, engagement, conversion. Channels that underperform get cut.
+11. **Sustaining-vs-campaign rhythm.** Baseline cadence plus campaign spikes for flagship launches.
+12. **Distribution capacity allocation.** Real budget; not done in the cracks.
+
+The output of the framework is a distribution program where each channel choice is deliberate, each cadence decision matches audience attention, each measurement informs the next decision, and the program's reach grows because the work is concentrated where it produces value.
+
+---
+
+## Reference files
+
+- [`references/channel-taxonomy.md`](references/channel-taxonomy.md) - Owned, earned, paid with sub-types. Newsletter, blog, social, communities, PR, syndication, mentions, boosted social, syndication networks, sponsored placements.
+- [`references/audience-channel-matching.md`](references/audience-channel-matching.md) - Where audiences actually engage. Common audience-channel maps. The presence-vs-engagement distinction.
+- [`references/content-channel-matching.md`](references/content-channel-matching.md) - Format-channel fit. The compose-with-repurposing pattern. The format-mismatch failure mode.
+- [`references/distribution-cadence-patterns.md`](references/distribution-cadence-patterns.md) - Frequency, mix, rhythm. Sustaining vs campaign. Common cadence patterns by program type.
+- [`references/owned-channel-discipline.md`](references/owned-channel-discipline.md) - Newsletter, blog, social, podcast, community discipline. The starvation anti-pattern.
+- [`references/earned-channel-work.md`](references/earned-channel-work.md) - PR, syndication, mentions, AI-search citation, word of mouth. Relationship investment.
+- [`references/paid-promotion-patterns.md`](references/paid-promotion-patterns.md) - Boosting organic content. When paid amplification fits and when it fails. The paid-as-substitute anti-pattern.
+- [`references/distribution-measurement.md`](references/distribution-measurement.md) - Per-channel metrics, channel-level analysis, cross-channel attribution, the measurement-honest program.
+- [`references/common-distribution-failures.md`](references/common-distribution-failures.md) - 11+ failure patterns with diagnoses and fixes.
+
+---
+
+## Closing: distribution is half the work
+
+Most content programs are production-heavy and distribution-light. The teams producing flagship pieces typically spend 90% of capacity producing and 10% distributing; the resulting reach matches the inverse ratio. Pieces that took 60 hours to produce reach a fraction of their potential audience because the 6 hours allocated to distribution were not enough to do the channel work.
+
+The discipline is not "distribute more"; it is "distribute deliberately." Channel-fit decisions concentrate distribution work where it produces value. Owned-channel investment builds durable foundations. Earned-channel relationships accumulate over years. Paid promotion amplifies what organic validated. Measurement informs what to keep and what to cut.
+
+When in doubt about whether a distribution program is ready, ask: are channels chosen for fit, is audience-channel matching deliberate, do formats fit channels, is cadence calibrated, is owned-channel investment in place, are earned-channel relationships being built, is paid amplification on organically-validated pieces, is measurement informing the next decisions? If yes to all of those, the program is real. If no to any, the gap is where reach will fall short of what the production work earned.

--- a/skills/content-distribution/references/audience-channel-matching.md
+++ b/skills/content-distribution/references/audience-channel-matching.md
@@ -1,0 +1,172 @@
+# Audience-channel matching
+
+Where audiences actually engage. Common audience-channel maps. The presence-vs-engagement distinction that prevents distributing on channels where the audience is technically present but not actually paying attention.
+
+The first and most consequential distribution decision is which channels to invest in. Most programs over-invest in channels with high audience presence but low audience engagement, and under-invest in smaller channels where the audience is genuinely paying attention. The audit shifts capacity to where engagement happens.
+
+---
+
+## The presence-vs-engagement distinction
+
+A channel where the audience is present is not necessarily a channel where the audience is engaging.
+
+**Presence.** Members of the target audience have accounts on the platform. They could see the program's content if they encountered it.
+
+**Engagement.** Members of the target audience are actively using the platform for the kind of content the program produces. They click; they comment; they share; they convert.
+
+**The mismatch failure mode.** A B2B technical program publishing TikTok content. The audience may have TikTok accounts (presence), but the audience is on TikTok for entertainment, not for B2B technical learning (low engagement for the program's content). The presence creates a false signal that the channel might work; the engagement reality is that distribution capacity goes to a low-return channel.
+
+**The audit question.** Not "is the audience on this channel?" but "is the audience consuming this kind of content on this channel?"
+
+---
+
+## Common audience-channel maps
+
+Mappings that show up repeatedly across program types. Programs should still validate against their own audience research; the maps below are starting points.
+
+### B2B technical audiences
+
+Engineers, technical decision-makers, developer-influencers, technical product managers.
+
+**High engagement.** LinkedIn (especially long-form posts and articles); X/Twitter (specific technical communities); industry-specific newsletters; specialized podcasts; specific subreddits and Discord servers; GitHub for code-adjacent content; technical conferences and analyst-influenced channels.
+
+**Moderate engagement.** YouTube for tutorial and conference-talk content; Hacker News for specific topics; vendor-platform community sites (AWS, Azure, GCP forums; specific tool communities).
+
+**Low engagement.** TikTok, Instagram, Facebook for the program's primary content. Some technical professionals consume these for entertainment but rarely for technical content.
+
+### B2B executive audiences
+
+C-suite, VPs, senior strategy leaders.
+
+**High engagement.** LinkedIn (long-form posts, articles, sometimes video); specific executive newsletters and podcasts; analyst-influence channels (Gartner, Forrester); event-driven media (high-quality conferences, executive roundtables).
+
+**Moderate engagement.** Industry-specific publications; some podcasts; X/Twitter for specific topics with executive commentary.
+
+**Low engagement.** Most consumer-focused social platforms. Executives often have low time for content consumption; the channels where they engage are concentrated.
+
+### Consumer mass audiences
+
+Broad consumer demographics for B2C brands.
+
+**High engagement.** Instagram, TikTok, YouTube, Facebook (varies by demographic age and interest). Email newsletter for engaged subscribers. Pinterest for visual-product categories. Specific subreddits for interest-driven topics.
+
+**Moderate engagement.** X/Twitter (declining for many consumer demographics). LinkedIn (low for most consumer use cases).
+
+**Low engagement.** Most B2B-oriented channels.
+
+### Niche specialist audiences
+
+Concentrated audiences within specific domains (cybersecurity professionals, fertility-tracking enthusiasts, specific hobby communities).
+
+**High engagement.** Specific subreddits, Discord servers, specialized newsletters and podcasts. Often higher engagement on smaller channels than on broad platforms.
+
+**Moderate engagement.** Domain-specific Twitter/X communities; some LinkedIn; YouTube for educational content.
+
+**Low engagement.** Broad social platforms where the audience is small fraction of total platform population.
+
+### Developer audiences
+
+Software developers across stacks and seniority levels.
+
+**High engagement.** GitHub (code-adjacent content); Hacker News (specific topics); specific subreddits; Twitter/X for parts of the dev community; dev-focused podcasts and newsletters; YouTube for tutorial content.
+
+**Moderate engagement.** LinkedIn for senior developers; Stack Overflow for Q&A-driven content (different distribution model than programs typically use); Discord servers for specific tools.
+
+**Low engagement.** TikTok, Instagram, Facebook, Pinterest for primary content.
+
+### Founder and startup audiences
+
+Founders, startup operators, early-stage investors.
+
+**High engagement.** Twitter/X (the founder community has historically been engaged here); LinkedIn for some segments; specific newsletters (Lenny's, Substack-based founder newsletters); specific podcasts; YC-adjacent forums.
+
+**Moderate engagement.** YouTube for some long-form content; specific subreddits.
+
+**Low engagement.** Most mass-consumer platforms.
+
+---
+
+## The audience-channel audit
+
+A short framework for matching audience to channels.
+
+1. **Define the target audience specifically.** Not "marketers" but "B2B SaaS marketing leaders at companies with 50-500 employees, primarily in North America and Western Europe." Specificity unlocks the matching.
+2. **Map where this audience spends time professionally.** Where do they get news, learn new ideas, hear from peers, encounter products?
+3. **Map where this audience spends time consuming the kind of content the program produces.** Different from professional time generally; specific to the content type.
+4. **Identify channels where the audience engages.** Not just where they have accounts. Engagement signals: comments, shares, conversion behaviors.
+5. **Score channels by engagement potential.** High, moderate, low. The high-engagement channels get primary distribution capacity.
+
+---
+
+## Audience-research methods for the audit
+
+How to actually identify where audiences engage.
+
+**Customer interviews.** Ask existing customers where they consume content related to the program's topic. The answers are the audience's revealed-preference distribution map.
+
+**Audience surveys.** Quantitative confirmation of channel-engagement patterns. Surveys can over-represent platforms respondents feel they should use; the customer interviews ground-truth the survey data.
+
+**Existing program data.** Where does the program's existing audience come from? Referral data, UTM analysis, conversion attribution. Channels that produce existing audience are channels where the audience is engaging with the program.
+
+**Competitive analysis.** Where do competing programs distribute? Where do they appear to earn engagement (visible signals: comments, shares, mentions)? Competitive distribution patterns inform but should not dictate the program's choices.
+
+**Industry research.** Some industry research firms publish channel-engagement data by audience segment. Useful as starting points; should be triangulated with the program's own data.
+
+---
+
+## The audience-channel mismatch failure mode
+
+The pattern when audience-channel matching is skipped.
+
+**The symptom.** The program publishes consistently on multiple channels. Engagement is flat or declining. Distribution capacity is spread thin. The team cannot identify which channels are working because none of them are working clearly.
+
+**The diagnosis.** Channels were chosen by industry default ("everyone is on LinkedIn") or by capacity availability ("we can post on TikTok") rather than by audience-engagement match.
+
+**The cure.** Run the audience-channel audit. Cut channels where the audience is present but not engaged. Increase investment in channels where the audience is genuinely engaged. The total distribution capacity stays the same; the allocation shifts.
+
+**Recovery time.** Cutting underperforming channels and concentrating capacity on engaging channels typically produces visible engagement improvements within 4-8 weeks.
+
+---
+
+## When audience-channel maps shift
+
+Audiences move across channels over time. Maps that fit a program 3 years ago may not fit now.
+
+**Common shifts.**
+
+- Twitter/X engagement has declined for many B2B audiences as the platform has changed; LinkedIn has absorbed some of the shifted attention.
+- TikTok has expanded into demographics it did not initially serve.
+- Newsletter consumption has grown across most audience types as inbox-based content consumption has become more accepted.
+- AI-search citation has emerged as a distribution channel that did not exist meaningfully before 2024.
+
+**The audit cadence.** Run the audience-channel audit at least annually. Maps that have not been refreshed for 18+ months are likely outdated.
+
+---
+
+## The audience-channel-content-type triangle
+
+Audience-channel matching is one of three matching decisions; content-channel matching is another (see `content-channel-matching.md`); the third is content-audience matching (the source piece is for the right audience in the first place).
+
+**The triangle.**
+
+- Audience matches channel.
+- Content matches channel.
+- Content matches audience.
+
+**The failure modes.**
+
+- Audience-channel mismatch: distribution where the audience is not engaged.
+- Content-channel mismatch: format does not fit the channel's conventions.
+- Content-audience mismatch: the piece is not actually for the channel's audience even if both fit individually.
+
+The triangle is what produces channel-fit distribution. All three matchings need to hold for distribution to produce engagement.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The presence-vs-engagement distinction, the common audience-channel maps, the audience-channel audit, audience-research methods, the mismatch failure mode, the map-shift recognition, the audience-channel-content-type triangle.
+
+## Implementation choices that stay internal
+
+Specific audience-research surveys and interview templates. Specific UTM tracking and attribution conventions. Specific competitive analysis tooling. Specific channel-engagement scoring rubrics. The team's own audience-segment definitions. These vary by team, audience, and tooling.

--- a/skills/content-distribution/references/channel-taxonomy.md
+++ b/skills/content-distribution/references/channel-taxonomy.md
@@ -1,0 +1,215 @@
+# Channel taxonomy
+
+Owned, earned, paid with sub-types. The full taxonomy that grounds channel-fit decisions.
+
+Programs that distribute well think in terms of the taxonomy. Programs that distribute poorly think in terms of "social media" or "content marketing" without distinguishing the categories. The distinction matters because owned, earned, and paid channels have different cost structures, different reach characteristics, and different roles in a program's distribution mix.
+
+---
+
+## Owned channels
+
+Channels the program owns and controls.
+
+### Newsletter and email
+
+The most direct owned distribution.
+
+**Characteristics.** Direct relationship with subscribers. The program controls what sends, when, and to whom. Near-100% delivery to inboxes (modulo spam filtering and engagement-based deliverability adjustments).
+
+**Strengths.** No platform algorithm between the program and the audience. Engagement is cleanly measured. Audience commitment signal is strong (people who subscribe and stay subscribed are valuable signal).
+
+**Weaknesses.** Slow to grow vs broad-reach social channels. Each subscriber is real work to acquire and retain.
+
+**The newsletter discipline.** Cadence consistency, content quality matching subscriber expectations, single-CTA-per-send, deliverability hygiene. See `email-sequences` for the email-specific discipline.
+
+### Blog and content site
+
+The program's content home.
+
+**Characteristics.** Owned property where pieces live as canonical versions. Search traffic compounds over years. Internal linking earns authority. Direct traffic from audiences who know the property.
+
+**Strengths.** Compounding asset. Content that earns search position keeps producing traffic indefinitely. Full design and presentation control.
+
+**Weaknesses.** Slow to start producing meaningful traffic. SEO investment is multi-year. Without distribution to the blog, pieces sit unread.
+
+**The blog discipline.** Architecture and technical SEO foundations (see `seo-technical`); pillar and cluster organization (see `pillar-content-architecture`); refresh discipline (see `content-refresh-system`); on-page optimization (see `seo-onpage`).
+
+### Social channels owned by the program
+
+LinkedIn company page, X account, YouTube channel, podcast feed, Instagram account, etc.
+
+**Characteristics.** The program runs the account; the platform controls reach via algorithms. Reach varies by platform algorithm changes, audience size, content engagement signals.
+
+**Strengths.** Larger potential audience than newsletter. Algorithmic favor can produce reach beyond follower base when content earns engagement signals.
+
+**Weaknesses.** Platform-controlled reach. Algorithm shifts can dramatically reduce reach without warning. Audiences are renting the platform; the program does not own the relationship the way newsletter signals ownership.
+
+**The owned-social discipline.** Per-platform conventions; cadence calibrated to platform attention rhythm; content adapted for platform; engagement-signal optimization; account-health hygiene.
+
+### Podcast
+
+Owned audio distribution.
+
+**Characteristics.** The show feed is owned; subscribers receive new episodes through their podcast app. Episodes also live on the blog with show notes; cross-platform distribution (Spotify, Apple Podcasts, YouTube) extends reach.
+
+**Strengths.** Intimate audience relationship. High engagement when audience is loyal. Long-form context for substantive content. Show notes are SEO assets.
+
+**Weaknesses.** Production cost is real (audio quality, editing, hosting). Discoverability depends on platform algorithms and word-of-mouth.
+
+**The podcast discipline.** See podcast-specific format conventions; show notes as derivative format; consistent episode cadence; cross-platform distribution for reach.
+
+### Communities
+
+Slack communities, Discord servers, dedicated discussion forums.
+
+**Characteristics.** Direct relationship with members. The program facilitates discussion; members engage with each other and with program content.
+
+**Strengths.** Highest-engagement audience the program has. Community feedback informs content and product. Members become advocates.
+
+**Weaknesses.** Community management is meaningful work. Communities require continuous facilitation; abandoned communities decay and signal decline.
+
+**The community discipline.** Active moderation; sustained value-delivery to members; integration with the broader content program (members get access; program content is shared in community).
+
+---
+
+## Earned channels
+
+Channels where content reaches audiences via third-party amplification, not paid placement.
+
+### PR and press coverage
+
+Journalists, podcasters, newsletter operators who cover the program's content.
+
+**Characteristics.** Third parties cover the program's content because it is newsworthy, insightful, or fits their editorial agenda. The program does not pay for coverage; the value exchange is editorial fit.
+
+**Strengths.** External authority signal. Reach into audiences the program does not have direct relationships with. Often higher trust signal than program's own distribution.
+
+**Weaknesses.** Hard to predict; relationship-dependent; pitches that miss editorial fit produce nothing.
+
+**The PR discipline.** Genuine relationship-building with relevant journalists. Pitches specific to recipient and to actual newsworthy content. Quality over quantity; mass-blast pitches earn no coverage and damage future relationship potential.
+
+### Syndication
+
+Other publications republishing or excerpting the program's content.
+
+**Characteristics.** Programs negotiate with other publications to republish or excerpt their content. Canonical link signaling preserves SEO value. Attribution is mandatory.
+
+**Strengths.** Reach into the syndication partner's audience. Some pieces reach more readers via syndication than via owned distribution.
+
+**Weaknesses.** Negotiation overhead. Risk of authority dilution if canonical signaling is wrong. Partners may discontinue syndication; the program cannot rely on syndication as primary distribution.
+
+**The syndication discipline.** Canonical link tags; clear attribution; partner relationship management; selective syndication (not every piece warrants syndication).
+
+### Mentions and citations
+
+Other content marketing programs, industry analysts, AI search engines citing the program's content.
+
+**Characteristics.** External programs reference the program's content as a source. The program's authority signal compounds with each citation.
+
+**Strengths.** Compounding authority. Long-term backlink and citation profile that informs SEO and AI-search positioning.
+
+**Weaknesses.** Largely outside the program's direct control. The program can produce citation-worthy content (specific data, framework introductions, primary research) but cannot force citation.
+
+**The citation-earning discipline.** Produce content with citation hooks: original data, named frameworks, primary research, contrarian-but-defensible positions. Pieces that are generic rarely get cited; pieces that are specifically valuable do.
+
+### Word of mouth and shares
+
+Audiences sharing pieces with their networks.
+
+**Characteristics.** The program's content becomes part of conversations beyond the program's distribution. Most valuable when sharing happens in private channels (DMs, Slack channels, internal corporate emails) where the program cannot directly track.
+
+**Strengths.** Highest-trust distribution. A piece shared by a colleague carries more weight than the same piece in a feed.
+
+**Weaknesses.** Hard to measure; hard to engineer deliberately. Pieces that earn word-of-mouth are pieces that are genuinely valuable to the audience.
+
+**The word-of-mouth discipline.** Produce content that audiences want to share. Specific, useful, citation-worthy. Avoid generic content that nobody bothers to share even if they read it.
+
+---
+
+## Paid channels
+
+Channels where paid spending amplifies content.
+
+### Boosted social posts
+
+Paying to extend reach of an organic post on LinkedIn, X, Facebook, Instagram.
+
+**Characteristics.** The program pays the platform to show the post to additional audiences (often defined by audience targeting parameters). The post still appears as an owned post; the paid spend extends its reach.
+
+**Strengths.** Quick to deploy; extends reach of pieces that have demonstrated organic engagement; measurable.
+
+**Weaknesses.** Costs accumulate; auction dynamics drive prices up over time; pieces that performed organically may not maintain engagement at scaled paid reach.
+
+**The boost discipline.** Boost pieces with strong organic engagement signals; do not boost pieces that did not earn engagement organically; treat boost spend as amplification of validation, not as substitute for organic.
+
+### Promoted newsletter sends
+
+Sponsored placements in third-party newsletters.
+
+**Characteristics.** The program pays a third-party newsletter to feature its content. The newsletter audience sees the program's content alongside the newsletter's editorial content.
+
+**Strengths.** Reach into newsletter audiences with strong attention rhythms. Often higher engagement than broad social paid amplification.
+
+**Weaknesses.** Requires negotiation; sponsorship feels different from editorial; price-per-send varies.
+
+**The sponsored-newsletter discipline.** Match the newsletter's audience and tone; sponsored content that fits the newsletter feels like value; sponsored content that clashes feels like an ad.
+
+### Syndication networks
+
+Outbrain, Taboola, native-content networks that distribute content via paid placement on third-party sites.
+
+**Characteristics.** Programs pay per click; content appears on third-party sites in "you may also like" or "recommended for you" placements.
+
+**Strengths.** Volume reach at variable cost; geographic and audience targeting.
+
+**Weaknesses.** Quality of audience varies; engagement often low; reputation challenges (some networks have brand-safety concerns).
+
+**The syndication-network discipline.** Test cautiously; measure beyond clicks (engagement, time-on-page); some networks fit some programs and not others.
+
+### Search advertising for content
+
+Paying for clicks on content pieces.
+
+**Characteristics.** Less common; usually search ads target conversion-intent queries while content takes the organic side. Some programs use search ads to drive traffic to specific high-value content.
+
+**Strengths.** High-intent audiences; quick reach for high-value content.
+
+**Weaknesses.** Cost-per-click on competitive queries; content that converts via paid clicks usually has clear conversion signals.
+
+**The content-search-ads discipline.** Reserve for content with clear conversion or lead-capture goals; measure paid traffic against owned-traffic comparison; high-value content only.
+
+### Sponsored podcast or content placements
+
+Pre-rolls, mid-rolls, sponsored segments in industry podcasts or newsletters.
+
+**Characteristics.** The program pays to be featured in a third-party podcast or newsletter, often via host-read endorsement.
+
+**Strengths.** Host-read endorsements carry strong trust signal. Audiences of niche podcasts and newsletters are highly engaged.
+
+**Weaknesses.** Cost varies; production quality matters; mismatched host-program fit damages both.
+
+**The sponsored-placement discipline.** Match host audience to program audience; provide hosts with substantive talking points; measure on engagement signals beyond impressions.
+
+---
+
+## Channel mix evolution over program maturity
+
+Programs at different stages have different channel mixes.
+
+**Early-stage programs.** Heavy owned-channel investment (newsletter, blog). Limited earned (relationships not yet built). Limited paid (budget often constrained). The early program is building the foundation.
+
+**Mid-stage programs.** Owned channels producing reliable distribution. Earned channels developing (PR relationships, syndication, mentions accumulating). Paid amplification of best organic pieces.
+
+**Mature programs.** Owned channels are reliable foundations. Earned channels are significant traffic and authority sources. Paid amplification is strategic, not load-bearing.
+
+**The maturity audit.** Programs heavily dependent on paid distribution often have under-invested in owned and earned. The dependency is visible: when paid budgets cut, reach collapses; when paid costs rise (as they do over time on auction-based platforms), program effectiveness degrades.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The owned/earned/paid taxonomy with sub-types, the characteristics and disciplines per sub-type, the channel mix evolution by program maturity, the maturity audit.
+
+## Implementation choices that stay internal
+
+Specific platform tooling per channel. Specific community management software. Specific PR-relationship CRMs. Specific paid-platform configurations and bidding strategies. Specific syndication-network vendor selections. The team's own conventions for channel-mix targets at different program stages. These vary by team, budget, and program shape.

--- a/skills/content-distribution/references/common-distribution-failures.md
+++ b/skills/content-distribution/references/common-distribution-failures.md
@@ -1,0 +1,193 @@
+# Common distribution failures
+
+Twelve-plus failure patterns with diagnoses and cures. The cross-cutting pattern: most distribution failures share a single root, which is treating distribution as posting-after-publishing rather than as the equal half of the work.
+
+---
+
+## Failure 1: Hope-and-pray (publish and wait)
+
+**Symptom.** The program publishes consistently. Reach is low. The team is unclear why; the content seems strong.
+
+**Diagnosis.** No deliberate distribution work. Publishing is treated as the end of the work; audiences are expected to find the content via search, social, and word of mouth without proactive distribution.
+
+**Cure.** Apply the channel-fit discipline. Identify which channels the audience engages on; distribute deliberately on those channels with appropriate format adaptation. Treat distribution as half the work.
+
+**Capacity recovery.** Programs that shift from hope-and-pray to deliberate distribution typically see 2-5x reach improvements within 8-12 weeks.
+
+---
+
+## Failure 2: Spam-everywhere
+
+**Symptom.** The program posts on every channel: LinkedIn, X, Facebook, Threads, Bluesky, Instagram, TikTok, plus 5 emails per week, plus paid promotion on every platform. Engagement is flat across all channels.
+
+**Diagnosis.** Distribution capacity diluted across channels where the audience is not engaged. Each channel gets cursory attention; none gets enough to produce real engagement.
+
+**Cure.** Apply the audience-channel matching discipline. Cut channels where the audience is present but not engaged. Concentrate capacity on channels that produce engagement.
+
+**Recovery time.** Cutting underperforming channels and concentrating capacity typically produces visible engagement improvements within 4-8 weeks.
+
+---
+
+## Failure 3: Newsletter open rates declining
+
+**Symptom.** The newsletter open rate has declined from 35% to 22% over 6 months. Subscribers are not opening sends.
+
+**Diagnosis.** Multiple possible causes. Cadence may be wrong (too aggressive or too sparse). List quality may be declining (lapsed subscribers depressing engagement signal). Subject lines may not be earning the open. Content may not be matching subscriber expectations.
+
+**Cure.** Diagnose first. Pull cohort data: are recent subscribers opening at higher rates than long-term subscribers (suggests content fit decline)? Are sends with specific subject-line patterns performing better (suggests subject line issue)? Is open rate consistent across send-times (rules out timing)?
+
+Apply the relevant fix: list pruning for lapsed subscribers; subject-line improvement; cadence adjustment; content recalibration.
+
+---
+
+## Failure 4: LinkedIn engagement falling
+
+**Symptom.** LinkedIn engagement on the program's posts has declined. Comments, shares, and reach signals all lower than 6 months ago.
+
+**Diagnosis.** Multiple possible causes. Algorithm shift; content-channel mismatch; cadence issue; account-health degradation. LinkedIn algorithm changes have affected many programs over the past several years.
+
+**Cure.** Audit content quality (does it match what worked previously?). Audit cadence (within platform-rewarded range?). Check account-health signals (engagement on others' content, not just own posts; profile completeness; consistent branding). If algorithm shifts are the cause, content patterns may need recalibration to fit current algorithmic preferences.
+
+---
+
+## Failure 5: PR pitches ignored
+
+**Symptom.** The program pitches journalists for coverage. Most pitches get ignored. Coverage is rare.
+
+**Diagnosis.** Mass-blast pitching, or relationships not built before pitching, or pitches not specific to recipient.
+
+**Cure.** Apply the relationship-first PR principle (see `earned-channel-work.md`). Build relationships with relevant journalists over months before pitching. Pitch specific to recipient with reference to their recent work. Reduce pitch volume; increase pitch quality.
+
+**Timeline.** PR relationships build over 1-3 years. Programs in mass-blast mode cannot fix this in a quarter; the cure is multi-year.
+
+---
+
+## Failure 6: Heavy paid investment, low engagement
+
+**Symptom.** The program spends significantly on paid amplification. Engagement metrics are low. Cost-per-engagement keeps rising.
+
+**Diagnosis.** Paid amplification is amplifying low-organic-engagement content. Or paid is substituting for owned-channel investment. Or both.
+
+**Cure.** Apply the boost-organic pattern. Only boost pieces that have demonstrated organic engagement. Reduce paid spend on pieces without organic validation. Reallocate capacity toward owned-channel investment for long-term durability.
+
+---
+
+## Failure 7: No measurement
+
+**Symptom.** The team operates on intuition about which channels are working. Different team members have different intuitions. Decisions about cadence, channel mix, and capacity are not informed by data.
+
+**Diagnosis.** No measurement infrastructure or no measurement-to-decision discipline.
+
+**Cure.** Establish per-channel metrics; channel-level analysis; cross-channel attribution. Quarterly measurement reviews that produce specific decision changes. See `distribution-measurement.md` for the discipline.
+
+---
+
+## Failure 8: Posting without distribution
+
+**Symptom.** Content publishes. The piece appears on the blog and is shared once on social. The team considers distribution complete.
+
+**Diagnosis.** Distribution is treated as the act of posting. The work of getting content TO audiences is not happening.
+
+**Cure.** Plan distribution at production time. Each piece has a distribution plan: which channels, what cadence, what cross-channel co-promotion. Distribution is part of the production work, not an afterthought.
+
+---
+
+## Failure 9: Campaign launches landing quietly
+
+**Symptom.** The team prepared a flagship launch with significant cross-format coordination. Launch day arrives. Engagement is muted.
+
+**Diagnosis.** Sustaining cadence was insufficient before the launch. Audiences were not warm; the campaign moment did not feel like a campaign moment because no audience habit primed it.
+
+**Cure.** Build sustaining cadence first. Campaign rhythm is earned by sustaining cadence. Programs that try to spike attention without sustaining baseline produce limited campaign engagement.
+
+---
+
+## Failure 10: Owned audience small after years
+
+**Symptom.** After 2-3 years of program operation, the newsletter has 800 subscribers; the blog gets 5,000 monthly visits; the community is small.
+
+**Diagnosis.** Long-term investment in owned channels was skipped. Program reach (if there is reach) is rented from third parties.
+
+**Cure.** Reallocate capacity. Reduce paid spend; reduce broad-platform investment. Increase newsletter, blog, and community investment. Recovery is multi-year; programs in starvation cannot rebuild quickly.
+
+---
+
+## Failure 11: Earned channels not producing
+
+**Symptom.** The program has occasional coverage from third parties but no reliable earned-channel reach. Mentions are rare; syndication is informal; AI-search citation rates are low.
+
+**Diagnosis.** Earned channels are being treated as automatic. Relationship investment, pitching discipline, and citation-hook content design are not in place.
+
+**Cure.** Apply the earned-channel investment discipline. Specific capacity to relationship-building, pitching, syndication, citation tracking. Investment compounds over years.
+
+---
+
+## Failure 12: Paid distribution costs rising
+
+**Symptom.** Paid amplification was producing acceptable cost-per-engagement 12-18 months ago. Costs have risen 50-100% since then. Engagement is similar; costs are higher.
+
+**Diagnosis.** Auction dynamics on paid platforms. Programs heavily dependent on paid see costs rise without offsetting owned/earned investment that would reduce paid dependence.
+
+**Cure.** Build owned and earned channels to reduce paid dependence. Within paid, focus on the highest-ROI placements; cut lower-performing paid spend. Recognize that paid costs typically rise over time on auction-based platforms; budget assumptions should account for this.
+
+---
+
+## Failure 13: Channels mismatched to audience
+
+**Symptom.** The program is present on multiple channels. Engagement is low across most of them. The team is confused because the channels seemed obvious choices.
+
+**Diagnosis.** Channels were chosen by industry default ("everyone is on LinkedIn") or by capacity availability ("we can post on TikTok") rather than by audience-engagement match.
+
+**Cure.** Run the audience-channel audit (see `audience-channel-matching.md`). Cut channels where the audience is present but not engaged. Increase investment in channels where the audience is genuinely engaged.
+
+---
+
+## Failure 14: Cadence too aggressive
+
+**Symptom.** Email subscribers are unsubscribing at higher rates. Social engagement is declining despite increased posting volume. The team is producing more content per week than ever; reception is worse.
+
+**Diagnosis.** Cadence has exceeded audience attention norms. The team is over-publishing.
+
+**Cure.** Reduce cadence to channel norms. Test reduced frequency for 6-8 weeks; observe whether engagement improves and unsubscribes slow. Most programs benefit from disciplined cadence rather than maximal cadence.
+
+---
+
+## Failure 15: Cadence inconsistent
+
+**Symptom.** The program publishes 3 times in a week, then nothing for 3 weeks, then 5 times in 4 days. Audiences cannot develop habit.
+
+**Diagnosis.** No cadence discipline. Production happens when capacity allows; distribution follows production rather than following audience-attention rhythm.
+
+**Cure.** Establish cadence targets per channel. Build content calendars that smooth publication across the period. Capacity that produces content unevenly should distribute the publication evenly even if production was uneven (held pieces release on schedule).
+
+---
+
+## Failure 16: No campaign rhythm
+
+**Symptom.** The program runs sustained cadence consistently. Flagship launches happen. The launches receive routine treatment; no campaign coordination produces outsized attention.
+
+**Diagnosis.** Campaign rhythm has not been built. The program has sustained cadence but no concentrated moments.
+
+**Cure.** Plan 4-12 campaign moments per year. Each campaign concentrates cross-format distribution for 4-6 weeks. The campaigns are earned by the sustaining cadence; together they produce the rhythm strong programs use.
+
+---
+
+## The cross-cutting pattern
+
+Most distribution failures share a single root: treating distribution as posting-after-publishing rather than as the equal half of the work.
+
+Posting-after-publishing thinking treats publication as the end of the work. The piece goes live; minimal distribution work follows; reach is whatever happens organically. Output: most pieces reach a fraction of their potential audience.
+
+Distribution-as-half-the-work thinking treats distribution as a discipline equal to production. Channel choices are deliberate; cadence is calibrated; owned-earned-paid mix is strategic; measurement informs decisions. Output: pieces reach engaged audiences because the distribution work earned the reach.
+
+The fix for almost any distribution failure is the same: treat distribution as a real discipline, not as posting. Allocate capacity proportionate to its importance. The capacity required is significant; the value extracted is also significant.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The sixteen failure patterns with diagnoses and cures, the cross-cutting pattern that connects most of them, the distribution-as-half-the-work framing.
+
+## Implementation choices that stay internal
+
+Specific tooling for distribution tracking. Specific reporting templates for distribution outcomes. Specific reviewer training on per-channel conventions. Specific automation that flags distribution gaps. The team's own conventions for failure-pattern detection in their distribution program. These vary by team and tooling.

--- a/skills/content-distribution/references/content-channel-matching.md
+++ b/skills/content-distribution/references/content-channel-matching.md
@@ -1,0 +1,181 @@
+# Content-channel matching
+
+Format-channel fit decisions. The compose-with-repurposing pattern. The format-mismatch failure mode that produces low engagement even when audience and channel match.
+
+Audience-channel matching answers "where is the audience?" Content-channel matching answers "does this format fit this channel?" Both must hold for distribution to produce engagement.
+
+---
+
+## Format-channel fit examples
+
+How specific formats land on specific channels.
+
+### Long-form analytical text
+
+**Strong fit.** Newsletter (long-form-tolerant subscribers expect depth). Owned blog (long-form is the blog's native register). LinkedIn long posts (the platform rewards substantive long content). X threads (when the community fits and the thread is well-paced).
+
+**Weak fit.** Instagram (the format does not support text-driven content as primary). TikTok (audiences come for short-form video, not long text). Most podcast platforms (audio is the format; long-form text is not what audiences came for).
+
+### Short-form video
+
+**Strong fit.** TikTok, Reels, YouTube Shorts (the platforms' native formats). Increasingly LinkedIn video (the platform has invested in video). Twitter/X video for some communities.
+
+**Weak fit.** Newsletter (where text leads and video is a supplement). Owned blog (where written long-form leads). Most podcast platforms (audio-only consumption).
+
+### Statistic-driven content
+
+**Strong fit.** Social with quote-graphic visual treatment (LinkedIn, X, Instagram with the right design). AI search snippets (search engines weight statistics with named sources). Podcast mentions (host-read statistic + source citation works well).
+
+**Weak fit.** As primary format on owned blog (where context develops the stat; the stat alone is thin). Newsletter as the entire content (the stat without development underdelivers).
+
+### Conversational expert content
+
+**Strong fit.** Podcasts (the format is conversational by design). Video interviews (long-form video supports the conversational depth). Long social threads on platforms where substantive content is rewarded.
+
+**Weak fit.** Short-form video (the conversational depth does not fit 60-second windows). Newsletter (where edited prose fits better than conversational transcript).
+
+### Reference content (definitions, glossaries, FAQs)
+
+**Strong fit.** Owned blog and FAQ pages (canonical home). AI search snippets (citation-ready). Documentation sites (where reference is the format).
+
+**Weak fit.** Most social channels (reference content does not earn engagement on attention-driven feeds). Podcasts (reference content does not work in audio).
+
+### Visual narrative content (case studies with custom visuals, illustrated guides)
+
+**Strong fit.** Instagram (visual-first). Pinterest (visual reference). Owned blog with strong design treatment.
+
+**Weak fit.** Podcast (audio cannot carry visual content). Newsletter (most newsletters do not support rich visual treatment).
+
+---
+
+## The compose-with-repurposing pattern
+
+When the audience is on a channel but the source format does not fit, the right answer is often to repurpose into a format that does fit.
+
+**The pattern.**
+
+- Source piece: 5,000-word whitepaper.
+- Audience: present and engaged on TikTok (consumer-oriented program; younger demographic).
+- Direct distribution: 5,000-word whitepaper does not fit TikTok.
+- Compose-with-repurposing: produce 60-second video derivatives from the whitepaper's key claims, framed for TikTok conventions. Distribute the derivatives on TikTok; keep the whitepaper as the source for audiences who want depth.
+
+**The discipline.** Distribution is downstream of repurposing. A program with strong audience-channel matching but weak content-channel matching solves it through repurposing, not through distributing inappropriate formats.
+
+**See `content-repurposing`** for the cross-format adaptation discipline. The two skills compose: repurpose first to fit the channel; then distribute on the channel.
+
+---
+
+## The format-mismatch failure mode
+
+The pattern when content-channel matching is skipped.
+
+**The symptom.** The program is present on the right channels (audience-channel matching held). Engagement is still low. The team is confused because the channels seem right but the content is not landing.
+
+**The diagnosis.** The format does not fit the channel even though the audience is there. The audience is on the channel for a different kind of content; the program's content does not match the channel's content expectations.
+
+**The cure.** Identify the format-channel mismatches. For channels with strong audience-channel match but weak content-channel match, repurpose to fit. For channels where neither matching holds, cut the channel.
+
+**Recovery time.** Format-mismatch fixes through repurposing typically produce visible engagement improvements within 4-12 weeks as the new format derivatives accumulate.
+
+---
+
+## Format conventions per channel
+
+Beyond the strong/weak fit, each channel has specific conventions that distinguish good fit from forced fit.
+
+### LinkedIn long-form posts
+
+- 800-2,500 character body.
+- First 1-3 lines must hook (truncation point).
+- Short paragraphs, white space, occasional emphasis.
+- Specific argument or position; vague observations underperform.
+- Engagement-earning closes (questions, polarizing claims, specific examples).
+
+### X/Twitter threads
+
+- 5-15 posts typical for substantive threads.
+- First post must hook; the thread is read sequentially.
+- Each post is a complete thought, not a 280-character split of a longer thought.
+- Conclusion specific.
+
+### Newsletter (substantive content)
+
+- 200-800 words for typical sends; 1,500-3,000 for engaged-audience long-form newsletters.
+- Subject line and preheader bear most engagement load.
+- Plain prose paragraphs render reliably.
+- Single clear CTA per send.
+
+### Podcast
+
+- Spoken-language sentence structure.
+- Conversational pacing with examples and asides.
+- Show notes with links and structured summary.
+- Consistent episode length; audiences develop expectations.
+
+### Owned blog
+
+- Format depends on the source-piece type; long-form articles, listicles, definitive guides, case studies, etc.
+- SEO conventions: target keyword in title and headings, internal linking, schema markup.
+- Visual rhythm appropriate to length.
+
+### TikTok / Reels / Shorts
+
+- 60-90 seconds typical.
+- Hook in first 1-2 seconds.
+- Captions essential.
+- Single specific point.
+- Visual variation, motion, or text-on-screen design.
+
+### Instagram (feed posts)
+
+- Visual-first; images carry the post's immediate impact.
+- Caption supplements; not all viewers expand caption.
+- Conventions vary by subgenre (educational carousels, product photography, lifestyle imagery).
+
+### YouTube (long-form)
+
+- 8-30 minutes typical for substantive content.
+- Pacing for spoken delivery.
+- Visual variation.
+- Audio quality matters more than video quality.
+- Thumbnail and title bear most click-through load.
+
+### AI-search snippets
+
+- 40-80 words for FAQ-style; 100-200 words for paragraph-style.
+- Standalone meaning.
+- Named-source citations.
+- Specific framings.
+- Schema markup where applicable.
+
+---
+
+## Format adaptation per channel within a single source
+
+A worked example: a research report that distributes across multiple channels.
+
+**Source.** 8,000-word research report on B2B paid media benchmarks.
+
+**Distribution by channel with content adaptation.**
+
+- **Owned blog.** Full report as the canonical version. Schema-marked. Internal-linked from related pieces. Sections support deep linking.
+- **Newsletter (substantive subscribers).** A 1,200-word digest sending the report's key findings, with a clear CTA to read the full report.
+- **LinkedIn long posts.** 4-6 long-form posts, each developing one finding from the report. Each post includes the report's most relevant statistic with named-source attribution.
+- **X threads.** 2-3 threads from the report, each focused on a specific finding. Threads link to the report.
+- **Podcast.** One episode interviewing a practitioner who has applied the report's findings, with the report as the show's spine.
+- **TikTok / Reels.** Statistic-driven 60-second videos, one per key statistic. Custom graphic treatment for each.
+- **AI-search snippets.** 15-20 FAQ extractions from the report. Schema-marked FAQ page on the owned property.
+- **Promoted newsletter.** Sponsored placement in 1-2 industry newsletters whose audience overlaps with the report's target.
+- **Boosted social.** Boost the LinkedIn posts that earn the highest organic engagement.
+
+The example shows the compose-with-repurposing pattern in practice. The source is one piece; the distribution adapts per channel. The cross-format set composes with the channel choices to produce engagement appropriate to each channel's conventions.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The format-channel fit examples, the compose-with-repurposing pattern, the format-mismatch failure mode, the format conventions per channel, the worked example of multi-channel distribution from one source.
+
+## Implementation choices that stay internal
+
+Specific platform tooling for format-specific publishing. Specific design templates per channel-format combination. Specific automation for cross-channel scheduling. The team's own conventions for format-fit decisions when ambiguous. These vary by team, tooling, and brand voice.

--- a/skills/content-distribution/references/distribution-cadence-patterns.md
+++ b/skills/content-distribution/references/distribution-cadence-patterns.md
@@ -1,0 +1,183 @@
+# Distribution cadence patterns
+
+Frequency, mix, rhythm. Sustaining vs campaign rhythm. Common cadence patterns by program type. The audit that catches cadence mismatches.
+
+Cadence is the rhythm of a program's distribution: how often each channel publishes, what mix of owned-earned-paid, and how steady-state baseline relates to campaign spikes. The wrong cadence produces predictable engagement decline: too aggressive exhausts audiences; too sparse loses connection; mismatched to channel attention rhythm produces underperformance at any frequency.
+
+---
+
+## Cadence axes
+
+Three axes that together define a program's distribution cadence.
+
+**Frequency per channel.** How often the program publishes to each channel. Newsletter weekly vs bi-weekly. LinkedIn 3 posts per week vs 1 per week. X 5-10 posts per week vs occasional. The frequency per channel is calibrated to the channel's audience attention rhythm.
+
+**Mix.** What proportion of distribution is owned vs earned vs paid. What proportion of pieces are original vs derivative. The mix reflects program strategy: owned-heavy programs invest in long-term audience-building; paid-heavy programs prioritize immediate reach.
+
+**Rhythm.** Sustaining baseline cadence vs campaign spikes. Most programs have a steady-state rhythm punctuated by occasional campaign moments around flagship launches. The rhythm shape determines how audiences experience the program.
+
+---
+
+## Common cadence patterns by program type
+
+Cadences that show up repeatedly across program shapes.
+
+### B2B program with content-led demand generation
+
+**Newsletter.** Weekly. Substantive sends; subscribers expect depth.
+
+**Blog.** 2-4 posts per week. Mix of new pieces, refresh updates, and cross-format derivatives.
+
+**LinkedIn.** 3-5 posts per week. Mix of long-form posts, link drops to blog content, occasional video.
+
+**X/Twitter.** 5-10 posts per week. Higher cadence than LinkedIn; mix of original observations, links, and replies.
+
+**Podcast.** Bi-weekly or weekly episodes.
+
+**Earned channels.** Pitches and PR work continuous; coverage when earned.
+
+**Paid amplification.** Boost of best-performing organic pieces; occasional sponsored newsletter sends.
+
+**Campaign rhythm.** Quarterly spikes around flagship launches: cross-format wave for 4-6 weeks per launch.
+
+### Consumer brand with broad-audience reach goals
+
+**Newsletter.** Weekly or 2x weekly depending on subscriber engagement.
+
+**Blog or content site.** 1-2 posts per week.
+
+**Instagram.** Daily content (often a mix of feed posts, stories, and reels).
+
+**TikTok.** 2-4 posts per week.
+
+**YouTube.** Weekly long-form video plus shorts.
+
+**Earned channels.** PR for major moments; influencer relationships continuous.
+
+**Paid amplification.** Continuous; brands often run paid amplification on most major content as part of standard practice.
+
+**Campaign rhythm.** Heavier campaign spikes around product launches, seasonal moments, and brand events.
+
+### Niche specialist program with concentrated audience
+
+**Newsletter.** Weekly or bi-weekly. Substantive sends; the audience is concentrated and engaged.
+
+**Blog.** 1-2 posts per month. Quality-focused; depth over volume.
+
+**Specific platforms (one or two).** 2-3 posts per week on the platforms where the niche audience engages.
+
+**Podcast (if applicable).** Bi-weekly or monthly episodes.
+
+**Earned channels.** High prioritization; relationships with niche publications and influencers compound.
+
+**Paid amplification.** Selective; most niche programs benefit more from earned-channel investment than from paid amplification.
+
+**Campaign rhythm.** Less pronounced than broader programs; sustaining cadence is the dominant rhythm.
+
+### Founder-led brand with personal-brand element
+
+**Newsletter.** Weekly; founder-voice register; personal insight alongside program content.
+
+**LinkedIn.** Daily posts (or near-daily). Founder voice; personal observations alongside program content.
+
+**X/Twitter.** Daily posts with conversation engagement.
+
+**Podcast.** Often the founder hosts; weekly episodes.
+
+**Earned channels.** Founder builds relationships personally; PR coverage often person-driven.
+
+**Paid amplification.** Selective; the program builds on organic reach earned by founder authority.
+
+**Campaign rhythm.** Less formal campaigns; the program reads more as continuous founder voice than as discrete campaign moments.
+
+---
+
+## Sustaining vs campaign rhythm
+
+The relationship between baseline cadence and campaign spikes.
+
+**Sustaining cadence.** The baseline rhythm. Audiences expect this cadence; deviations affect engagement. Sustaining cadence builds audience habit (subscribers who expect a Tuesday send keep paying attention; subscribers who get inconsistent sends start ignoring even the good ones).
+
+**Campaign rhythm.** Spikes around flagship launches, major announcements, or significant events. Concentrated cross-format distribution that briefly exceeds the sustaining cadence.
+
+**The relationship.** Campaign rhythm is earned by sustaining cadence. Programs without sustaining cadence cannot run effective campaigns; the audiences are not warm. Campaigns that spike out of nowhere produce limited engagement because no audience habit primes the moment.
+
+**The balance.** Strong programs run mostly sustaining cadence with occasional campaign spikes. The campaign spikes are 4-6 weeks total, 4-12 times per year. Programs running continuous "campaign" rhythm exhaust audiences; programs running only sustaining without campaigns miss the moments where flagship work could earn outsized attention.
+
+---
+
+## Per-channel cadence tuning
+
+Each channel rewards different cadences. Cadence tuning matches channel-specific norms.
+
+**Newsletter.** Weekly is the most common B2B cadence. Bi-weekly works for higher-investment formats. Daily works for highly-engaged subscriber bases. The cadence should be predictable: subscribers should know roughly when to expect sends.
+
+**LinkedIn.** Algorithmic favor rewards 1-2 posts per day for individual accounts; company pages typically post less frequently (2-5 posts per week). Lower cadences (1-2 per week) work but limit reach.
+
+**X/Twitter.** The platform rewards higher cadence than other platforms. 5-15 posts per day is normal for engaged accounts; less can work but limits reach.
+
+**Instagram.** 1 post per day is common for engaged consumer accounts; 3-5 per week works for B2B and niche programs. Stories and reels often have higher cadence than feed posts.
+
+**TikTok.** Algorithmic recommendation rewards higher cadence; 1+ posts per day typical for accounts trying to grow.
+
+**YouTube.** Weekly long-form video is the upper-frequency norm; many channels publish less frequently. Shorts can publish more often (multiple per week).
+
+**Podcast.** Weekly is the most common cadence; bi-weekly works for higher-investment shows; daily works for high-volume formats (news-style podcasts).
+
+**Owned blog.** SEO programs benefit from regular publishing (2-4 posts per week typical for active programs); less frequent publishing limits the program's compounding traffic potential.
+
+---
+
+## The cadence audit
+
+A short framework for auditing a program's cadence.
+
+1. **Pull current cadence per channel over the last 90 days.** What is the program actually doing? Often differs from the program's stated cadence target.
+2. **Compare to channel-specific norms.** Are channel cadences within the engagement-rewarding range, or are they too sparse or too aggressive?
+3. **Identify cadence inconsistencies.** Are there gaps where the program goes silent for weeks, then spikes? Inconsistency damages audience habit even when total volume is similar.
+4. **Match cadence to capacity.** Is the program able to sustain the current cadences, or is it running unsustainably?
+5. **Identify the campaign rhythm.** When were the last 3 flagship launches? Did sustaining cadence support them? Did campaigns earn outsized attention?
+
+The audit produces a calibration plan: which cadences to maintain, which to adjust, where the program is over-investing or under-investing.
+
+---
+
+## Cadence anti-patterns
+
+**Inconsistent cadence.** 3 posts in one week, then nothing for 3 weeks. Audiences cannot develop habit; the program disappears between bursts.
+
+**Volume-driven cadence.** "We need to post X times per week" without reference to channel norms or audience attention. Volume without engagement is presence; presence without engagement is wasted capacity.
+
+**Identical cadence across channels.** Treating LinkedIn, X, TikTok, and newsletter all on the same cadence ignores channel-specific norms. Each channel has a different attention rhythm.
+
+**No campaign rhythm.** Pure sustaining cadence with no spikes. Flagship launches receive routine treatment; the moments where the program could earn outsized attention pass without the campaign coordination they warrant.
+
+**Continuous campaign rhythm.** Pure campaign rhythm with no sustaining baseline. Audiences never develop habit; every "launch" feels like another launch in a continuous stream of launches.
+
+**Cadence beyond capacity.** The team commits to LinkedIn daily, X 10x per day, newsletter twice weekly. Capacity cannot sustain; cadence drifts; audiences notice the drift.
+
+---
+
+## When to adjust cadence
+
+Signals that cadence needs change.
+
+**Engagement declining steadily on a channel.** May indicate cadence too aggressive (audience fatigue) or too sparse (audience disengagement) or content-fit issues (different problem). Investigate.
+
+**Subscriber unsubscribes spiking on newsletter.** Cadence too aggressive, or content quality declining, or both. Cure depends on diagnosis.
+
+**Algorithm changes on a platform.** Some platform algorithm shifts reward different cadences. Adjust based on observed engagement signals.
+
+**Capacity changes.** Team grows or shrinks; cadence should match sustainable capacity. Programs with shrinking teams that maintain prior cadence often produce drift in quality.
+
+**Audience-research findings.** New data about audience attention rhythms. Adjust cadence to fit revealed audience patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The cadence axes, common cadence patterns by program type, sustaining-vs-campaign rhythm, per-channel cadence tuning, the cadence audit, the cadence anti-patterns, the signals for cadence adjustment.
+
+## Implementation choices that stay internal
+
+Specific scheduling tools the team uses. Specific cadence-tracking dashboards. Specific cadence-by-channel calendars. The team's own conventions for cadence-vs-quality tradeoffs when capacity is constrained. These vary by team, tooling, and program shape.

--- a/skills/content-distribution/references/distribution-measurement.md
+++ b/skills/content-distribution/references/distribution-measurement.md
@@ -1,0 +1,203 @@
+# Distribution measurement
+
+Per-channel metrics, channel-level analysis, cross-channel attribution, the measurement-honest program. The discipline that prevents distribution-theater and turns distribution into a learning system.
+
+Distribution without measurement runs on assumption. Channels stay in the mix because they have always been in the mix; cadence stays at current levels because nobody has asked whether it is right; paid spend continues because budget exists. Measurement is the discipline that surfaces what is actually working and what is not.
+
+---
+
+## Per-channel metrics
+
+Metrics organized by what they reveal about a channel's effectiveness.
+
+**Reach metrics.**
+
+- Impressions: how many times the content was shown.
+- Unique reach: how many unique people saw the content.
+- Audience growth: how the channel's owned audience size is changing.
+
+**Engagement metrics.**
+
+- Click-through rate (CTR): clicks divided by impressions.
+- Time-on-page: how long visitors stay on the linked content.
+- Scroll depth: how far down the content visitors scroll.
+- Completion rate: for video and audio, what percentage finishes.
+- Comment, share, and reaction signals on social.
+- Reply rate on email.
+
+**Conversion metrics.**
+
+- Newsletter signups attributed to the channel.
+- Content downloads attributed to the channel.
+- Qualified-lead actions (form submissions, demo requests, free-trial starts).
+- Sales-cycle progression for B2B programs.
+- Attributed revenue for revenue-tracked programs.
+
+**Channel-health metrics.**
+
+- Audience retention rate (subscribers staying vs unsubscribing).
+- Engagement-rate trend over time (rising, stable, falling).
+- Algorithm-favor signals (for platform-controlled channels).
+- Deliverability rate (for email).
+
+---
+
+## Channel-level analysis
+
+Aggregating metrics into channel effectiveness assessments.
+
+**Engagement-per-distribution-effort.**
+
+- Some channels look impressive (high reach numbers) but produce low engagement.
+- Some channels produce moderate reach but very high engagement.
+- The channels that compound value are usually the engagement-heavy ones, not the reach-heavy ones.
+
+**Conversion-per-channel.**
+
+- Reach without conversion is vanity. Conversion is value.
+- Channels driving conversion at favorable cost (whether owned-channel investment cost or paid-channel spend) earn their place in the mix.
+- Channels driving impressive reach but no conversion may be building brand awareness (which is real value) or producing nothing of value (which is wasted capacity).
+
+**Trend over time.**
+
+- Channels' performance changes. Algorithm shifts, audience migrations, competitive landscape changes affect channel effectiveness.
+- A channel that was effective 18 months ago may be underperforming now.
+- A channel that was marginal 18 months ago may be the program's strongest now.
+- Quarterly review of channel-level trends catches these shifts.
+
+**The relative-effectiveness audit.**
+
+Rank channels by engagement-per-effort and by conversion-per-effort. Channels at the top of both rankings are the program's strongest; channels at the bottom of both are candidates for cutting or restructuring.
+
+---
+
+## Cross-channel attribution
+
+The audience member encounters the program on multiple channels before converting. Attribution should reflect this reality.
+
+**Single-touch attribution failures.**
+
+- **Last-touch attribution.** Credits the last channel before conversion. Misrepresents which channels actually drove the audience relationship; usually overweights the conversion channel (often newsletter or direct site visit) and underweights the discovery channels.
+- **First-touch attribution.** Credits the first channel of contact. Misrepresents the role of nurturing channels; usually overweights discovery channels and underweights nurturing channels.
+
+**Multi-touch attribution patterns.**
+
+- **Linear attribution.** Equal weight to all touchpoints. Simple; usually a step up from single-touch.
+- **Time-decay attribution.** More weight to touchpoints closer to conversion. Reflects the commonsense intuition that recent touches matter more than distant ones.
+- **Position-based attribution.** Significant weight to first and last touch; remaining weight distributed across middle touches. Reflects the importance of discovery and conversion moments.
+- **Data-driven attribution.** Algorithmic weighting based on observed conversion patterns. Most accurate; requires sufficient data and tooling.
+
+**The attribution honesty discipline.**
+
+- Attribution models are simplifications. None is "correct"; all are useful approximations.
+- Programs should pick an attribution model and stay consistent. Switching attribution models produces apparent performance changes that are not real.
+- Cross-reference attribution data with other signals (subscriber surveys, sales conversation reports). Triangulation is more honest than relying on attribution data alone.
+
+---
+
+## The measurement-honest program
+
+Discipline that turns measurement into a decision-making input rather than into reporting theater.
+
+**Cuts channels that consistently underperform.**
+
+- A channel underperforming for 2-3 quarters is a real signal, not noise.
+- Cutting underperforming channels reallocates capacity to channels that produce.
+- The decision is hard because cutting feels like admitting failure; programs that cut decisively outperform programs that maintain everything indefinitely.
+
+**Increases investment in channels that consistently produce.**
+
+- Strong channels deserve disproportionate investment.
+- Programs often spread investment evenly across channels regardless of performance; the measurement-honest discipline allocates investment to where return is highest.
+
+**Adjusts cadence based on engagement patterns.**
+
+- Cadence that is too aggressive shows up in declining engagement and rising unsubscribes.
+- Cadence that is too sparse shows up in audience-habit decay.
+- Engagement patterns inform cadence adjustments.
+
+**Calibrates paid spend based on organic validation.**
+
+- Boost what organic validates.
+- Reduce or eliminate paid spend on content that does not earn organic engagement.
+- Paid spend should be a function of organic signal, not a function of available budget.
+
+---
+
+## The measurement-theater anti-pattern
+
+When measurement is performed without informing decisions.
+
+**The pattern.** The team produces quarterly reports with channel-level metrics. Reports are presented to leadership. Decisions are not changed based on the reports. Underperforming channels stay in the mix; over-performing channels do not get additional investment. The program continues as it would have continued without the measurement.
+
+**Why it happens.**
+
+- Measurement is treated as performance theater rather than as decision input.
+- Leadership signals that all channels should continue (political pressure, sunk cost, brand reasons).
+- The team has measurement capacity but lacks decision-authority over distribution.
+
+**The cure.** Tie measurement to specific decisions. Each quarter, the measurement review produces a list of changes: cuts, additions, cadence adjustments, capacity reallocations. Reviews without decisions are theater.
+
+---
+
+## Common measurement failures
+
+**No measurement.** Distribution runs on assumption. Channels stay in the mix because they always have. Cadence and capacity allocation persist regardless of effectiveness.
+
+**Measurement without action.** Measurement is performed; decisions are not changed. The program runs as if no measurement happened.
+
+**Vanity metrics.** Reach and impressions reported as primary success metrics. Engagement and conversion underreported. The program looks like it is working when it may not be.
+
+**Single-touch attribution dominance.** All attribution analysis runs on last-touch or first-touch. The realities of multi-touch journeys are missed.
+
+**No trend analysis.** Channel performance reported in quarterly snapshots; trends across quarters are not surfaced. Channel decay is detected late.
+
+**Cross-program comparison failures.** The program compares itself to industry benchmarks without context. Benchmark numbers from other industries or audience segments may not apply; comparison produces false signals.
+
+---
+
+## Measurement infrastructure
+
+The tooling and processes that support measurement.
+
+**Analytics platform.** Web analytics that tracks per-channel traffic, engagement, and conversion. Standard requirement for any program with a content site.
+
+**Email analytics.** Open rates, click-through rates, unsubscribe rates, deliverability rates. Standard for any program with a newsletter.
+
+**Social analytics.** Per-platform analytics from each social platform; supplemented by social-listening tools where the program tracks mentions and shares beyond direct posts.
+
+**Attribution tooling.** From simple UTM tracking and Google Analytics multi-touch reports to sophisticated attribution platforms (depending on program scale and complexity).
+
+**Channel-specific dashboards.** Programs often build per-channel dashboards that surface the metrics most relevant to that channel's optimization.
+
+**Cross-channel rollup.** A program-level dashboard that aggregates channel-level data into a coherent view of distribution effectiveness.
+
+The infrastructure cost is real; the alternative (running distribution without measurement) is more expensive over time because capacity gets allocated to wrong places.
+
+---
+
+## Measurement cadence
+
+When to measure what.
+
+**Continuous.** Some metrics update daily or weekly: website traffic, social engagement, email opens. The team monitors these continuously.
+
+**Weekly.** Per-channel summaries of recent performance. Catches sharp decay or sharp improvements early.
+
+**Monthly.** Channel-level rollup. Detects trends developing across multiple weeks.
+
+**Quarterly.** Strategic measurement review. Decisions about channel cuts, additions, cadence adjustments, capacity reallocations.
+
+**Annual.** Program-level measurement review. Strategic shifts in channel mix, attribution-model adjustments, capacity reallocations across the program.
+
+The cadence should match the decision cadence. Programs with monthly capacity-allocation decisions need monthly measurement; programs with quarterly decisions need quarterly measurement.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The per-channel metric categories, channel-level analysis approaches, cross-channel attribution patterns, the measurement-honest discipline, the measurement-theater anti-pattern, common measurement failures, infrastructure requirements, measurement cadence.
+
+## Implementation choices that stay internal
+
+Specific analytics platforms (the team's chosen GA configuration, alternative platforms, attribution tools). Specific dashboard designs and reporting templates. Specific UTM tagging conventions. Specific attribution-model parameters tuned for the program. The team's own conventions for benchmark comparisons. These vary by team, tooling, and program scale.

--- a/skills/content-distribution/references/earned-channel-work.md
+++ b/skills/content-distribution/references/earned-channel-work.md
@@ -1,0 +1,172 @@
+# Earned-channel work
+
+PR, syndication, mentions, AI-search citation, word of mouth. The relationship investment that compounds over years. The pitching discipline that earns coverage rather than burning relationships.
+
+Earned channels reach audiences the program cannot reach directly. The work to earn the channel is real: relationships built over years, pitches that demonstrate the program's value, content that earns citation. Programs treating earned channels as automatic produce nothing; programs investing in the relationships earn ongoing channel access.
+
+---
+
+## PR and press
+
+Journalists, podcasters, newsletter operators who cover the program's content.
+
+**The relationship-first principle.** Coverage follows relationships. Cold pitches from unknown senders get ignored at high rates; warm pitches from known senders get read. Programs that build relationships before they need coverage are the programs that earn coverage when they have flagship work to share.
+
+**Building relationships.**
+
+- Read the journalists, podcasters, and operators in the program's space. Know what they cover, what their angles are, what they have written or aired recently.
+- Engage substantively before pitching. Comment thoughtfully on their work; share their pieces with attribution; respond if they ask for input.
+- Build the relationship to a level of mutual recognition before the first pitch.
+
+**Pitching when the relationship exists.**
+
+- Pitch specific to the recipient. Reference their recent work; explain why the program's content fits their angle.
+- Lead with the angle, not with the company. Recipients care about the story, not about the program's brand.
+- Provide everything the recipient needs: the source piece, key statistics, possible quotes, a clear point of contact.
+- Make it easy to say yes; make it easy to say no.
+
+**The mass-blast pitching anti-pattern.**
+
+- Identical pitches sent to dozens of recipients. Recipients detect mass-blast quickly; relationships are damaged not built.
+- Pitches focused on the program rather than on the story. Recipients filter these as ads.
+- Follow-up pressure. Excessive follow-ups damage future relationship potential.
+
+**The PR investment timeline.** Real PR relationships build over 1-3 years. Programs without prior PR investment cannot generate coverage on a deadline; programs with sustained investment have relationships that produce ongoing coverage.
+
+---
+
+## Syndication
+
+Other publications republishing or excerpting the program's content with appropriate attribution.
+
+**The syndication exchange.** The program provides quality content; the partner provides reach into their audience. Both parties win when the exchange is fair.
+
+**Negotiation patterns.**
+
+- **Republishing with canonical link.** The partner runs the full piece; canonical link tag points to the program's version for SEO. Reach extends; SEO authority preserves.
+- **Excerpt with link.** The partner runs an excerpt with a link to the full piece on the program's site. Less full reach but stronger funnel back to the program.
+- **Republishing without canonical.** Less common; risks SEO duplication issues; should be avoided unless specifically negotiated with the partner about which version is canonical.
+
+**Common syndication failures.**
+
+- Canonical link mishandling. The piece appears on the partner's site as the canonical version; the program's version drops in rankings.
+- Partner relationships not maintained. Syndication partners that stop running the program's content; the channel goes silent.
+- Indiscriminate syndication. Every piece syndicated regardless of fit; partner audiences see content that does not match their interests; partner removes the program from rotation.
+
+**The selective-syndication discipline.** Not every piece warrants syndication. Match piece-to-partner: which pieces fit which partners; which partners' audiences will engage with which pieces. Selective syndication produces stronger partner relationships than blanket syndication.
+
+---
+
+## Mentions and citations
+
+Other content marketing programs, industry analysts, AI search engines citing the program's content.
+
+**Citation as compounding authority.** Each citation increases the program's authority signal. Citations from authoritative sources weight more than citations from less authoritative ones. Citation accumulation over years is one of the most durable signals of program quality.
+
+**Earning citations.**
+
+- Produce content with citation hooks. Original data; named frameworks; primary research; contrarian-but-defensible positions.
+- Build identifiable phrasings or term coinages. If the program names a concept, others citing the concept cite the program.
+- Make content discoverable when others are researching the topic. SEO and AI-search visibility matter for citation discoverability.
+
+**The generic-content-no-citation problem.** Pieces that do not have specific citation hooks rarely get cited even if they are well-written. The hook is what other writers reach for.
+
+**AI-search citation specifically.** AI engines cite content that matches their retrieval criteria. See `content-repurposing`'s AEO extraction patterns for the discipline of producing AI-citation-friendly content. Programs that design for AI citation earn more citations than programs that publish without that consideration.
+
+---
+
+## Word of mouth and shares
+
+Audiences sharing pieces with their networks.
+
+**The hardest channel to engineer.** Word of mouth follows from genuine usefulness. Pieces that audiences want to share are pieces that are genuinely valuable; pieces that are generic do not get shared even if they are read.
+
+**Patterns that earn shares.**
+
+- Specific, useful content. Audiences share pieces that help them or that they think will help others.
+- Citation-worthy content. Audiences share pieces they want to point to as references.
+- Provocative-but-defensible content. Audiences share pieces that take a position they want to amplify.
+- Memorable framings. Audiences share pieces that introduce concepts or framings they find useful.
+
+**Patterns that do not earn shares.**
+
+- Generic content. Pieces that say what every other piece on the topic says do not earn the share.
+- Surface-level coverage. Pieces that scratch the surface without substantive depth do not feel worth sharing.
+- Defensive content. Pieces that hedge every position do not earn the share because they do not say anything specific.
+
+**The measurement challenge.** Word-of-mouth sharing often happens in private channels (DMs, internal Slack, work emails) where the program cannot directly measure. Indirect signals: referral traffic from unknown sources, audience members reporting "a colleague sent me this," conversion-without-tracked-attribution.
+
+---
+
+## Earned-channel investment
+
+The capacity allocation question.
+
+**Programs without earned-channel investment.** Treat earned channels as automatic. Coverage that happens, happens; coverage that does not happen, does not. Output: limited earned reach; the program is dependent on owned and paid distribution.
+
+**Programs with strategic earned-channel investment.** Allocate specific capacity to relationship-building, pitching, syndication negotiation, citation tracking. Output: earned channels become reliable distribution over years.
+
+**The investment shape.**
+
+- **PR work.** A specific person owns relationships and pitching. Investment level varies by program: from 5% of one person's time at smaller programs to dedicated PR roles at larger programs.
+- **Syndication negotiation.** Periodic outreach to potential partners; relationship maintenance; canonical-link verification.
+- **Citation tracking.** Monitoring where the program is being cited; engaging with those citations (thanking citers; building relationships with frequent citers).
+- **AI-search citation.** Tracking AI engine citation rates; iterating on AEO extraction patterns based on what gets cited.
+
+**The investment payoff timeline.** Earned-channel investment compounds over 2-5 years. Year 1 produces limited returns; years 3-5 produce significant returns if the investment was sustained.
+
+---
+
+## Common earned-channel failures
+
+**Mass-blast pitching.** Pitches sent to dozens of recipients identical or near-identical. Recipients detect; relationships damaged; future coverage potential reduced.
+
+**No relationship investment.** The program tries to "do PR" only when it has flagship work to share. Without prior relationship investment, pitches go cold even when the content is genuinely strong.
+
+**Syndication mishandled.** Canonical-link issues; partner relationships not maintained; SEO authority drained to partner sites.
+
+**No citation hooks.** Pieces produced without elements that earn citation. Mentions and AI-search citation rates stay low because nothing in the content prompts citation.
+
+**Earned channel as automatic.** Treating earned channels as if they happen on their own. Without investment, they do not.
+
+**Limited PR scope.** Pitching only the same 3-5 trade publications repeatedly. The relationship gets over-extended; coverage drops; broader earned-channel work is not happening.
+
+---
+
+## Earned-channel measurement
+
+Earned channels are harder to measure than owned or paid, but measurement is still possible.
+
+**PR coverage.**
+
+- Volume: how many pieces of coverage per quarter.
+- Quality: which publications, which authors, what reach those publications have.
+- Sentiment: positive coverage, neutral, critical.
+- Attribution: traffic and conversions sourced from coverage moments.
+
+**Syndication.**
+
+- Reach via partner: traffic and engagement on partner-published versions.
+- Funnel back: traffic from partner content to program's own site.
+- Authority preservation: SEO position holding given canonical link signaling.
+
+**Mentions and citations.**
+
+- Citation count over time. Tools that track mentions across the web help here.
+- Citing-source quality. Citations from high-authority sources weight more.
+- AI-search citation rates. Tools that track AI engine citations are emerging; the measurement infrastructure is improving.
+
+**Word of mouth.**
+
+- Indirect signals: referral traffic from unknown sources, audience reports, sustained organic growth without proportional paid amplification.
+- Survey data: when audience members are asked how they discovered the program, word-of-mouth signals appear.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The relationship-first PR principle, the syndication exchange and selective-syndication discipline, the citation-earning patterns, the word-of-mouth observations, the earned-channel investment shape and timeline, the common failures, the measurement approaches.
+
+## Implementation choices that stay internal
+
+Specific PR-relationship CRM tooling. Specific pitching templates and tracking. Specific syndication negotiation conventions. Specific citation tracking software. Specific AI-search citation tracking infrastructure. The team's own conventions for relationship-investment cadence. These vary by team, budget, and program scope.

--- a/skills/content-distribution/references/owned-channel-discipline.md
+++ b/skills/content-distribution/references/owned-channel-discipline.md
@@ -1,0 +1,156 @@
+# Owned-channel discipline
+
+Newsletter, blog, social, podcast, community discipline. The starvation anti-pattern. The patterns that turn owned channels from posting infrastructure into durable distribution foundations.
+
+Owned channels are the most reliable distribution a program has. The newsletter delivers to every subscriber's inbox; the blog persists indefinitely; the owned social accounts run on the program's terms (within platform constraints). Programs that under-invest in owned channels become dependent on third-party distribution; when platforms change, when paid costs rise, when earned channels go quiet, the dependent program's reach collapses.
+
+---
+
+## Newsletter discipline
+
+The most direct owned distribution.
+
+**The discipline shape.**
+
+- **Cadence consistency.** Subscribers develop expectations. Weekly send on Tuesdays gets opened more reliably than weekly send that drifts to Thursday or Wednesday or Friday.
+- **Content quality matching subscriber expectations.** What subscribers signed up for; the program delivers it. Drift in quality (or in topic) produces unsubscribes.
+- **Single CTA per send.** Multi-CTA emails dilute. Subscribers process one action; competing actions reduce all of them.
+- **Deliverability hygiene.** Spam-trigger words, unbalanced text-to-image ratios, technical configuration (SPF, DKIM, DMARC) all affect deliverability. Programs that ignore deliverability watch open rates decline.
+- **List health.** Engaged subscribers vs lapsed subscribers; pruning lapsed segments improves overall deliverability and engagement metrics.
+
+**Common newsletter failures.**
+
+- Cadence drift. The "weekly" newsletter that becomes bi-weekly, then monthly, then sporadic. Subscribers stop expecting; engagement decays.
+- Subject lines that announce instead of earning the open. "Newsletter for week of November 14" performs worse than specific subject lines tied to the email's content.
+- Multi-topic emails that try to cover everything the program produced this week. Single-topic focus produces stronger engagement.
+- No segmentation. The same email goes to every subscriber regardless of interest patterns. Programs with multiple distinct content streams benefit from segmented sends.
+
+**See `email-sequences`** for the email-specific discipline including subject-line patterns, sequence design, and lifecycle campaigns.
+
+---
+
+## Blog discipline
+
+The owned content home.
+
+**The discipline shape.**
+
+- **Architecture and technical SEO foundations.** Crawlability, indexability, page speed, schema markup. Without these, the blog cannot earn search traffic regardless of content quality.
+- **Pillar and cluster organization.** Topical hubs that compound authority over years. See `pillar-content-architecture`.
+- **Refresh discipline.** Library does not decay into staleness. See `content-refresh-system`.
+- **Internal linking.** Strong internal-link graph that distributes authority and earns rankings.
+- **On-page optimization.** Per-page SEO discipline. See `seo-onpage`.
+
+**Common blog failures.**
+
+- Publishing without distribution to the blog. The blog is the destination; if no traffic flows to it from owned and earned distribution, only the slowly-compounding search traffic builds.
+- Architectural neglect. The blog's information architecture rots; URL structures change without redirects; old content drags down newer pages' authority.
+- Refresh starvation. The library accumulates stale pieces; new pieces have to compete with the team's own decaying content for rankings.
+- No design investment. The blog reads as a content dump rather than as a property; visitors do not return.
+
+**The blog as compounding asset.** A well-disciplined blog produces traffic for years. Programs that invest in blog foundations early earn compounding returns; programs that under-invest never earn the compounding effect.
+
+---
+
+## Owned social discipline
+
+LinkedIn company page, X account, YouTube channel, Instagram account, etc.
+
+**The discipline shape.**
+
+- **Per-platform conventions.** Each platform rewards different content shapes. LinkedIn rewards substantive long-form posts; X rewards conversation; YouTube rewards specific topic and audio quality; Instagram rewards visuals.
+- **Cadence calibrated to platform attention rhythm.** Daily on platforms that reward daily; weekly on platforms that work weekly. Mismatch reduces reach regardless of content quality.
+- **Engagement-signal optimization.** Algorithmic recommendation rewards content that earns engagement signals (comments, shares, time-watched, click-through). Content designed for these signals reaches more.
+- **Account-health hygiene.** Posting consistency; authentic engagement (not spam-replies); profile completeness; consistent branding.
+
+**Common owned-social failures.**
+
+- Cross-posting identical content across platforms. Each platform has different conventions; identical posts perform poorly on all platforms.
+- Generic posting templates. Audiences detect template-driven posting; engagement decays.
+- No engagement with the audience. Posting without responding to comments or engaging with industry conversations reduces algorithmic favor over time.
+- Reliance on a single platform. Platform algorithms shift; programs dependent on one platform's reach are exposed to algorithm risk.
+
+**Owned vs platform-controlled.** Owned-social channels are owned in the sense that the program runs the account; not owned in the sense that the platform controls reach. The distinction matters for risk: programs treating owned-social as fully owned underestimate platform-algorithm risk.
+
+---
+
+## Podcast discipline
+
+Owned audio distribution.
+
+**The discipline shape.**
+
+- **Audio quality.** Listeners tolerate uneven video far more than uneven audio. Audio investment returns more than video investment up to a point.
+- **Consistent episode cadence.** Weekly is most common; bi-weekly works for higher-investment shows. Drift undermines listener habit.
+- **Show notes as derivative format.** Show notes do the print work the audio cannot: links, citations, structured summary. Treat show notes as their own derivative format with quality discipline.
+- **Cross-platform distribution.** Apple Podcasts, Spotify, YouTube, Google Podcasts. Each is a discoverability surface.
+- **Format consistency within the show.** Listeners develop expectations; format changes can lose listeners.
+
+**Common podcast failures.**
+
+- Production quality drift. The first 10 episodes are well-produced; episodes 30+ show production decay.
+- No cross-platform distribution. The show lives on one platform; potential listeners on other platforms cannot find it.
+- Show notes treated as afterthought. Thin show notes reduce SEO value and listener navigation.
+- Cadence inconsistency. Drift between episodes undermines listener habit.
+
+**The podcast as relationship channel.** Engaged listeners feel connected to the host(s); the audience relationship is intimate. Podcasts produce trust signal that other channels often cannot match.
+
+---
+
+## Community discipline
+
+Slack communities, Discord servers, dedicated discussion forums.
+
+**The discipline shape.**
+
+- **Active moderation.** Communities require continuous facilitation. Spam, off-topic content, and unaddressed conflict damage community health.
+- **Sustained value-delivery.** Members come and stay because the community delivers value. Value can be peer connection, expert access, content access, or product feedback.
+- **Integration with the broader content program.** Members get early access; program content is shared in the community; community feedback informs program decisions.
+- **Member-driven content.** Strong communities have member-to-member interaction beyond program-to-member broadcasting.
+
+**Common community failures.**
+
+- Abandonment. Communities launched with fanfare and then under-staffed. Members leave; the community decays into a ghost town signaling the program's decline.
+- Broadcast-only. The program posts to the community as if it were another social channel; no facilitation of member interaction.
+- Membership-quality drift. Open communities accumulate members who do not contribute; the signal-to-noise ratio degrades.
+- No moderation policy. Conflict, spam, or off-brand content erodes the community's character.
+
+**Community as audience-relationship multiplier.** The community is often the program's most engaged audience segment. Investment in the community returns at multiple points: feedback, advocacy, product input, content participation.
+
+---
+
+## The starvation anti-pattern
+
+Programs that under-invest in owned channels become dependent on third-party distribution.
+
+**The pattern.** The program invests heavily in paid acquisition or in social platforms it does not own. Reach grows on those channels. The program does not build newsletter, blog, or community in proportion. When platforms change algorithms or paid costs rise, reach collapses; the program has no owned channels to fall back on.
+
+**The visibility.** Programs in this state often have impressive total reach numbers but low conversion to owned-audience signals (newsletter subscribes, account creations, community memberships). The reach is rented, not owned.
+
+**The cure.** Reallocate capacity. Reduce paid spend; reduce broad-platform investment. Increase newsletter, blog, and community investment. Recovery is multi-year; programs in starvation cannot rebuild quickly.
+
+**Prevention.** Programs in early stages should over-invest in owned channels relative to the reach those channels initially produce. The investment compounds over years; the alternative is decade-long dependency on third-party distribution.
+
+---
+
+## The owned-channel investment timeline
+
+Owned channels reward long investment.
+
+**Year 1.** Newsletter and blog established; cadence consistent; subscriber count and traffic both small. The investment feels like it is producing little; the cadence is the foundation.
+
+**Year 2-3.** Newsletter list grows; blog accumulates SEO traffic; community starts to form (if part of the strategy). The investment starts to compound; engagement signals improve.
+
+**Year 4+.** Owned channels are reliable distribution. Newsletter sends produce predictable engagement; blog earns substantial organic traffic; community is a meaningful audience asset. The early investment compounds.
+
+**The patience cost.** Owned-channel investment is multi-year; the visible returns lag the investment. Programs that abandon owned-channel investment in years 1-2 because returns feel small often regret it in years 3-5 when peers who sustained the investment are reaping the compounding effect.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The owned-channel disciplines (newsletter, blog, social, podcast, community), the common failures per channel type, the starvation anti-pattern, the investment timeline.
+
+## Implementation choices that stay internal
+
+Specific newsletter platforms and templates. Specific blog CMS and design systems. Specific social-publishing tools. Specific podcast hosting and editing tools. Specific community-management software (Slack, Discord, custom forums). The team's own conventions for cadence and quality thresholds. These vary by team, budget, and program scope.

--- a/skills/content-distribution/references/paid-promotion-patterns.md
+++ b/skills/content-distribution/references/paid-promotion-patterns.md
@@ -1,0 +1,181 @@
+# Paid promotion patterns
+
+When boosting organic content earns its keep. The paid-as-substitute anti-pattern. The disciplines that distinguish strategic paid amplification from spending budget on content that did not validate organically.
+
+Paid promotion of organic content is an amplification layer. The pattern works when paid spend extends the reach of content that organic engagement has already validated; the pattern fails when paid spend substitutes for organic validation or for owned-channel investment.
+
+---
+
+## The boost-organic pattern
+
+The most common and effective form of paid content amplification.
+
+**The shape.** A piece publishes organically. Some pieces show strong engagement signals: high CTR, high time-on-page, organic shares, comment engagement. The program boosts those validated pieces with paid spend to extend reach.
+
+**Why it works.** The content has audience validation. Audiences engage with the boosted content because it is genuinely engaging. The paid spend amplifies what already worked rather than gambling on what might work.
+
+**Implementation patterns.**
+
+- **Engagement-threshold boosting.** Pieces that exceed defined engagement thresholds in the first 24-48 hours get boosted. The thresholds (CTR, share rate, comment volume) vary by program.
+- **Editorial-judgment boosting.** Editorial reviews recent organic pieces and selects which ones merit boost spend based on broader strategic fit, not just engagement metrics.
+- **Hybrid.** Engagement-threshold boost for tactical amplification; editorial-judgment boost for strategic amplification of pieces that align with program goals beyond engagement metrics.
+
+**Capacity allocation.** Most strong programs allocate 5-20% of distribution capacity to paid amplification of organic content. Higher allocations often signal under-investment in owned channels.
+
+---
+
+## Promoted newsletter sends
+
+Sponsored placements in third-party newsletters.
+
+**The shape.** The program pays a third-party newsletter to feature its content. The newsletter's audience sees the program's content alongside the newsletter's editorial content.
+
+**Why it works.** Newsletter audiences have strong attention rhythms; sponsored content placed in a newsletter the audience reads gets meaningful attention.
+
+**Implementation patterns.**
+
+- **Single-send sponsorship.** The program pays for one prominent placement in a single send. Strongest engagement; highest cost per send.
+- **Multi-send package.** The program pays for placements across multiple sends. Weaker per-send engagement; lower cost per send.
+- **Co-marketing.** The program partners with the newsletter on a co-produced piece; both parties benefit. Often the most effective format when it fits both audiences.
+
+**Selection criteria.**
+
+- Audience overlap with target audience.
+- Newsletter editorial fit (content tone matches the program's voice).
+- Engagement metrics (open rates, click-through rates, sponsor performance history).
+- Cost relative to alternative paid options.
+
+**Common newsletter-sponsorship failures.**
+
+- Mismatched audience. The newsletter has reach but does not match the program's target audience.
+- Mismatched tone. Sponsored content clashes with the newsletter's voice; readers tune out.
+- Generic sponsored content. Sponsored placements that read as ads underperform sponsorships that read as editorial fit.
+
+---
+
+## Syndication networks (Outbrain, Taboola, native networks)
+
+Paid placement on third-party sites via "you may also like" or "recommended for you" units.
+
+**The shape.** Programs pay per click; content appears on third-party sites in recommendation units.
+
+**Implementation patterns.**
+
+- **Bid management.** Per-piece bidding; cost-per-click optimization.
+- **Geographic and audience targeting.** Some networks support targeting; others are broader.
+- **Brand-safety controls.** Choose where the content appears; some networks have brand-safety concerns about co-placement.
+
+**Effectiveness.** Variable. Some programs see meaningful traffic with reasonable cost-per-engagement; others see high traffic numbers but low engagement once visitors land on the program's content. The audience quality varies significantly across networks.
+
+**Common syndication-network failures.**
+
+- Click optimization without engagement measurement. The program optimizes for cost-per-click; clicks arrive; engagement is low; the audience is the wrong audience.
+- Brand-safety incidents. Content appears in unwanted contexts; brand association damaged.
+- Treating syndication networks as primary distribution. The networks supplement; they do not substitute for owned and earned channels.
+
+**The cautious-test discipline.** Test syndication networks at small budget; measure beyond clicks (engagement, time-on-page, conversion); expand only if the audience quality matches expectations.
+
+---
+
+## Search advertising for content
+
+Paying for clicks on content pieces via search ads.
+
+**The shape.** Less common than other paid content amplification. Usually search ads target conversion-intent queries while content takes the organic side. Some programs use search ads to drive traffic to specific high-value content.
+
+**When it fits.**
+
+- High-value content with clear conversion or lead-capture goals.
+- Pieces targeting queries where organic ranking is hard to achieve.
+- Time-sensitive content where waiting for organic ranking is not an option.
+
+**When it fails.**
+
+- Routine blog posts boosted via search ads. Cost-per-click usually exceeds the value of the click.
+- Content that does not have clear conversion paths. Paid traffic without conversion produces sunk cost.
+- Competitive queries where ad costs are high. Programs may be unable to justify cost-per-click in highly contested categories.
+
+**The selective-discipline.** Reserve search ads for content with clear conversion goals; measure paid traffic against owned-traffic comparison; high-value content only.
+
+---
+
+## Sponsored podcast placements
+
+Pre-rolls, mid-rolls, sponsored segments in industry podcasts.
+
+**The shape.** Programs pay to be featured in third-party podcasts. Often via host-read endorsement; sometimes via produced ads.
+
+**Why host-read works.** The podcast host's voice carries trust signal; audiences hearing the host endorse content engage at higher rates than they engage with produced ads. Host-read endorsements are often the highest-engagement paid content amplification available.
+
+**Selection criteria.**
+
+- Host audience alignment with the program's target.
+- Host content alignment with the program's voice.
+- Per-episode reach and download numbers (with verification; some self-reported numbers are inflated).
+- Cost relative to expected engagement.
+
+**Common podcast-sponsorship failures.**
+
+- Mismatched host. The host's audience does not match the program's audience.
+- Mismatched content. The host reads the program's pitch awkwardly because the content does not fit the host's editorial voice.
+- Production quality issues. Poorly produced sponsored segments damage the host's show; future sponsorship opportunities reduce.
+
+**The host-collaboration discipline.** Provide the host with substantive talking points, not scripted ad copy. Hosts read better when they have material they can adapt to their voice. The collaboration produces stronger sponsorships than rigid scripts.
+
+---
+
+## The paid-as-substitute anti-pattern
+
+When paid promotion substitutes for organic validation or for owned-channel investment.
+
+**The pattern.** The program does not invest in newsletter, blog, community, or earned channels. Paid amplification produces visible reach; the program looks like it is working. Underlying owned-channel growth is minimal; the program is rented reach without owned-audience growth.
+
+**Why it fails over time.**
+
+- Paid costs rise. Auction dynamics on paid platforms drive prices up; the program's cost-per-engagement increases.
+- Algorithm shifts. Paid platforms change targeting; previously-effective audiences become harder to reach or more expensive.
+- Audience saturation. Audiences encountering the program's paid content develop ad-blindness; engagement decays.
+- No compounding effect. Each paid impression is paid for separately; nothing compounds the way newsletter or blog growth compounds.
+
+**The visibility.** Programs in this state often have impressive total reach numbers but low conversion to owned-audience signals (newsletter subscriptions, account creations, community memberships). The reach is rented, not owned.
+
+**The cure.** Reallocate capacity. Reduce paid spend; increase newsletter, blog, and community investment. Recovery is multi-year; programs in paid-substitute state cannot rebuild quickly.
+
+---
+
+## Paid amplification of low-organic-engagement content
+
+Boosting pieces that did not earn engagement organically.
+
+**The pattern.** A piece publishes organically. Engagement is low. The team boosts the piece anyway, reasoning that more reach will produce more engagement.
+
+**Why it fails.** Audiences who did not engage organically rarely engage when shown the same content via paid amplification. The piece's value proposition is not landing; paid amplification compounds the problem.
+
+**The cure.** Boost organically-validated content; do not substitute paid for organic validation. Pieces that did not engage organically should be evaluated for whether they should be refreshed (see `content-refresh-system`) or whether they were the wrong piece for the audience.
+
+**Exception cases.** Some content may be specifically targeted at audiences who do not see the organic version (different geographic markets, different audience segments). In those cases, paid amplification to specific audiences may be appropriate even without organic validation in the original audience. The rule is "validate within the addressable audience"; not necessarily "validate organically before any paid spend."
+
+---
+
+## Capacity allocation for paid promotion
+
+Most programs benefit from a clear capacity allocation.
+
+**Capacity guidelines.**
+
+- **0-5% of distribution capacity to paid.** Programs with strong owned and earned channels; paid is selective amplification of best organic pieces.
+- **5-20% of distribution capacity to paid.** Programs balancing organic-first with strategic paid amplification.
+- **20-50% of distribution capacity to paid.** Programs with explicit paid-amplification strategy; usually B2C brands or programs with strong conversion-funnel logic.
+- **50%+ of distribution capacity to paid.** Often signals under-investment in owned and earned; should be reviewed against the paid-as-substitute anti-pattern.
+
+**The allocation review.** Quarterly, review actual spend allocation. Programs drifting toward paid-heavy allocation should consider whether the drift reflects strategy or under-investment in alternatives.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The boost-organic pattern, sponsored newsletter discipline, syndication network cautious-test discipline, search advertising selective discipline, sponsored podcast host-collaboration discipline, paid-as-substitute anti-pattern, paid amplification of low-organic-engagement failure, capacity allocation guidelines.
+
+## Implementation choices that stay internal
+
+Specific paid platform configurations and bidding strategies. Specific engagement-threshold values for boost decisions. Specific newsletter sponsorship vendor selections. Specific syndication network testing protocols. Specific podcast sponsorship measurement infrastructure. The team's own conventions for paid-vs-organic capacity tradeoffs. These vary by team, budget, and platform mix.

--- a/skills/content-refresh-system/SKILL.md
+++ b/skills/content-refresh-system/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: content-refresh-system
+description: "Systematic content refresh discipline. Quarterly audits, refresh prioritization (which pieces, when, how deep), refresh-vs-merge-vs-delete decisions, the lifecycle that distinguishes intentional refresh from set-and-forget decay. Builds on the refresh sections of pillar-content-architecture and editorial-qa with a program-level discipline. Triggers on content refresh, content decay, content audit, refresh prioritization, content lifecycle, refresh strategy, traffic decay, ranking drop, content freshness, evergreen content, content maintenance. Also triggers when traffic is eroding silently across an aging content library, when teams cannot decide which pieces to refresh, or when refresh work is happening but the impact is unclear."
+category: content
+catalog_summary: "Systematic content refresh: quarterly audits, refresh prioritization, refresh-vs-merge-vs-delete decisions, the lifecycle discipline that distinguishes intentional programs from set-and-forget decay"
+display_order: 10
+---
+
+# Content Refresh System
+
+A senior editorial leader's playbook for systematic content refresh. The discipline that distinguishes intentional refresh programs from set-and-forget decay, and the prioritization framework that prevents both over-refresh (refresh-everything-on-calendar) and under-refresh (refresh-nothing-until-traffic-collapses).
+
+Content decays. Search behavior shifts; SERP intent reshapes; facts go stale; competitors publish stronger pieces; the brand's own positioning evolves past what older pieces represent. Programs that ignore this reality watch traffic erode silently across the library. Programs that overreact (rewriting everything on calendar) burn editorial capacity that should be producing new flagship work. The discipline is in the middle: refresh what matters when signals say so, and document the decisions so the program is auditable.
+
+This skill is the program-level refresh discipline across the whole content library. It builds on `pillar-content-architecture`'s hub-level refresh consideration (refresh as ONE consideration in hub design) and `editorial-qa`'s pre-publish quality gate (this skill is post-publish lifecycle, not pre-publish QA). Together those skills cover content quality at the moments quality decisions get made; this skill covers the moments between, when content is in the field and decaying or holding.
+
+The voice is the senior editorial leader who has watched refresh programs fail in both directions and who has shipped the systems that produced durable refresh discipline.
+
+When to use this skill: building a refresh program from scratch, auditing why refresh work is happening but traffic is not responding, designing the prioritization that keeps refresh tractable across a 200-piece or 2,000-piece library, or fixing a refresh program that is eating editorial capacity without clear results.
+
+---
+
+## What this skill covers
+
+This skill spans the post-publish lifecycle of content. The content suite distinction:
+
+- `content-strategy` is program scope: what to produce.
+- `pillar-content-architecture` is HUB scope; refresh appears as ONE consideration in hub design.
+- `content-brief-authoring` is per-piece scope at production time.
+- `content-and-copy` is execution scope at production time.
+- `editorial-qa` is gate scope: pre-publish verification.
+- **`content-refresh-system` (this skill)** is lifecycle scope: program-level refresh discipline across the whole content library, after pieces are in the field.
+
+The audience: editorial leads, content directors, content ops managers, in-house teams running content libraries of 50-5,000+ pieces, agencies maintaining client content programs across years.
+
+What is not in scope: writing the refreshed pieces themselves (that is `content-and-copy`), the brief that drives the refresh (that is `content-brief-authoring`), the pre-publish gate on the refreshed piece (that is `editorial-qa`). This skill is the prioritization and lifecycle discipline; the actual content work plugs into the existing skills.
+
+---
+
+## Refresh-everything vs refresh-nothing vs triaged-refresh
+
+The keystone framing. Two failure modes plus the discipline.
+
+**Refresh-everything.** Full rewrites on calendar. Every piece gets a refresh on a 12-month or 18-month rotation regardless of signals. Output: editorial capacity consumed by maintenance work that often was not needed, while strong pieces are touched into worse versions and weak pieces consume the same effort as flagship pieces. Cost: opportunity cost on new flagship production; maintenance fatigue in the editorial team; some pieces that were performing well get diluted by unnecessary edits.
+
+**Refresh-nothing.** Set-and-forget. Pieces ship and never get touched again. Output: traffic decays silently across the library as facts go stale, competitors publish stronger pieces, and SERP intent shifts away from the piece's framing. The library's compounding value erodes invisibly until an algorithm update or a competitor's flagship piece exposes the rot. Cost: cumulative traffic loss that nobody attributes to refresh failure because the loss is gradual; trust loss when readers find stale facts in pieces they expected to be current.
+
+**Triaged-refresh.** Refresh what matters when signals say so. Audit cadence catches decay early; prioritization concentrates effort on high-value-decaying pieces; weak pieces get refresh-vs-merge-vs-delete dispositions instead of automatic refresh; the program is auditable because every refresh decision was a deliberate response to specific signals. Output: editorial capacity preserved for new production; the library's compounding value protected; refresh work is seen, understood, and measured.
+
+The litmus test. Ask of any refresh decision: what signal triggered this refresh, what depth of refresh did the signal warrant, what outcome do we expect, and how will we measure whether the refresh worked? If the answer is "it was scheduled" or "we always refresh after 12 months," the program is on calendar rather than on signal.
+
+---
+
+## Refresh signals
+
+Five categories of signal that trigger refresh consideration. Pieces that show no signals do not need refresh; pieces that show multiple signals are higher priority.
+
+**Traffic decay.** Organic traffic to the piece is trending down over a 90+ day window beyond the seasonal baseline. The decay can be slow (5-10% over a year) or sharp (40%+ in a month after an algorithm update). Slow decay typically indicates content drift; sharp decay typically indicates external change.
+
+**Ranking drops.** The piece is losing position on its target keywords. Drops from page 1 to page 2-3 are particularly consequential; drops within page 1 (position 3 to position 7) are less so but still tracked. Persistent ranking drops over 30+ days indicate a real shift, not search-result volatility.
+
+**Factual staleness.** The piece contains statistics, references, examples, or claims that are dated. A 2018 stat in a 2026 piece on a fast-moving topic is staleness; a piece that references defunct products or platforms is staleness; a piece that uses pre-shift framings ("AI is starting to influence search" in 2026) is staleness.
+
+**SERP intent shift.** The dominant SERP format for the target keyword has changed. The piece was written when articles ranked for the keyword; now the SERP wants product comparisons, video, or AI-overview-style answers. The piece may still rank but increasingly for the wrong reason.
+
+**Content drift.** The piece's positioning no longer matches the brand's current positioning. Voice has evolved; the brand's POV on the topic has sharpened or shifted; the piece reads as the brand-of-three-years-ago. Internal signal more than external; readers may not notice but the team will.
+
+The audit. Every piece in the library can be characterized by which signals it shows. Pieces with zero signals are stable; pieces with one or two signals warrant attention; pieces with three or more signals are typically in active decay.
+
+Detail in `references/refresh-signals-checklist.md`.
+
+---
+
+## The audit cadence
+
+How often to look. Two cadences with different tradeoffs.
+
+**Quarterly audit.** A formal review of the content library every 90 days. The team pulls traffic, ranking, and recency data; reviews each piece against the signals; assigns dispositions (refresh, merge, delete, or leave alone). Output: a refresh queue with priorities and a backlog of merge/delete decisions.
+
+- Strength: predictable, auditable, fits naturally into editorial calendar planning.
+- Weakness: 90-day delay in detecting sharp decay; piece that lost 40% traffic in week 2 of a quarter is in decay for 75 days before the audit catches it.
+
+**Continuous monitoring.** Automated detection of traffic and ranking shifts with alerts when thresholds are crossed. Pieces that lose more than X% traffic in Y days trigger a review.
+
+- Strength: catches sharp decay early; allows fast response to algorithm updates.
+- Weakness: requires monitoring infrastructure; can produce alert fatigue if thresholds are too tight; misses slow decay that does not cross thresholds.
+
+**The hybrid pattern.** Most strong refresh programs run both. Quarterly audits catch slow decay, content drift, and pieces that are stable but no longer match the brand's current positioning. Continuous monitoring catches sharp decay and algorithm-update fallout. The two cadences cover different failure modes.
+
+Detail in `references/audit-cadence-patterns.md`.
+
+---
+
+## Refresh prioritization
+
+Prioritization is the discipline. Most libraries have more pieces showing signals than the team has capacity to refresh. Prioritization concentrates effort on the pieces where refresh produces the most value.
+
+The 2x2 matrix: piece value (high vs low) crossed with traffic state (decaying vs stable).
+
+**High-value, decaying.** Top priority. Pieces that drive meaningful traffic, conversions, or topical authority and are losing position. Refresh these first; the traffic loss compounds and the lost equity is hard to recover.
+
+**High-value, stable.** Monitor; do not refresh proactively. Pieces that are performing should not be touched without clear signal; refresh-everything-on-calendar treats this quadrant the same as the high-value-decaying quadrant and damages performance.
+
+**Low-value, decaying.** Audit for merge or delete. Pieces with low traffic that are decaying further are usually candidates for merge (consolidate into a stronger sibling piece) or delete (and 301 to the closest sibling). Refresh on these pieces rarely justifies the effort; the underlying issue is usually that the piece never had strong demand.
+
+**Low-value, stable.** Leave alone. Low traffic is the floor; the piece is not costing anything to keep. Touching these pieces in a refresh program burns capacity for no return.
+
+The matrix shifts the program from refresh-everything to refresh-the-quadrant-that-warrants-it. Detail in `references/refresh-prioritization-matrix.md`.
+
+---
+
+## Refresh depth options
+
+Not every refresh is the same kind of work. Four depth levels.
+
+**Light edit.** Update statistics, replace dead links, fix factual errors, swap dated examples. Keeps the piece's structure and argument intact. Time investment: 30-90 minutes per piece. Use when the piece is structurally sound and only the surface details have aged.
+
+**Substantial revision.** Light edit plus rewrite of 1-3 sections that have aged badly. Update the introduction or closing. Add coverage of topics that emerged after the piece was written. Time investment: 2-4 hours per piece. Use when the piece's structure is sound but specific sections have become weak.
+
+**Full rewrite.** Keep the URL and topic; rewrite the piece end-to-end. Time investment: similar to writing a new piece, sometimes more because of the constraint of preserving the URL and the existing internal links. Use when the piece's structure no longer fits the current SERP intent or the brand's positioning has shifted enough that the piece needs to be re-conceived.
+
+**Structural redesign.** Full rewrite plus consolidation with sibling pieces, restructuring of internal linking, possible URL change with redirects. Time investment: a multi-piece project. Use when refresh is part of a larger structural change in the content library (a hub being rebuilt, a category being consolidated).
+
+The depth-decision discipline. Match depth to signal strength. Sharp decay or major SERP intent shift may warrant full rewrite; slow decay with stale stats may warrant only a light edit. Treating every refresh as a full rewrite is refresh-everything energy in a different shape.
+
+Detail in `references/refresh-depth-decision.md`.
+
+---
+
+## Refresh vs merge vs delete decisions
+
+Not every piece in decay should be refreshed. Three dispositions.
+
+**Refresh.** The piece has a clear topic, real demand, and either a strong-enough current position to recover or a strong-enough strategic role in the library to justify the work.
+
+**Merge.** Two or more pieces are competing for the same query, splitting authority and confusing the reader. Combine into one stronger piece; redirect the merged URLs.
+
+**Delete.** The piece has no real demand, the topic is no longer relevant to the brand's positioning, or the piece is a low-quality artifact from an earlier era of the program. Delete and redirect to the closest sibling or, if no sibling exists, to the relevant hub or category page.
+
+The decision criteria. Refresh when the piece has demand and a path back. Merge when authority is being split. Delete when there is no path forward and the piece is not worth maintaining.
+
+The under-recognized failure mode: refreshing pieces that should have been merged or deleted. The team spends hours improving a low-value piece that even at its best will not recover meaningful traffic, while a merge candidate that would have produced a stronger consolidated piece sits unaddressed.
+
+Detail in `references/refresh-vs-merge-vs-delete.md`.
+
+---
+
+## Refresh execution patterns
+
+Who does the work, how it ships.
+
+**Ownership.** A single owner per refresh, not a committee. The owner is accountable for the outcome and runs the work through to ship. Refreshes that pass through multiple hands without an accountable owner often get partially done and then stall.
+
+**Editorial integration.** Refreshes typically run through the same editorial workflow as new pieces (brief, draft, edit, QA gate, publish), scaled to the depth chosen. A light edit may skip the brief and go straight to edit; a full rewrite goes through every step.
+
+**Capacity allocation.** Refresh work consumes editorial capacity that would otherwise produce new pieces. The capacity decision is a real tradeoff: a team producing 20 pieces per quarter might allocate 5 of those slots to refresh work, leaving 15 for new production. The split varies by program maturity (older libraries often need 30-40% refresh allocation; newer libraries may need 5-10%).
+
+**Refresh batching.** Some teams batch refresh work into dedicated weeks or sprints; others integrate one refresh per week into the steady-state production cadence. Batching produces focus but interrupts new production; integration sustains new production but slows refresh velocity. Either works; the failure mode is no allocation discipline at all, which produces refresh work happening in the cracks at unpredictable cadence.
+
+Detail in `references/refresh-execution-patterns.md`.
+
+---
+
+## Re-promotion after refresh
+
+Refreshed pieces need to signal to search engines and audiences that they have been updated.
+
+**To search engines.** Update the modified date in schema markup. Update the published-or-modified-date in the visible metadata. Submit the URL for re-crawl through Search Console. Some teams update the URL minimally (e.g., adding a year to the slug for evergreen pieces), but URL changes carry redirect risk and should be reserved for substantial-revision or full-rewrite refreshes.
+
+**To audiences.** Re-share the refreshed piece on the channels where the original landed: newsletter, social, syndication partners. Treat the refresh as a publication event, not as silent maintenance. The re-promotion is part of the refresh's value proposition: the piece earns new attention as well as preserved search position.
+
+**Internal linking refresh.** Pieces that link to the refreshed piece may benefit from anchor-text updates if the refreshed piece's positioning shifted. Sister pieces that should now link to the refreshed piece can be updated to do so.
+
+**The refresh that nobody tells anyone about.** A refreshed piece that is not re-promoted often performs only marginally better than the original. The refresh's signal to search engines is the modified date; the refresh's value to the program is partly the audience re-engagement.
+
+Detail in `references/re-promotion-after-refresh.md`.
+
+---
+
+## Refresh tracking and effectiveness measurement
+
+The discipline that prevents refresh-theater: tracking which refreshes worked, which did not, and what the patterns reveal.
+
+**Per-refresh tracking.** Each refresh is logged with: the signals that triggered it, the depth chosen, the date shipped, the predicted outcome, the actual outcome at 30 days and 90 days post-refresh. The log is the refresh program's evidence base.
+
+**Effectiveness metrics.** The primary metrics depend on the refresh's purpose. Traffic-decay refreshes track post-refresh traffic recovery; ranking-drop refreshes track post-refresh ranking position; content-drift refreshes track post-refresh engagement metrics (time on page, return visits) more than search metrics.
+
+**Pattern detection.** The log reveals patterns over time. Some signal types produce reliable recovery; others rarely produce recovery and indicate a deeper problem (the topic itself is dying; the brand's positioning on the topic is wrong; competitors are too strong to displace). The patterns inform program-level decisions.
+
+**The refresh-that-did-not-work review.** Refreshes that did not produce the expected recovery should get a structured review. Was the depth wrong? Was the merge or delete decision the right disposition that we did not take? Did the underlying problem turn out to be something refresh cannot fix?
+
+Detail in `references/effectiveness-measurement.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-refresh-failures.md`.
+
+- "We refresh every piece annually and traffic is still declining." Refresh-everything pattern; the calendar-based work is not catching the actual decay signals.
+- "We have not touched the library in 18 months and traffic has eroded 30%." Refresh-nothing pattern; the decay went uncaught.
+- "We refresh pieces but the traffic does not come back." Wrong disposition; the pieces were merge or delete candidates, not refresh candidates.
+- "Our refresh queue is 200 pieces deep and growing." No prioritization; everything that shows any signal goes in the queue regardless of value.
+- "We refreshed a flagship piece and traffic dropped." Refresh damaged a piece that was performing; the refresh was triggered by calendar rather than signal.
+- "The team is exhausted from refresh work." Capacity allocation is wrong; either refresh ratio is too high, or new production is suffering, or the depth choices are over-investing.
+- "We do not know if our refreshes are working." No tracking; refresh work happens but its effectiveness is invisible.
+- "Some pieces always get refreshed; others never do." The signal triage is informal and inconsistent; some pieces are getting attention because they are visible, not because they are most decayed.
+- "We refreshed a piece and forgot to re-promote it." Refresh-without-re-promotion; the piece's modified date updated but no audience or channel re-engagement happened.
+- "Our quarterly audit catches things 75 days late." Quarterly cadence alone is missing sharp decay; add continuous monitoring for traffic-loss thresholds.
+- "We refresh sister pieces but the hub orchestration is unchanged." Pieces refreshed in isolation when the hub-level architecture also needed updating; coordinate with `pillar-content-architecture` discipline.
+
+---
+
+## The framework: 12 considerations for content refresh
+
+When designing or auditing a refresh program, walk these 12 considerations.
+
+1. **Triaged-refresh, not refresh-everything or refresh-nothing.** Refresh on signal, not on calendar.
+2. **Signal categories named.** Traffic decay, ranking drops, factual staleness, SERP intent shift, content drift.
+3. **Audit cadence committed.** Quarterly audit plus continuous monitoring; both running.
+4. **Prioritization matrix applied.** High-value-decaying first; low-value-decaying audited for merge or delete.
+5. **Depth matched to signal.** Light edit, substantial revision, full rewrite, structural redesign.
+6. **Disposition decided per piece.** Refresh, merge, or delete; not all decay warrants refresh.
+7. **Single ownership per refresh.** Accountable owner runs the work to ship.
+8. **Capacity allocation explicit.** Refresh ratio of editorial capacity is a real number, planned.
+9. **Re-promotion built into the workflow.** Schema, visible date, search-engine resubmit, audience re-share.
+10. **Per-refresh tracking.** Signals, depth, outcomes logged for pattern detection.
+11. **Effectiveness measurement.** Recovery tracked at 30 and 90 days; patterns inform program decisions.
+12. **The-refresh-that-did-not-work review.** Failed refreshes get structured review; lessons compound.
+
+The output of the framework is a refresh program that is auditable, capacity-respecting, and producing visible value for the library's compounding equity.
+
+---
+
+## Reference files
+
+- [`references/refresh-signals-checklist.md`](references/refresh-signals-checklist.md) - Five signal categories with detection patterns. Traffic decay, ranking drops, factual staleness, SERP intent shift, content drift. The audit pattern that surfaces signals across the library.
+- [`references/audit-cadence-patterns.md`](references/audit-cadence-patterns.md) - Quarterly audit vs continuous monitoring vs hybrid. Tradeoffs, integration patterns, alert-threshold design.
+- [`references/refresh-prioritization-matrix.md`](references/refresh-prioritization-matrix.md) - 2x2 matrix with quadrant strategies. High-value-decaying as top priority; low-value-decaying audited for merge or delete; the discipline of NOT refreshing the high-value-stable quadrant.
+- [`references/refresh-depth-decision.md`](references/refresh-depth-decision.md) - Light edit, substantial revision, full rewrite, structural redesign. Time investment per depth, signal-to-depth matching, depth-creep anti-pattern.
+- [`references/refresh-vs-merge-vs-delete.md`](references/refresh-vs-merge-vs-delete.md) - Disposition criteria. When to refresh, when to merge, when to delete and redirect. The under-recognized failure of refreshing pieces that should have been merged.
+- [`references/refresh-execution-patterns.md`](references/refresh-execution-patterns.md) - Single owner per refresh, editorial-workflow integration, capacity allocation, batching vs integration tradeoffs.
+- [`references/re-promotion-after-refresh.md`](references/re-promotion-after-refresh.md) - Schema markup, visible-date update, search-engine resubmission, audience re-share, internal linking refresh.
+- [`references/effectiveness-measurement.md`](references/effectiveness-measurement.md) - Per-refresh tracking, 30/90-day recovery measurement, pattern detection, the refresh-that-did-not-work review.
+- [`references/common-refresh-failures.md`](references/common-refresh-failures.md) - 11+ failure patterns with diagnoses and fixes.
+
+---
+
+## Closing: refresh is content's immune system
+
+A content library is a long-running system. The pieces in it interact with search algorithms that change, audiences that shift, brands that evolve, and competitors that publish. Set-and-forget treats the library as a static asset and watches it decay. Refresh-everything treats it as a maintenance project and burns capacity that should be producing new flagship work.
+
+The discipline is the immune system: signals are detected early, prioritization concentrates effort where the value is highest, depth matches signal strength, dispositions include merge and delete (not just refresh), and the work is tracked so the program learns. Programs that run this discipline preserve the library's compounding value. Programs that do not watch the library erode and discover the loss only when an algorithm update or a competitor's flagship piece exposes how far the rot has spread.
+
+When in doubt about whether a refresh program is ready, ask: does the program detect signals, prioritize on value, match depth to signal, decide between refresh and merge and delete, allocate capacity explicitly, re-promote the refreshed pieces, and track effectiveness? If yes to all of those, the program is real. If no to any, the gap is where decay will compound.

--- a/skills/content-refresh-system/references/audit-cadence-patterns.md
+++ b/skills/content-refresh-system/references/audit-cadence-patterns.md
@@ -1,0 +1,162 @@
+# Audit cadence patterns
+
+Quarterly audit vs continuous monitoring vs hybrid. Tradeoffs, integration patterns, and alert-threshold design.
+
+The audit cadence determines how quickly decay signals turn into refresh decisions. Programs that audit annually catch decay 9-12 months late; programs that monitor continuously without an audit layer catch sharp decay early but miss the slow-drift and content-drift signals that need human review. The hybrid pattern is the standard for mature programs.
+
+---
+
+## The quarterly audit
+
+A formal review of the content library every 90 days.
+
+**The mechanics.**
+
+- The team blocks 1-3 days per quarter for the audit.
+- Pull data: traffic per URL over the last 90 and 180 days, rankings on target keywords, last-modified dates, target-keyword SERP samples.
+- Run each piece through the five-signal checklist (see `refresh-signals-checklist.md`).
+- Assign each piece a disposition: refresh (with depth), merge, delete, monitor, no action.
+- Output a refresh queue prioritized by the prioritization matrix.
+
+**Strengths.**
+
+- Predictable. The team knows when audit work happens and can plan around it.
+- Auditable. Each quarter's decisions are documented; patterns over multiple quarters become visible.
+- Comprehensive. The signal types that need human judgment (content drift, SERP intent shift) get reviewed; continuous monitoring cannot detect these without human eyes.
+- Capacity-aware. Audit work happens at known times; new production schedules can flex around it.
+
+**Weaknesses.**
+
+- 90-day delay in detecting sharp decay. A piece that lost 40% traffic in week 2 of the quarter is in decay for 75 days before the audit catches it.
+- Heavy lift. Auditing 200-2,000 pieces in 1-3 days requires structured tooling; teams without tooling burn out.
+- Focus on the audit moment can crowd out continuous attention. "We will catch it next quarter" becomes the answer to issues that warrant immediate response.
+
+---
+
+## Continuous monitoring
+
+Automated detection of traffic and ranking shifts with alerts when thresholds are crossed.
+
+**The mechanics.**
+
+- Define thresholds for sharp decay: e.g., traffic drop of 25%+ in 14 days, ranking drop of 5+ positions in 14 days.
+- Automated monitoring runs daily or weekly, comparing current data to baseline.
+- Alerts route to the editorial owner of the affected piece (or to a refresh queue triage owner if pieces do not have individual owners).
+- Triage decides whether the alert warrants immediate refresh, addition to the next quarterly audit's queue, or dismissal as noise.
+
+**Strengths.**
+
+- Catches sharp decay early. Algorithm-update fallout, technical regressions, and dramatic SERP intent shifts get attention within days, not 75-90 days.
+- Allows fast response. A piece that lost 50% traffic on a specific date can be investigated while the cause is fresh.
+- Reduces audit-day exhaustion. Sharp signals are handled in real time; the quarterly audit focuses on the slower signals.
+
+**Weaknesses.**
+
+- Requires monitoring infrastructure. Teams need rank tracking, traffic monitoring, and alerting that can route to specific URL owners.
+- Alert fatigue if thresholds are too tight. Daily alerts on minor fluctuations train the team to ignore the alerts; thresholds need calibration.
+- Misses slow decay. Pieces declining 5-8% per quarter never cross thresholds; they accumulate decay invisibly. The quarterly audit is what catches these.
+- Misses non-traffic signals. Continuous monitoring on traffic and rankings cannot detect content drift or factual staleness.
+
+---
+
+## The hybrid pattern
+
+Most strong refresh programs run both. The quarterly audit catches slow decay, content drift, and pieces that are stable but no longer match the brand's current positioning. Continuous monitoring catches sharp decay and algorithm-update fallout.
+
+**Integration shape.**
+
+- Continuous monitoring runs daily or weekly with a small set of well-calibrated thresholds.
+- Quarterly audit runs the full signal checklist on the whole library.
+- Pieces that triggered continuous-monitoring alerts during the quarter get fast-track disposition; the quarterly audit reviews the rest.
+- The continuous-monitoring log feeds into the quarterly audit so the team can see whether thresholds are calibrated correctly (too many false alerts, too few real ones).
+
+**Capacity split.** A typical hybrid pattern might allocate 5-10% of editorial capacity to continuous-monitoring response (a few hours per week) and a concentrated 1-3 days per quarter to the audit. The split scales with library size and decay rates.
+
+---
+
+## Alert-threshold design
+
+Calibrating continuous-monitoring thresholds is its own discipline.
+
+**Threshold goals.**
+
+- High precision: when the threshold is crossed, the alert is usually a real signal, not noise.
+- Reasonable recall: catches the sharp-decay events that matter; does not need to catch every minor fluctuation (the audit catches those).
+- Sustainable cadence: alerts arrive at a frequency the team can triage without fatigue.
+
+**Threshold patterns that work.**
+
+- Traffic: 25%+ drop in 14 days, sustained over 21 days. The sustainment requirement filters volatility.
+- Ranking: 5+ position drop on a tracked keyword, sustained over 14 days. Single-day drops are noise; sustained drops are signal.
+- Indexing: any unexpected change in indexed status (200 to non-200 status, sudden noindex tag, sudden disappearance from index). These are usually technical regressions and warrant immediate attention.
+- Schema validation: schema breaking or warnings appearing on a piece that previously validated cleanly. Often indicates a CMS update or template change.
+
+**Threshold patterns that fail.**
+
+- 10% traffic drop alerts produce far too many false positives; teams stop reading the alerts.
+- Single-day rank drop alerts produce noise; SERP volatility within a few positions is normal.
+- Aggregate-traffic alerts on whole categories rather than per-URL alerts hide which specific pieces are decaying.
+
+**Threshold tuning.** Run alerts in shadow mode for 4-6 weeks before committing. Track whether alerts correspond to real signals on review. Adjust thresholds based on the precision-recall observed.
+
+---
+
+## When to audit more frequently
+
+Some programs warrant more than quarterly audits.
+
+**Programs in active rebuild.** Content libraries undergoing structural redesign or hub reorganization benefit from monthly audits during the rebuild phase. The signal volume is higher and the decisions need faster cycle time.
+
+**Post-algorithm-update period.** In the 30-90 days after a major algorithm update, signal volume spikes. Some teams run a special audit at the 30-day post-update mark in addition to the regular quarterly cadence.
+
+**Programs with rapid topic evolution.** Topics that move quickly (AI tools, evolving regulatory environments, tactical playbooks in fast-moving fields) may benefit from monthly factual-staleness checks even when traffic and ranking signals are stable.
+
+---
+
+## When to audit less frequently
+
+Some programs can run on lighter cadence.
+
+**Small libraries (under 50 pieces) with stable performance.** Bi-annual audits may be sufficient if continuous monitoring is in place and the library has shown stable decay rates over multiple cycles.
+
+**Libraries dominated by evergreen pieces.** When the topical mix is heavily evergreen (foundational concepts that move slowly), quarterly audits may produce limited signal volume. Combine with continuous monitoring; reduce audit frequency.
+
+The discipline. Cadence should match decay rate, not be fixed by convention. Programs that decay quickly need faster cadence; programs that decay slowly can run longer audit cycles.
+
+---
+
+## Audit anti-patterns
+
+**Annual audit as the only cadence.** Catches decay 9-12 months late; the library is in significant erosion before the audit runs.
+
+**Continuous monitoring without quarterly audit.** Catches sharp decay; misses slow decay, content drift, and SERP intent shifts that need human review.
+
+**Audit happening but no follow-through.** The team runs the audit, produces a queue, then loses momentum on actually executing the refreshes. The audit becomes a documentation exercise rather than a refresh-driving exercise.
+
+**Audit without prioritization.** The output is a list of every piece showing any signal, with no value-weighted prioritization. The team does the cheapest refreshes first regardless of value, leaving high-value-decaying pieces in the backlog.
+
+**Audit without depth assignment.** Pieces are tagged "refresh" without specifying depth. Refresh execution defaults to whatever depth the team has time for, which is often light edit even when substantial revision is needed.
+
+---
+
+## Audit governance
+
+Who runs the audit, who approves dispositions, how the queue routes to execution.
+
+**Single audit owner.** A specific person runs the audit each quarter, accountable for signal quality and disposition recommendations.
+
+**Disposition review.** Refresh, merge, and delete dispositions are reviewed by a content lead or director. Delete dispositions in particular need approval because they are irreversible (pieces deleted and not redirected can lose authority that did not need to be lost).
+
+**Queue routing.** The refresh queue routes to specific editorial owners based on capacity, expertise, and the depth of work required. Light edits route to anyone with capacity; full rewrites route to the writer or editor best matched to the topic.
+
+**Audit log.** Each quarter's audit, dispositions, and outcomes are logged. The log feeds the next quarter's review (which dispositions actually shipped, which produced recovery, which patterns are emerging).
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The quarterly audit mechanics, continuous monitoring mechanics, hybrid pattern, alert-threshold design principles, audit-cadence variations, audit governance shape, and the anti-patterns.
+
+## Implementation choices that stay internal
+
+Specific monitoring tools the team uses (rank trackers, analytics platforms, alerting systems). Specific threshold values calibrated to the team's data. Specific dashboards and reporting templates. Specific ticketing or queue systems for refresh routing. Specific automation scripts that pull data into audit-ready formats. The team's own audit-day rituals and tooling. These vary by team, tooling, and library size.

--- a/skills/content-refresh-system/references/common-refresh-failures.md
+++ b/skills/content-refresh-system/references/common-refresh-failures.md
@@ -1,0 +1,169 @@
+# Common refresh failures
+
+Eleven-plus failure patterns with diagnoses and cures. The patterns appear across programs of different sizes, library ages, and editorial team compositions; the underlying causes are rarely about people and almost always about discipline, prioritization, or measurement gaps.
+
+---
+
+## Failure 1: Refresh-everything-on-calendar
+
+**Symptom.** Every piece gets refreshed on a 12-month or 18-month rotation regardless of signals. Editorial capacity is consumed by maintenance work that often was not needed.
+
+**Diagnosis.** The program treats refresh as a calendar event rather than as a signal-driven decision. Pieces that were performing get touched into worse versions; pieces that were decaying are scheduled for refresh whenever their rotation comes up rather than when the decay signals warrant.
+
+**Cure.** Replace calendar-driven refresh with the prioritization matrix and the signal-driven audit cadence. Refresh on signals; leave stable pieces alone.
+
+**Capacity recovery.** Programs that abandon refresh-everything typically recover 30-50% of their refresh capacity for higher-value work or for new production.
+
+---
+
+## Failure 2: Set-and-forget
+
+**Symptom.** The team has not touched the library in 18+ months. Traffic has eroded across the library; the team is uncertain how much loss is from refresh failure vs other causes.
+
+**Diagnosis.** The program lacks both audit cadence and continuous monitoring. Decay accumulates silently because no system is detecting it.
+
+**Cure.** Establish the hybrid audit pattern: quarterly audit plus continuous monitoring. The first audit will surface a large queue (typical when starting from set-and-forget); the queue should be triaged by the prioritization matrix and worked through over multiple quarters rather than tackled all at once.
+
+---
+
+## Failure 3: Refresh that should have been merge or delete
+
+**Symptom.** The team spends hours refreshing pieces that even at their best will not produce meaningful recovery. The same pieces appear in queue across multiple audits.
+
+**Diagnosis.** The disposition decision was wrong. Refresh was the default disposition because it felt less destructive than merge or delete; the actual right disposition was merge into a stronger sibling or delete with redirect.
+
+**Cure.** Make merge and delete first-class dispositions in the audit. Every piece in the audit gets one of: refresh, merge, delete, monitor, no action. Train the audit owner on the disposition decision flow (see `refresh-vs-merge-vs-delete.md`).
+
+---
+
+## Failure 4: Unprioritized refresh queue
+
+**Symptom.** The refresh queue is 200 pieces deep and growing. The team works through the queue in order of arrival or in order of "easiest first" rather than by value.
+
+**Diagnosis.** No prioritization matrix is being applied. Every piece showing any signal goes in the queue regardless of value.
+
+**Cure.** Apply the 2x2 matrix (value × traffic state). Queue entries get tagged by quadrant. Work focuses on high-value-decaying first; low-value-decaying gets disposition decisions (often merge or delete) rather than refresh; stable quadrants get monitor or no action.
+
+---
+
+## Failure 5: Refresh-on-stable-piece regression
+
+**Symptom.** A flagship piece was performing well. The team refreshed it because it was the next piece in the rotation. After the refresh, traffic dropped 30% and rankings dropped 5 positions.
+
+**Diagnosis.** Refresh-everything-on-calendar damaged a stable piece. The refresh introduced changes that shifted the SERP signals or the piece's structural fit; the new version performs worse than the original.
+
+**Cure.** Stop refreshing high-value-stable pieces by default. Pieces in this quadrant get monitor disposition unless content drift is severe enough to warrant the regression risk. When refreshing a stable piece is genuinely warranted, plan for fast revert if regression occurs.
+
+**Recovery.** Some refresh regressions can be partially reversed by going back to a closer-to-original version of the piece. Some cannot. The lesson informs future stable-piece refresh decisions.
+
+---
+
+## Failure 6: Capacity overcommitment
+
+**Symptom.** The team is exhausted from refresh work. New-piece production is suffering. The team complains of refresh fatigue.
+
+**Diagnosis.** Capacity allocation to refresh is too high (or new-production commitments are too high; the result is the same). The team is being asked to do more total work than capacity allows.
+
+**Cure.** Right-size the allocation. Reduce refresh queue intake by tightening prioritization (only highest-value items enter the queue); or reduce new-production commitments; or temporarily increase capacity. The status quo is unsustainable.
+
+**Sustainability check.** Capacity is real. Programs that pretend capacity is infinite produce burnout, quality drift, and team turnover. The capacity audit (see `refresh-execution-patterns.md`) is what catches this before burnout.
+
+---
+
+## Failure 7: Effectiveness invisible
+
+**Symptom.** "We do not know if our refreshes are working." Refresh work happens but its effectiveness is not tracked or reviewed.
+
+**Diagnosis.** No per-refresh tracking is in place. The program runs without learning data.
+
+**Cure.** Establish the minimum log (see `effectiveness-measurement.md`). Backfill the log for recent refreshes if possible. Establish 30-day and 90-day measurement windows. Run quarterly pattern-detection reviews.
+
+**Adoption.** Logging adds overhead. Programs that resist logging often discover later that the program's effectiveness has been declining for quarters and they cannot tell why because the data was not captured. The overhead of logging is small compared to the cost of running the program blind.
+
+---
+
+## Failure 8: Inconsistent refresh attention
+
+**Symptom.** Some pieces always get refreshed; others never do. The pattern correlates with which writers prefer which topics, not with which pieces need refresh most.
+
+**Diagnosis.** The signal triage is informal and inconsistent. Pieces are getting attention because they are visible to certain people, not because they are most decayed.
+
+**Cure.** Formalize the audit so signal detection is data-driven rather than memory-driven. The matrix and the audit log force visibility on the whole library, not just on the pieces individual team members happen to think of.
+
+---
+
+## Failure 9: Refresh-without-re-promotion
+
+**Symptom.** Refreshes ship. Modified dates update. The team waits for traffic recovery. Recovery is marginal at best. The team concludes refresh does not work.
+
+**Diagnosis.** Re-promotion was skipped. Search engines saw the modified date but audiences did not engage; the recovery curve that re-promotion typically produces did not happen.
+
+**Cure.** Build re-promotion into the workflow as a non-skippable step. Match re-promotion intensity to refresh depth (see `re-promotion-after-refresh.md`). The refresh is not "done" when published; the refresh is "done" when re-promotion has executed.
+
+---
+
+## Failure 10: Audit without follow-through
+
+**Symptom.** The team runs the quarterly audit; produces a queue; the queue largely sits unworked; the next quarter's audit shows the same pieces in queue.
+
+**Diagnosis.** No owner-of-owners is keeping the queue moving. The audit becomes a documentation exercise rather than a refresh-driving exercise.
+
+**Cure.** Assign an owner-of-owners role for the refresh program as a whole. Their job is queue movement, escalation of stalled refreshes, and program-level reporting. Without this role, even good audits do not produce execution.
+
+---
+
+## Failure 11: Quarterly cadence too slow for sharp decay
+
+**Symptom.** The quarterly audit catches a piece in significant decay. The traffic loss has been accumulating for 75 days before the audit caught it. The recovery is harder because the decay has compounded.
+
+**Diagnosis.** Quarterly cadence alone is missing sharp decay. The lag between decay and detection is too long.
+
+**Cure.** Add continuous monitoring for traffic-decay and ranking-drop thresholds. Sharp decay alerts route to fast-track triage; the quarterly audit focuses on slower signals that continuous monitoring cannot detect (content drift, factual staleness, SERP intent shift).
+
+---
+
+## Failure 12: Refresh in isolation when hub orchestration changed
+
+**Symptom.** Pieces are refreshed individually but the hub-level architecture also needed updating. The refreshes ship; the hub-level decay continues because the architecture problem was unaddressed.
+
+**Diagnosis.** Piece-level refresh is being done without coordination with hub-level architecture. Some refresh queues need to escalate to structural-redesign disposition rather than be addressed at piece level.
+
+**Cure.** Coordinate with `pillar-content-architecture` discipline. When piece-level refresh is bumping against architecture-level issues, escalate to a structural-redesign project. Some refresh attempts cannot succeed without the hub-level work.
+
+---
+
+## Failure 13: Stalled refreshes accumulating
+
+**Symptom.** The refresh queue contains zombie items: pieces assigned months ago that have not shipped and are not progressing. Everyone knows they are stalled; nobody is removing them.
+
+**Diagnosis.** No stalled-refresh recovery process. Refreshes that get stuck stay stuck because there is no review mechanism to escalate or reassign.
+
+**Cure.** Build stalled-refresh review into each quarterly audit. Refreshes that have been in queue more than two cycles get reviewed: reassign owners, re-scope depth, or remove from queue if the disposition was wrong. The review prevents zombie accumulation.
+
+---
+
+## Failure 14: Light-edit-as-default
+
+**Symptom.** Most refreshes are light edits regardless of signal strength. The light edits do not move the needle on pieces that needed substantial revision; the team concludes "refresh does not work" when the actual issue is depth mismatch.
+
+**Diagnosis.** Depth assignment is defaulting to light edit because light edits are the easiest to schedule. Substantial revision and full rewrite are being skipped because they are harder to fit into capacity.
+
+**Cure.** Match depth to signal strength explicitly. Depth-light when signals support light edit; depth-deeper when signals warrant. Capacity allocation should account for depth distribution; if the team consistently has capacity only for light edits, the allocation needs adjustment, not the depth assignment.
+
+---
+
+## The cross-cutting pattern
+
+Most refresh failures share a single root: shortcuts in discipline. Calendar-refresh shortcuts the signal analysis. No-measurement shortcuts the learning. Refresh-as-default shortcuts the disposition decision. Light-edit-as-default shortcuts the depth decision. No-re-promotion shortcuts the audience-engagement work. Each shortcut feels like it is saving capacity; each shortcut is actually shifting capacity to lower-value work.
+
+The fix for almost any refresh failure is the same: surface the discipline that was being shortcutted, and pay the cost of running the discipline. The capacity recovered from eliminating low-value refreshes typically more than pays for the discipline overhead.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The fourteen failure patterns with diagnoses and cures, the cross-cutting pattern that connects most of them, the discipline-as-cure observation.
+
+## Implementation choices that stay internal
+
+Specific tooling for stalled-refresh detection. Specific reporting templates for owner-of-owners updates. Specific reviewer training on disposition decisions. Specific automation that catches refresh-without-re-promotion. The team's own conventions for capacity recalibration when overcommitment is detected. These vary by team, tooling, and program structure.

--- a/skills/content-refresh-system/references/effectiveness-measurement.md
+++ b/skills/content-refresh-system/references/effectiveness-measurement.md
@@ -1,0 +1,150 @@
+# Effectiveness measurement
+
+Per-refresh tracking, 30/90-day recovery measurement, pattern detection, the refresh-that-did-not-work review. The discipline that prevents refresh-theater and turns the refresh program into a learning system.
+
+Refresh effectiveness measurement is the difference between a program that learns and a program that runs. Programs without measurement run the same patterns indefinitely, including the patterns that do not work; programs with measurement see which refreshes produce recovery, which do not, and what the patterns reveal about depth, signal interpretation, and disposition decisions.
+
+---
+
+## Per-refresh tracking
+
+Each refresh is logged with the data needed to evaluate it.
+
+**The minimum log.**
+
+- **URL.** The refreshed piece.
+- **Date shipped.** When the refresh published.
+- **Signals that triggered the refresh.** Which of the five signal categories were active; signal severity.
+- **Disposition.** Refresh, merge, delete (with target URLs for merge).
+- **Depth.** Light edit, substantial revision, full rewrite, structural redesign.
+- **Owner.** Who shipped the refresh.
+- **Capacity spent.** Hours of editorial time invested.
+- **Predicted outcome.** What the team expected the refresh to produce (recovery within X% in Y days, or qualitative expectation).
+- **Actual outcome at 30 days.** Traffic, ranking, engagement metrics post-refresh vs pre-refresh.
+- **Actual outcome at 90 days.** Same metrics extended to 90 days.
+- **Notes.** Qualitative observations on what happened, surprising patterns, questions raised.
+
+**Why the minimum log.** Each field is load-bearing for pattern detection. Without signals, you cannot tell whether decay-driven refreshes recover differently from drift-driven refreshes. Without depth, you cannot tell whether full rewrites outperform substantial revisions. Without capacity, you cannot evaluate ROI.
+
+**The log as program memory.** Across years, the log becomes the program's accumulated learning. A team that has logged 200 refreshes can answer questions like "what is the typical recovery curve for substantial-revision refreshes on traffic-decayed pieces?" with data; a team without the log answers the same question with anecdote.
+
+---
+
+## 30-day recovery measurement
+
+The first measurement window post-refresh.
+
+**What the 30-day window shows.**
+
+- **Schema and indexing recognition.** Search engines have crawled the updated piece and registered the modified date.
+- **Initial ranking response.** Some ranking shifts happen within days as the search engine re-evaluates; others take longer.
+- **Audience engagement spike.** Re-promotion produces traffic from newsletter, social, and syndication. The 30-day window captures the immediate engagement.
+- **Quick wins or regressions.** If the refresh broke something (regressions in indexing, schema, or ranking), the 30-day window catches it.
+
+**What the 30-day window does not show.**
+
+- **Sustained recovery.** Initial spikes from re-promotion fade; the 30-day window cannot distinguish sustained recovery from re-promotion afterglow.
+- **Algorithm-update response.** If an algorithm update happens after the refresh, the 30-day measurement may be confounded.
+- **Long-tail keyword recovery.** Some long-tail rankings move slowly; the 30-day window may show only head-term response.
+
+**The 30-day pattern.** Most refreshes that will produce sustained recovery show some signal at 30 days: ranking improvement, traffic uptick, engagement spike. Refreshes that show no signal at 30 days are not necessarily failures, but they warrant attention; the 90-day measurement will resolve the question.
+
+---
+
+## 90-day recovery measurement
+
+The longer-window measurement that confirms or refutes the 30-day signal.
+
+**What the 90-day window shows.**
+
+- **Sustained recovery.** Initial spikes have faded; what remains is the refresh's durable contribution.
+- **Algorithm-update integration.** Most algorithm updates have been digested; the 90-day data reflects the new state.
+- **Long-tail keyword response.** Slower-moving rankings have settled.
+- **Engagement-based metrics.** Time on page, return visits, scroll depth post-refresh vs pre-refresh.
+
+**The 90-day pattern.**
+
+- **Strong recovery.** Traffic and rankings are above pre-refresh baseline by 20%+. The refresh worked.
+- **Modest recovery.** Traffic and rankings are 5-20% above pre-refresh baseline. The refresh helped but did not produce dramatic improvement.
+- **No recovery.** Traffic and rankings are within 5% of pre-refresh baseline. The refresh was not effective.
+- **Regression.** Traffic or rankings are below pre-refresh baseline. The refresh damaged the piece.
+
+The 90-day measurement is the primary effectiveness measurement. The 30-day is the early-warning; the 90-day is the verdict.
+
+---
+
+## Pattern detection across refreshes
+
+Individual refresh measurements are noisy. Patterns across refreshes are signal.
+
+**Patterns the log reveals.**
+
+- **Depth-effectiveness.** Are full rewrites producing better recovery than substantial revisions on similar signals? If yes, the team should consider deeper depth on similar future cases.
+- **Signal-effectiveness.** Are traffic-decay refreshes recovering more reliably than content-drift refreshes? If yes, the program may benefit from prioritizing traffic-decay queue and being more selective about content-drift refresh.
+- **Disposition-effectiveness.** Are pieces in the high-value-decaying quadrant recovering when refreshed, or are they continuing to decay? If continuing decay, the disposition may be wrong (merge or delete may have been better) or the underlying cause is structural (the topic is dying; competitors too strong).
+- **Owner-effectiveness.** Are some owners producing better recovery than others on similar refreshes? Possibly skill differential, possibly capacity issues, possibly random variation that needs more data.
+- **Topic-effectiveness.** Are refreshes on some topics recovering reliably while others do not? Some topics may be in structural decline; the program may need to reduce investment in those topics rather than increase refresh effort.
+
+**Pattern detection cadence.** Quarterly review of accumulated refresh data. Year-over-year reviews on multi-year programs. The patterns inform program-level decisions about allocation, prioritization, and disposition defaults.
+
+---
+
+## The refresh-that-did-not-work review
+
+Refreshes that did not produce recovery are the program's most valuable learning data.
+
+**The review questions.**
+
+- **Was the depth wrong?** Did the refresh need more depth than was applied? Light edit when substantial revision was needed produces no recovery on substantial-decay signals.
+- **Was the disposition wrong?** Should the piece have been merged or deleted instead of refreshed? Refreshing a piece that should have been merged produces ongoing decay because the underlying authority-splitting was not addressed.
+- **Was the signal interpretation wrong?** Did the team read decay as content-drift when it was actually competitor-displacement? Refresh on the wrong cause does not produce recovery.
+- **Is the topic in structural decline?** Some topics decline structurally; refresh cannot recover what the topic itself has lost. The right disposition may be to reduce investment in the topic and reallocate capacity.
+- **Did re-promotion happen?** Refresh-without-re-promotion underperforms; some "did not work" cases are actually "did not get re-promoted."
+
+**The review output.** Each non-recovery refresh produces either: a re-disposition (try merge or delete), a depth re-attempt (next quarter try the deeper depth), or an acknowledgment that the topic is in decline and the program should reduce investment.
+
+**The review's program impact.** Without the review, non-recovery refreshes accumulate as silent program failures. With the review, the patterns surface and the program adjusts.
+
+---
+
+## Effectiveness metrics by refresh purpose
+
+Different refresh purposes warrant different primary metrics.
+
+**Traffic-decay refreshes.** Primary metric: post-refresh traffic recovery vs pre-refresh baseline at 90 days. Secondary: ranking position recovery on target keywords.
+
+**Ranking-drop refreshes.** Primary metric: ranking position recovery on target keywords at 90 days. Secondary: traffic recovery (rankings without traffic recovery suggest CTR issues that ranking alone does not capture).
+
+**Factual-staleness refreshes.** Primary metric: less straightforward; the refresh's purpose is correctness, not recovery. Track that the staleness was caught before reader-detected errors compound. Secondary: any traffic recovery is bonus.
+
+**SERP-intent-shift refreshes.** Primary metric: ranking on target keywords (rankings reflect format-fit). Secondary: engagement metrics (the refresh changed format; does the new format engage better?).
+
+**Content-drift refreshes.** Primary metric: engagement metrics (time on page, return visits, conversions). Secondary: voice consistency review (qualitative; the refresh purpose was alignment with current brand positioning).
+
+The metric should match the purpose. Programs that measure every refresh by traffic recovery miss the value of refreshes whose purpose was correctness or alignment rather than recovery.
+
+---
+
+## Common measurement failures
+
+**No measurement at all.** Refreshes ship; outcomes are not tracked; the program runs without learning. Each refresh is a fresh prediction with no accumulated evidence.
+
+**Measurement at the wrong window.** Measuring at 7 days captures only re-promotion afterglow; measuring at 6 months conflates many other variables. 30 and 90 days are the workable windows.
+
+**Single-metric measurement.** Measuring only traffic ignores ranking, engagement, and conversion metrics. Different refresh purposes warrant different metrics.
+
+**Measurement without context.** Comparing post-refresh metrics to pre-refresh metrics without accounting for seasonality, algorithm updates, or competitor activity produces noisy attribution.
+
+**No pattern detection.** Per-refresh measurement happens but never gets aggregated into pattern review; the program does not learn across refreshes.
+
+**No non-recovery review.** Successful refreshes get celebrated; failed refreshes get forgotten. The asymmetry hides the program's most valuable learning.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The minimum per-refresh log fields, the 30-day and 90-day measurement windows, the pattern-detection cadence, the refresh-that-did-not-work review, the metric-by-purpose mapping, the common measurement failures.
+
+## Implementation choices that stay internal
+
+Specific analytics dashboards that pull refresh metrics. Specific log structure in the team's project-management or content system. Specific seasonality models the team uses to baseline. Specific competitor-activity tracking that contextualizes attribution. Specific reviewer workflow for non-recovery refreshes. The team's own pattern-detection rituals. These vary by team, tooling, and analytics setup.

--- a/skills/content-refresh-system/references/re-promotion-after-refresh.md
+++ b/skills/content-refresh-system/references/re-promotion-after-refresh.md
@@ -1,0 +1,159 @@
+# Re-promotion after refresh
+
+Schema markup, visible-date update, search-engine resubmission, audience re-share, internal linking refresh. The patterns that signal a refresh to search engines and audiences.
+
+A refreshed piece that is not re-promoted often performs only marginally better than the original. The refresh's signal to search engines is the modified date; the refresh's value to the program is partly the audience re-engagement that re-promotion produces. Programs that ship refreshes silently leave value on the table.
+
+---
+
+## Signal to search engines
+
+What the search engine needs to see to recognize the refresh.
+
+**Modified-date in schema markup.** Schema.org Article (and related types) include a `dateModified` field. Update this when the refresh ships. Many CMS platforms update this automatically on save; verify the automation is working. Schemas with stale modified dates signal that the refresh is technical rather than substantive.
+
+**Visible modified-date on the page.** The page should display "Updated [date]" or similar visible signal. Some templates show "Published [date]" without an updated date; these should be updated to surface the refresh date.
+
+**Sitemap update.** The XML sitemap's `lastmod` field for the URL should reflect the refresh date. Most sitemap generators handle this automatically; verify after the refresh ships.
+
+**Search Console URL inspection and resubmission.** For high-priority refreshes, use Search Console's URL inspection tool and request indexing. This signals the refresh to the index without waiting for the next crawl. Use sparingly; bulk resubmission of every refresh can throttle.
+
+**Internal-link-graph signals.** When sister pieces add or update links to the refreshed piece, the additional internal-link signals reinforce that the URL is current and load-bearing. Refresh that updates internal linking from sister pieces sends stronger signals than refresh that does not.
+
+---
+
+## Substantive vs cosmetic modifications
+
+Search engines distinguish between substantive content changes and cosmetic touch-ups.
+
+**Substantive changes.** Body content edits, section additions or removals, lede or closing rewrites, factual updates, restructuring. The refresh has changed what the piece says.
+
+**Cosmetic changes.** Date stamp updates without content changes. CSS or template changes. Whitespace edits. These do not constitute refresh; updating the modified date without substantive change is signaling a refresh that did not happen.
+
+**Why the distinction matters.** Search engines that detect the modified-date signal as cosmetic rather than substantive can devalue the signal. Programs that bump modified dates without substantive change to chase the refresh signal are running a tactic that has been increasingly detected and discounted. The honest signal is a real refresh; the tactic of date-bumping without change is short-lived value at best.
+
+**The audit.** Refreshes should produce diff'able content changes. If the refresh ships without diff'able changes, it is not a refresh.
+
+---
+
+## Signal to audiences
+
+The other half of re-promotion: re-engaging the audiences who saw the original.
+
+**Newsletter re-share.** For pieces that originally went to the newsletter, a refreshed piece deserves a re-share. The framing is "we updated this with [specific updates]," not "here is a piece you may have seen before." Specificity earns re-engagement; vague re-shares feel like filler.
+
+**Social re-share.** For pieces that originally landed on social channels, the refresh is a social moment. New angle, new pull-quote, new visual, framing the refresh as the news the piece now carries.
+
+**Syndication partner update.** For pieces syndicated to partner platforms, the refresh may warrant communication with syndication partners about the updated version. Some partners pull the latest content automatically; some do not. The refresh communication closes the loop.
+
+**Email-list segmentation.** For programs with sophisticated email-list segmentation, refreshed pieces can be sent to segments that did not see the original or that engaged with the original and may benefit from the updated version.
+
+**Re-share cadence discipline.** Not every refresh deserves the same re-share intensity. Light edits typically do not warrant social re-share; substantial revisions or full rewrites do. Calibrate re-share to depth.
+
+---
+
+## Internal linking refresh
+
+Pieces that link to the refreshed piece may benefit from anchor-text updates.
+
+**When anchor-text update fits.** The refreshed piece's positioning shifted, and the anchor text on sister pieces should now describe the piece differently. A piece that linked to the refreshed piece as "our guide to programmatic SEO" may now want to link as "our guide to programmatic SEO durability" if the refreshed piece's framing is now durability-focused.
+
+**When sister pieces should now link to the refreshed piece.** Some refreshes add coverage of topics that sister pieces discuss. Pieces discussing those topics that did not previously link to the refreshed piece may now warrant new internal links.
+
+**The internal-link-refresh pass.** Some programs run a quick pass after each substantial refresh: search the library for pieces mentioning the refreshed piece's topic, audit whether the existing anchor text and link presence are correct, update where warranted.
+
+**The over-linking failure.** Refreshes that trigger 30 internal-link updates across the library can create maintenance overhead disproportionate to value. The internal-link refresh should be targeted, not exhaustive.
+
+---
+
+## URL preservation vs URL change
+
+Most refreshes preserve the URL. Some warrant URL change.
+
+**Preserve the URL when:**
+
+- The refresh is light edit, substantial revision, or most full rewrites.
+- The existing URL has authority worth preserving (rankings, backlinks, internal-link references).
+- The URL slug fits the refreshed piece's framing reasonably well even if not perfectly.
+
+**Change the URL when:**
+
+- The refresh is a structural redesign and the URL slug no longer fits.
+- The piece is being merged with a sibling and the consolidated piece needs a new URL.
+- The original URL was a structural mistake (wrong category, awkward slug) that the refresh is correcting.
+
+**The URL-change cost.** Even with 301 redirects, URL changes incur authority transfer cost; some authority does not survive the redirect. URL changes should be earned by structural rationale, not chosen for cosmetic reasons.
+
+**The URL-preservation discipline.** Most refreshes should preserve URLs. The default disposition is preserve; URL change is the exception requiring rationale.
+
+---
+
+## The refresh that nobody told anyone about
+
+The pattern when re-promotion is skipped.
+
+**The symptom.** A refresh ships. Modified date updates. Schema validates. The piece sits in the library with the refresh complete on paper. Traffic recovers marginally if at all. The team concludes refresh does not work.
+
+**The actual cause.** Re-promotion was skipped. The refresh signaled to the search engine but did not signal to audiences. New-piece-style audience engagement (newsletter, social, syndication) did not happen. The refresh produced search-engine recognition without the audience-engagement spike that often drives broader recovery.
+
+**The cure.** Build re-promotion into the refresh workflow as a non-skippable step. The refresh is not "done" when the piece is published; the refresh is "done" when the re-promotion has been executed. Define re-promotion intensity per depth (light edit may need only modified-date and schema; substantial revision needs newsletter and social re-share; full rewrite needs full re-promotion treatment).
+
+---
+
+## Re-promotion checklist by depth
+
+A short framework matching re-promotion to refresh depth.
+
+**Light edit re-promotion.**
+
+- Modified date in schema and visible.
+- Sitemap lastmod.
+- No audience re-share required for routine light edits.
+- Internal-link audit only if specific anchor text changes warranted.
+
+**Substantial revision re-promotion.**
+
+- Modified date and visible date.
+- Sitemap lastmod.
+- Newsletter re-share with framing on what was updated.
+- Social re-share to channels that originally promoted the piece.
+- Internal-link audit on sister pieces with relevant topics.
+
+**Full rewrite re-promotion.**
+
+- All of the above.
+- Search Console URL inspection and resubmission.
+- Syndication partner update where applicable.
+- Email-list segment send to engaged segments.
+- Visual asset refresh for social and newsletter (new pull-quote graphics, new hero image if applicable).
+
+**Structural redesign re-promotion.**
+
+- All of the above.
+- Coordination with the broader hub or category being redesigned (see `pillar-content-architecture`).
+- Cross-piece internal-link audit across the affected hub or category.
+- Possible launch communication if the redesign represents a major program milestone.
+
+---
+
+## Re-promotion failure modes
+
+**Skipping re-promotion entirely.** The refresh produces marginal recovery; the team concludes refresh does not work; the program loses momentum.
+
+**Bulk-resubmitting every refresh URL to Search Console.** Search Console's URL submission has implicit rate limits; bulk submission of low-value refreshes throttles the team's submission capacity for the cases that warrant it.
+
+**Re-share without specificity.** "We refreshed this piece; here it is" lacks the specific framing that earns re-engagement. Specific framing ("we added the 2026 data and a new section on X") earns clicks; vague re-shares get ignored.
+
+**Anchor-text updates that proliferate.** Internal-link refresh that touches every mention of the topic across the library is over-investment. Target specifically; touch sparingly.
+
+**Modified-date bumping without content change.** The signal that gets discounted by search engines and signals to careful auditors that the team is gaming the metric rather than producing substantive refresh.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The signal-to-search-engine patterns, the substantive-vs-cosmetic distinction, the audience re-promotion patterns, the internal-link refresh discipline, the URL-preservation default, the re-promotion checklist by depth, the re-promotion failure modes.
+
+## Implementation choices that stay internal
+
+Specific schema markup automation in the team's CMS. Specific newsletter and social-publishing tooling and templates. Specific Search Console workflow conventions. Specific internal-link-audit automation. Specific syndication-partner communication channels. The team's own depth-to-re-promotion-intensity mappings. These vary by team, stack, and channel mix.

--- a/skills/content-refresh-system/references/refresh-depth-decision.md
+++ b/skills/content-refresh-system/references/refresh-depth-decision.md
@@ -1,0 +1,174 @@
+# Refresh depth decision
+
+Light edit, substantial revision, full rewrite, structural redesign. Time investment per depth, signal-to-depth matching, the depth-creep anti-pattern.
+
+Refresh depth is one of the most consequential decisions in the program. The wrong depth produces predictable failure: light edits on pieces that needed substantial revision produce no recovery; full rewrites on pieces that only needed factual updates burn capacity. The discipline is matching depth to signal strength.
+
+---
+
+## Depth 1: Light edit
+
+**The work.** Update statistics. Replace dead links. Fix factual errors. Swap dated examples. Update product or platform references. Verify external links still resolve and still go where they should.
+
+**Time investment.** 30-90 minutes per piece for typical pieces. Longer for research-heavy pieces with many external citations.
+
+**The piece's structure stays intact.** Section weights, lede, closing, archetype, voice, claims-and-arguments are all preserved. The light edit is surface maintenance.
+
+**Use when.**
+
+- Factual staleness is the only or dominant signal.
+- Traffic is stable or only slightly decayed.
+- The piece's structural framing still fits current SERP intent and brand positioning.
+- The piece is performing well enough that significant changes would risk performance.
+
+**Common failures.**
+
+- Light-editing when substantial revision is warranted. Surface fixes do not address the structural reasons for decay; the piece continues to decay after the light edit ships.
+- Light edits that touch more than they should. A "light edit" that becomes 4 hours of work because the editor kept finding things has lost the depth discipline; either commit to substantial revision or stop at the originally scoped scope.
+
+---
+
+## Depth 2: Substantial revision
+
+**The work.** Light edit plus rewrite of 1-3 sections that have aged badly. Update the introduction or closing. Add coverage of topics that have emerged since the piece was written. Restructure 1-3 H2 sections without redesigning the piece's overall shape.
+
+**Time investment.** 2-4 hours per piece for typical pieces. Longer for pieces with extensive new sections to add.
+
+**The piece's spine stays intact.** The archetype, the central thesis, and most sections survive. Specific sections are rewritten or added.
+
+**Use when.**
+
+- Traffic has decayed moderately but not catastrophically.
+- Specific sections of the piece have aged badly (often the introduction, closing, or a section on a topic that has shifted).
+- New topics have emerged that the piece needs to cover to stay current.
+- The piece's structural framing is mostly fine but needs targeted updates.
+
+**Common failures.**
+
+- Substantial revision drifting into full rewrite. The "substantial revision" that becomes 8 hours of work has crossed into full-rewrite territory; either commit to full rewrite or scope back to the original substantial-revision plan.
+- Substantial revision that rewrites the introduction without rewriting the closing, leaving the piece structurally inconsistent (the introduction promises one shape; the closing delivers a different one).
+- Rewriting sections without auditing whether the rewrites match each other in voice and density.
+
+---
+
+## Depth 3: Full rewrite
+
+**The work.** Keep the URL and topic; rewrite the piece end-to-end. New lede, new structure (possibly new archetype), new closing. The new piece occupies the old piece's URL and connects to the existing internal-link graph.
+
+**Time investment.** Similar to writing a new piece, sometimes more because of the constraint of preserving the URL and the existing internal links. 8-16 hours for typical long-form rewrites.
+
+**The piece's spine changes.** New archetype possible. New positioning possible. The connection to the URL and the existing topical authority is what is being preserved; everything else can change.
+
+**Use when.**
+
+- Traffic has decayed sharply or persistently.
+- The piece's structural framing no longer fits current SERP intent.
+- The brand's positioning has shifted enough that the piece needs to be re-conceived.
+- Light edit and substantial revision have already been tried and did not produce recovery.
+
+**Common failures.**
+
+- Full rewrite that loses what worked. The original piece had specific strengths (a memorable lede, a particular section that drew links). The rewrite that does not preserve those strengths can perform worse than the original even if the rewrite is technically stronger.
+- Full rewrite that breaks internal linking. Section IDs change, anchor links from sister pieces break, the internal-link graph that supported the piece's authority is disrupted.
+- Full rewrite that ignores the URL constraint. The team rewrites as if writing a new piece, then realizes the URL is locked and the new framing does not fit the existing slug. Either accept the slug mismatch (suboptimal) or change the URL (incurring redirect cost).
+
+---
+
+## Depth 4: Structural redesign
+
+**The work.** Full rewrite plus consolidation with sibling pieces, restructuring of internal linking, possible URL change with redirects. Often part of a larger structural change in the content library: a hub being rebuilt, a category being consolidated, a topic cluster being reorganized.
+
+**Time investment.** A multi-piece project. 1-3 weeks for a hub-level restructure involving multiple pieces.
+
+**Multiple URLs and pieces are affected.** The piece being refreshed is one node in a graph that is being reshaped.
+
+**Use when.**
+
+- Refresh of an individual piece is bumping against architecture-level issues that cannot be addressed at the piece level.
+- A hub is being redesigned and pieces within the hub need to be reconceived as part of the redesign.
+- Multiple pieces are competing for the same query and a consolidated piece would produce stronger authority than any of the individual pieces.
+
+**Common failures.**
+
+- Treating structural redesign as a refresh exercise rather than as a project. The work scope is project-scope; treating it as a refresh queue item leads to under-resourcing.
+- Structural redesign without coordination with `pillar-content-architecture` discipline. The hub-level work and the piece-level work need to compose; doing them separately produces friction.
+- Redirect plans that do not account for all the URLs being consolidated. Some authority is lost in transit because some redirects were missed.
+
+---
+
+## Signal-to-depth matching
+
+A short framework for choosing depth from the signals.
+
+**Light edit when:**
+
+- Factual staleness is the dominant signal.
+- Traffic stable or only slightly decayed (under 10%).
+- Rankings stable or only slightly drifted.
+- No SERP intent shift detected.
+- No content drift detected.
+
+**Substantial revision when:**
+
+- Multiple signal types present (factual + content drift, or traffic decay + ranking drops).
+- Traffic decayed moderately (10-25%).
+- Rankings drifted but still on page 1.
+- Specific sections have aged badly while others are sound.
+- SERP intent has not shifted dramatically.
+
+**Full rewrite when:**
+
+- Traffic decayed sharply (25%+).
+- Rankings dropped from page 1 to page 2 or beyond.
+- SERP intent has shifted substantially (the dominant SERP format has changed).
+- Brand positioning has shifted enough that the piece reads as the brand-of-multiple-years-ago.
+- Light edit or substantial revision already attempted without recovery.
+
+**Structural redesign when:**
+
+- The piece's issues are architecture-level rather than piece-level.
+- A hub or category is being reorganized.
+- Multiple sibling pieces are competing for the same query and consolidation would produce stronger authority.
+
+---
+
+## The depth-creep anti-pattern
+
+Refreshes that grow during execution from their planned depth into a deeper depth that was not budgeted.
+
+**The pattern.** A refresh planned as a light edit becomes substantial revision because the editor "kept finding things." The substantial revision becomes a full rewrite because once you are restructuring two sections you might as well restructure the rest. The piece ships 6 weeks after planned, having consumed 4x the planned capacity.
+
+**Why it happens.** Editors and writers are pattern-matchers; once they start working on a piece, they see all its problems and want to fix all of them. The discipline of staying at the planned depth is not natural to editorial work.
+
+**The cure.** Two options.
+
+1. **Stop at scope.** When the editor finds work beyond the planned depth, log it but do not do it. The next quarter's audit can decide whether the piece needs deeper work; this refresh ships at the planned depth.
+2. **Re-scope explicitly.** When the editor discovers the planned depth is wrong, halt the refresh and re-scope formally. The capacity allocation gets adjusted; the timing gets adjusted; the team is aware the refresh became a bigger project.
+
+The failure mode is the third option: keep going at deeper depth without explicit re-scoping. That produces capacity overruns and missed timelines that affect other work.
+
+---
+
+## Multi-depth refresh sequences
+
+Some pieces benefit from a sequence of refreshes at different depths over time.
+
+**The pattern.**
+
+- Light edit ships first to address factual staleness while broader investigation continues.
+- Substantial revision follows in the next quarter once SERP intent shift has been analyzed and the right structural changes are clear.
+- Full rewrite follows in 2-3 quarters if the substantial revision did not produce recovery.
+
+**When this pattern fits.** High-value-decaying pieces where the right disposition is unclear and the team wants to avoid premature commitment to a full rewrite. Light-edit-first preserves what works while buying time for analysis.
+
+**When this pattern fails.** Programs that always start with light edit on high-value-decaying pieces, regardless of signal strength, because light edit is the easiest depth to schedule. The light edit does not move the needle, and the next quarter's audit shows the same piece in the same queue.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The four depth levels with their work, time investment, and use cases. The signal-to-depth matching framework. The depth-creep anti-pattern with its cure. The multi-depth refresh sequence pattern.
+
+## Implementation choices that stay internal
+
+Specific time-tracking that captures actual depth per refresh. Specific scope-confirmation tooling that flags depth-creep. Specific writer or editor assignment patterns by depth (some writers are stronger at light edits; some at full rewrites). Specific brief templates per depth in the team's writing system. These vary by team and tooling.

--- a/skills/content-refresh-system/references/refresh-execution-patterns.md
+++ b/skills/content-refresh-system/references/refresh-execution-patterns.md
@@ -1,0 +1,154 @@
+# Refresh execution patterns
+
+Single owner per refresh, editorial-workflow integration, capacity allocation, batching vs integration tradeoffs. The execution patterns that turn audit queues into shipped refreshes.
+
+The audit produces a queue. The execution patterns turn the queue into shipped work. Programs that produce strong audits but weak execution end up with documentation of what should have been refreshed rather than refreshed pieces.
+
+---
+
+## Single owner per refresh
+
+Each refresh has one owner accountable for shipping it.
+
+**The pattern.** When a refresh is assigned, one person is named as the owner. The owner runs the work end-to-end: confirming the depth, doing or coordinating the actual editorial work, running the QA gate, shipping, re-promoting, logging the outcome.
+
+**Why single ownership matters.** Refreshes that pass through multiple hands without a clear owner often get partially done and then stall. One person believes another is finishing the work; the work sits between them; the audit's next pass shows the piece still in queue. The accountability gap is the failure mode.
+
+**Owner selection.** Typically the writer or editor best matched to the topic. For light edits, the owner can be anyone with capacity; for substantial revision and full rewrite, ownership matches expertise. For structural redesign, ownership often sits with a content lead because the work spans multiple pieces.
+
+**Owner-of-owners.** A single person owns the refresh program as a whole. Their job is keeping the queue moving, escalating stalled refreshes, ensuring effectiveness measurement is happening, and reporting on the program's health to leadership. Without this role, the program drifts even if individual refreshes have owners.
+
+---
+
+## Editorial-workflow integration
+
+Refreshes typically run through the same editorial workflow as new pieces, scaled to the chosen depth.
+
+**Light edit workflow.** May skip the brief and go straight to edit. The editor pulls the piece, identifies the specific updates, makes them, runs a QA pass, and ships. 30-90 minutes of editorial time; minimal coordination.
+
+**Substantial revision workflow.** Brief, draft, edit, QA gate, publish. The brief covers the targeted sections being rewritten; the draft is partial-rewrite; the edit and QA gate match new-piece discipline. 2-4 hours of editorial time; coordination similar to a short blog post.
+
+**Full rewrite workflow.** Brief, draft, edit, QA gate, publish. Full new-piece workflow with the additional constraint of preserving the URL and existing internal-link integration. 8-16 hours of editorial time; coordination at long-form-piece scale.
+
+**Structural redesign workflow.** Project-scope coordination. Multiple briefs, multiple drafts, redirect plans, internal-link audits. Multi-week timeline; coordination at flagship-project scale.
+
+The integration discipline. Refreshes are not a separate workflow; they plug into the existing editorial workflow at the appropriate depth. Teams that build a parallel refresh workflow create coordination overhead and quality drift; teams that integrate refresh into the standard workflow benefit from the workflow's existing discipline.
+
+---
+
+## Capacity allocation
+
+Refresh work consumes editorial capacity that would otherwise produce new pieces. The capacity decision is a real tradeoff.
+
+**Allocation patterns.**
+
+- **Newer libraries (under 100 pieces, under 2 years old):** 5-15% of capacity to refresh. Most pieces are still relatively current; signals are limited.
+- **Mid-stage libraries (100-500 pieces, 2-5 years old):** 15-30% of capacity to refresh. Decay rates have built up; high-value-decaying queue is meaningful.
+- **Mature libraries (500+ pieces, 5+ years old):** 25-40% of capacity to refresh. Cumulative decay is significant; without sustained refresh capacity, the library erodes.
+
+**The capacity-vs-new-production tradeoff.**
+
+A team producing 20 pieces per quarter might allocate 5 of those slots to refresh work, leaving 15 for new production. Or 8 to refresh, 12 to new. The split affects program shape: heavy-refresh programs preserve existing equity; heavy-new-production programs build new topical authority.
+
+**Right-sizing the allocation.**
+
+- If refresh queues are growing quarter-over-quarter, allocation is too low.
+- If new-production output is dropping or the team complains of refresh fatigue, allocation may be too high.
+- If high-value-decaying pieces stay in queue across multiple audits, allocation is misallocated (volume of work, not allocation share, may be the issue, but allocation review is the first step).
+
+**The capacity audit.** Quarterly, review the actual refresh time spent vs the planned allocation. Programs that consistently exceed their allocation are signaling that the queue's growth rate exceeds the allocation; either grow allocation, narrow the prioritization, or accept slower queue cycle times.
+
+---
+
+## Batching vs integration
+
+Two patterns for how refresh work fits into the cadence.
+
+**Batching.** Dedicated weeks or sprints for refresh work. The team blocks 1-2 weeks per quarter for concentrated refresh execution.
+
+- **Strength.** Focus. The team is in refresh mode; context-switching costs are low; throughput on refresh work is high.
+- **Weakness.** Interrupts new production. New-piece workflows pause during refresh sprints; pieces in the new-production pipeline stall.
+- **Fits.** Mid-stage libraries with manageable refresh queues; teams that prefer focused work blocks; programs with predictable seasonality where new production has natural pauses.
+
+**Integration.** One refresh per week (or similar steady cadence) integrated into the regular production cadence.
+
+- **Strength.** Sustains new production. New-piece work continues without pauses.
+- **Weakness.** Slower refresh velocity per piece; context-switching costs are higher; refresh work can get deprioritized in favor of "more urgent" new-piece work.
+- **Fits.** Mature libraries with continuous refresh queues; teams that prefer sustained pacing; programs where new production has tight commitments.
+
+**Hybrid.** A baseline integration cadence plus periodic batching for the high-priority queue.
+
+- **Strength.** Sustained refresh on lower-priority work; periodic concentration on high-value-decaying queues.
+- **Weakness.** Coordination overhead; the team manages both modes.
+- **Fits.** Mature programs with sophisticated capacity planning.
+
+The discipline. Pick a pattern. The failure mode is no allocation discipline at all, which produces refresh work happening in the cracks at unpredictable cadence and a queue that never clears.
+
+---
+
+## The refresh that needs to happen now
+
+Some refreshes cannot wait for the next allocation slot.
+
+**Trigger conditions.**
+
+- Sharp decay (40%+ traffic loss in 30 days) on a high-value piece.
+- Algorithm-update fallout affecting a high-value piece.
+- Factual error producing reputational risk.
+- Broken page state (indexing failure, schema regression, redirect loop).
+
+**The fast-track pattern.**
+
+- Continuous monitoring detects the issue.
+- The owner-of-owners decides whether the issue warrants fast-track.
+- Fast-track refreshes get pulled out of the queue and shipped within days.
+- The refresh skips some workflow steps if necessary (briefer brief, faster QA) but does not skip the QA gate; pieces that ship without QA produce regressions that compound.
+
+**Fast-track capacity.** Teams need a small reserve for fast-track work. The reserve is typically 5-10% of total capacity. Without reserve, fast-track work pushes other work out and produces cascade delays.
+
+---
+
+## Stalled refresh recovery
+
+Refreshes that have been in queue for more than two audit cycles need intervention.
+
+**Common causes.**
+
+- Owner is over-committed; the refresh is not the highest priority on their plate.
+- The refresh's depth was wrong (planned as light edit, actually needed substantial revision); the owner stalled rather than escalate.
+- The refresh's disposition was wrong (planned as refresh, should have been merge); the owner is uncertain how to proceed.
+
+**The recovery pattern.**
+
+- Owner-of-owners reviews stalled refreshes at each audit.
+- Reassign owners where capacity is the issue.
+- Re-scope where depth was wrong; re-disposition where the disposition was wrong.
+- For refreshes stalled because the analysis revealed a deeper issue, escalate to a content lead for decision.
+
+The stalled-refresh review prevents the queue from accumulating zombie items that everyone knows are not getting done but nobody is removing.
+
+---
+
+## Common execution failures
+
+**No single owner.** Refreshes are assigned to "the team"; nobody is accountable; the refresh stalls.
+
+**Workflow shortcuts.** The refresh skips the QA gate or the brief. Quality drifts; regressions compound.
+
+**Capacity overcommitment.** The team plans 20% capacity for refresh; actual refresh work consumes 35%; new production suffers; team burns out.
+
+**Refresh queue without owner-of-owners.** The queue grows; nobody is reporting on its health; the program drifts toward set-and-forget within the formal-program shape.
+
+**Fast-track without reserve.** Urgent refreshes push planned work out; cascade delays affect downstream pieces.
+
+**Stalled refreshes accumulating.** The queue has zombie items in it; the queue's reported health does not match the queue's actual state.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The single-owner discipline, editorial-workflow integration shapes by depth, capacity allocation patterns by library stage, batching vs integration vs hybrid tradeoffs, the refresh-that-needs-to-happen-now pattern, the stalled-refresh recovery pattern.
+
+## Implementation choices that stay internal
+
+Specific project-management tooling for the refresh queue. Specific notification systems for refresh assignments. Specific time-tracking for capacity audits. Specific reserves and fast-track triage workflows. The team's own conventions for owner reassignment. These vary by team, tooling, and program shape.

--- a/skills/content-refresh-system/references/refresh-prioritization-matrix.md
+++ b/skills/content-refresh-system/references/refresh-prioritization-matrix.md
@@ -1,0 +1,148 @@
+# Refresh prioritization matrix
+
+The 2x2 prioritization matrix with quadrant strategies. The discipline of NOT refreshing the high-value-stable quadrant. The under-recognized failure of treating low-value-decaying as automatic refresh candidates.
+
+Most libraries have more pieces showing signals than the team has capacity to refresh. Without prioritization, refresh work happens on the cheapest pieces or the most visible pieces, leaving high-value-decaying pieces in the backlog while editorial capacity goes to pieces that would not have produced recovery worth the effort.
+
+The matrix shifts the program from refresh-everything to refresh-the-quadrant-that-warrants-it.
+
+---
+
+## The two axes
+
+**Piece value.** A composite of business value, traffic value, and strategic role.
+
+- **Business value.** Pieces that drive conversions, qualified leads, or specific business outcomes. Sometimes measurable directly (pieces that close a defined funnel step), sometimes attributed (pieces that influence subsequent conversions).
+- **Traffic value.** Pieces that drive meaningful organic traffic, especially on commercial-intent keywords or topical-authority-building queries.
+- **Strategic role.** Pieces that anchor a hub, that establish the brand's POV on a flagship topic, or that earn external citations and links. Strategic role can outweigh raw traffic; a 500-traffic flagship piece is high-value if it is the canonical statement of the brand's position.
+
+Pieces are classified as high-value (HV) or low-value (LV). The line between HV and LV is judgment-driven; teams typically settle the criteria by establishing tiers (top 10% by value, next 30%, bottom 60%, or similar).
+
+**Traffic state.** A composite of recent and trending traffic.
+
+- **Stable.** Traffic over the last 90 days is within 10-15% of the prior 90-day baseline, accounting for seasonality.
+- **Decaying.** Traffic over the last 90 days is down meaningfully (15%+ beyond seasonal baseline), or trending consistently down over multiple quarters.
+
+Pieces are classified as stable or decaying. The classification is the easier of the two axes because traffic data is cleanly measurable.
+
+---
+
+## Quadrant 1: High-value, decaying
+
+**Top priority.**
+
+**The pieces.** Pieces that drive meaningful traffic, conversions, or topical authority and are losing position.
+
+**The strategy.** Refresh first; the traffic loss compounds and the lost equity is hard to recover. These pieces are usually worth substantial-revision or full-rewrite refresh depth because the value at stake justifies the work.
+
+**The disposition decision.** Almost always refresh. Merge candidates in this quadrant exist (a high-value piece that is decaying because a sister piece is competing for the same query) but are uncommon. Delete is essentially never the right disposition for a high-value piece.
+
+**Capacity allocation.** This quadrant gets the largest share of refresh capacity. Many programs allocate 60-70% of total refresh capacity to high-value-decaying pieces.
+
+**Expected outcomes.** Recovery measured at 30 and 90 days. Strong refreshes on this quadrant typically produce 20-50% traffic recovery within 90 days; full rewrites can produce more.
+
+**Common failures.**
+
+- Treating this quadrant as "save for later" because the work is heavy. The traffic loss continues during the delay.
+- Light-editing high-value-decaying pieces when substantial revision is warranted. The light edit does not move the needle and the team concludes refresh does not work.
+- Not investigating the cause. A piece that is decaying because a competitor published a better resource needs different work than a piece decaying because of SERP intent shift.
+
+---
+
+## Quadrant 2: High-value, stable
+
+**Monitor; do not refresh proactively.**
+
+**The pieces.** Pieces that are performing strongly and showing no decay signals.
+
+**The strategy.** Leave alone. Refresh-everything-on-calendar treats this quadrant the same as the high-value-decaying quadrant and damages performance. Pieces that are working should not be touched without clear signal.
+
+**The disposition decision.** No action; monitor through continuous monitoring for emerging decay; review at quarterly audits for content drift signals.
+
+**The discipline.** This is the quadrant that calendar-refresh programs damage most. A piece ranking position 2 with stable traffic gets refreshed because it is the next piece in the rotation; the refresh introduces minor changes that shift the SERP signals; ranking drops to position 5; traffic drops 30%. The refresh that was meant as maintenance was actually destruction.
+
+**When to revisit.** Monitor for emerging signals. If traffic starts decaying or rankings drop, the piece moves to high-value-decaying. If content drift becomes pronounced (the piece is performing but the team sees positioning misalignment), substantial revision may be warranted but only if the team is willing to risk the performance.
+
+**Common failures.**
+
+- Refresh-on-calendar damaging stable pieces.
+- Treating stable rankings as a refresh target because the team wants to "improve" the piece. Improvement on stable pieces is a high-risk operation.
+- Touching the URL, schema, or core copy of a stable piece without strong rationale.
+
+---
+
+## Quadrant 3: Low-value, decaying
+
+**Audit for merge or delete.**
+
+**The pieces.** Pieces with low traffic that are decaying further. Pieces that never had strong demand and are now losing what little they had.
+
+**The strategy.** The default disposition is NOT refresh. Refresh on these pieces rarely justifies the effort; the underlying issue is usually that the piece never had strong demand. The actual disposition is usually merge (consolidate into a stronger sibling piece) or delete (and 301 to the closest sibling or relevant hub).
+
+**The disposition decision.**
+
+- **Merge** when a sibling piece on a related topic is performing better and could absorb the failing piece's content. Merging consolidates authority and produces a stronger consolidated piece. The merged URLs redirect to the survivor.
+- **Delete** when no merge candidate exists, the topic is not load-bearing for the program, and the piece's residual value (small as it is) does not justify maintenance. Delete and redirect to the closest sibling piece or hub.
+- **Refresh** is occasionally warranted: when the piece has clear strategic role (anchors a small but important sub-topic) and the decay is recoverable. Rare in this quadrant.
+
+**Capacity allocation.** This quadrant gets the smallest share of refresh capacity but a meaningful share of disposition work (merges and deletes are real work, less than full rewrites but more than light edits).
+
+**Common failures.**
+
+- Refreshing pieces in this quadrant by default. The team spends hours improving a low-value piece that even at its best will not recover meaningful traffic, while a merge candidate that would have produced a stronger consolidated piece sits unaddressed.
+- Skipping the merge analysis. Pieces that should have been merged get refreshed in isolation, leaving the authority-splitting problem intact.
+- Avoiding deletes because deleting feels destructive. Maintaining a library of low-value pieces forever costs ongoing audit attention and dilutes overall library quality.
+
+---
+
+## Quadrant 4: Low-value, stable
+
+**Leave alone.**
+
+**The pieces.** Pieces with low traffic that are not actively decaying. They are at the floor.
+
+**The strategy.** Leave alone. Low traffic is the floor; the piece is not costing anything to keep. Touching these pieces in a refresh program burns capacity for no return.
+
+**The disposition decision.** No action. Pieces that have been low-traffic-stable for multiple audits are candidates for batch consideration: do they collectively represent a topic that is no longer load-bearing for the program? If yes, a structural decision (delete the topic cluster, merge into a hub, archive) may be warranted at program level. If no, leave alone.
+
+**When the strategy fails.** If a low-value-stable piece starts decaying further (moves to low-value-decaying), the disposition is reconsidered. Usually merge or delete.
+
+**Common failures.**
+
+- Refresh-on-calendar touching this quadrant. Pure capacity waste.
+- Treating low-traffic as a problem to be solved. Low traffic on a low-value piece is the right outcome; not every piece needs to drive significant traffic. Some pieces serve narrow but real strategic roles at low volume.
+
+---
+
+## Capacity allocation by quadrant
+
+A typical refresh program's capacity might split as:
+
+- **High-value, decaying:** 60-70% of refresh capacity. The largest share, on the highest-value work.
+- **Low-value, decaying:** 15-20% of capacity, mostly on merge and delete dispositions, occasional refresh on strategically important pieces.
+- **High-value, stable:** 5-10% of capacity, on the rare cases where content drift warrants substantial revision despite stable performance.
+- **Low-value, stable:** 0-5% of capacity. Mostly batch reviews to identify topic-level decisions.
+
+The allocation varies by library age and decay rates. Newer libraries with limited decay have less work in the decaying quadrants and may invest more in continuous-monitoring infrastructure. Older libraries with significant decay have more work to do across quadrants.
+
+---
+
+## Common matrix failures
+
+**The "every piece is high-value" trap.** Teams that classify too many pieces as high-value lose the prioritization signal. A library where 60% of pieces are "high-value" is essentially unprioritized; the matrix fails to discriminate.
+
+**The traffic-only value classification.** Classifying value purely by traffic misses strategic-role pieces that have lower traffic but high importance. A flagship manifesto that earns 800 visits a month but drives external citations and brand recognition is high-value despite lower traffic.
+
+**The "refresh = recovery" assumption.** Some pieces in the high-value-decaying quadrant cannot be recovered through refresh. The topic is genuinely declining; competitors are too strong; SERP intent has shifted away from any format the brand can produce. The matrix prioritizes refresh; it does not promise refresh will work. The effectiveness measurement (see `effectiveness-measurement.md`) catches the cases where refresh is not producing recovery.
+
+**Static classification.** Value and traffic state both shift over time. A piece in low-value-stable that suddenly draws traffic from an emerging keyword moves to high-value-stable; a piece in high-value-decaying that fully recovers moves to high-value-stable. The matrix is not a one-time classification; it is the framework run at each audit.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The two axes (value, traffic state), the four quadrants with strategies, the capacity allocation guidance, the common matrix failures, the dynamic-classification discipline.
+
+## Implementation choices that stay internal
+
+Specific value-classification rubrics the team uses (revenue attribution models, strategic-role tagging, traffic-tier definitions). Specific scripts that classify pieces into quadrants from data pulls. Specific dashboards that visualize the matrix at audit time. The team's own conventions for high-value-stable refresh decisions when content drift is pronounced. These vary by team, business model, and analytics setup.

--- a/skills/content-refresh-system/references/refresh-signals-checklist.md
+++ b/skills/content-refresh-system/references/refresh-signals-checklist.md
@@ -1,0 +1,164 @@
+# Refresh signals checklist
+
+Five signal categories that trigger refresh consideration, with detection patterns and the audit shape that surfaces signals across the library.
+
+Pieces that show no signals do not need refresh. Pieces that show one or two signals warrant attention. Pieces that show three or more signals are typically in active decay and should be high in the prioritization queue. The signal taxonomy below is what distinguishes triaged refresh from calendar refresh.
+
+---
+
+## Signal 1: Traffic decay
+
+Organic traffic to the piece is trending down over a 90+ day window beyond seasonal baseline.
+
+**Detection patterns.**
+
+- Pull traffic data per URL over rolling 90-day windows.
+- Compare current 90 days to prior 90 days, accounting for known seasonality.
+- A drop of more than 15-20% beyond seasonality on a piece that previously had stable traffic is a real signal.
+- A drop of more than 40% in a 30-day window is a sharp signal warranting urgent review.
+
+**What the signal usually means.**
+
+- **Slow decay (5-10% over a year):** content drift. The piece is gradually losing relevance as the topic evolves or the brand's voice shifts.
+- **Moderate decay (15-30% in a quarter):** ranking position drift, or SERP intent shifting, or competitor publication.
+- **Sharp decay (40%+ in a month):** algorithm update, indexing issue, dramatic SERP intent shift, or technical regression on the URL.
+
+**Diagnostic next steps.** When traffic decay is detected, check ranking positions for the piece's target keywords (signal 2 may also be active), check for technical issues (indexability, page speed, broken redirects), and check the SERP for intent shift (signal 4).
+
+**Anti-patterns in detection.**
+
+- Comparing month-over-month rather than 90-day windows over-attributes seasonal noise to decay.
+- Ignoring known seasonality (holiday traffic, B2B dropping in late December) produces false positives.
+- Looking only at total traffic instead of organic specifically blurs the signal with referral or paid changes.
+
+---
+
+## Signal 2: Ranking drops
+
+The piece is losing position on its target keywords.
+
+**Detection patterns.**
+
+- Track each piece's primary 3-10 target keywords with rank tracking.
+- Drops from page 1 to page 2-3 are particularly consequential because click-through rates fall sharply at the page-1-to-page-2 boundary.
+- Drops within page 1 (position 3 to position 7) reduce clicks but are less existential.
+- Persistent drops over 30+ days are real shifts; week-over-week volatility within a few positions is normal.
+
+**What the signal usually means.**
+
+- A piece that was at position 3 and is now at position 8 has been displaced by stronger competing pieces. The displacement is informative; review what is now ranking and what those pieces have that this piece does not.
+- A piece that was at position 5 and is now at position 35 has likely been algorithm-affected, indexing-affected, or technically regressed. Investigate before refresh; refreshing a piece with an indexing issue does not solve the indexing issue.
+- Drops on long-tail keywords with simultaneous gains on broader head terms can indicate the piece's focus has broadened beneficially. Not always a refresh signal.
+
+**Diagnostic next steps.** Pull the SERP for each target keyword. Examine what is ranking. Identify whether the new rankings are stronger pieces (refresh signal: improve the piece) or different SERP intent (signal 4: SERP intent shift, possibly different format needed).
+
+**Anti-patterns in detection.**
+
+- Treating any rank movement as a refresh signal produces refresh-on-noise; require persistence over 30+ days.
+- Tracking only branded keywords misses the meaningful organic ranking signal.
+- Ignoring keyword cannibalization (multiple pieces competing for same keyword) treats split rankings as a refresh signal when the actual disposition is merge.
+
+---
+
+## Signal 3: Factual staleness
+
+The piece contains statistics, references, examples, or claims that are dated.
+
+**Detection patterns.**
+
+- Annual review of statistics in the piece. Any stat older than 3 years on a fast-moving topic is a candidate for staleness flagging.
+- Reference checks for defunct products, platforms, services, or companies named in the piece.
+- Example checks for examples that have aged poorly (a 2019 case study of a company that has since gone bankrupt or changed direction).
+- Framing checks for claims that no longer match current reality ("AI is starting to influence search" in 2026 is anachronistic).
+
+**What the signal usually means.**
+
+- Factual staleness alone is often a light-edit signal: update the stats, replace dead links, swap dated examples. The piece's structure may be sound.
+- Factual staleness combined with traffic decay or ranking drops is a stronger signal that the piece's broader framing has aged, not just the surface details.
+- Factual staleness on a flagship piece is more urgent than on a low-traffic piece because flagship pieces are read by more people who notice the staleness.
+
+**Diagnostic next steps.** List the specific stale facts, references, and examples. Estimate the light-edit time required to refresh them. If the structural framing is also stale, the depth required is substantial revision rather than light edit.
+
+**Anti-patterns in detection.**
+
+- Treating every old stat as stale when the stat may still be current (some stats genuinely have not changed in 3 years) produces unnecessary refresh.
+- Ignoring framing-level staleness while updating individual stats produces pieces that are technically current in stats but feel old in voice.
+
+---
+
+## Signal 4: SERP intent shift
+
+The dominant SERP format for the target keyword has changed.
+
+**Detection patterns.**
+
+- Pull the current SERP for each target keyword. What format is dominating? Articles? Listicles? Videos? Product comparisons? AI overviews?
+- Compare to the piece's format. If the piece is an article and the SERP wants product comparisons, intent has shifted.
+- Watch for new SERP features that did not exist when the piece was written: AI overviews, generative answers, knowledge panels, featured-snippet shifts.
+
+**What the signal usually means.**
+
+- The piece may still rank but increasingly for the wrong reasons. Click-through rates fall as the SERP signals the piece is not the dominant intent match.
+- The piece may need format restructuring (full rewrite or substantial revision rather than light edit) to fit the new dominant intent.
+- Sometimes the right disposition is to write a NEW piece in the new dominant format and either consolidate the old piece into it or keep the old piece for the residual intent it still serves.
+
+**Diagnostic next steps.** Read the top-ranking pieces for the target keyword. What format are they? What questions do they answer that the piece does not? Decide whether refresh in the new format will recover the position, or whether a new piece in the new format is the better disposition.
+
+**Anti-patterns in detection.**
+
+- Ignoring AI-overview presence on the SERP. AI overviews change click-through rates substantially and may indicate the piece needs restructuring for AI search citation.
+- Assuming SERP intent is stable. Some keywords have stable intent for years; others shift quarterly. The audit should be active.
+
+---
+
+## Signal 5: Content drift
+
+The piece's positioning no longer matches the brand's current positioning.
+
+**Detection patterns.**
+
+- The piece's voice reads as the brand-of-three-years-ago. Vocabulary, tone, level of conviction.
+- The piece's POV on the topic has not kept up with how the brand now thinks. The brand has sharpened a position the piece treats with old hedging.
+- The piece's framing fits the audience the brand had then, not the audience the brand has now.
+- The piece's calls-to-action, internal linking, and product references reflect older brand offerings that have since changed.
+
+**What the signal usually means.**
+
+- Content drift is internal signal. Readers may not consciously notice, but the team will, and over time the library's voice incoherence weakens the brand.
+- Content drift is often paired with the team's discomfort about which pieces in the library represent the brand best when sharing externally.
+- Content drift is rarely the sole driver of a refresh decision (because traffic and rankings may be fine), but it determines depth: a content-drift refresh is usually substantial revision or full rewrite, not light edit.
+
+**Diagnostic next steps.** Identify which sections drift hardest from current positioning. If drift is concentrated in introduction, closing, and CTAs, substantial revision can address it. If drift is throughout, full rewrite is the cleaner disposition.
+
+**Anti-patterns in detection.**
+
+- Treating every voice evolution as drift triggers calendar refresh of pieces that are still serving readers.
+- Ignoring drift because the piece is performing in search produces a library that performs but no longer represents the brand.
+
+---
+
+## The library audit
+
+Running the signal taxonomy across the whole library.
+
+**Audit shape.**
+
+- Pull a per-URL data set: traffic over time, rankings, last-modified date, target keywords, business-value tag (high/medium/low).
+- For each URL, run the five signal checks. Mark each signal as present or absent.
+- Pieces with zero signals: stable; no action.
+- Pieces with one or two signals: candidate queue; review individually for disposition.
+- Pieces with three or more signals: active-decay queue; high priority for disposition decision.
+
+**Output.** A spreadsheet or database of pieces with their signals and the resulting disposition (refresh, merge, delete, monitor). The output feeds the prioritization matrix and the refresh queue.
+
+**Cadence.** Full audit quarterly. Continuous monitoring for traffic-decay and ranking-drop signals; manual signal checks (factual staleness, SERP intent shift, content drift) at quarterly cadence.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five signal categories with detection patterns and what each signal means; the audit shape across the library; the cadence; the anti-patterns in detection. The signal-to-disposition mapping that informs prioritization.
+
+## Implementation choices that stay internal
+
+Specific data pulls from the team's analytics platform. Specific rank-tracking thresholds. Specific automation that runs continuous monitoring. Specific reviewer dashboards that surface signals. Specific seasonality models the team uses to baseline traffic. The team's own tags for business-value classification. These vary by team, tooling, and analytics setup.

--- a/skills/content-refresh-system/references/refresh-vs-merge-vs-delete.md
+++ b/skills/content-refresh-system/references/refresh-vs-merge-vs-delete.md
@@ -1,0 +1,137 @@
+# Refresh vs merge vs delete
+
+The disposition decision. When to refresh, when to merge, when to delete and redirect. The under-recognized failure of refreshing pieces that should have been merged or deleted.
+
+Most refresh programs default to refresh as the disposition. The default is wrong. Some pieces should be merged into stronger siblings; some should be deleted and redirected. The disposition decision is upstream of the depth decision: a piece getting deleted does not need depth, and a piece being merged is doing a different kind of work than refresh.
+
+---
+
+## Refresh
+
+The piece has a clear topic, real demand, and either a strong-enough current position to recover or a strong-enough strategic role in the library to justify the work.
+
+**Criteria for refresh disposition.**
+
+- The piece has demonstrated demand: it draws meaningful traffic now or did historically.
+- The topic is one the brand wants to own; the piece's existence is strategically warranted.
+- A path to recovery exists: refresh of the right depth has a reasonable chance of producing improvement.
+- No sister piece is competing for the same query in a way that splits authority.
+- The piece's URL has accumulated authority worth preserving.
+
+**When refresh fits but might not.**
+
+- Sometimes a refresh-eligible piece is also a merge candidate. A high-value-decaying piece that is decaying because a sister piece is stronger may produce more value through merge than through refresh of either piece alone.
+- Sometimes refresh has been tried and did not produce recovery. The first failed refresh shifts disposition consideration toward merge or full-rewrite-with-new-positioning rather than another refresh attempt.
+
+**Refresh failure modes.**
+
+- Refreshing pieces that are not recoverable. The topic is dying; the brand cannot win against the competition; the SERP intent has shifted to a format the brand does not produce. Refresh in these cases is theater.
+- Refreshing without resolving the underlying issue. If a piece is decaying because a sister piece is competing for the same query, refresh of the original piece does not solve the cannibalization. Both pieces continue to underperform.
+
+---
+
+## Merge
+
+Two or more pieces are competing for the same query, splitting authority and confusing the reader. Combine into one stronger piece; redirect the merged URLs.
+
+**Criteria for merge disposition.**
+
+- Two or more pieces target the same primary query or a closely overlapping query cluster.
+- Combined authority across the pieces is meaningful; merging would produce a piece with stronger authority than any individual piece has.
+- The pieces' coverage overlaps enough that consolidation produces a coherent piece, not a Frankenstein of mismatched sections.
+- The team can identify which URL the survivor occupies (typically the one with strongest existing authority) and which URLs redirect to the survivor.
+
+**The merge decision in detail.**
+
+- **Identify the survivor URL.** Usually the URL with strongest existing rankings, traffic, and backlinks. The survivor inherits the consolidated content; other URLs redirect to it.
+- **Plan the consolidated content.** Outline the merged piece. Decide which sections come from which source piece. Plan the gaps where new content will fill what neither piece had.
+- **Author the consolidated piece.** Write or rewrite as needed. The consolidated piece is usually stronger than any of the source pieces because it is built from the strongest components plus targeted new content.
+- **Implement redirects.** 301 redirects from the merged URLs to the survivor. Redirects need to be implemented at publish time, not after; the merged URLs going to 404 or 410 produces traffic loss that did not need to happen.
+- **Update internal links.** Pieces that linked to the merged URLs should be updated to link to the survivor.
+
+**Merge failure modes.**
+
+- Merging without redirects. The merged URLs go to 404; the consolidated authority does not transfer; traffic is lost.
+- Merging pieces that did not actually compete. If two pieces target different intents, merging them produces a piece that does neither well.
+- Frankenstein merges. The consolidated piece reads as multiple pieces stitched together rather than as a unified piece. Cure: rewrite the consolidated piece as a piece in its own right, using the source pieces as input rather than as components.
+
+---
+
+## Delete
+
+The piece has no real demand, the topic is no longer relevant to the brand's positioning, or the piece is a low-quality artifact from an earlier era of the program.
+
+**Criteria for delete disposition.**
+
+- The piece draws minimal traffic and has minimal residual authority.
+- The topic is not load-bearing for the program; the brand does not need to own it.
+- No merge candidate exists; the piece's content does not consolidate cleanly into any stronger piece.
+- Maintaining the piece costs ongoing audit attention without proportional return.
+
+**The delete decision in detail.**
+
+- **Identify the redirect target.** The deleted URL should redirect to the closest sibling piece, or to the relevant hub or category page, or to the homepage if no other target fits. Deleting without redirect (returning 404 or 410) is correct only when the piece's residual authority is genuinely zero, which is rare.
+- **Implement the redirect.** 301 redirect to the chosen target.
+- **Update internal links.** Pieces that linked to the deleted URL should be updated to link to the redirect target directly. The redirect chain still works but direct links are cleaner.
+- **Document the deletion.** The audit log should capture the delete decision, the rationale, and the redirect target. Future audits can reference the log if a question arises about the URL.
+
+**Delete failure modes.**
+
+- Avoiding delete because deleting feels destructive. The library accumulates low-value pieces forever, costing ongoing audit attention and diluting overall library quality.
+- Delete without redirect. The URL returns 404; whatever residual authority existed is lost; users who linked to the URL or bookmarked it find a dead link.
+- Delete of pieces that should have been merged. The piece's content had value the team did not recognize; merging would have preserved it. Delete is appropriate when no merge candidate exists, not as the easy path to avoid the merge analysis.
+
+---
+
+## The disposition decision flow
+
+A short framework for choosing.
+
+1. **Does the piece have demonstrated demand?** Traffic, rankings, conversions, or strategic role. If yes, continue. If no, the disposition is likely delete (or merge if there is a candidate).
+2. **Is there a sibling piece competing for the same query?** If yes, evaluate merge. The merged piece has a strong chance of outperforming both original pieces.
+3. **Is the topic load-bearing for the brand?** If no, refresh disposition is unlikely to be the right answer; consider merge into a stronger sibling or delete.
+4. **Has refresh been tried recently without recovery?** If yes, the next disposition should be merge or full-rewrite-with-new-positioning, not another refresh attempt.
+5. **What is the cheapest disposition that addresses the actual problem?** Refresh is often defaulted to because it feels less destructive; merge and delete are sometimes the cheaper paths to the actual outcome.
+
+---
+
+## The under-recognized failure: refreshing what should have been merged or deleted
+
+The pattern that costs refresh programs the most capacity.
+
+**How it shows up.** The team spends 4 hours refreshing a low-value-decaying piece that even at its best will not draw meaningful traffic. The refresh ships. The piece ranks slightly better for two weeks, then drifts back down. Three months later the piece is in the same audit queue.
+
+**Why it happens.**
+
+- Refresh feels less destructive than merge or delete.
+- The merge analysis takes time; refresh feels like the immediate action.
+- Delete requires team agreement; refresh can be done by a single owner.
+- The team has not internalized that some pieces should not be refreshed.
+
+**The cure.** Make merge and delete first-class dispositions in the audit. Every piece in the audit gets one of: refresh, merge, delete, monitor, no action. The audit is not "which pieces to refresh"; it is "what disposition each piece should get." Refresh becomes one option among several rather than the default.
+
+**The capacity recovery.** Programs that adopt the merge-and-delete-as-first-class-dispositions discipline typically recover 20-40% of refresh capacity for higher-value work. The pieces that were getting refreshed but should have been merged or deleted stop consuming capacity; the freed capacity goes to high-value-decaying pieces that produce real recovery.
+
+---
+
+## Disposition decisions that need approval
+
+Some dispositions are higher-risk than others and warrant approval beyond the audit owner.
+
+**Delete dispositions.** Always need approval. Deletes are essentially irreversible without significant work to undelete; the redirect strategy is consequential; the team should be aligned on the decision.
+
+**Merge dispositions involving high-value pieces.** Need approval. Merging into a survivor URL means the non-survivor URLs lose their identity. If the non-survivor pieces had high-value characteristics, the merge needs review.
+
+**Refresh dispositions on stable high-value pieces.** Need approval. Touching a stable high-value piece is a high-risk operation; the audit owner should not unilaterally decide to refresh.
+
+**Light edit and substantial revision on decaying pieces.** Usually do not need approval beyond the audit owner. The risk-reward is straightforward.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The three dispositions and their criteria, the disposition decision flow, the under-recognized failure of refreshing what should have been merged or deleted, the merge and delete mechanics, the dispositions that need approval.
+
+## Implementation choices that stay internal
+
+Specific redirect implementation in the team's CMS or hosting layer. Specific internal-link update automation that catches links to merged or deleted URLs. Specific approval workflows for high-risk dispositions. Specific audit-log templates that capture disposition rationale. These vary by team, tooling, and CMS.

--- a/skills/content-repurposing/SKILL.md
+++ b/skills/content-repurposing/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: content-repurposing
+description: "Cross-format content adaptation. Turning one substantial piece into many derivative formats (blog series, email sequences, social posts, webinars, podcasts, video shorts) without losing the original's value or producing AI-slop variants. The discipline of adaptation per medium rather than mass-blast distribution. Triggers on content repurposing, content adaptation, cross-format content, content atomization, content multiplication, content distribution across formats, source-piece-to-derivative, video shorts from blog, email from whitepaper, podcast from article, blog series from research. Also triggers when a flagship piece is shipping but the team has not planned how to extend it across formats, when repurposing is happening but the derivatives feel mass-produced, or when AI-assisted repurposing is producing slop variants of strong source pieces."
+category: content
+catalog_summary: "Cross-format content adaptation: one piece becomes many (blog series, email, social, webinar, podcast, video) with per-format adaptation rather than mass-blast that ignores medium constraints"
+display_order: 11
+---
+
+# Content Repurposing
+
+A senior editorial leader's playbook for cross-format content adaptation. The discipline of turning one substantial piece into many derivative formats without losing the original's value or producing slop variants.
+
+Most content programs underspend on repurposing. A flagship piece costs 40-80 hours to produce; the program publishes it once, shares it on three channels, and moves on. The same piece could have produced a blog series, an email sequence, a webinar, a podcast episode, a dozen social posts, video shorts, and FAQ extractions for AI search visibility. The work to extend the source piece across formats is small relative to the value extracted; programs that skip repurposing leave most of the value unrealized.
+
+The failure mode in the other direction is mass-blast: the same content reposted across channels without adaptation. A blog post pasted into LinkedIn as a long-text post; the email newsletter is the blog's first three paragraphs with "read more" tacked on; the YouTube video is a slideshow of the article text read aloud. Mass-blast respects neither the medium nor the audience. AI-assisted repurposing has made mass-blast cheap; the result is a wave of derivative content that performs poorly across every channel because it was adapted to none of them.
+
+This skill is the discipline of adaptation per medium. Each format has constraints, conventions, and reader expectations the source piece does not have. Repurposing that respects those constraints produces work that earns engagement on the new format; repurposing that ignores them produces filler.
+
+When to use this skill: planning the extension of a flagship piece across formats, auditing a repurposing pipeline that is producing low-engagement derivatives, calibrating an AI-assisted repurposing workflow that is producing slop, or designing the cross-format adaptation conventions for a content program.
+
+---
+
+## What this skill is for
+
+This skill spans cross-format adaptation work after a source piece has been produced. The content suite distinction:
+
+- `content-strategy` decides what to produce.
+- `pillar-content-architecture` designs the topical hub.
+- `content-brief-authoring` briefs each piece.
+- `content-and-copy` writes the original piece in any single format.
+- **`content-repurposing` (this skill)** turns one piece INTO many formats.
+- `content-distribution` gets content TO audiences via channels.
+- `editorial-qa` verifies pre-publish, including derivatives.
+- `ai-content-collaboration` is the workflow layer; AI participation rules apply within repurposing.
+
+The distinction from `content-distribution` is load-bearing. Distribution is channel work: getting content to audiences via the right channels. Repurposing is transformation work: turning one piece INTO many formats, each adapted for its medium. They compose: repurpose first, then distribute the right format on the right channel.
+
+The audience: editorial leads, content directors, content ops managers, in-house teams running multi-format programs, agencies producing derivative content for clients, anyone planning to extend a flagship piece across formats.
+
+What is not in scope: the original piece's production (covered by `content-and-copy` and the long-form skills), the channels themselves (covered by `content-distribution`), the editorial QA on derivatives (covered by `editorial-qa`).
+
+---
+
+## One-and-done vs mass-blast vs adapt-by-format
+
+The keystone framing.
+
+**One-and-done.** Publish once on the source format; never reuse. The piece took 60 hours to produce; it generates traffic for 90 days; it gets shared three times; it goes silent. The team treats publication as the end of the piece's life. Output: most of the source piece's value goes unrealized; the team is always producing new flagship work because old flagship work is not being extended.
+
+**Mass-blast.** Same content reposted across channels without adaptation. Blog post text pasted into LinkedIn as a long post. Email newsletter is the blog's first three paragraphs. The YouTube version is a slideshow of the text read by AI voice. Output: low engagement on every channel because nothing was adapted to any channel's conventions. Audiences perceive the cross-channel sameness as low-effort filler. AI-assisted repurposing has made this pattern cheap and common.
+
+**Adapt-by-format.** Per-medium adaptation that respects each format's constraints and conventions. The blog series breaks the source piece into chapters with new ledes and closings per chapter. The email sequence builds on the source's framework with sender-voice adjustments. Social posts use platform-native conventions. The webinar adds Q&A and live elements. Output: each derivative earns engagement on its medium because it was made for that medium; the source piece's value compounds across formats.
+
+The litmus test. Read each derivative as if you had not seen the source piece. Does it stand on its own? Does it use the medium's conventions? Would it earn engagement if it were the only thing the audience saw of this work? If yes to all three, the adaptation succeeded. If the derivative reads as "I should have read the original instead," the adaptation failed.
+
+---
+
+## Source-piece selection
+
+Not every piece is worth repurposing. Selection is the first discipline.
+
+**Strong source-piece characteristics.**
+
+- The source has a clear central argument or framework that travels across formats.
+- The source has standalone sections, examples, or sub-arguments that work as derivative pieces.
+- The source's audience overlaps with the audiences on the target formats.
+- The source's voice is distinctive enough that derivative voice can stay coherent.
+- The source has accumulated demand: traffic, links, mentions, social shares.
+
+**Weak source-piece characteristics.**
+
+- The source is a tightly-integrated argument where every section depends on context.
+- The source is a list-style piece where the items do not have standalone weight.
+- The source's value depended on being read end-to-end (a narrative arc, a layered argument with payoff).
+- The source's audience does not exist on most target formats.
+- The source's voice is generic; derivative voice has nothing to anchor.
+
+**The selection audit.** Run candidate pieces through these questions before committing to repurposing. Pieces that fail the audit may still be valuable but as one-and-done; programs that try to repurpose unsuitable pieces produce derivatives that feel forced.
+
+Detail in `references/source-piece-selection-criteria.md`.
+
+---
+
+## Format adaptation patterns
+
+Eight common source-to-derivative adaptations with worked examples.
+
+**Long-form to blog series.** A 6,000-word whitepaper becomes 4-6 standalone blog posts, each developing one of the whitepaper's sub-arguments with new ledes and closings.
+
+**Blog post to email sequence.** A 1,500-word blog post on a multi-step framework becomes a 5-email sequence, one email per step, with sender-voice adaptation and per-email engagement hooks.
+
+**Whitepaper to webinar.** Substantive whitepaper becomes a 30-45 minute webinar with the whitepaper's framework as the spine, plus live Q&A, plus interactive elements that print do not support.
+
+**Long-form to social posts.** Pull-quote-style posts, framework summaries, key-question posts, contrarian-claim posts. Each social post is one moment from the source, framed for the platform's conventions.
+
+**Article to podcast episode.** Article becomes the episode's spine; the host adds context, examples, and conversational elaboration; sometimes a guest interview drives the episode while the article is the show notes.
+
+**Long-form to video shorts.** 60-90 second video clips on individual claims, examples, or framework elements from the source. Each short is a standalone unit; series-of-shorts can extend the source over weeks of social posting.
+
+**Research report to FAQ extractions.** Specific Q&A extractions from the source piece, formatted for AI search citation and snippet capture.
+
+**Multi-piece source to ebook.** Several related pieces (blog posts, articles, even social threads) consolidated into an ebook, with new connective tissue, an introduction that frames the body, and a conclusion that synthesizes.
+
+Detail in `references/format-adaptation-patterns.md`.
+
+---
+
+## Per-format constraints
+
+Each medium demands and forbids specific things. Repurposing that ignores the constraints produces derivatives that fail the medium.
+
+**Email.**
+
+- Subject line and preheader bear most of the engagement load.
+- Plain prose paragraphs work; complex formatting often breaks across email clients.
+- Length tolerance varies by audience; 200-800 words common.
+- Single clear CTA per email; multiple competing CTAs underperform.
+
+**Social posts (text-driven platforms).**
+
+- Hook in the first 1-2 lines; readers decide to expand or scroll.
+- Platform-specific conventions (LinkedIn long-post structure differs from X/Twitter thread structure).
+- Visual or quote-graphic options to break up text.
+- One specific point per post; multi-point posts dilute.
+
+**Video (long-form).**
+
+- Pacing differs from print; spoken delivery requires different sentence structure.
+- Visuals carry information print does not need; talking-head video alone for 30+ minutes underperforms.
+- Audio quality matters more than video quality up to a point; bad audio kills retention.
+
+**Video (short-form).**
+
+- 60-90 second window for most platforms; 15-30 seconds for some.
+- Captions essential; many viewers watch without sound.
+- Hook in the first 1-2 seconds; algorithmic recommendation rewards retention from second 1.
+- One specific point or moment per short.
+
+**Podcast.**
+
+- Spoken-language sentence structure; print-style sentences read aloud sound stilted.
+- Conversational pacing rewards examples and asides; tightly-argued print sections feel stiff.
+- Show notes do the print work the audio cannot; treat show notes as a derivative format too.
+
+**Webinar.**
+
+- Live element: Q&A, polls, interactive moments. Static webinar is a video; interactive webinar earns the format.
+- Slide design matters; text-heavy slides fail.
+- Length: 30-60 minutes typical; longer requires high engagement design.
+
+Detail in `references/per-format-constraints.md`.
+
+---
+
+## Voice consistency across formats
+
+The source piece's voice anchors the derivatives. The discipline is staying recognizable through the format shifts.
+
+**What stays constant.**
+
+- The brand's POV on the topic.
+- Distinctive vocabulary, specific framings, recognizable phrasings.
+- The level of conviction or hedging the brand uses.
+- The audience-respect register (talking up to, down to, alongside the audience).
+
+**What adapts per format.**
+
+- Sentence length and structure (spoken voice differs from written).
+- Density (visual formats can carry less per minute than text).
+- Conversational vs declarative register (podcasts are conversational; whitepapers declarative).
+- Direct-address frequency ("you" usage varies by format).
+
+**The voice audit per derivative.** Read or watch the derivative. Does it sound like the brand? Could a reader who knows the source piece tell the derivative is from the same source? If voice has drifted to AI-default or to the platform's default register, the adaptation lost the voice.
+
+**The AI-repurposing voice problem.** AI-assisted repurposing is particularly prone to voice drift. The source piece may have specific voice characteristics; AI generation of derivatives without strong voice prompts produces derivatives that sound more generic than the source. See `ai-content-collaboration` for the voice-preservation discipline that applies to repurposing workflows.
+
+Detail in `references/voice-consistency-across-formats.md`.
+
+---
+
+## Sequencing and cadence
+
+When to release derivatives relative to the source, and at what pace.
+
+**Sequencing patterns.**
+
+- **Source-first, derivatives following.** Source publishes; derivatives roll out over the following 2-12 weeks. The source carries authority; derivatives extend reach.
+- **Derivatives-first, source as anchor.** Social posts and short-form video tease ideas; the source piece publishes as the synthesizing flagship. Less common; works for built-up audiences who follow the program.
+- **Simultaneous launch.** Source and a wave of derivatives publish on the same day. Maximum splash; risks audience fatigue if every channel is firing the same day.
+
+**Cadence within the rollout.**
+
+- **Concentrated.** Most derivatives ship within 4-6 weeks of source. Maximum momentum from the source's authority; minimum time for individual derivatives to land.
+- **Distributed.** Derivatives ship over 3-6 months. Each derivative has space to land; the program is extracting value over a longer window; risks losing connection to source if the gap grows too long.
+- **Indefinite.** Derivatives keep being created from the source as long as the source remains relevant. Common for evergreen flagship pieces; rare otherwise.
+
+**The pacing audit.** Match cadence to the source's traffic curve. Pieces with sharp early traffic (trending topics) benefit from concentrated rollout; pieces with sustained evergreen traffic can support distributed rollout over many months.
+
+Detail in `references/sequencing-and-cadence-patterns.md`.
+
+---
+
+## Cross-promotion across derivatives
+
+Derivatives that link to each other and to the source compound. Derivatives that ship in isolation underperform.
+
+**Linking patterns.**
+
+- **Derivative back to source.** Each derivative includes a link or reference to the source piece for readers who want depth. The source's traffic compounds.
+- **Source forward to derivatives.** The source piece is updated to include links to derivatives as they ship. The source becomes the hub for the cross-format extension.
+- **Derivatives across.** Where appropriate, derivatives link to other derivatives in the cross-format set. The series feeling helps audiences engage with multiple pieces.
+
+**Attribution within derivatives.** When a derivative is clearly drawn from a source piece, acknowledge: "This is adapted from our recent piece on X." Attribution earns reader trust; uncredited derivatives can feel like the same work being recycled without acknowledgment.
+
+**Co-promotion across channels.** A blog post derivative can be re-shared on social where the original blog post was; a social post derivative can be promoted in the email newsletter. Cross-channel flow extends each derivative's reach.
+
+Detail in `references/cross-promotion-patterns.md`.
+
+---
+
+## Repurposing for AI search visibility
+
+A specific repurposing pattern worth its own treatment.
+
+**FAQ extraction.** Pull specific question-answer pairs from the source piece. Each Q&A is 40-80 words. Format as standalone FAQ entries that can be cited by AI search engines.
+
+**Snippet design.** Identify standalone paragraphs in the source that answer specific queries cleanly. These paragraphs can be quoted, schema-marked, and presented in derivative pieces or in dedicated FAQ pages.
+
+**Statistic extractions.** AI engines weight statistics with named sources. Extract specific stats from the source (with citations to the underlying primary research) into format that AI can cite cleanly.
+
+**Definition and entity extractions.** Source pieces often define specific terms or describe specific entities authoritatively. Extract these as standalone definitions in glossaries, FAQ pages, or knowledge-base entries.
+
+**The AI-search-derivative discipline.** Treat AI-search optimization as a derivative format with its own conventions: specific question framings, named-source citations, standalone-paragraph design. Pieces that do this well earn AI citations; pieces that do not still get cited but at lower rates and with less control over framing.
+
+Detail in `references/aeo-extraction-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-repurposing-failures.md`.
+
+- "Our derivatives feel like AI slop." Mass-blast pattern; AI-assisted repurposing without per-format adaptation. Cure: add adaptation discipline, voice prompts, per-format review.
+- "We repurposed but engagement is low." Format constraints ignored. Cure: audit each derivative against per-format conventions.
+- "The blog post derivative outperforms the source." Either the source was the wrong format for the topic (the derivative format fits better), or the derivative cannibalizes the source. Investigate.
+- "We never reuse pieces." One-and-done pattern; the program is leaving 70-90% of source-piece value unrealized.
+- "Our LinkedIn posts are blog-post text dumps." Mass-blast on a platform with specific conventions. Cure: rewrite for platform-native structure.
+- "The email newsletter is the blog's first paragraphs with 'read more' tacked on." Mass-blast email pattern. Cure: rewrite as a standalone email with engagement hooks.
+- "Our podcast episodes are articles read aloud." Print-to-audio without spoken-language adaptation. Cure: rewrite for spoken delivery; add conversational pacing.
+- "We extracted FAQ pages but they are not getting cited by AI search." Format may be wrong (snippets not standalone) or content may not be authoritative enough; audit against AI-search norms.
+- "Our voice drifts across derivatives." AI-repurposing voice failure. Cure: stronger voice prompts; per-derivative voice audit.
+- "We launched 12 derivatives in a week and audiences were exhausted." Concentrated cadence too aggressive. Cure: distributed cadence with engagement-driven sequencing.
+- "Our derivatives compete with the source for the same query." Cannibalization. Cure: clear primary-keyword assignment per piece; consolidate or restructure.
+
+---
+
+## The framework: 12 considerations for content repurposing
+
+When designing or auditing a repurposing program, walk these 12 considerations.
+
+1. **Adapt-by-format, not mass-blast or one-and-done.** Each derivative respects its medium.
+2. **Source-piece selection.** Strong sources have travelable arguments and standalone sections.
+3. **Format adaptation patterns chosen.** Match source-piece characteristics to derivative formats.
+4. **Per-format constraints respected.** Each medium's conventions, length norms, and reader expectations.
+5. **Voice consistency across formats.** Brand POV stays; sentence structure adapts.
+6. **Sequencing and cadence planned.** Source-first vs simultaneous; concentrated vs distributed.
+7. **Cross-promotion across derivatives.** Linking, attribution, co-promotion.
+8. **AI-search extraction.** FAQ, snippet, statistic, entity extractions designed deliberately.
+9. **Cannibalization avoided.** Derivatives complement the source; do not compete for the same query.
+10. **Engagement-per-format measured.** Derivatives evaluated on each medium's metrics.
+11. **AI-assisted repurposing with voice discipline.** Voice prompts, per-derivative review, slop prevention.
+12. **Capacity allocation explicit.** Repurposing is real work; budgeted, not done in the cracks.
+
+The output of the framework is a repurposing program that turns each strong source piece into a coherent multi-format extension, with each derivative earning engagement on its medium.
+
+---
+
+## Reference files
+
+- [`references/source-piece-selection-criteria.md`](references/source-piece-selection-criteria.md) - Strong vs weak source-piece characteristics. The selection audit. Pieces that should stay one-and-done.
+- [`references/format-adaptation-patterns.md`](references/format-adaptation-patterns.md) - Eight source-to-derivative adaptations with worked examples. Long-form to blog series, blog to email, whitepaper to webinar, etc.
+- [`references/per-format-constraints.md`](references/per-format-constraints.md) - What each medium demands and forbids. Email, social, video, podcast, webinar, AI search. Length norms, conventions, hooks.
+- [`references/voice-consistency-across-formats.md`](references/voice-consistency-across-formats.md) - What stays constant and what adapts. The voice audit per derivative. The AI-repurposing voice problem.
+- [`references/sequencing-and-cadence-patterns.md`](references/sequencing-and-cadence-patterns.md) - Source-first vs simultaneous vs derivative-first. Concentrated vs distributed cadence. Pacing audits.
+- [`references/cross-promotion-patterns.md`](references/cross-promotion-patterns.md) - Linking patterns, attribution, co-promotion across channels.
+- [`references/aeo-extraction-patterns.md`](references/aeo-extraction-patterns.md) - FAQ extraction, snippet design, statistic extractions, entity extractions for AI search citation.
+- [`references/repurposing-pipeline-templates.md`](references/repurposing-pipeline-templates.md) - Workflow templates by source-piece type. Whitepaper pipeline, blog post pipeline, research report pipeline, multi-piece consolidation pipeline.
+- [`references/common-repurposing-failures.md`](references/common-repurposing-failures.md) - 11+ failure patterns with diagnoses and fixes.
+
+---
+
+## Closing: adaptation is craft, not duplication
+
+Repurposing is widely treated as a content multiplication problem to be solved with AI: feed the source into a tool, get derivatives out. The output of that approach is mass-blast, slop, and audiences that learn to ignore the program. The teams producing repurposing that earns engagement are the ones treating each derivative as a piece in its own right, adapted for its medium, written with the source's voice but the format's craft.
+
+Adaptation is craft, not duplication. The source piece is the starting material; the derivative is its own work. Programs that hold this discipline get value compounding across formats; programs that skip it produce a wall of derivative content that performs worse, not better, than publishing only the source.
+
+When in doubt about whether a repurposing program is ready, ask: does each derivative respect its medium's conventions, does voice stay consistent across the set, are derivatives cross-promoting and linking back to the source, is AI-search extraction part of the plan, is cannibalization being managed, is the cadence pacing earning engagement? If yes to all of those, the program is real. If no to any, the gap is where the derivatives will read as filler and audiences will tune out.

--- a/skills/content-repurposing/references/aeo-extraction-patterns.md
+++ b/skills/content-repurposing/references/aeo-extraction-patterns.md
@@ -1,0 +1,205 @@
+# AEO extraction patterns
+
+FAQ extraction, snippet design, statistic extractions, entity extractions for AI search citation. The repurposing pattern that turns long-form content into AI-search-ready derivatives.
+
+AI search engines (the citation-driven generative answer engines) cite content in specific shapes. Pieces that are designed for citation get cited at higher rates and with better framing control; pieces that are not designed for citation still get cited but at lower rates and with less control over how the citation appears.
+
+The AEO (answer engine optimization) extraction is its own derivative format with its own conventions. Treating it as a derivative is the discipline.
+
+---
+
+## The AEO extraction frame
+
+AI engines retrieve and cite content paragraph-by-paragraph or snippet-by-snippet. They favor content that:
+
+- Has standalone meaning (the snippet works without surrounding context).
+- Cites named sources within the snippet (specific authority).
+- Uses specific phrasings (queryable framings).
+- Has structural signals (FAQ schema, headings, lists where appropriate).
+
+Source pieces written without these properties may have the same content but in shapes the engines do not cite cleanly. AEO extraction restructures the content into citation-ready shape.
+
+---
+
+## Pattern 1: FAQ extraction
+
+The most common AEO extraction pattern.
+
+**The shape.** Specific question-answer pairs derived from the source piece. Each Q&A is 40-80 words. Format as standalone FAQ entries.
+
+**Question framing.**
+
+- Use phrasings users actually search. "What is X?" "How does X work?" "Why does X matter?" "When should I use X?"
+- Avoid phrasings users do not search. "What are the considerations around X?" rarely matches search intent.
+- Specific is better than generic. "How long should a B2B sales email be?" performs better than "What length should sales emails be?"
+
+**Answer framing.**
+
+- Standalone meaning. The answer works as a paragraph; no pronoun references that depend on outside context.
+- Named source within the answer where applicable. "According to a 2025 Forrester study, B2B sales emails between 75 and 150 words have the highest reply rates" performs better than "Studies show shorter emails work better."
+- Specific framings, not hedged. "The strongest length is 75-150 words" performs better than "Generally, shorter tends to be better."
+- Length: 40-80 words typical. Longer answers get truncated or cited partially; shorter answers may not have enough substance to cite.
+
+**Where the FAQ lives.**
+
+- A dedicated FAQ section at the bottom of the source piece, schema-marked with FAQPage.
+- A standalone FAQ page that aggregates multiple FAQs across topics, deeply linked to source pieces.
+- Inline within the source piece as a callout box, surfacing the Q&A while the surrounding prose develops the topic.
+
+---
+
+## Pattern 2: Snippet design
+
+Standalone paragraphs in the source piece designed to be citation-ready.
+
+**The shape.** A paragraph (100-200 words typical) that answers a specific query cleanly and can be cited as a unit.
+
+**Snippet framing.**
+
+- Opens with a specific claim or definition. Snippets that open with throat-clearing rarely get cited cleanly.
+- Includes named source citations where the claims need authority.
+- Uses specific framings. "B2B sales emails between 75 and 150 words have a 32% reply rate, compared to 18% for emails over 250 words" is citation-ready; "shorter emails tend to do better" is not.
+- Stands alone. The paragraph's meaning does not depend on the prior or following paragraphs.
+
+**Where snippets live.**
+
+- Throughout the source piece as load-bearing paragraphs that incidentally meet snippet criteria.
+- As deliberately-designed snippets in specific positions (often after each H2 question for AEO-optimized pieces; see `editorial-qa`'s SEO/AEO compliance for the answer-paragraph discipline).
+- As standalone snippets in derivative pieces (FAQ pages, glossaries, knowledge-base entries).
+
+---
+
+## Pattern 3: Statistic extractions
+
+AI engines weight statistics with named sources at high citation rates.
+
+**The shape.** Specific statistic with named source, framed for citation.
+
+**Statistic framing.**
+
+- The number is specific. "32% of B2B buyers" performs better than "around a third of buyers."
+- The source is named. "According to the 2025 Salesforce State of Marketing report" performs better than "according to a recent study."
+- The context is clear. "Among B2B SaaS buyers in the $50M-500M revenue band" rather than just "among buyers."
+- The currency is specified. The stat's date matters for AI engines deciding which sources to cite as current.
+
+**Where statistic extractions live.**
+
+- Throughout the source piece where data supports claims.
+- In dedicated "key statistics" callouts that schema-mark the stats.
+- As standalone tweet-graphic-style social derivatives (the stat on its own with the source citation).
+- In FAQ-style answers that frame "what does the data say about X?"
+
+**The citation-laundering avoidance.** Statistic extractions that cite secondary sources (other content marketing pieces) rather than primary sources reduce citation rates. AI engines increasingly detect citation laundering and discount it.
+
+---
+
+## Pattern 4: Definition and entity extractions
+
+Source pieces often define specific terms or describe specific entities authoritatively.
+
+**The shape.** Standalone definitions or entity descriptions that can serve as canonical references.
+
+**Definition framing.**
+
+- "X is [definition], typically [characterization], distinguished from [related concept] by [distinction]."
+- 50-150 words for substantive definitions.
+- Specific authority signals: who developed the concept, when, in what context.
+
+**Entity framing.**
+
+- For products, companies, frameworks: who, what, when, why, where used.
+- Specific dates, named people, named organizations.
+- Source attribution where the entity claim depends on authority.
+
+**Where definition and entity extractions live.**
+
+- Glossary pages. Many programs underuse glossaries; they are AI-search valuable real estate.
+- Knowledge-base entries.
+- Schema-marked definitions within source pieces (Article schema with appropriate sub-types).
+- Wikipedia and similar entity authorities where the entity is significant enough to warrant external listings (different from on-property AEO but related; AI engines weight cross-source consistency).
+
+---
+
+## Pattern 5: Comparison extractions
+
+Source pieces that compare options, frameworks, or approaches produce comparison-extraction derivatives.
+
+**The shape.** Side-by-side or table comparisons with specific axes, citation-ready.
+
+**Comparison framing.**
+
+- Defined axes (price, feature set, fit, scale).
+- Specific values per axis per option.
+- Tradeoff summary that AI can quote.
+- Recommendation framing where the source piece commits a position.
+
+**Where comparison extractions live.**
+
+- Tables within the source piece, schema-marked where appropriate.
+- Standalone comparison pages.
+- FAQ-style answers framing "How does X compare to Y?"
+- Decision-guide derivatives that walk readers through the comparison.
+
+---
+
+## Pattern 6: How-to extractions
+
+Source pieces with sequential instructions produce how-to extractions.
+
+**The shape.** Step-by-step instructions that AI can cite as a procedure.
+
+**How-to framing.**
+
+- Numbered steps in a clear sequence.
+- Each step is a complete instruction (not "do this, then that" run together).
+- Schema-marked with HowTo where the source is an instructional piece.
+
+**Where how-to extractions live.**
+
+- Within source pieces as schema-marked procedures.
+- Standalone how-to pages on specific tasks.
+- Tutorial derivatives in video format.
+
+---
+
+## AEO extraction failures
+
+**Generic FAQs.** Questions that do not match user search phrasings get little citation. Cure: query research; phrase questions in user voice.
+
+**Context-dependent answers.** Answers that reference "this approach" or "the method described above" do not cite cleanly. Cure: each answer is rewritten to stand alone with full context.
+
+**Hedged answers.** "Generally, in some cases, depending on context, X might work" rarely gets cited. AI engines prefer specific framings. Cure: where the source piece is genuinely uncertain, scope the answer to the specific case where the answer is specific.
+
+**Missing schema.** FAQs and snippets without schema markup do not signal cleanly to engines. Cure: add appropriate schema (FAQPage, HowTo, Article) where formats fit.
+
+**No source citations within answers.** Statistics and specific claims without named sources within the answer paragraph get cited at lower rates. Cure: include source citations within the answer body, not just in surrounding context.
+
+**Citation laundering.** FAQs citing other content marketing pieces rather than primary sources. Cure: trace claims to primary sources; cite the primary.
+
+**Over-extraction.** Producing 50 FAQs from a 5,000-word source piece dilutes; not every question deserves a standalone FAQ. Cure: extract the 10-15 highest-value questions; let the rest live within the source's prose.
+
+---
+
+## AEO extraction integration with the cross-format set
+
+AEO extractions integrate with other derivatives.
+
+**FAQ pages link to the source.** The FAQ page is a derivative; the source piece is the canonical version. Cross-promotion follows the standard pattern.
+
+**Statistic extractions appear in social posts.** Each stat with its source citation can become a social post (often with quote-graphic visual treatment).
+
+**Definition extractions appear in glossaries that the source piece links to.** The glossary entry serves as the canonical definition for the term across the program.
+
+**Comparison extractions appear in decision-guide derivatives.** The comparison from the source becomes the spine of a separate decision-guide piece.
+
+**The integration discipline.** AEO extraction is one derivative type among several; the cross-format set's coordination includes the AEO extractions, not as a separate workflow but as part of the rollout plan.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The six AEO extraction patterns, the question/answer/snippet framing principles, the schema markup integration, the AEO extraction failures, the integration with the broader cross-format set.
+
+## Implementation choices that stay internal
+
+Specific schema markup automation. Specific FAQ-page templates in the team's CMS. Specific glossary-page architecture. Specific statistic-extraction tooling. Specific monitoring of AI citation rates per piece. The team's own conventions for FAQ length within the bands. These vary by team, CMS, and AI-citation tracking infrastructure.

--- a/skills/content-repurposing/references/common-repurposing-failures.md
+++ b/skills/content-repurposing/references/common-repurposing-failures.md
@@ -1,0 +1,175 @@
+# Common repurposing failures
+
+Eleven-plus failure patterns with diagnoses and cures. The cross-cutting pattern: most repurposing failures share a single root, which is treating repurposing as content multiplication rather than as cross-format craft.
+
+---
+
+## Failure 1: Mass-blast (same content reposted across channels)
+
+**Symptom.** Blog post text pasted into LinkedIn as a long post. Email is the blog's first three paragraphs with "read more." YouTube version is a slideshow of the article text read aloud.
+
+**Diagnosis.** Repurposing without per-format adaptation. The team is treating "more channels" as the goal rather than treating each derivative as a piece adapted for its medium.
+
+**Cure.** Apply the per-format constraints discipline (see `per-format-constraints.md`). Each derivative gets rewritten for the target format. AI-assisted repurposing without strong format prompts produces this failure; the cure includes voice prompts and per-format instructions.
+
+---
+
+## Failure 2: AI-slop derivatives
+
+**Symptom.** Derivatives feel like AI slop. Generic, derivative, signal-less. Voice has drifted from the source.
+
+**Diagnosis.** AI-assisted repurposing without voice discipline. AI generation regresses to model defaults; multiple derivatives generated without voice anchor compound the drift.
+
+**Cure.** Apply the voice-consistency-across-formats discipline (see `voice-consistency-across-formats.md`). Voice prompts including sample text from the source. Per-derivative voice review. Reject the bland; rewrite generic sentences in voice. See also `ai-content-collaboration` for the broader voice-preservation discipline.
+
+---
+
+## Failure 3: One-and-done
+
+**Symptom.** Source pieces publish; never get repurposed. The team produces new flagship work continuously while older flagship work sits unused.
+
+**Diagnosis.** No repurposing discipline; the team treats publication as the end of the piece's life. Most of the source-piece value goes unrealized.
+
+**Cure.** Establish source-piece tiering (see `source-piece-selection-criteria.md`). Tier 1 and Tier 2 pieces get cross-format extension plans at production time. Capacity allocation for repurposing becomes a real budget line.
+
+---
+
+## Failure 4: Repurposing the wrong pieces
+
+**Symptom.** Repurposing capacity goes to pieces that resist extension. The derivatives feel forced; engagement is low.
+
+**Diagnosis.** Source-piece selection is choosing pieces by availability rather than by suitability. Pieces with tightly-integrated arguments, list-style structure, or no demand signal are being repurposed when they should stay one-and-done.
+
+**Cure.** Apply the selection audit. Run candidates through the strong vs weak source-piece characteristics. Some pieces stay one-and-done; that is the right disposition for them.
+
+---
+
+## Failure 5: Format constraints ignored
+
+**Symptom.** Derivatives feel awkward on their target formats. Engagement is low. Audiences scroll past or unsubscribe.
+
+**Diagnosis.** Each medium has constraints; the derivatives violate them. LinkedIn long posts as walls of text; emails as image-only layouts; podcasts as articles read aloud.
+
+**Cure.** Apply the per-format constraints discipline. Each format has demand-and-forbid lists. Derivatives must respect them, even at cost of departing from the source's surface.
+
+---
+
+## Failure 6: Derivative outperforms source (cannibalization)
+
+**Symptom.** A blog-post derivative outperforms the source whitepaper for the source's target keyword. Authority is splitting between the two pieces.
+
+**Diagnosis.** Either the source was the wrong format for the topic (the derivative format fits SERP intent better), or the derivative is targeting the same keyword as the source and cannibalizing.
+
+**Cure.** Two options. If the source was the wrong format, consider whether the derivative should become the canonical piece (with the source decommissioned or repositioned). If the derivative is cannibalizing, reassign primary keywords: the source keeps the high-value head term; the derivative gets a long-tail variant.
+
+---
+
+## Failure 7: Voice drift across the cross-format set
+
+**Symptom.** Each derivative is fine alone but the cross-format set reads as voice variants. Audiences who follow the program notice the inconsistency.
+
+**Diagnosis.** Multiple writers or AI generators produced derivatives without voice coordination. Voice drifted across producers.
+
+**Cure.** Single voice owner across the cross-format set. Voice library with examples. Calibration sessions where multiple writers reconcile voice expectations. AI tools include the same voice prompts across all derivative generations.
+
+---
+
+## Failure 8: Cadence too aggressive
+
+**Symptom.** Cross-format set ships a wave of 12 derivatives in one week. Audiences disengage by day 3. Most derivatives produce minimal engagement.
+
+**Diagnosis.** Concentrated cadence too tight for the audience attention rhythm. The cross-format presence on a single week exhausts rather than reinforces.
+
+**Cure.** Apply the sequencing-and-cadence discipline. Match cadence to source's traffic curve and audience attention norms. Most cross-format sets benefit from concentrated-but-not-collapsed pacing (4-6 weeks rather than 1 week).
+
+---
+
+## Failure 9: No cross-promotion
+
+**Symptom.** Derivatives ship in isolation. No links to source. No links between derivatives. No mention of the cross-format set on the channels where audiences could discover it.
+
+**Diagnosis.** Cross-promotion was treated as optional or as an afterthought. The compounding effects of cross-linking and co-promotion are missing.
+
+**Cure.** Apply the cross-promotion discipline (see `cross-promotion-patterns.md`). Every derivative includes a derivative-to-source link. The source piece is updated to reference derivatives. Co-promotion across channels is planned at rollout time.
+
+---
+
+## Failure 10: AEO extraction skipped or generic
+
+**Symptom.** The cross-format set ships without FAQ extractions or with generic FAQ extractions. AI-search citation rates are low.
+
+**Diagnosis.** AEO extraction was not part of the plan, or the FAQ questions do not match user search phrasings, or the answers are context-dependent rather than standalone.
+
+**Cure.** Apply the AEO extraction patterns. Treat FAQ extraction, snippet design, and statistic extractions as derivative formats with their own conventions. Schema-mark where appropriate.
+
+---
+
+## Failure 11: No source-piece updating after rollout
+
+**Symptom.** The source piece publishes; derivatives ship; the source piece is never updated to reference the derivatives. The source remains static.
+
+**Diagnosis.** The forward-promotion from source to derivatives was skipped. The source's role as cross-format hub is wasted.
+
+**Cure.** Plan source-piece updates as part of the rollout. As each derivative ships, the source's "related" or "see also" section gets updated. The source becomes a navigation hub for the cross-format set.
+
+---
+
+## Failure 12: Capacity underestimation
+
+**Symptom.** The team planned 30 hours for a whitepaper repurposing pipeline; actual cost is 70 hours. New production suffers; team burns out.
+
+**Diagnosis.** Capacity estimates were based on optimistic assumptions or on prior pipelines that were not as substantial.
+
+**Cure.** Track actual capacity per pipeline (see `repurposing-pipeline-templates.md`). Calibrate estimates over time. Some pipelines genuinely cost more than the team has budget for; the right answer may be to reduce scope rather than to overrun.
+
+---
+
+## Failure 13: No measurement
+
+**Symptom.** Cross-format sets ship; the team has a vague sense some perform better than others; the program does not learn.
+
+**Diagnosis.** No per-pipeline or per-derivative tracking. Outcomes are anecdotal rather than data-driven.
+
+**Cure.** Establish a minimum log per pipeline run: source piece, derivatives planned vs delivered, capacity spent, outcomes per derivative, lessons learned. Pattern-detect across pipelines to inform future ones.
+
+---
+
+## Failure 14: Pipeline dogmatism
+
+**Symptom.** The team applies the same pipeline template to every source piece regardless of the source's characteristics or the audience overlap. Some derivatives consistently underperform; the team keeps producing them anyway.
+
+**Diagnosis.** Treating templates as fixed shapes rather than as starting points to customize.
+
+**Cure.** Customize pipelines per source piece. Audience characteristics, source characteristics, and capacity should adjust the cross-format set. Drop derivatives that consistently underperform for the program's audience mix.
+
+---
+
+## Failure 15: AI repurposing as the strategy
+
+**Symptom.** "We use AI to repurpose, so we can scale." The output is a wave of low-engagement derivatives across many channels. The team is producing more derivative content than ever; engagement is flat or declining.
+
+**Diagnosis.** AI is being treated as a substitute for the craft of cross-format adaptation. Volume is being prioritized over quality.
+
+**Cure.** AI is a tool within the workflow, not the workflow itself. The discipline of adaptation per medium is still the work; AI accelerates parts of it. See `ai-content-collaboration` for the workflow discipline that prevents AI-assisted repurposing from drifting into mass-blast and slop.
+
+---
+
+## The cross-cutting pattern
+
+Most repurposing failures share a single root: treating repurposing as content multiplication rather than as cross-format craft.
+
+Multiplication thinking treats each derivative as another item in a quota: more channels, more pieces, more reach. The output is mass-blast and slop because adaptation is skipped.
+
+Craft thinking treats each derivative as a piece in its own right, adapted for its medium, holding the source's voice while respecting the format's conventions. The output is a coherent cross-format set where each derivative earns engagement on its medium.
+
+The fix for almost any repurposing failure is the same: stop multiplying, start adapting. The capacity required for craft-driven repurposing is higher than multiplication-driven repurposing; the value extracted is also higher, often by an order of magnitude.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The fifteen failure patterns with diagnoses and cures, the cross-cutting pattern that connects most of them, the multiplication-vs-craft framing.
+
+## Implementation choices that stay internal
+
+Specific tooling for derivative tracking. Specific reporting templates for cross-format outcomes. Specific reviewer training on per-format conventions. Specific automation that flags voice drift across derivatives. The team's own conventions for failure-pattern detection in their pipelines. These vary by team and tooling.

--- a/skills/content-repurposing/references/cross-promotion-patterns.md
+++ b/skills/content-repurposing/references/cross-promotion-patterns.md
@@ -1,0 +1,170 @@
+# Cross-promotion patterns
+
+Linking patterns, attribution, and co-promotion across channels. The mechanics that turn a cross-format set into a coordinated extension rather than scattered derivatives.
+
+Derivatives that link to each other and to the source compound. Derivatives that ship in isolation underperform. The cross-promotion discipline is small per-derivative but compounds significantly across the set.
+
+---
+
+## Derivative back to source
+
+Each derivative includes a link or reference to the source piece for readers who want depth.
+
+**The pattern.**
+
+- Blog-post derivative includes "This is one of six pieces drawing from our recent whitepaper on X. Read the full whitepaper here."
+- Email derivative ends with "Want the full framework? Read the original piece here."
+- Social-post derivative includes a link to the source in profile, in comments, or as part of a multi-post thread.
+- Podcast episode show notes link to the source article.
+- Video description links to the source.
+
+**Why it works.** The source's traffic compounds. Audiences who engage with a derivative and want depth click through; the source piece earns continued traffic from the cross-format set. The source's authority benefits from the inbound links from derivative pieces.
+
+**The discipline.** Every derivative includes a derivative-to-source link as a non-negotiable element of the format adaptation. The link is not buried; it is positioned where readers who want more naturally find it.
+
+---
+
+## Source forward to derivatives
+
+The source piece is updated to include links to derivatives as they ship.
+
+**The pattern.**
+
+- A "related" or "see also" section at the end of the source piece, updated as derivatives ship.
+- Inline links from specific source sections to corresponding derivatives that develop those sections.
+- A dedicated "this piece's extensions" callout linking to the cross-format set.
+
+**Why it works.** The source becomes the hub for the cross-format extension. Audiences who land on the source can navigate to derivatives that match their preferred format. The source's role as canonical anchor strengthens.
+
+**The discipline.** Update the source piece as the cross-format set rolls out. Stale source pieces that do not reference their derivatives miss the cross-promotion opportunity.
+
+---
+
+## Derivatives across
+
+Where appropriate, derivatives link to other derivatives in the cross-format set.
+
+**The pattern.**
+
+- Blog post 3 in a series links to blog posts 1, 2, 4, 5, 6 either inline or in a "more in this series" footer.
+- Email 5 in a sequence references email 4's framework or previews email 6.
+- Podcast episode show notes link to a related video, blog series, or webinar.
+- Webinar registration page links to the relevant blog series and the underlying source piece.
+
+**Why it works.** The series feeling helps audiences engage with multiple pieces. Internal linking compounds across the set. SEO benefits accrue when derivatives strengthen each other's authority.
+
+**The discipline.** Plan the cross-derivative link graph at production time. Each derivative's link plan is part of the production work, not an afterthought.
+
+---
+
+## Attribution within derivatives
+
+When a derivative is clearly drawn from a source piece, acknowledge.
+
+**The pattern.**
+
+- "This is adapted from our recent piece on X."
+- "Drawing from our research on [topic]."
+- "Originally published as [source piece title]."
+- For social posts: "From our recent whitepaper on X, [insight]."
+
+**Why it works.** Attribution earns reader trust. Uncredited derivatives can feel like the same work being recycled without acknowledgment; audiences notice and discount the program's perceived effort.
+
+**The discipline.** Attribution is honest about the derivative status. The format adaptation is the value-add; pretending the derivative is independent work overstates the production effort and reads as low-trust positioning.
+
+**Anti-pattern: hiding derivatives.** Some teams treat derivatives as if they were independent pieces, with no acknowledgment that they draw from a source. Audiences who follow the program detect the recycling and the cross-format coherence is lost.
+
+---
+
+## Co-promotion across channels
+
+Derivatives can be promoted on channels other than the channel where they natively live.
+
+**The pattern.**
+
+- A blog post derivative gets re-shared on social where the original blog post might not have been re-shared without the derivative pretext.
+- A social post derivative gets mentioned in the email newsletter as "our latest LinkedIn post on X."
+- A podcast episode gets promoted on social, in the email, and on the blog.
+- A video derivative gets embedded in a blog post or shared via email.
+
+**Why it works.** Each derivative's reach extends beyond its native channel. Audiences encountering a derivative through cross-channel promotion discover both the derivative and the channel where it lives.
+
+**The discipline.** Plan cross-channel promotion as part of the rollout. Each derivative has a primary channel (where it lives natively) and a secondary channel set (where it gets promoted from). The plan is explicit, not improvised.
+
+---
+
+## Internal linking refresh on related pieces
+
+Pieces in the library that are related to the source's topic may benefit from updated internal linking when the source's cross-format set rolls out.
+
+**The pattern.**
+
+- Sister pieces that mention the source's topic get updated to link to the source piece (if they did not already) and possibly to the most relevant derivative.
+- Pieces in the same hub or category get updated where the cross-format set makes new linking opportunities sensible.
+- Anchor text on existing internal links may benefit from refresh if the source's positioning shifted.
+
+**Why it works.** The source's authority benefits from internal links across the library. Derivatives benefit from being part of the link graph rather than orphaned.
+
+**The discipline.** Run a brief internal-linking audit when the cross-format set rolls out. The audit catches obvious linking opportunities; over-investing in this pass is the failure mode (touching too many pieces, producing diminishing returns).
+
+---
+
+## The cross-promotion graph
+
+Visualizing the cross-promotion structure as a graph helps catch gaps.
+
+**Nodes.** The source piece and each derivative.
+
+**Edges.**
+
+- Source-to-derivative links.
+- Derivative-to-source links.
+- Derivative-to-derivative links.
+- Cross-channel co-promotion (each channel promoting each piece).
+
+**Audit.** Each derivative should connect to the source. Each derivative should connect to at least one other derivative where format-appropriate. Each derivative should be co-promoted on at least one secondary channel where audience overlap exists.
+
+**Output of the audit.** A planned link and promotion graph for the cross-format set, with the gaps identified before the rollout begins.
+
+---
+
+## Common cross-promotion failures
+
+**Derivatives shipping in isolation.** Each derivative ships without links to source or to other derivatives. The cross-format set reads as scattered pieces; the compounding effect of cross-linking is lost.
+
+**Source piece not updated.** Source publishes; derivatives ship; the source piece is never updated to reference the derivatives. The hub function of the source is wasted.
+
+**Attribution skipped.** Derivatives ship without acknowledging the source. Audiences detect the recycling; trust degrades.
+
+**Cross-channel co-promotion skipped.** Each derivative stays on its native channel. Reach is limited to the audiences who happen to be on each channel.
+
+**Internal-linking refresh skipped.** Existing pieces in the library do not get linked to the new source piece. The library's internal-link graph stays static; the source piece's authority does not benefit.
+
+**Over-investment in cross-promotion.** Internal-link refresh that touches 50+ pieces in the library produces diminishing returns and maintenance overhead. Cure: target the highest-value linking opportunities; skip the marginal ones.
+
+---
+
+## Cross-promotion in mature programs
+
+Programs with established cross-promotion discipline accumulate compounding effects over time.
+
+**The pattern in mature programs.**
+
+- Every flagship piece has an established cross-format extension plan.
+- Every derivative has documented linking and promotion structure.
+- The library's internal-link graph reflects accumulated cross-promotion across multiple cross-format sets over years.
+- Audiences trust that pieces from the program connect; navigation between pieces feels intuitive.
+
+**The compounding effect.** Older flagship pieces continue to draw traffic because their cross-format sets extended their reach; their derivatives continue to draw traffic because their cross-promotion brought audiences in. The library's traffic profile reflects accumulated cross-format work, not just individual-piece performance.
+
+**The maturity audit.** Do new flagship pieces' cross-format sets connect to older flagship pieces' cross-format sets where topics overlap? Mature programs cross-promote across time; immature programs treat each cross-format set as isolated.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The cross-promotion link patterns, attribution discipline, co-promotion across channels, internal linking refresh, the cross-promotion graph, the common failures, the maturity-audit pattern.
+
+## Implementation choices that stay internal
+
+Specific link-graph tooling. Specific automation that surfaces missing cross-format links. Specific channel-promotion calendars. Specific internal-link audit tools. The team's own conventions for attribution language. These vary by team, CMS, and tooling.

--- a/skills/content-repurposing/references/format-adaptation-patterns.md
+++ b/skills/content-repurposing/references/format-adaptation-patterns.md
@@ -1,0 +1,202 @@
+# Format adaptation patterns
+
+Eight source-to-derivative adaptations with worked examples. The patterns that distinguish thoughtful adaptation from mass-blast.
+
+Each pattern below is a recurring shape: a particular source-piece type adapting into a particular derivative format. The patterns are not the only adaptations; they are the most common, with the most predictable success and failure modes.
+
+---
+
+## Pattern 1: Long-form to blog series
+
+**Source.** A 4,000-8,000 word whitepaper, definitive guide, or research report.
+
+**Derivatives.** 4-6 standalone blog posts. Each post takes one of the source's H2 sections (or one of its sub-arguments) and develops it as a piece in its own right.
+
+**Adaptation work.**
+
+- New lede per post. The source's lede establishes the whole piece's thesis; each derivative needs its own lede that establishes its standalone scope.
+- New closing per post. Source closing addresses the whole piece's argument; derivative closings address the post's specific argument.
+- Connective tissue. Each derivative briefly references the source piece ("This is one of six pieces drawing from our recent whitepaper on X") and links forward to other derivatives in the series and back to the source.
+- SEO targeting per derivative. The source piece may target one primary keyword cluster; each derivative can target a more specific long-tail keyword.
+
+**Example.** A whitepaper "The complete framework for content distribution" with H2 sections on owned, earned, paid channels, audience-channel matching, content-channel matching, and distribution measurement. Derivatives: 6 blog posts, one per section, each developing the section into a standalone piece (typically 1,200-1,800 words each).
+
+**Common failures.**
+
+- Derivative posts that are paste-ins of source sections without rewriting. Reads as duplicate content; SEO penalty risk; voice flatness.
+- Derivative posts that compete with the source for the same keyword (cannibalization). Cure: explicit primary-keyword assignment per piece, with derivatives on long-tail variants.
+- Derivative posts that drop the source's voice. Cure: voice prompts and review per derivative.
+
+---
+
+## Pattern 2: Blog post to email sequence
+
+**Source.** A 1,200-2,500 word blog post on a multi-step framework, methodology, or process.
+
+**Derivatives.** 3-7 emails delivered over 1-3 weeks. Each email develops one step or section of the source's framework with sender-voice adaptation.
+
+**Adaptation work.**
+
+- Sender voice. Email voice is more direct and conversational than blog voice. Sentences shorter; "you" usage higher; more direct address.
+- Engagement hooks per email. Subject line and preheader carry most of the email's open-rate burden. Hooks need to be earned per email.
+- One CTA per email. Email format rewards single clear CTAs; multi-CTA emails underperform.
+- Sequential building. Each email assumes the prior emails have been read; the sequence builds; the final email synthesizes.
+
+**Example.** A blog post on "the 5-step framework for product launches" becomes a 6-email sequence: introduction email, one email per step, synthesis email. Each email is 200-500 words with a single CTA.
+
+**Common failures.**
+
+- Emails that are blog paragraphs with "read more" links. Mass-blast pattern.
+- Emails that lose voice consistency. Cure: voice anchored to source's distinctive register; per-email review.
+- Sequences that are too long. 12-email sequences from a 1,500-word source are over-extension; audiences disengage. Cure: match sequence length to source's actual content depth.
+
+---
+
+## Pattern 3: Whitepaper to webinar
+
+**Source.** A substantive whitepaper or research report.
+
+**Derivatives.** A 30-45 minute webinar with the whitepaper's framework as the spine, plus live elements that print does not support: Q&A, polls, interactive moments, possibly guest appearances.
+
+**Adaptation work.**
+
+- Spine selection. The webinar typically takes the whitepaper's 3-5 most load-bearing sections as its spine. Lower-priority sections from the source become spoken asides or get cut.
+- Spoken-language adaptation. Print-style sentences read aloud sound stilted. The webinar script (or speaker notes) is rewritten in spoken voice.
+- Interactive design. Polls, Q&A, audience prompts. Webinar without interactivity is a video; webinar with interactivity earns the format.
+- Slide design. Text-heavy slides fail; the visual layer carries the audience's attention while the speaker delivers the content.
+- Recording and follow-up. Most webinars become video derivatives after the live session; the recording extends value indefinitely.
+
+**Example.** A 6,000-word research report on B2B paid media benchmarks becomes a 40-minute webinar: 25-minute walkthrough of the report's framework with the speaker's commentary, 10-minute Q&A, 5-minute conclusion with specific recommendations. The recording is later cut into derivative video clips.
+
+**Common failures.**
+
+- Webinars that read the whitepaper aloud. The whitepaper is published; the webinar adds nothing.
+- No interactivity. Live audiences disengage when the format is one-way.
+- Text-heavy slides that compete with the speaker. Cure: visuals carry the design; speaker carries the content.
+
+---
+
+## Pattern 4: Long-form to social posts
+
+**Source.** A long-form piece (whitepaper, definitive guide, research report).
+
+**Derivatives.** 8-30 social posts across the platforms where the audience exists. Each post is one specific moment from the source: a pull quote, a framework summary, a key statistic, a contrarian claim.
+
+**Adaptation work.**
+
+- Platform-specific structure. LinkedIn long-post structure differs from X/Twitter thread structure differs from Threads structure. Adaptation is per platform.
+- Hook in the first 1-2 lines. Social readers decide to expand or scroll within seconds; the hook earns expansion.
+- Visual or quote-graphic options. Many social posts benefit from accompanying visuals (quote graphics, statistic graphics, framework diagrams).
+- One specific point per post. Multi-point social posts dilute; one clear point earns engagement.
+- Series cadence. Posts shipped over weeks rather than dumped in one day; audiences engage with each post if they are spaced.
+
+**Example.** A whitepaper on AI search optimization becomes 18 social posts: 6 framework-summary posts, 4 statistic posts (with custom graphics), 4 contrarian-claim posts, 4 question-prompt posts. Distributed over 6 weeks across LinkedIn and X.
+
+**Common failures.**
+
+- Posts that are quote graphics with no context. The graphic is decoration; the post needs text that earns engagement.
+- Posts that read as blog-text paste-ins. Mass-blast on social.
+- Cadence too aggressive. 18 posts in one week exhausts audiences; distributed cadence performs better.
+
+---
+
+## Pattern 5: Article to podcast episode
+
+**Source.** A substantive article (1,500-3,500 words).
+
+**Derivatives.** A podcast episode with the article as spine, plus host commentary, examples, and possibly guest interviews.
+
+**Adaptation work.**
+
+- Spoken-language adaptation. Article sentences read aloud sound stiff. The episode script (or talking-points outline) is in spoken voice.
+- Conversational pacing. Examples and asides that print would cut earn their place in audio because the conversation needs space to breathe.
+- Show notes as derivative format. The show notes do the print work the audio cannot: links, citations, structured summary. Treat show notes as a derivative in their own right.
+- Guest dynamics where applicable. Some podcast episodes pair the article's framework with guest perspective; the article is the show's structured input, the guest adds expert commentary.
+
+**Example.** An article on programmatic SEO durability becomes a podcast episode: 5-minute introduction by the host, 30-minute interview with a practitioner who has run programmatic operations, 10-minute synthesis by the host. Show notes link to the source article and to several mentioned references.
+
+**Common failures.**
+
+- Episodes that read the article aloud. The article is published; the episode adds nothing.
+- Episodes without spoken-language adaptation. Stilted delivery; low completion rates.
+- Show notes that are afterthoughts. Show notes that fail their own format reduce the episode's discoverability and value.
+
+---
+
+## Pattern 6: Long-form to video shorts
+
+**Source.** A long-form piece with travelable elements (specific examples, framework moments, contrarian claims).
+
+**Derivatives.** 6-20 short-form video clips, 30-90 seconds each. Each short is one standalone moment.
+
+**Adaptation work.**
+
+- Hook in seconds 1-2. Algorithmic recommendation rewards retention from second 1; openings must earn continued viewing.
+- Captions essential. Many viewers watch without sound; captions carry the message.
+- Visual presence. Talking-head shorts work for some audiences; many short-form platforms reward visual variation, motion, or text-on-screen design.
+- Single specific point per short. Short-form does not support multi-point delivery; one moment per clip.
+- Platform-specific aspect ratios and conventions. TikTok shorts, Instagram Reels, YouTube Shorts each have specific norms.
+
+**Example.** A research report becomes 12 video shorts: 4 statistic shorts (text-on-screen with audio narration), 4 framework moment shorts (whiteboard-style explanation), 4 contrarian-claim shorts (talking head). Distributed across LinkedIn video, YouTube Shorts, Instagram Reels.
+
+**Common failures.**
+
+- Shorts without strong opening hooks. Algorithmic feed deprioritizes; reach is minimal.
+- Shorts without captions. 50%+ of audience cannot consume the content.
+- Shorts that try to cover too much in 60 seconds. Cure: one moment, one point, one short.
+
+---
+
+## Pattern 7: Research report to FAQ extractions
+
+**Source.** A research report or definitive guide with specific Q&A-able material.
+
+**Derivatives.** Standalone FAQ entries (40-80 words each), formatted for AI search citation, possibly aggregated into FAQ pages or schema-marked snippets within the source piece.
+
+**Adaptation work.**
+
+- Question framing. AI search engines cite content that matches likely user-query phrasings. FAQ questions need to use the phrasings users actually search.
+- Standalone answer paragraphs. Each FAQ answer must work as a standalone paragraph; AI engines cite paragraphs, not contextual passages.
+- Source attribution within the answer. Statistics and specific claims need named sources within the answer paragraph; AI engines weight named-source claims at higher rates.
+- Schema markup. FAQPage schema where the FAQ aggregates as a dedicated page; structured data signals the format to search engines.
+
+**Example.** A research report on content distribution effectiveness becomes 15 FAQ extractions: "What channels produce highest engagement for B2B content?" "How does audience size affect channel selection?" "What is the typical engagement rate decay across channel types?" Each Q&A is 40-80 words with named-source citations.
+
+**Common failures.**
+
+- Questions that do not match how users phrase queries. Cure: query research; phrase questions in user voice.
+- Answers that depend on context outside the answer paragraph. AI engines may not cite cleanly; paragraphs need to stand alone.
+- Missing schema markup. The FAQ format does not signal cleanly to search engines without schema.
+
+---
+
+## Pattern 8: Multi-piece source to ebook
+
+**Source.** Several related pieces (blog posts, articles, social threads) that together cover a topic.
+
+**Derivatives.** An ebook with the multi-piece content as the bulk, plus new connective tissue: introduction, chapter framings, conclusions, and possibly new chapters that fill gaps the source pieces did not cover.
+
+**Adaptation work.**
+
+- Topic synthesis. The multi-piece source covers the topic in scattered ways; the ebook needs to organize the content into a coherent sequence.
+- New connective tissue. Introductions, chapter prefaces, transitions, conclusion. Often 20-30% of the ebook is new content not present in the source pieces.
+- Voice consolidation. Pieces written over months may have voice variation; the ebook needs to read as one unified work, which often means rewriting passages to match a target voice.
+- Design and production. Ebook format expectations: chapter design, table of contents, possibly downloadable PDF. Higher production cost than other repurposing patterns.
+
+**Example.** Twelve blog posts on a topical theme, written over 18 months, are consolidated into a 22,000-word ebook. New material includes a 1,500-word introduction, chapter framings totaling 3,000 words, a 1,500-word conclusion, and a 2,500-word new chapter that fills a gap the original posts did not address.
+
+**Common failures.**
+
+- Ebook that reads as posts stitched together. Cure: rewrite for unity; the ebook is a piece in its own right.
+- No new connective tissue. The ebook adds no value over reading the source pieces.
+- Voice inconsistency. Voice drift across pieces becomes visible when consolidated; cure: unified voice editing pass.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The eight adaptation patterns with their work, examples, and common failures. The recurring lesson: adaptation is per-format craft, not source-text recycling.
+
+## Implementation choices that stay internal
+
+Specific platform automation tooling. Specific design templates per derivative format. Specific tooling for video clip extraction from longer videos. Specific show-notes templates. Specific schema markup patterns the team uses for FAQ extractions. The team's own conventions for connective-tissue length in ebook consolidation. These vary by team, stack, and platform mix.

--- a/skills/content-repurposing/references/per-format-constraints.md
+++ b/skills/content-repurposing/references/per-format-constraints.md
@@ -1,0 +1,192 @@
+# Per-format constraints
+
+What each medium demands and forbids. Length norms, conventions, hooks, and the underlying observation: derivatives that ignore the medium's constraints fail the medium even when the source content was strong.
+
+Each format below has specific reader expectations. Pieces that meet expectations earn engagement; pieces that violate expectations get scrolled past or ignored regardless of content quality. Repurposing capacity goes to waste when derivatives fail the format-specific tax.
+
+---
+
+## Email
+
+**Length norms.** 200-800 words per email for most B2B and consumer audiences. Newsletter-style emails can run longer (1,500-3,000 words) for engaged audiences but shorter is generally safer.
+
+**What email demands.**
+
+- A subject line that earns the open. Most engagement happens or fails at the subject-line level.
+- A preheader that supports the subject line. The preheader is the second-most-read element of the email and most templates underuse it.
+- Plain prose paragraphs that render reliably. Many email clients break complex formatting; tables, columns, and rich layouts can fail.
+- A single clear CTA. Multi-CTA emails dilute; readers process one action at a time.
+- Mobile-first design. 60-70% of email opens are on mobile; readability on small screens is essential.
+
+**What email forbids.**
+
+- Image-only emails. Many clients block images by default; image-only emails arrive blank.
+- Link-laden text dumps. More than 3-4 links in body text dilutes attention.
+- Multi-CTA layouts that compete for the click.
+- Subject lines that announce the topic without earning the open ("Newsletter for week of X").
+
+**Adaptation discipline.** Email derivatives need new ledes (the source's lede does not transfer); spoken-direct voice (more "you" usage; shorter sentences than blog voice); a single CTA per email even when the source piece had multiple potential actions.
+
+---
+
+## LinkedIn (long-form text post)
+
+**Length norms.** 800-2,500 characters typical; long-form posts up to ~3,000 characters. The character count matters because the platform truncates with "see more"; the truncation point is the hook.
+
+**What LinkedIn demands.**
+
+- A first line that earns the "see more" click. The first 1-3 lines determine whether readers expand the post.
+- Clear structure: short paragraphs, white space, occasional emphasis. Walls of text get scrolled past.
+- A specific point or argument. Narrative-style posts that take time to land work; vague observations do not.
+- Engagement hooks: questions, polarizing claims, specific examples that invite comment.
+- Original perspective. Repurposed content marked clearly as such; uncredited recycling reads as low effort.
+
+**What LinkedIn forbids.**
+
+- Walls of text without paragraph breaks.
+- Generic motivational content; the platform has decreasing tolerance for this.
+- Posts that read as ads with no substantive content.
+- Heavy use of emoji decoration without purpose.
+
+**Adaptation discipline.** Source content needs to be restructured for LinkedIn rhythm: short opening hook, body with paragraph breaks every 2-3 sentences, specific examples or stakes, possibly a question at the close that invites comment.
+
+---
+
+## X/Twitter (single post and threads)
+
+**Length norms.** Single post: 280 characters (or up to 4,000 for premium accounts; conventions vary). Thread: 5-15 posts typical for substantive threads.
+
+**What X demands (single post).**
+
+- Tight phrasing. Each character matters; specific framings that fit the format earn engagement.
+- Stand-alone meaning. Tweets that depend on context outside the tweet often fail.
+- Specific points or claims. Vague observations underperform.
+
+**What X demands (threads).**
+
+- A first post that earns the next click. Threads are read sequentially; the first post must hook.
+- One coherent argument across the thread. Threads that wander get abandoned mid-way.
+- Reasonable length. Threads longer than 15-20 posts often lose readers; very long threads may be better as a blog post linked from a shorter thread.
+
+**What X forbids.**
+
+- Threads that read as a blog post split into 280-character chunks. The platform's conversational rhythm is different.
+- Hashtags-as-content. Heavy hashtag usage signals SEO chasing rather than communication.
+
+**Adaptation discipline.** Source content for threads needs to be re-paced: each post a complete thought, the thread building, the conclusion specific.
+
+---
+
+## Long-form video (YouTube, in-depth content)
+
+**Length norms.** 8-30 minutes typical for substantive content. Some categories support longer (45-90 minutes for deep technical content); the algorithm rewards retention over duration.
+
+**What long-form video demands.**
+
+- Pacing for spoken delivery. Print-style sentences read aloud sound stilted; video scripts need spoken voice.
+- Visual variation. Talking-head video alone for 30+ minutes underperforms; cuts, b-roll, on-screen text, illustrations carry attention.
+- Audio quality. Bad audio kills retention faster than bad video; audio investment usually returns more than video investment.
+- A specific topic. The video's title and thumbnail need to communicate scope; vague titles underperform in algorithmic recommendation.
+
+**What long-form video forbids.**
+
+- Slideshows of text read aloud. Mass-blast pattern in video form.
+- No editing. Filler words, long pauses, and unedited rambling reduce retention.
+- Talking head only with no visual variation across long durations.
+
+**Adaptation discipline.** Source content for video needs scripting in spoken voice (or talking-points for unscripted delivery), visual planning per segment, and an opening that earns the next 30 seconds of viewing.
+
+---
+
+## Short-form video (TikTok, Reels, Shorts)
+
+**Length norms.** 60-90 seconds typical; 15-30 seconds for some platforms. Algorithmic recommendation typically rewards retention from second 1.
+
+**What short-form demands.**
+
+- Hook in seconds 1-2. Viewers scroll past the opening if it does not earn the next 5 seconds.
+- Captions. Many viewers watch without sound; captions carry the message.
+- A single specific point. Short-form does not support multi-point delivery.
+- Visual presence. Motion, text-on-screen, or visual variation within the short. Static talking heads underperform.
+
+**What short-form forbids.**
+
+- Content that takes 10+ seconds to land. Viewers leave before the point.
+- Long-form video clipped without re-pacing. The pacing assumed in the source piece does not match short-form expectations.
+- Captions that lag the audio. Mistimed captions distract.
+
+**Adaptation discipline.** Source content for shorts needs extreme compression: one moment, one point, one short. Each short is a standalone unit.
+
+---
+
+## Podcast
+
+**Length norms.** 20-90 minutes typical for substantive content. Daily-news-style podcasts can be shorter (8-15 minutes); deep-interview podcasts can run 90-180 minutes.
+
+**What podcast demands.**
+
+- Spoken-language sentence structure. Print-style sentences read aloud sound stiff.
+- Conversational pacing. Examples, asides, and natural speech earn engagement; tightly-argued print sections feel cold.
+- Audio quality. Listening is intimate; bad audio breaks the connection. Better audio than video matters here.
+- Show notes that do the print work the audio cannot. Links, structured summary, citations, references.
+
+**What podcast forbids.**
+
+- Reading articles aloud without adaptation.
+- Scripts that sound scripted (over-rehearsed delivery, no conversational rhythm).
+- Episodes without show notes or with thin show notes.
+- Inconsistent episode length within a series; audiences develop expectations.
+
+**Adaptation discipline.** Source content for podcasts becomes the show's spine; the host adds context, examples, and conversational elaboration. Show notes are a distinct derivative format with their own constraints.
+
+---
+
+## Webinar
+
+**Length norms.** 30-60 minutes typical. Longer webinars (90+ minutes) require very high engagement design or strong specific draws (like premiere announcements).
+
+**What webinars demand.**
+
+- A live element. Q&A, polls, interactive moments. Static webinars are videos; interactive webinars earn the format.
+- Slide design that supports rather than competes with delivery. Text-heavy slides distract; visual slides with the speaker carrying the content work.
+- Pacing for live audience attention. Audience attention dips in the middle; engagement design needs to address the dip.
+- Recording strategy. Most webinars become video assets after the live session; the recording extends value indefinitely.
+
+**What webinars forbid.**
+
+- Reading slides aloud. The audience can read; the speaker should add the value the slides cannot carry.
+- No engagement design. Audiences disengage in pure one-way webinars.
+- Webinars that try to cover too much in 30 minutes. Cure: narrow the topic to what 30 minutes can deliver.
+
+**Adaptation discipline.** Source content for webinars typically takes the source's 3-5 most load-bearing sections as the spine, plus interactive moments, plus Q&A.
+
+---
+
+## AI-search snippet (for citation by AI engines)
+
+**Length norms.** 40-80 words per snippet for FAQ-style extractions; 100-200 words for paragraph-style extractions.
+
+**What AI-search snippets demand.**
+
+- Standalone meaning. The snippet works without the surrounding context; AI engines extract paragraphs, not full pieces.
+- Named-source citations within the snippet. AI engines weight named-source claims; "according to a 2025 Forrester study" performs better than "studies show."
+- Specific framings. Vague phrasings rarely get cited; specific phrasings do.
+- Schema markup where applicable. FAQPage and similar schemas signal the format.
+
+**What AI-search snippets forbid.**
+
+- Floating claims without sources.
+- Pronoun references that depend on outside context ("This is why..." with no clear referent within the snippet).
+- Hedged language on claims that can be specific.
+
+**Adaptation discipline.** Source content for AI snippets needs to be extractable as standalone paragraphs with internal citations and specific framings. Often the source piece needs additions specifically designed for snippet citation.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The format constraints by medium, the length norms, the demand-and-forbid lists, the adaptation discipline per format. The underlying observation: medium constraints are non-negotiable.
+
+## Implementation choices that stay internal
+
+Specific platform automation. Specific design templates per format. Specific captioning workflows. Specific schema markup patterns. Specific A/B testing of format-specific elements (subject lines, hooks, opening lines). The team's own conventions on length within the bands. These vary by team and platform mix.

--- a/skills/content-repurposing/references/repurposing-pipeline-templates.md
+++ b/skills/content-repurposing/references/repurposing-pipeline-templates.md
@@ -1,0 +1,237 @@
+# Repurposing pipeline templates
+
+Workflow templates by source-piece type. Whitepaper pipeline, blog post pipeline, research report pipeline, multi-piece consolidation pipeline. The repeatable shapes that turn ad-hoc repurposing into a predictable program.
+
+Repurposing without templates produces ad-hoc workflows: each cross-format extension is invented from scratch, capacity estimates are unreliable, quality varies. Templates make repurposing a known production shape, with predictable capacity and predictable quality.
+
+The templates below are recurring shapes; teams adapt them to specific source pieces and program contexts.
+
+---
+
+## Pipeline 1: Whitepaper
+
+**Source.** A 4,000-8,000 word whitepaper or definitive guide.
+
+**Cross-format set (typical).**
+
+- 4-6 blog posts (one per major section).
+- 5-7 email sequence.
+- 1 webinar.
+- 12-18 social posts across LinkedIn, X, possibly Instagram or Threads.
+- 6-12 video shorts.
+- 10-15 FAQ extractions for AI search.
+- Possibly 1 podcast episode.
+
+**Production sequence.**
+
+- Week 0: Source piece publishes.
+- Week 1: First social posts ship; email teaser sends. FAQ extractions ship as part of the source piece (or as an immediately-following FAQ page).
+- Weeks 2-6: Blog posts ship at 1-per-week cadence. Email sequence sends in parallel. More social posts ship from each blog post's release.
+- Weeks 4-8: Webinar runs. Webinar recording becomes additional video derivatives.
+- Weeks 6-10: Video shorts ship. Podcast episode (if applicable) records and releases.
+
+**Capacity.** Typical whitepaper pipeline costs 30-60 hours of editorial and production work across 8-10 weeks, on top of the source piece's production cost.
+
+**Owner structure.** Single owner-of-extensions for the whitepaper. Specific derivative owners by format (blog series owner, email sequence owner, social owner, video owner). The owner-of-extensions coordinates timing and ensures cross-promotion happens.
+
+---
+
+## Pipeline 2: Blog post (substantive)
+
+**Source.** A 1,500-2,500 word substantive blog post on a multi-step framework or substantive topic.
+
+**Cross-format set (typical).**
+
+- 5-7 email sequence (if the source has a multi-step framework).
+- 4-8 social posts.
+- 2-4 video shorts.
+- 3-5 FAQ extractions.
+- Possibly 1 podcast episode segment (not full episode).
+
+**Production sequence.**
+
+- Week 0: Blog post publishes.
+- Week 1: First social posts ship; email teaser if part of a sequence; FAQ extractions added to the post.
+- Weeks 2-4: Email sequence sends. Additional social posts. Video shorts ship.
+- Weeks 4-6: Long-tail social and AI-search-snippet refinement.
+
+**Capacity.** Typical substantive blog post pipeline costs 8-15 hours of additional work across 4-6 weeks.
+
+**Owner structure.** Often one owner runs the full extension for blog-post-tier sources because the work is small enough to coordinate in one head.
+
+---
+
+## Pipeline 3: Research report
+
+**Source.** A 4,000-12,000 word research report with primary data.
+
+**Cross-format set (typical).**
+
+- 5-8 blog posts (one per major finding or section).
+- 7-10 email sequence.
+- 1-2 webinars (often a launch webinar plus a deeper-dive webinar).
+- 20-30 social posts (research reports produce many statistic-driven social derivatives).
+- 8-15 video shorts (statistic-focused).
+- 15-25 FAQ extractions.
+- 1-2 podcast episodes.
+- Possibly an interactive data visualization or microsite.
+
+**Production sequence.**
+
+- Week -2 to Week 0: Pre-launch promotion teasers (research findings preview).
+- Week 0: Source report publishes; launch webinar announces; first wave of statistic-focused social ships.
+- Weeks 1-4: Heavy email sequence; blog posts ship; webinars run; social posts continue.
+- Weeks 4-12: Video shorts roll out; podcast episodes record and release; FAQ extractions get refined as AI-search citations are tracked; second webinar runs for deeper-dive audience.
+- Indefinitely: Statistics from the report continue to be cited in subsequent program pieces; the report becomes a reference asset.
+
+**Capacity.** Research report pipelines are the highest-investment repurposing efforts. Typical cost: 60-150 hours of additional work across 8-16 weeks, on top of the report's production cost.
+
+**Owner structure.** Owner-of-extensions plus dedicated derivative owners. Often a research report's cross-format extension is treated as a project with its own project manager rather than as a routine repurposing pipeline.
+
+---
+
+## Pipeline 4: Multi-piece consolidation (ebook)
+
+**Source.** Multiple existing pieces (blog posts, articles, social threads) on a related topic.
+
+**Cross-format set (typical).**
+
+- 1 ebook (the primary consolidation).
+- New introduction, chapter framings, conclusion within the ebook (often 20-30% new content).
+- 4-7 promotional blog posts (potentially excerpting chapters or introducing the ebook).
+- 5-8 email sequence promoting the ebook.
+- 1 webinar based on the ebook's framework.
+- 8-15 social posts promoting the ebook and its chapters.
+- 3-6 video shorts.
+
+**Production sequence.**
+
+- Months 1-3: Source-piece selection and consolidation. Identify which existing pieces fit; outline the ebook; write new connective tissue; consolidate and edit for unified voice.
+- Month 3-4: Production: design, layout, possibly PDF generation, gating setup if applicable.
+- Month 4: Ebook launches. First promotional blog posts and emails ship. Webinar runs.
+- Months 5-8: Promotional cadence continues. Video shorts and social posts roll out.
+
+**Capacity.** Multi-piece consolidation pipelines often cost 60-120 hours of consolidation and production work, plus the standard derivative production. Total: 80-180 hours across 4-8 months.
+
+**Owner structure.** A consolidation lead drives the editorial work; standard derivative owners run the promotional set. The consolidation lead often is a senior editor because the unified-voice editing is substantial.
+
+---
+
+## Pipeline 5: Trending topic editorial
+
+**Source.** A 1,000-2,500 word editorial piece on a trending or news-driven topic.
+
+**Cross-format set (typical, lighter than evergreen).**
+
+- 4-7 social posts (concentrated in the first week to ride the trend).
+- 1-2 video shorts.
+- 1-2 FAQ extractions if the topic supports it.
+- Often no email sequence (trending topics may not justify a multi-email investment).
+- Often no webinar (production cycle is too long for trending topics).
+
+**Production sequence.**
+
+- Day 0: Source piece publishes.
+- Days 1-7: Social posts ship rapidly to ride the trend. Video shorts ship if production cycle allows.
+- Weeks 2-4: Long-tail social and AI-search-snippet refinement if the topic has staying power.
+- After 4 weeks: Pipeline typically winds down as the trend fades.
+
+**Capacity.** Trending topic pipelines are deliberately light: 4-10 hours of additional work across 1-2 weeks.
+
+**Owner structure.** Often one owner runs the full extension because timeliness matters more than coordinated multi-format depth.
+
+---
+
+## Pipeline 6: Case study
+
+**Source.** A 2,000-4,000 word case study with real specifics.
+
+**Cross-format set (typical).**
+
+- 3-5 blog posts pulling specific lessons or framework moments from the case.
+- 3-5 email sequence (if the case study has clear teachable steps).
+- 6-10 social posts (often statistic-driven from the case's outcomes).
+- 1-3 video shorts (often featuring the case's customer if available, with their consent).
+- 3-5 FAQ extractions.
+- Possibly 1 webinar featuring the customer.
+
+**Production sequence.**
+
+- Week 0: Case study publishes.
+- Week 1: First social posts ship; FAQ extractions added.
+- Weeks 2-6: Blog posts and emails ship. Webinar runs (if part of the plan, often with customer participation).
+- Weeks 4-10: Video shorts and additional social.
+
+**Capacity.** Typical case study pipeline costs 15-30 hours of additional work, plus customer coordination time for any derivatives featuring the customer.
+
+**Owner structure.** Customer-coordination owner plus standard derivative owners. The customer-coordination owner manages the relationship; derivative owners produce the work; the customer reviews customer-facing derivatives before they ship.
+
+---
+
+## Pipeline customization
+
+Templates are starting points; programs adapt them.
+
+**Customization based on audience.**
+
+- B2B technical audiences: more LinkedIn, more whitepaper-driven; less TikTok and Instagram.
+- Consumer audiences: more video and visual social; less long-form.
+- Vertical-specific audiences: platform mix may differ (YouTube heavy in some industries; Twitter/X heavy in others).
+
+**Customization based on capacity.**
+
+- Smaller teams may execute Pipeline 1 with reduced scope (3 blog posts instead of 6, 6 social posts instead of 18).
+- Larger teams may extend pipelines with additional derivatives the templates do not include (interactive tools, microsites, dedicated landing pages).
+
+**Customization based on source characteristics.**
+
+- Highly visual source pieces benefit from heavier video and visual-social investment.
+- Voice-distinctive source pieces benefit from heavier email and podcast investment (where voice carries).
+- Citation-rich source pieces benefit from heavier AEO-extraction investment.
+
+---
+
+## Pipeline tracking
+
+Each pipeline run produces data that informs future pipelines.
+
+**The minimum log per pipeline.**
+
+- Source piece title, type, length, traffic at launch.
+- Cross-format set planned vs delivered.
+- Capacity spent (hours per derivative type).
+- Outcomes per derivative (engagement, traffic, conversion, citation rates).
+- Lessons learned (what worked, what failed, what to change next time).
+
+**Pattern detection across pipelines.**
+
+- Are some pipeline templates outperforming others on similar source types?
+- Are some derivative types consistently outperforming others?
+- Are capacity estimates accurate, or do certain pipelines consistently overrun?
+- Are some channels consistently underperforming for the program's audience mix?
+
+The log informs program-level decisions: which pipelines to invest in more deeply, which to drop, which to redesign.
+
+---
+
+## Common pipeline failures
+
+**Pipeline-as-checklist.** The team treats the pipeline as a checklist to complete rather than as a coordinated plan. Each derivative gets produced; nothing connects to the others; cross-promotion is missing.
+
+**Capacity underestimation.** Teams plan a Pipeline 1 expecting 30 hours; actual cost is 70 hours; new production suffers. Cure: track actual capacity per pipeline; calibrate estimates.
+
+**Pipeline dogmatism.** Treating the template as a fixed shape regardless of source-piece characteristics. Some source pieces fit the template; some need customization. Cure: customize pipelines per source.
+
+**No tracking.** Pipelines run; outcomes are not measured; the program does not learn. Cure: minimum log per pipeline.
+
+**No owner-of-extensions.** Pipelines run with derivative owners but no overall coordination. Cross-promotion gaps; cadence drift; no single accountable person. Cure: assign an owner-of-extensions per pipeline.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The six pipeline templates with cross-format set, sequencing, capacity, and ownership structures. The pipeline customization framework. The pipeline tracking log. The common pipeline failures.
+
+## Implementation choices that stay internal
+
+Specific project-management templates per pipeline. Specific calendar tooling for cross-format scheduling. Specific time-tracking that captures pipeline capacity. Specific reporting templates for pipeline outcomes. The team's own conventions for which pipelines apply to which source-piece tiers. These vary by team, tooling, and program scale.

--- a/skills/content-repurposing/references/sequencing-and-cadence-patterns.md
+++ b/skills/content-repurposing/references/sequencing-and-cadence-patterns.md
@@ -1,0 +1,198 @@
+# Sequencing and cadence patterns
+
+When to release derivatives relative to the source. Concentrated vs distributed cadence. Pacing audits. The patterns that match cadence to the source's traffic curve and audience attention.
+
+The release sequence and cadence determine how the cross-format set lands. The wrong sequencing can produce a wave of derivatives that exhausts audiences, or a trickle that loses connection to the source's authority. The right sequencing matches the source's traffic curve and the audiences' attention rhythm.
+
+---
+
+## Sequencing patterns
+
+Three patterns for how derivatives sequence relative to the source.
+
+### Source-first, derivatives following
+
+**The pattern.** The source piece publishes; derivatives roll out over the following 2-12 weeks. The source carries the initial authority and traffic spike; derivatives extend reach and re-engage audiences over time.
+
+**Strengths.**
+
+- The source piece's launch is concentrated, earning the full attention of the program's audiences. The launch is a moment.
+- Derivatives reference the source's authority. Each derivative can link back to the source as the canonical version; the source's ranking and authority compounds.
+- Audiences who engaged with the source are primed for derivatives; the first derivative often performs well because the audience is warm.
+
+**Weaknesses.**
+
+- The source needs to support the launch with strong promotion. If the source publishes quietly, the launch moment is muted.
+- Audiences who missed the source see derivatives without context; the derivatives need to stand alone.
+
+**Fits.** Most programs. The default sequencing pattern.
+
+### Simultaneous launch
+
+**The pattern.** Source and a wave of derivatives publish on the same day. Multiple channels fire at once.
+
+**Strengths.**
+
+- Maximum splash. The cross-format presence on a single day signals significance to audiences.
+- Cross-channel reinforcement. Audiences encountering the program on multiple channels in one day register the significance more strongly than serial encounters.
+
+**Weaknesses.**
+
+- Risks audience fatigue. If every channel is firing the same day, audiences may tune out before they engage with any individual piece.
+- Heavy production load on launch day. All derivatives must be ready simultaneously, which can compress quality.
+- Less time for individual derivatives to land. Each derivative competes for attention with every other derivative on the same day.
+
+**Fits.** Major flagship launches where the moment itself is part of the value (annual research reports, ebook releases, manifesto-style pieces). Tier 1 source pieces.
+
+### Derivatives-first, source as anchor
+
+**The pattern.** Social posts and short-form video tease ideas; the source piece publishes as the synthesizing flagship after the buildup.
+
+**Strengths.**
+
+- Builds anticipation. Audiences who engage with the early derivatives expect the source piece.
+- The source piece publishes into a primed audience.
+
+**Weaknesses.**
+
+- Less common; works only for built-up audiences who follow the program closely.
+- Risks giving away too much before the source. If the early derivatives expose the source's argument, the source publishes into an audience that feels they have already read it.
+- Coordination overhead. The cross-format buildup needs to land at the right cadence to support the source's launch.
+
+**Fits.** Programs with engaged audiences and strong social presence. Less common than source-first; specific to programs that have earned anticipation.
+
+---
+
+## Cadence within the rollout
+
+Three pacing patterns within the chosen sequencing.
+
+### Concentrated cadence
+
+**The pattern.** Most derivatives ship within 4-6 weeks of source.
+
+**Strengths.**
+
+- Maximum momentum from the source's authority. The source's traffic curve is highest in the first 2-4 weeks; derivatives launching during that window benefit from the source's freshness.
+- The cross-format set feels coherent. Audiences see the program everywhere within a short window; the campaign feeling earns engagement.
+- Easier to coordinate. Production and scheduling concentrate; the team is in launch mode for a defined period.
+
+**Weaknesses.**
+
+- Limited time for individual derivatives to land. A derivative in week 5 has less attention available than the source did in week 1.
+- Audience fatigue risk. Audiences may disengage before week 4-6 if the cadence feels relentless.
+- Less long-tail value. After week 6, the cross-format set largely stops producing new touchpoints.
+
+**Fits.** Tier 1 and Tier 2 source pieces. Programs running flagship launches where the campaign nature is part of the strategy.
+
+### Distributed cadence
+
+**The pattern.** Derivatives ship over 3-6 months.
+
+**Strengths.**
+
+- Each derivative has space to land. No internal competition for audience attention.
+- Long-tail value. The program continues to produce touchpoints over a longer window.
+- Sustainable. The team is not in launch mode for months; production fits steady-state cadence.
+
+**Weaknesses.**
+
+- Risk of losing connection to source. By month 3, the source piece may be background context rather than the active reference.
+- Less momentum. The campaign feeling fades; each derivative is a standalone moment rather than part of a coherent push.
+- Coordination overhead extended. Owners and producers need to maintain focus across months.
+
+**Fits.** Evergreen flagship pieces with sustained traffic curves. Programs with smaller production capacity that cannot sustain concentrated cadence.
+
+### Indefinite cadence
+
+**The pattern.** Derivatives keep being created from the source as long as the source remains relevant.
+
+**Strengths.**
+
+- Maximum long-term value extraction.
+- Adapts to audience response. Derivatives that perform well inform what to produce next; the program learns from the cross-format set's reception.
+
+**Weaknesses.**
+
+- Most programs cannot sustain indefinite attention to a single source. Discipline tends to decay.
+- Risk of voice drift. Derivatives produced 12 months apart may have voice variation that the original launch cadence avoided.
+- Less coherent campaign feel. Audiences see scattered derivatives over a long window without a clear narrative.
+
+**Fits.** Truly evergreen sources whose value compounds for years. Rare; usually reserved for major flagship pieces (defining manifestos, definitive research reports).
+
+---
+
+## Pacing audits
+
+Match cadence to the source's traffic curve and the audience's attention rhythm.
+
+**The source's traffic curve.**
+
+- **Sharp early traffic, fast decay.** Trending-topic pieces, news-driven analysis. Concentrated cadence; the audience is paying attention for a short window.
+- **Sustained high traffic for weeks.** Flagship reports on hot topics. Concentrated to mid-distributed cadence; the audience attention extends but eventually fades.
+- **Slow build, sustained traffic for months.** Evergreen flagship pieces, definitive guides. Distributed cadence; the audience encounter is continuous over time.
+- **Sustained low traffic with occasional spikes.** Reference pieces that get rediscovered. Indefinite cadence works if the production capacity supports it.
+
+**The audience's attention rhythm.**
+
+- **Email subscribers.** Engagement varies; sequences spaced 5-7 days work for most B2B; daily for high-engagement consumer audiences.
+- **Social audiences.** Platform-specific. LinkedIn rewards 1-2 posts per week from program accounts; X rewards higher frequency; Instagram somewhere in between.
+- **Podcast audiences.** Episodic; weekly cadence common; bi-weekly works for higher-production-effort shows.
+- **YouTube audiences.** 1-2 videos per week typical for active channels; long-form video can be less frequent.
+
+**The pacing decision.** Match the source's traffic curve and the audiences' attention rhythm. If they conflict, the source's curve usually wins; the cross-format set's coherence depends on the source's authority window.
+
+---
+
+## Sequencing and cadence per derivative type
+
+Some derivatives have natural sequencing within the rollout.
+
+**Derivatives that should ship early.**
+
+- Email teaser or preview email. Sets up the source's launch with the email audience.
+- Social posts that announce the source. Visibility on launch day.
+- Short-form video that introduces the topic. Algorithmic recommendation responds best when the content is fresh.
+
+**Derivatives that should ship 1-3 weeks in.**
+
+- First blog post in a series. The source piece is still drawing traffic; the blog post benefits from internal linking and the audience's continued interest.
+- Webinar based on the source. Allows time for audience registration and promotion.
+- First batch of social pull-quote posts. The source's themes are familiar; the pull quotes resonate.
+
+**Derivatives that should ship 1-3 months in.**
+
+- Podcast episode. Production cycle is longer; podcast audience overlap with source audience may be partial.
+- Subsequent blog posts in a series. Distributed cadence; each post earns its own attention.
+- Email sequence (if not the immediate teaser). The sequence develops the source's framework over time.
+
+**Derivatives with flexible timing.**
+
+- FAQ extractions and AI-search snippets. These can ship at source-launch or any time after; AI search citation accumulates over months.
+- Ebook consolidation. Often ships 6-12 months after source pieces accumulate; the consolidation work itself takes time.
+
+---
+
+## Common sequencing and cadence failures
+
+**All-at-once dumping.** A wave of 12 derivatives in 5 days. Audiences disengage by day 3; most derivatives produce little engagement. Cure: distributed cadence with audience-attention spacing.
+
+**Source quietly publishing while derivatives ship loudly.** The derivatives carry the launch but the source piece itself launches without the attention it deserves. Cure: source-first launch with promotion focused on the source; derivatives follow.
+
+**Source publishing months after promised derivatives.** Derivatives that previewed a coming source piece ship; the source publishes 4 months later. Audiences have lost connection. Cure: tighten production schedule or flip the sequencing to source-first.
+
+**Cadence too aggressive for the audience.** Email subscribers receiving daily emails for 2 weeks unsubscribe. Cure: match cadence to audience attention norms; email audiences typically tolerate 1-2 sends per week from a program.
+
+**Cadence too slow.** Distributed cadence stretched too long; by month 4, audiences have forgotten the source. Cure: bring cadence closer to source's traffic curve; consider indefinite cadence only when the source genuinely supports it.
+
+**No sequencing plan.** Derivatives ship as they happen to be ready, with no coordination. Cross-format set feels random; audiences see scattered touchpoints with no coherent narrative. Cure: even rough sequencing planning at production time produces better outcomes than no plan.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The three sequencing patterns, the three cadence patterns, the pacing audit, the per-derivative-type sequencing, the common failures.
+
+## Implementation choices that stay internal
+
+Specific calendar tooling. Specific automation that schedules derivatives across channels. Specific coordination workflows between producers and channel owners. Specific A/B testing of cadence variants. The team's own conventions for fast-track vs queued derivatives. These vary by team and tooling.

--- a/skills/content-repurposing/references/source-piece-selection-criteria.md
+++ b/skills/content-repurposing/references/source-piece-selection-criteria.md
@@ -1,0 +1,125 @@
+# Source-piece selection criteria
+
+Strong vs weak source-piece characteristics. The selection audit. Pieces that should stay one-and-done. The discipline that prevents repurposing capacity from being spent on pieces that will not extend cleanly across formats.
+
+Not every piece is worth repurposing. Selection is the first decision, and getting it wrong produces derivative work that feels forced, fails to engage on the new formats, and consumes capacity that would have produced better return on stronger source pieces.
+
+---
+
+## Strong source-piece characteristics
+
+A piece that extends cleanly across formats usually has several of the following.
+
+**Clear central argument or framework.** The piece has a thesis, a framework, or a structured set of positions that survives translation. The reader of any derivative can extract the argument; the reader of the source can recognize it.
+
+**Standalone sections.** The piece's H2 sections work as standalone units. A reader who only sees one section can still get value; the section does not depend on the cumulative context of preceding sections to make sense. Pieces with this property produce blog-series and social-post derivatives easily.
+
+**Travelable examples and case studies.** The piece contains specific examples, case studies, or worked illustrations that can stand alone. These travel into video shorts, social posts, and podcast episodes as natural anchors.
+
+**Audience overlap with target formats.** The source's audience exists on the platforms where derivatives will live. A B2B technical whitepaper extends well into LinkedIn long-form posts and into podcast episodes; less well into TikTok shorts.
+
+**Distinctive voice.** The piece has voice characteristics specific enough that derivative voice can stay coherent. Pieces in generic voice produce derivatives that sound like AI-default; pieces in distinctive voice anchor derivatives to recognizable register.
+
+**Accumulated demand.** The source has demonstrated reader interest: traffic, links, mentions, shares, citations. Pieces with traction support derivatives because the demand is real; pieces without traction produce derivatives that draw on no underlying interest.
+
+**Multi-angle topic.** The topic has multiple angles, sub-questions, or applications. Pieces on narrow single-angle topics produce few derivatives; pieces on broader topics with sub-questions produce more.
+
+---
+
+## Weak source-piece characteristics
+
+Pieces that resist repurposing usually have several of the following.
+
+**Tightly-integrated argument.** The piece is a layered argument where every section depends on the cumulative context. Extract any section and it loses meaning. Whitepapers with this structure (high-rigor analytical pieces) often resist clean derivative extraction; the value is in reading end-to-end.
+
+**List-style without standalone weight.** The piece is a list of items where individual items are not substantial enough to support derivatives. "Top 10 marketing tips" with one-paragraph items per tip cannot produce strong derivatives because no single item justifies a derivative piece.
+
+**Narrative-arc dependence.** The piece's value comes from the unfolding narrative; reading any segment alone misses the arc. Some narrative case studies and feature-style longform have this property. Derivatives can summarize but cannot replace.
+
+**Audience-format mismatch.** The source's audience does not exist (or exists thinly) on most target formats. A regulatory-technical whitepaper for compliance officers extends poorly to TikTok; the audience is not there.
+
+**Generic voice.** The source piece reads in default-AI or generic-content-marketing voice. Derivatives generated from a generic source compound the genericness. Without a distinctive source voice, derivatives drift further from any recognizable register.
+
+**No demand signal.** The source piece has not earned traffic, links, or shares. Repurposing rarely creates demand that did not exist; pieces without demand should be evaluated for whether they should have been published in the first place.
+
+**Highly time-bound.** The source piece is about a specific event, news cycle, or moment that will not be relevant in the cadence's timeframe. Derivatives that ship 4-6 weeks after the source may already be out of date.
+
+---
+
+## The selection audit
+
+A short framework for evaluating a candidate source piece.
+
+1. **Read the piece's central argument or framework.** Can you state it in one sentence? If not, the piece may not extend cleanly. If yes, the argument is the spine that derivatives will extend.
+2. **Identify standalone sections.** Which H2 sections work alone? If most sections work alone, blog-series and social derivatives are natural. If only one section works alone, fewer derivative formats fit.
+3. **List travelable elements.** Specific examples, case studies, statistics, or claims that could anchor derivatives. Pieces with 5-10 travelable elements support multi-format extension; pieces with 0-2 do not.
+4. **Check audience-format overlap.** For each candidate derivative format, is the source's audience present on the format? If most candidate formats fail this check, the source may not be a multi-format candidate.
+5. **Audit voice distinctiveness.** Read three paragraphs from different sections. Could a reader who knows the brand identify this as the brand's work? If yes, derivatives have voice anchor. If no, derivatives will drift.
+6. **Check demand signal.** Has the source earned traffic, links, mentions, or shares? Pieces without demand signal do not transmit demand to derivatives.
+7. **Estimate extraction yield.** Given the above, how many derivative pieces could the source plausibly support? Pieces yielding 1-2 derivatives may not be worth a formal repurposing plan; pieces yielding 6-12 are clear repurposing candidates.
+
+---
+
+## Pieces that should stay one-and-done
+
+Some pieces are valuable but resist repurposing. Recognizing them prevents wasted effort.
+
+**Tightly-argued analytical whitepapers.** Pieces whose value is in the cumulative argument. Often valuable as flagship content but produce few clean derivatives. The right disposition: ship the source piece; create one or two derivative pieces (a summary blog post, an email teaser); accept that most of the value is in the source itself.
+
+**Highly specific case studies.** Pieces about a single specific situation that does not generalize cleanly. The case is valuable; abstraction loses the specifics that gave the case its weight. The right disposition: ship the case study; create derivative pieces only where the case has clear teachable moments that travel.
+
+**Time-bound editorial.** Pieces about a specific event, news cycle, or moment. The piece may be valuable in the moment but the moment passes. The right disposition: ship; minimal repurposing during the moment; archive after.
+
+**Highly visual source pieces.** Pieces whose value is primarily in custom visuals (data dashboards, illustrated guides, complex diagrams). Text derivatives often cannot carry the visual value. The right disposition: derivative video and visual-format extensions only; text derivatives often underperform.
+
+**Niche-audience pieces.** Pieces for a small specific audience that does not exist on most other formats. The right disposition: minimal repurposing; the audience is concentrated where the source already published.
+
+---
+
+## Tier-based selection
+
+Programs with regular flagship production benefit from explicit tiering of source pieces by repurposing intensity.
+
+**Tier 1: Major flagship (1-3 per year).** The source piece is treated as the spine of a multi-month repurposing campaign. 8-15 derivative pieces planned. Cross-format extension covers blog series, email sequence, webinar, podcast, social waves, video shorts, AI-search extractions. Capacity allocation is significant; the source's value is being maximally extracted.
+
+**Tier 2: Standard flagship (4-12 per year).** Source piece supports 4-8 derivative pieces. Cross-format extension covers a subset of formats: blog series or email sequence (not both), social posts, FAQ extractions for AI search. Capacity allocation is moderate.
+
+**Tier 3: Routine substantive piece (12-50 per year).** Source piece supports 1-3 derivative pieces. Often a social-post wave, an email mention, an internal-link refresh on related pieces. Minimal additional capacity.
+
+**Tier 4: One-and-done (the majority of pieces).** Source piece publishes; appears in newsletter once; shares on social once; no derivative pieces planned. Capacity allocation only on the source.
+
+The tiering discipline. Most programs have too few Tier 1 and Tier 2 pieces and too many Tier 3 and Tier 4 pieces masquerading as flagship work. The audit shifts capacity allocation toward the few pieces that genuinely warrant multi-format extension.
+
+---
+
+## When a piece grows into stronger source-piece status
+
+Some pieces start as Tier 4 and earn promotion based on performance.
+
+**The signal.** A piece that was published as routine starts drawing significant traffic, earning links, getting mentioned externally, or producing reader engagement disproportionate to its production tier.
+
+**The response.** Promote the piece into a higher tier. Plan derivatives. Some of the strongest source pieces in mature programs are pieces that performed unexpectedly well after publication; recognizing them quickly extracts the additional value.
+
+**The audit.** Quarterly review of pieces' performance. Pieces showing strong demand that have not been repurposed are candidates for retroactive extraction; pieces showing weak demand that were originally tiered as flagship may need their derivative plans reduced or canceled.
+
+---
+
+## Common selection failures
+
+**Repurposing every piece.** Treating all pieces as repurposing candidates spreads capacity thin. Most programs benefit from concentrating capacity on 10-20% of pieces and accepting one-and-done for the rest.
+
+**Repurposing the wrong pieces.** Selecting source pieces because they are easy (recent, fresh in mind) rather than because they are strong source-piece candidates. The selection audit catches this.
+
+**Ignoring weak-source-piece signals.** Pushing through repurposing on pieces with tightly-integrated argument, list-style structure, or no demand signal produces derivatives that fail.
+
+**Static tiering.** Pieces tiered at production never get re-tiered based on performance. Strong sleeper pieces never get repurposed; weak flagship pieces consume planned derivative capacity.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The strong vs weak source-piece characteristics, the selection audit, the one-and-done dispositions, the tiering framework, the dynamic-tiering discipline, the common selection failures.
+
+## Implementation choices that stay internal
+
+Specific scoring rubrics the team uses to score source pieces. Specific dashboards that surface high-performing pieces for retroactive promotion. Specific calendar templates that allocate repurposing capacity by tier. The team's own thresholds for when a routine piece warrants Tier 2 promotion. These vary by team and program shape.

--- a/skills/content-repurposing/references/voice-consistency-across-formats.md
+++ b/skills/content-repurposing/references/voice-consistency-across-formats.md
@@ -1,0 +1,146 @@
+# Voice consistency across formats
+
+What stays constant and what adapts. The voice audit per derivative. The AI-repurposing voice problem and the discipline that prevents it.
+
+Voice is the most visible casualty of careless repurposing. The source piece may have specific voice characteristics; derivatives generated without strong voice discipline drift toward AI-default or platform-default register. Audiences detect the drift even when they cannot articulate it; the cross-format set reads as work from different brands rather than as a coherent program.
+
+---
+
+## What stays constant
+
+The brand-voice elements that should survive every format adaptation.
+
+**The brand's POV on the topic.** If the source piece argues a specific position, the derivatives carry the same position. A derivative that hedges where the source committed, or that takes a different angle than the source, breaks the cross-format coherence.
+
+**Distinctive vocabulary.** Brand-specific terms, framings, and phrasings that signal "this is from this brand." If the source uses a particular word for a concept, derivatives use the same word. If the source has a recognizable phrase, derivatives carry the phrase.
+
+**Level of conviction or hedging.** Brands have characteristic stance positions. Some brands commit; some hedge thoughtfully; some are confrontational. The derivatives carry the brand's stance pattern even when format conventions might pull toward different stance defaults.
+
+**Audience-respect register.** Brands address audiences in specific ways: peer-to-peer, expert-to-novice, alongside-the-reader. The register stays consistent across formats; derivatives that suddenly talk down to the audience break voice coherence.
+
+**Anti-patterns the brand avoids.** If the brand does not use particular framings (motivational filler, generic-content-marketing voice, hype-driven language), derivatives also avoid them. Anti-pattern adherence is part of voice.
+
+---
+
+## What adapts per format
+
+Voice elements that should adjust to the medium.
+
+**Sentence length and structure.** Spoken voice differs from written. Email voice differs from blog voice. Social-post voice differs from email voice. The brand's voice characteristics survive through these adaptations, but the surface-level sentence patterns change.
+
+- Print: medium sentences with occasional layered constructions.
+- Email: shorter sentences, more direct address.
+- Spoken (podcast, video): conversational rhythm with natural pauses and asides.
+- Social: tight phrasing in first lines, paragraph breaks frequent.
+
+**Density.** Visual formats can carry less per minute than text formats. A short video cannot fit the density of a paragraph; the same point in video form has more breathing room.
+
+**Conversational vs declarative register.** Podcasts are conversational; whitepapers are declarative. The brand's POV stays the same in both; the framing register adapts.
+
+**Direct-address frequency.** "You" usage varies by format. Emails often use "you" frequently; whitepapers may use "the reader" or "marketers" more often. The shift is appropriate; pulling email voice into a whitepaper or vice versa would feel off.
+
+**Visual element usage.** Some formats use visuals heavily (social, video); others rely on text (email, long-form). Voice adapts to whether visuals are doing some of the work.
+
+---
+
+## The voice audit per derivative
+
+A short framework for verifying voice consistency.
+
+1. **Read or watch the derivative as if encountering it cold.** Could a reader who knows the brand identify this as the brand's work? If yes, voice is working.
+2. **Compare to the source piece.** Does the derivative carry the source's POV, vocabulary, and stance? Where it differs, is the difference appropriate format adaptation or unwanted drift?
+3. **Check against the brand's voice anti-patterns.** Is the derivative slipping into framings the brand normally avoids? AI-default voice often slips in through derivatives.
+4. **Check sentence-level patterns.** Sentence length, paragraph length, direct-address frequency, vocabulary. Are they format-appropriate but brand-recognizable?
+5. **Read aloud (for written derivatives) or read the script (for spoken derivatives).** Does it sound like the brand's voice as the brand would speak it?
+
+The voice audit is one of the easiest to skip and one of the most consequential. Pieces that pass everything else but fail voice audit damage the cross-format coherence.
+
+---
+
+## The AI-repurposing voice problem
+
+AI-assisted repurposing is particularly prone to voice drift.
+
+**The pattern.** The source piece has specific voice characteristics. AI generation of derivatives is asked to "summarize this for LinkedIn" or "turn this into emails." The AI produces derivatives that are technically related to the source but written in AI-default voice rather than the source's distinctive voice.
+
+**Why it happens.** AI generation regresses to model defaults unless the writer actively pulls it back. Without strong voice prompts, the derivatives sound like the AI's voice using the source's content. Multiple derivatives generated without voice anchor compound the drift; by the tenth derivative the cross-format set has lost the source's voice entirely.
+
+**The cure.**
+
+- **Voice guidelines as prompt input.** Every AI generation includes the brand voice guidelines as context. Generic prompts produce generic outputs.
+- **Sample text as voice anchor.** Feed the AI 2-3 paragraphs of the source piece in their original voice. AI mimics what it sees more than what it is told.
+- **Per-derivative voice review.** Each derivative gets a voice audit. Drift detected gets revision. The audit is non-negotiable.
+- **Rewrite the bland.** Any sentence that could appear in any other piece on the topic gets rewritten in voice. Voice lives in the specific.
+
+See `ai-content-collaboration` for the broader voice-preservation discipline that applies across AI-assisted content workflows. The repurposing-specific application is that voice drift compounds across multiple derivatives in ways that single-piece AI generation does not.
+
+---
+
+## When format conventions pull against brand voice
+
+Sometimes a format's conventions push toward voice that does not match the brand.
+
+**LinkedIn motivational tone.** LinkedIn rewards a particular kind of motivational and personal-narrative content. Brands with crisp analytical voice may resist the convention; the right answer is usually to maintain voice rather than to drift into LinkedIn-default motivational tone, even at cost of platform-specific engagement.
+
+**TikTok's high-energy delivery.** TikTok rewards high-energy short-form delivery. Brands with measured analytical voice may not fit naturally; the right answer may be to skip TikTok rather than to produce content that sounds wrong for the brand.
+
+**Podcast-host conversational warmth.** Some podcast styles reward warm conversational delivery; a brand with confrontational analytical voice may struggle to produce derivatives that fit. The right answer may be to format-fit (use a different format) or to produce derivatives that hold the brand's voice even at engagement cost.
+
+**The discipline.** Format-fit decisions are upstream of voice-adaptation decisions. If a format genuinely cannot accommodate the brand's voice, skipping the format is sometimes the right answer; voice integrity matters more than universal cross-format presence.
+
+---
+
+## Voice prompts for AI-assisted repurposing
+
+When AI generates derivatives, the prompts should carry voice instructions.
+
+**Components of a voice prompt.**
+
+- 2-3 paragraphs of the source piece in original voice as anchor.
+- A short voice description (3-5 specific characteristics).
+- A short anti-pattern list (3-5 framings the brand avoids).
+- Per-format adjustments (sentence length, register, direct-address frequency).
+
+**A worked prompt example pattern.** "The source piece below is in the brand's voice. Convert it into [target format]. The voice characteristics to preserve: [specific characteristics]. The anti-patterns to avoid: [specific anti-patterns]. The format adaptations: [format-specific]. Source piece: [text]."
+
+The discipline is including the voice instructions in every derivative generation, not assuming the AI will infer voice from the source alone. AI tools differ in how well they infer voice from samples; the safest discipline is explicit voice instruction.
+
+---
+
+## Voice consistency across multiple writers or AI generators
+
+Programs with multiple writers or AI generators producing derivatives have a multi-source voice drift problem.
+
+**The risk.** Writer A produces three derivatives in slightly different voice from writer B's four derivatives, plus AI generates two more in default voice. The cross-format set has three voice variants, none of them quite the source's voice.
+
+**The discipline.**
+
+- **Single voice owner.** One person reviews all derivatives in the cross-format set for voice consistency. Catches drift across writers.
+- **Voice library.** Documented brand voice with examples; all writers and AI generators reference the same library.
+- **Calibration sessions.** Periodically, multiple writers (or writers plus the editorial lead) review derivatives together and reconcile voice expectations.
+
+Programs with sophisticated voice discipline can run multi-writer derivative production without losing voice; programs without discipline produce voice variants that audiences notice.
+
+---
+
+## Common voice failures in repurposing
+
+**AI-default drift.** Derivatives sound like the AI's voice rather than the brand's voice. Cure: stronger voice prompts; per-derivative review.
+
+**Platform-default drift.** Derivatives sound like the platform's default register rather than the brand's voice. Cure: voice-over-platform-fit discipline; sometimes skip the platform.
+
+**Cross-derivative drift.** Each derivative is fine alone but the cross-format set reads as voice variants. Cure: single voice owner across the set.
+
+**Source-voice loss.** Derivatives carry the source's content but not the source's voice characteristics. Cure: voice anchor with sample text from the source.
+
+**Voice-only-on-source.** The source piece has voice; the derivatives default to generic. Cure: voice discipline applies to derivatives, not just to the source.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The constant-vs-adapting voice elements, the voice audit, the AI-repurposing voice problem and its cure, the format-vs-voice tension, the multi-writer voice discipline, the common voice failures.
+
+## Implementation choices that stay internal
+
+Specific voice-prompt templates per AI tool. Specific voice-library documentation in the team's writing system. Specific calibration session formats. Specific reviewer dashboards that surface cross-derivative voice variation. The team's own conventions for voice-vs-format tradeoffs. These vary by team, AI tooling, and brand voice maturity.

--- a/skills/long-form-content-frameworks/SKILL.md
+++ b/skills/long-form-content-frameworks/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: long-form-content-frameworks
+description: "Patterns for individual long-form content pieces. Case studies, whitepapers, research reports, definitive guides, manifestos, ebooks, long-form tutorials. The structural disciplines that distinguish publication-quality long-form from bloggy-long padding or academic bloat. Different from pillar-content-architecture (which covers hub structure); this skill covers individual deep-dive pieces. Triggers on long-form content, case study writing, whitepaper, research report, definitive guide, ebook, manifesto, long-form tutorial, deep-dive article, anchor piece, foundational article, structural archetypes. Also triggers when a piece is over 3,000 words and the team is unsure how to structure it, when a long-form draft feels padded or saggy, or when a flagship asset needs the depth to actually earn the length."
+category: content
+catalog_summary: "Structural patterns for individual long-form pieces (case studies, whitepapers, research reports, definitive guides, manifestos, ebooks, long-form tutorials) that distinguish publication-quality work from bloggy-long padding or academic bloat"
+display_order: 9
+---
+
+# Long-Form Content Frameworks
+
+A senior editorial leader's playbook for individual long-form content pieces. The structural disciplines that distinguish publication-quality work from bloggy-long padding or academic bloat.
+
+Long-form is where most content programs lose their nerve or lose their way. Teams either stretch a 1,500-word post to 5,000 with filler (the bloggy-long failure mode), or they over-document the topic with no editorial spine (the academic-bloat failure mode). The pieces that earn their length are the ones where each section justifies its weight, the lede sets a thesis the body actually delivers, and the closing leaves the reader with something specific.
+
+This skill covers the individual long-form piece: the case study, the whitepaper, the research report, the manifesto, the ebook chapter or full ebook, the definitive guide, the long-form tutorial. Different from `pillar-content-architecture` (which covers HUB architecture: how a pillar plus cluster system fits together), this skill covers the long-form PIECE itself, regardless of whether it sits at the center of a hub or stands alone.
+
+The voice is the senior editorial leader who has shipped dozens of flagship long-form assets and watched plenty of others fail. Honest about which formats earn their length, which structural archetypes fit which problems, and where long-form most often goes wrong.
+
+When to use this skill: planning a flagship long-form piece, structuring a draft that feels saggy, reviewing a long-form piece that is technically correct but emotionally flat, or auditing a content library to find the long-form pieces that should have been blog posts.
+
+---
+
+## What this skill is for
+
+This skill spans individual long-form content pieces. The content suite distinction:
+
+- `content-strategy` is program scope: what to produce across the program.
+- `pillar-content-architecture` is HUB scope: pillar plus cluster as a topical hub system.
+- **`long-form-content-frameworks` (this skill)** is PIECE scope for long-form: individual deep-dive pieces, standalone or as pillars.
+- `content-and-copy` is execution scope at any length: writing the words.
+- `content-brief-authoring` is per-piece brief scope at any length: the contract.
+- `editorial-qa` is gate scope: pre-publish verification.
+- `ai-content-collaboration` is workflow scope: how humans and AI compose.
+
+A pillar page IS often a long-form piece. The two skills compose: pillar-content-architecture decides the hub shape and which pieces sit where; this skill is how you structure the long-form pieces themselves so they earn the length they take up.
+
+The audience: editorial leads, content directors, in-house teams shipping flagship long-form, agencies producing whitepapers and research reports, anyone planning a piece that will run 3,000+ words and need to hold a reader to the end.
+
+What is not in scope: blog-post-length writing (covered by `content-and-copy`), the brief itself (covered by `content-brief-authoring`), the hub architecture around a long-form piece (covered by `pillar-content-architecture`), or the pre-publish QA pass (covered by `editorial-qa`).
+
+---
+
+## Bloggy-long vs academic-bloat vs publication-quality
+
+The keystone framing. Two failure modes plus the discipline.
+
+**Bloggy-long.** A regular blog post stretched to 5,000 words via padding. Same structural shape as 1,500 words, just inflated: more transitional paragraphs, more "before we get into it," more recap sections, more bullet expansions of single ideas. The reader notices within 600 words and skims. Output: a piece that ranked because it was long, never gets read all the way through, never gets shared, never earns links because nobody finished it.
+
+**Academic-bloat.** Exhaustive coverage that loses the thread. 8,000 words where 4,500 would have served. Every adjacent topic surveyed; every definition restated; every caveat documented. Reader respects the effort and skims for the parts they need. Output: a "comprehensive" piece that nobody reads end-to-end, that does not change anyone's mind, that performs in search but underperforms in trust.
+
+**Publication-quality.** Structural depth that earns the length. Each section justifies its weight. The lede establishes a thesis the body delivers. The closing is specific. Reading flow varies in density, register, and rhythm so the piece sustains attention. The piece reads as the work of someone who had something specific to say and the discipline to say it well at length.
+
+The litmus test. Ask of any long-form draft: would cutting this section weaken the argument, or would it just make the piece shorter? If cutting strengthens it, the section was filler. The piece earns its length when each section is doing structural work the argument requires.
+
+---
+
+## Long-form formats and when each fits
+
+Seven formats, each with a different structural shape and a different reader contract.
+
+**Case study.** A specific company, project, or initiative with quantified outcomes. Reader contract: "Show me what worked and why, with specifics." Length: 2,000 to 4,000 words typical. Structural archetype: usually problem-solution. The case-study tax: real numbers, real names, real specificity. Generic case studies signal nothing.
+
+**Whitepaper.** A position document on a substantive topic, typically with original analysis. Reader contract: "Take me through your reasoning on this question with the rigor I would expect from a serious source." Length: 3,000 to 8,000 words. Structural archetype: layered argument or comparative analysis. Often gated. The whitepaper tax: original synthesis, not survey of existing literature.
+
+**Research report.** Original primary research presented with methodology, findings, implications. Reader contract: "Show me the data, how you collected it, what it means." Length: 4,000 to 12,000 words. Structural archetype: taxonomic survey or comparative analysis. The research-report tax: actual primary research, not "we surveyed 300 marketers" with leading questions.
+
+**Definitive guide.** Comprehensive coverage of a topic for a specified audience. Reader contract: "Be the canonical resource on this." Length: 4,000 to 10,000 words. Structural archetype: taxonomic survey. The definitive-guide tax: actual comprehensiveness; gaps reveal that the guide is not actually definitive.
+
+**Manifesto.** A position paper on what the writer believes and why, often confrontational. Reader contract: "Tell me what you think and convince me." Length: 1,500 to 6,000 words. Structural archetype: layered argument or narrative arc. The manifesto tax: actual conviction, not diplomatic hedging.
+
+**Ebook.** Multi-chapter long-form, often a sequence of related pieces with introduction and conclusion. Reader contract: "Take me through a body of work." Length: 8,000 to 30,000+ words. Structural archetype: usually narrative arc across chapters. The ebook tax: each chapter earns its place; the table of contents is not padding.
+
+**Long-form tutorial.** Instructional content where the reader is following along. Reader contract: "Take me from where I am to where I want to be, step by step." Length: 3,000 to 8,000 words. Structural archetype: problem-solution with sequential steps. The long-form-tutorial tax: every step actually works; gaps in the sequence break the reader.
+
+Detail in `references/format-decision-framework.md`.
+
+---
+
+## Structural archetypes
+
+Five archetypes that fit different long-form problems.
+
+**Problem-solution.** State the problem with weight; develop why it matters; present the solution; show how it works; address objections. Fits case studies, long-form tutorials, manifestos with a clear opposition. Risk: feels formulaic if every piece uses it.
+
+**Narrative arc.** Beginning, middle, end. A protagonist (often the company, sometimes a person, sometimes the reader) faces a complication and resolves it. Fits ebooks, some case studies, longer manifestos. Risk: forced narrative on topics that are not actually stories.
+
+**Layered argument.** Position stated; layer 1 evidence; layer 2 evidence; counter-arguments addressed; synthesis. Fits whitepapers, manifestos, position pieces. Risk: feels academic if the layers do not build to a real synthesis.
+
+**Taxonomic survey.** A topic mapped into categories; each category explored; relationships among categories surfaced. Fits definitive guides, research reports surveying a landscape. Risk: feels like a list with subheads if the taxonomy is not actually load-bearing.
+
+**Comparative analysis.** Multiple options, frameworks, or positions compared along defined axes; tradeoffs surfaced; the writer's recommendation argued. Fits whitepapers, decision-guide research reports, technology comparisons. Risk: feels like a feature matrix if the analysis is shallow.
+
+Most strong long-form pieces use one archetype as the spine and borrow from another for variation. A whitepaper might be a layered argument with comparative-analysis sections. A definitive guide might be a taxonomic survey with problem-solution chapters. The archetype is the spine; variation prevents the piece feeling formulaic.
+
+Detail in `references/structural-archetype-patterns.md`.
+
+---
+
+## Section weight calibration
+
+How long sections should be relative to each other, varying by format.
+
+The general principle: section weights match how much load the section is bearing in the argument. Throat-clearing introductions get cut. Setup sections are short. Argument-bearing middle sections are longest. Closings are specific and tight.
+
+**Whitepaper / research report typical weights.** Introduction 8-12% (thesis stated, scope set). Methodology or framing 10-15% (how the analysis works). Body 60-70% (the actual argument or findings, divided into 3-5 weighted sections). Implications 10-15%. Closing 3-5%.
+
+**Case study typical weights.** Setup and context 15-20% (the company, the problem, why it mattered). Solution narrative 50-60% (what was done, in sequence). Outcomes 15-20% (quantified results, what worked, what did not). Reflection 5-10% (what the team would change).
+
+**Manifesto typical weights.** Position 5-10% (what is believed, stated early and clearly). Argument 70-80% (why, with the layers building intensity). Call 10-15% (what should change as a result).
+
+**Definitive guide typical weights.** Introduction 5-8% (what the guide covers, who it serves). Body across taxonomic sections 80-85% (each section roughly even). Closing and additional resources 7-10%.
+
+**Long-form tutorial typical weights.** Setup 10-15% (what the reader will achieve, what they need). Sequential steps 70-80% (each step its own subsection). Troubleshooting and edge cases 10-15%.
+
+The audit. If one section is more than 3x the length of another bearing similar argumentative load, the piece is structurally unbalanced. Either the long section needs to be split, or the short section needs to be deepened, or the imbalance reflects an actual content problem the writer has not surfaced.
+
+Detail in `references/section-weight-calibration.md`.
+
+---
+
+## Lede patterns for long-form
+
+Long-form ledes do different work than blog-post ledes.
+
+A blog-post lede answers the user's likely query in the first 200 words. A long-form lede establishes a thesis the next 5,000 words will deliver, sets the reader's expectations for the piece's depth, and earns the reader's attention for the time investment ahead.
+
+**Patterns that work.**
+
+- **The contested-claim opener.** A surprising or contested position stated cleanly, then the rest of the piece argues for it. Fits manifestos, opinionated whitepapers.
+- **The problem-with-stakes opener.** A problem stated with the stakes made tangible. Fits case studies, problem-solution pieces.
+- **The data-anomaly opener.** A piece of data that does not fit the consensus, framed as the question the piece will answer. Fits research reports, analytical whitepapers.
+- **The scene opener.** A specific moment, person, or scene that grounds the abstract topic. Fits narrative-arc pieces, magazine-style longform.
+- **The orientation opener.** What this piece covers, who it is for, what reading it costs and pays. Fits definitive guides and tutorials where the reader's first question is "is this the right resource for me."
+
+**Patterns that fail.**
+
+- The throat-clear opener ("Content marketing has changed dramatically over the past decade. In this article, we will explore...") signals filler ahead.
+- The dictionary-definition opener ("According to Merriam-Webster, X is defined as...") signals an unwillingness to commit a position.
+- The history-of-the-topic opener (paragraphs of background before the argument starts) loses readers before the thesis lands.
+- The "in this article we will discuss" tour opener flattens the piece into an outline before the writer has earned attention.
+
+The first paragraph of a long-form piece is the writer's only sales pitch for the next 30+ minutes of the reader's attention. Spending it on filler is the most common long-form failure.
+
+Detail in `references/lede-patterns-for-long-form.md`.
+
+---
+
+## Sustaining attention across 5,000+ words
+
+Long pieces that hold readers vary their density, register, and rhythm. Pieces that lose readers feel uniform: same paragraph length, same sentence rhythm, same density of claim, page after page.
+
+**Density variation.** Some sections argue tightly (claim, evidence, claim, evidence). Others reflect, illustrate, or breathe. The argument-tight sections earn the breathing sections; the breathing sections give readers room to absorb.
+
+**Register variation.** Most long-form pieces sustain a primary register (analytical, narrative, instructional) while occasionally shifting to a secondary register (anecdotal, reflective, declarative) for variation. A whitepaper that is purely analytical for 6,000 words exhausts the reader; a whitepaper with a mid-piece anecdote or a closing reflection lands harder.
+
+**Rhythm variation.** Sentence length variation matters more in long-form than short. Strings of 25-word sentences blur; strings of 8-word sentences fragment. The pattern that holds attention: medium sentences with occasional short punches and occasional layered longer constructions.
+
+**Visual rhythm.** Subheads, pull quotes, callouts, charts, illustrations break the page into navigable units. Long-form pieces with no visual rhythm are walls of text; long-form pieces with too many breakouts feel like marketing collateral. The rhythm: visual element every 600-1,000 words on average, varied in type.
+
+**Mid-piece micro-thesis.** Around the 40-60% mark, restate the central claim with new framing. Long-form readers' attention naturally dips mid-piece; the mid-piece restatement reorients them and refreshes engagement.
+
+Detail in `references/attention-sustaining-techniques.md`.
+
+---
+
+## Citations and source authority
+
+Long-form pieces cite more, and cite more authoritatively, than blog posts. The reader is investing 30+ minutes; the writer owes them claims they can verify.
+
+**Source hierarchy for long-form.**
+
+- Primary research: original studies, datasets, interviews, the writer's own data work. Highest authority.
+- Authoritative secondary sources: peer-reviewed papers, government data, established research firms, primary reporting from credible outlets.
+- Industry-credible sources: vendor research with disclosed methodology, reputable trade publications, recognized expert practitioners.
+- Linked-aware secondary sources: reputable blogs and publications where the source is verifying claims, not just amplifying them.
+- Avoid: citation laundering through other content marketing pieces, "studies show" claims with no link, anonymous "experts," reposts of reposts.
+
+**Citation density.** Long-form arguments need citations roughly proportional to claim density. A piece making 30 falsifiable claims needs 30 citations; a piece making 5 strong claims with extensive elaboration may need 5. The audit: every falsifiable claim is either cited or attributed to the writer's own analysis.
+
+**Source freshness.** Statistics older than 3 years for fast-moving topics need refresh or explicit acknowledgment. The "85% of marketers" stat from 2018 in a 2026 piece signals stale research.
+
+**Inline vs endnote citations.** Long-form on the web typically uses inline links to authoritative sources. For research-heavy pieces, endnote-style citations (numbered footnotes) signal academic rigor; for editorial whitepapers, inline links keep momentum. Either works; pick one and stay consistent within the piece.
+
+Detail in `references/citation-and-source-authority.md`.
+
+---
+
+## Visualization and breakouts
+
+Long-form earns visual breakouts; blog posts often do not. The discipline is which breakouts earn their place.
+
+**Visual element types.**
+
+- Charts and graphs: data visualization that the prose alone cannot convey efficiently.
+- Diagrams: relationships, flows, architectures, taxonomies that benefit from visual structure.
+- Pull quotes: moments where a single sentence deserves visual weight.
+- Sidebars: tangential but valuable context that does not fit the main thread.
+- Tables: comparison data, structured reference material.
+- Inline callouts: definitions, warnings, "if you only read one section" pointers.
+
+**Earned-position rule.** Each visual element earns its place by carrying argumentative load the prose alone cannot. Decorative charts that restate the prose visually weaken the piece; charts that surface a pattern the prose can only summarize strengthen it.
+
+**Production tax.** Each visual element costs design time, accessibility work (alt text, screen-reader-friendly tables), and revision overhead when the underlying content changes. Long-form pieces with 25 charts each take meaningful production time to maintain. Plan visual count against production capacity, not against ideal-world maximalism.
+
+**Anti-pattern: the stock-image header.** Generic stock imagery at the top of a long-form piece signals the writer did not commission visual work for the piece. Either commission specific visual work (custom illustrations, branded data visualizations, scene photography) or skip the hero image.
+
+Detail in `references/breakouts-and-visualization.md`.
+
+---
+
+## Closing patterns
+
+Long-form pieces with strong closings get shared, get linked, and get remembered. Pieces with throat-clearing closings disappear after the last subhead.
+
+**Closings that work.**
+
+- **The specific call.** What should the reader do, decide, or change as a result of reading this. Concrete, not generic.
+- **The reframed thesis.** The opening claim restated with the weight the body has now earned, often inverted or sharpened.
+- **The open question.** The question this piece's findings raise but do not answer, framed as the next investigation.
+- **The personal reflection.** The writer's stake in the topic surfaced briefly. Fits manifestos, opinionated long-form.
+- **The provocation.** A challenge to the reader, the field, or the consensus. Fits manifestos.
+
+**Closings that fail.**
+
+- The recap closing ("In this piece we covered X, Y, Z") signals the writer ran out of energy.
+- The "more research is needed" closing on every research report signals the writer did not commit a position.
+- The throat-clear closing ("As we have seen, content is important and only getting more so") delivers no payload.
+- The CTA-as-closing ("Book a demo") on a long-form piece breaks the editorial contract; if a CTA belongs, it sits below the closing, not as the closing.
+
+The audit. Ask of any long-form closing: does this leave the reader with something specific to do, decide, or think about, or does it just signal the piece is ending? If the latter, rewrite.
+
+Detail in `references/closing-patterns.md`.
+
+---
+
+## Distribution implications for long-form
+
+Long-form's distribution shape differs from blog-post distribution. The format choices echo through how the piece reaches readers.
+
+**Gated vs ungated.** Whitepapers and research reports often gate behind a form to capture leads; ebooks frequently do; case studies sometimes do. The tradeoff: gating cuts reach by 70-90%; the gated audience is qualified but small. Manifestos and definitive guides typically stay ungated to maximize reach and link equity. The decision turns on whether the piece's primary value is reach (ungated) or qualified-lead capture (gated).
+
+**Format choices.** Long-form web page (HTML), downloadable PDF, mixed (web with PDF download option), interactive (web with embedded tools or visualizations). Web pages earn search traffic; PDFs earn email-shareable assets; mixed maximizes both. The production cost rises with format count.
+
+**Syndication and excerpting.** Long-form pieces lend themselves to chapter excerpts, summary blog posts, and email-newsletter serializations. Plan the excerpting at piece-design time so the chapters or sections are excerpt-ready. See `content-repurposing` for the cross-format adaptation discipline.
+
+**Refresh schedule.** Long-form pieces with research components need annual or quarterly refresh on the data; long-form pieces with timeless framings need lighter touch. See `content-refresh-system` for refresh prioritization.
+
+The decision sequence: format first, distribution shape second. A research report's distribution shape (often gated, often PDF, often paired with a webinar) follows from the format choice; trying to retrofit distribution onto a piece that was written for the wrong shape produces friction.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-long-form-failures.md`.
+
+- "We wrote 5,000 words and traffic is flat." Bloggy-long: stretched to length, no structural depth. Cut to 1,800 words or rewrite as publication-quality.
+- "Our whitepaper looked authoritative but nobody finished it." Academic-bloat: comprehensive but not load-bearing. Cut sections that did not move the argument.
+- "The lede took 800 words to get to the thesis." Throat-clearing opener; rewrite to land the position in the first 150-250 words.
+- "Each section is the same length and rhythm." No section weight calibration; sections all bearing the same argumentative load suggests an undifferentiated piece.
+- "The piece sags around the 60% mark." Standard mid-piece attention dip; add a mid-piece micro-thesis and rhythm variation.
+- "The closing repeated the introduction." Recap closing; rewrite to a specific call, reframed thesis, or open question.
+- "Citations are mostly other blog posts." Citation laundering; replace with primary or authoritative secondary sources.
+- "We commissioned 12 charts, the team is exhausted, traffic is the same." Visual count exceeded production capacity and earned-position discipline; cut to charts that bear argumentative load.
+- "The case study has no specifics." Generic case-study failure; the case-study tax is real numbers, real names, real specificity. Without those, the format does not work.
+- "Our manifesto reads as diplomatic." Manifesto failure: the format demands conviction; if the writer cannot commit, write a different format.
+- "The definitive guide has obvious gaps." Definitive-guide failure: the format requires actual comprehensiveness. Either fill the gaps or rename the piece.
+
+---
+
+## The framework: 12 considerations for long-form content
+
+When planning or auditing a long-form piece, walk these 12 considerations.
+
+1. **Format fits the work.** Case study, whitepaper, research report, definitive guide, manifesto, ebook, or long-form tutorial. Format chosen for reader contract, not arbitrary length.
+2. **Structural archetype selected.** Problem-solution, narrative arc, layered argument, taxonomic survey, or comparative analysis as the spine.
+3. **Lede earns the next 30 minutes.** Thesis stated, stakes set, position committed within the first 150-250 words.
+4. **Section weights calibrated to argumentative load.** No section 3x another bearing similar load; throat-clearing sections cut.
+5. **Density variation.** Argument-tight sections balanced with reflective or illustrative sections.
+6. **Register variation.** Primary register sustained with secondary-register moments for variation.
+7. **Rhythm variation.** Sentence and paragraph length varies; visual breakouts every 600-1,000 words.
+8. **Mid-piece micro-thesis.** Central claim restated around the 40-60% mark.
+9. **Citations match claim density.** Falsifiable claims cited; primary or authoritative sources preferred; sources fresh.
+10. **Visual elements earn position.** Each chart, diagram, sidebar carries load the prose alone cannot.
+11. **Closing is specific.** Specific call, reframed thesis, open question, or provocation. Not recap.
+12. **Distribution shape matches format choice.** Gating, format mix, syndication plan, refresh schedule planned at piece-design time.
+
+The output of the framework is a long-form piece that earns its length: every section justified, every page sustaining attention, every claim verifiable, every closing specific.
+
+---
+
+## Reference files
+
+- [`references/format-decision-framework.md`](references/format-decision-framework.md) - When each long-form format fits. Reader contracts, length norms, structural archetype tendencies, format-specific taxes.
+- [`references/structural-archetype-patterns.md`](references/structural-archetype-patterns.md) - Five archetypes (problem-solution, narrative arc, layered argument, taxonomic survey, comparative analysis) with worked examples and combination patterns.
+- [`references/section-weight-calibration.md`](references/section-weight-calibration.md) - Typical weight ratios by format. Whitepaper, case study, manifesto, definitive guide, long-form tutorial profiles. The 3x audit.
+- [`references/lede-patterns-for-long-form.md`](references/lede-patterns-for-long-form.md) - Five patterns that work, four that fail. The first-paragraph sales-pitch frame.
+- [`references/attention-sustaining-techniques.md`](references/attention-sustaining-techniques.md) - Density variation, register variation, rhythm variation, visual rhythm, mid-piece micro-thesis discipline.
+- [`references/citation-and-source-authority.md`](references/citation-and-source-authority.md) - Source hierarchy, citation density, freshness, inline vs endnote conventions, citation-laundering anti-pattern.
+- [`references/breakouts-and-visualization.md`](references/breakouts-and-visualization.md) - Visual element types, earned-position rule, production-tax discipline, the stock-image-header anti-pattern.
+- [`references/closing-patterns.md`](references/closing-patterns.md) - Five closings that work, four that fail. The specific-call, reframed-thesis, open-question, personal-reflection, provocation patterns.
+- [`references/common-long-form-failures.md`](references/common-long-form-failures.md) - 11+ failure patterns with diagnoses, including bloggy-long, academic-bloat, throat-clearing leads, visual-count overruns, citation laundering, format-tax failures.
+
+---
+
+## Closing: long-form earns its length or it does not
+
+Length is not a virtue. A 5,000-word piece is only worth more than a 1,500-word piece if those extra 3,500 words carry structural and argumentative load the shorter version could not. Most long-form content underperforms because the team chose length first and structural depth second.
+
+The discipline is the inversion. Decide what the piece needs to deliver, choose the format and archetype that fit, calibrate sections to actual argumentative load, and let the length follow. Pieces written that way earn their length and read as the work of someone who had something to say. Pieces written length-first read as filler, no matter how many subheads dress them up.
+
+When in doubt about whether a long-form piece is ready, ask: does each section justify its weight, does the lede earn the next 30 minutes, does the closing leave the reader with something specific, are claims cited, do visuals carry load, does the mid-piece micro-thesis refresh attention? If yes to all of those, the piece is publication-quality. If no to any, the gap is where the reader stops reading.

--- a/skills/long-form-content-frameworks/references/attention-sustaining-techniques.md
+++ b/skills/long-form-content-frameworks/references/attention-sustaining-techniques.md
@@ -1,0 +1,129 @@
+# Attention-sustaining techniques
+
+How long-form pieces hold readers across 5,000+ words. The patterns that keep reader attention across the time investment, and the underlying observation: readers leave because pieces feel uniform.
+
+The pieces that lose readers in long-form are the ones that feel monotone. Same paragraph length, same sentence rhythm, same density of claim, page after page. Even competent writing reads as exhausting under that pattern. The pieces that hold readers vary their density, register, and rhythm so the reader's attention has somewhere to recover and somewhere to engage.
+
+---
+
+## Density variation
+
+Long-form pieces should alternate between argument-tight sections and breathing sections.
+
+**Argument-tight sections.** Claim, evidence, claim, evidence. Specific, direct, intellectually demanding. The reader is doing work to follow the argument.
+
+**Breathing sections.** Reflection, illustration, anecdote, restatement. Lower density of new claims; higher density of integration with what was just argued.
+
+The pattern that holds. After an argument-tight section, a breathing section gives the reader room to absorb. After a breathing section, the reader returns to argument-tight work refreshed. Pieces that are argument-tight throughout exhaust readers; pieces that breathe throughout never feel substantive.
+
+The audit. For each section, characterize it as argument-tight or breathing. If the sequence is all argument-tight, the piece is dense and exhausting. If the sequence is all breathing, the piece is shallow despite its length. The mix is the discipline.
+
+---
+
+## Register variation
+
+Most long-form pieces sustain a primary register while shifting briefly to secondary registers for variation.
+
+**Primary registers.**
+
+- Analytical: claim-evidence-implication, measured tone, distance from the topic.
+- Narrative: scene-driven, character-driven, time-progressive.
+- Instructional: do-this-then-this, addressed to the reader directly.
+- Declarative: positions stated, opinions committed, weight on conviction.
+
+**Secondary registers.** Anecdotal moments inside an analytical piece. Reflective moments inside an instructional piece. A specific scene inside a declarative manifesto. A measured analytical section inside a narrative.
+
+The pattern that holds. A whitepaper sustained in analytical register for 6,000 words exhausts readers; the same whitepaper with a mid-piece anecdote and a closing reflection lands harder. A long-form tutorial sustained in instructional register for 5,000 words feels mechanical; the same tutorial with a brief reflective section on common failures and a personal note from the writer feels human.
+
+The discipline. Choose the primary register first; insert secondary-register moments at section transitions where the shift will refresh attention rather than disorient.
+
+---
+
+## Rhythm variation
+
+Sentence and paragraph length variation matters more in long-form than in short.
+
+**Sentence length.**
+
+- Strings of 25-word sentences blur. The reader's eye glides over the text without the cognitive checkpoints short sentences create.
+- Strings of 8-word sentences fragment. The text reads as choppy, and the reader's attention is interrupted constantly.
+- The pattern that holds: medium sentences with occasional short punches and occasional layered longer constructions.
+
+**Paragraph length.**
+
+- Long paragraphs (8+ sentences) feel academic. Suitable for argument-tight sections; exhausting if sustained.
+- Short paragraphs (1-2 sentences) feel staccato. Suitable for emphasis and for breaking dense passages; fragmenting if sustained.
+- The pattern that holds: most paragraphs 3-5 sentences with occasional shorter ones for emphasis and occasional longer ones for layered argument.
+
+**Heading rhythm.** H2 every 600-1,200 words on average. H3 within H2 sections to break navigation. Headings that come at uniform intervals feel mechanical; headings that follow the actual structural breaks feel natural.
+
+The audit. Read the piece aloud. Does the rhythm vary, or does every sentence and paragraph land with the same beat? If the latter, the piece needs rhythm work even if every individual sentence is competent.
+
+---
+
+## Visual rhythm
+
+Long-form pieces with no visual rhythm are walls of text; long-form pieces with too many breakouts feel like marketing collateral.
+
+**The norm.** A visual element every 600-1,000 words on average. Visual elements include subheads, pull quotes, callouts, charts, diagrams, sidebars, tables, and images.
+
+**Variation in type.** All-subheads-no-charts feels under-designed for the piece's length. All-charts-no-pull-quotes feels like a research dump. The visual rhythm should vary: a subhead, then 800 words of prose, then a chart, then 600 words of prose, then a pull quote, then 700 words of prose, then a callout, then 900 words and the next subhead.
+
+**The earned-position rule.** Each visual element earns its place by carrying load the prose alone cannot. Decorative charts that restate the prose visually weaken the piece; charts that surface a pattern the prose can only summarize strengthen it. See `breakouts-and-visualization.md` for the discipline.
+
+**Mobile reading reality.** Long-form on mobile gets read in landscape stretches. Subheads should be visible without scrolling on each major section transition; pull quotes should be visible early to preview the piece's depth; charts should be readable without horizontal scrolling.
+
+---
+
+## Mid-piece micro-thesis
+
+Long-form readers' attention naturally dips around the 40-60% mark. Pieces that survive the dip have a structural move that refreshes engagement at that point.
+
+**The micro-thesis pattern.** Around the midpoint, restate the central claim with new framing. The restatement does three things at once: it reorients readers who have been following sections, it gives drifting readers a checkpoint to re-engage, and it sets up the second half of the piece.
+
+**Worked example.** A whitepaper opens with the claim "Most teams treating content marketing as a volume problem will continue to underperform." At the midpoint, after the structural argument and the first empirical layer, the writer restates: "The pattern across the data is consistent. The teams that broke the volume-first cycle did not produce more; they produced less, and committed harder to what they produced." The reader is reoriented; the second half of the piece can build on the restatement.
+
+**Anti-pattern: the recap micro-thesis.** Restating "as we have seen so far, content marketing is changing" is filler, not micro-thesis. The micro-thesis should add framing or sharpen the claim, not recap.
+
+**Where the micro-thesis sits structurally.** Often at the boundary between two body sections, especially the boundary between the first and second halves of a layered argument or the boundary between the third and fourth chapters of an ebook.
+
+---
+
+## Combining the techniques
+
+A 6,000-word whitepaper using all five techniques.
+
+- **Lede.** Contested-claim opener, declarative register, short paragraphs for opening punch.
+- **Setup section.** Analytical register, medium-density argument, 3-5 sentence paragraphs.
+- **First body section.** Argument-tight density, analytical register sustained, longer paragraphs as the argument layers.
+- **Mid-piece micro-thesis.** A short paragraph that restates the claim with new framing. Brief register shift to declarative.
+- **Second body section.** Argument-tight density, but with a worked example inserted as a breathing pause. Worked example shifts briefly to narrative register.
+- **Counter-argument section.** Argument-tight again, analytical register, with the counter-arguments engaged seriously.
+- **Synthesis.** Density lower, register declarative, paragraphs short and emphatic.
+- **Closing.** Declarative, short, specific.
+
+The piece reads as varied across its length even though it is a single sustained argument.
+
+---
+
+## Common attention-loss patterns
+
+Patterns that show up when readers drop off mid-piece.
+
+**The mid-piece sag.** Around the 50% mark, the piece becomes harder to follow. Cause: no micro-thesis, no rhythm variation, the reader is exhausted from sustained argument-tight density. Cure: add micro-thesis at the section boundary nearest the midpoint; insert a breathing section.
+
+**The wall-of-text section.** A 1,500-word body section with no subheads, no visuals, no rhythm variation. Cause: the writer was deep in the argument and stopped attending to the reader. Cure: identify the natural sub-structure within the section, add subheads or visuals at the boundaries.
+
+**The abstract drift.** The piece's specifics decrease as it progresses. Concrete examples in the early sections; vague generalizations in the later sections. Cause: the writer ran low on specific examples; padded with abstraction. Cure: cut to the depth where specificity holds; better a shorter piece with sustained specificity than a longer piece that drifts abstract.
+
+**The energy-decline closing.** The closing reads as a writer who ran out of energy. Cause: writers fatigue before readers do. Cure: write the closing first or revise the closing last with fresh attention; the closing is too important to deliver tired.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five techniques (density variation, register variation, rhythm variation, visual rhythm, mid-piece micro-thesis), the combining pattern, the common attention-loss patterns and their cures, the read-aloud audit.
+
+## Implementation choices that stay internal
+
+Specific draft-review tooling that flags rhythm patterns. Specific reading-time analytics that detect mid-piece drop-off in the team's content. Specific paragraph-length analyzers in the team's writing tool. Specific A/B testing of structural variants. The team's own conventions for visual-element budgets per long-form piece. These vary by team, stack, and analytics setup.

--- a/skills/long-form-content-frameworks/references/breakouts-and-visualization.md
+++ b/skills/long-form-content-frameworks/references/breakouts-and-visualization.md
@@ -1,0 +1,147 @@
+# Breakouts and visualization
+
+Visual element types for long-form, the earned-position rule, the production-tax discipline, and the stock-image-header anti-pattern. The patterns that distinguish visual rhythm from visual clutter.
+
+Long-form earns visual breakouts; blog posts often do not. A 1,500-word blog post can carry one image; a 5,000-word whitepaper can carry six or eight visual elements before they feel like clutter. The discipline is not visual count but earned position: which visuals carry argumentative load, and which are decoration.
+
+---
+
+## Visual element types
+
+Six categories, each with different work to do.
+
+**Charts and graphs.** Data visualization that conveys patterns the prose alone cannot convey efficiently. Line charts for time series, bar charts for comparisons, scatter plots for correlations, distributions for spread. The chart's value is showing the pattern; if the prose can summarize the pattern in one sentence and the chart adds nothing, the chart is decoration.
+
+**Diagrams.** Relationships, flows, architectures, taxonomies that benefit from visual structure. Process diagrams, system architectures, hierarchical relationships, decision trees. The diagram's value is making structure visible; topics with simple linear structure rarely need diagrams.
+
+**Pull quotes.** Moments where a single sentence deserves visual weight. Used sparingly for emphasis; one or two per long-form piece typical. The pull quote's value is signaling "this matters"; using pull quotes too often dilutes the signal.
+
+**Sidebars.** Tangential but valuable context that does not fit the main thread. Background detail, related concepts, optional deeper coverage. The sidebar's value is letting the main thread stay focused while preserving context for readers who want it.
+
+**Tables.** Comparison data, structured reference material. Side-by-side option comparisons, parameter listings, multi-axis evaluations. The table's value is making parallel data scannable; tables for non-parallel data are confusing.
+
+**Inline callouts.** Definitions, warnings, "if you only read one section" pointers. Short, focused, specific. The callout's value is interrupting flow for a specific purpose; callouts without specific purpose are decoration.
+
+---
+
+## The earned-position rule
+
+Each visual element earns its place by carrying argumentative load the prose alone cannot.
+
+**Earned visuals.**
+
+- A chart that shows a pattern the prose can only summarize in vague terms ("increasing over time" becomes specific with the line chart).
+- A diagram that makes a complex relationship instantly visible (a system architecture; a process flow with decision points).
+- A pull quote that captures a position the writer wants to stand alone for emphasis.
+- A sidebar with context that would derail the main thread if inline.
+- A table that makes parallel comparison instant when the prose would require careful reading.
+
+**Decorative visuals.**
+
+- A chart that restates a number the prose just stated (the chart adds visual interest, not information).
+- A diagram of a relationship the prose described in one sentence ("the marketing funnel" diagrammed, when the prose said "marketing has stages").
+- A pull quote of a sentence that did not deserve standalone weight.
+- A sidebar with information that should have been cut entirely or integrated into the main thread.
+- A table where the rows or columns are not actually parallel.
+- A stock image at the top of the piece that signals only that the writer wanted a hero image.
+
+The audit. For each visual, ask: does cutting this visual lose information or capability that the prose alone cannot replace? If yes, the visual is earned. If no, the visual is decoration.
+
+---
+
+## Production tax
+
+Visual elements cost more than writers often estimate.
+
+**Per-visual costs.**
+
+- Design time. Even simple charts require choices about color, scale, labeling, formatting.
+- Accessibility work. Charts need alt text or alternative-format descriptions; tables need proper header markup; complex visuals need text equivalents.
+- Revision overhead. When the data changes, the chart changes. When the framing changes, the diagram changes. Visual elements that go stale because they were not updated when the underlying content changed are worse than no visuals.
+- Production review. Editors review prose; design or production review visuals. Pieces with many visuals need more review cycles.
+
+**The capacity audit.** Before committing to a visual count for a piece, check: does the team have the design capacity, the data-engineering capacity (for charts based on data), and the maintenance capacity to keep this number of visuals current? Pieces that ship with 12 visuals and decay because nobody updates them are worse than pieces that ship with 4 visuals that stay current.
+
+**The MVP-visuals approach.** Plan the minimum viable visual count: which visuals are load-bearing for the argument, which would be nice to have, which would be decoration. Ship the load-bearing ones. Add nice-to-haves only if capacity permits and the piece is genuinely long enough to need more visual rhythm.
+
+---
+
+## The stock-image-header anti-pattern
+
+Generic stock imagery at the top of a long-form piece signals the writer did not commission visual work for the piece.
+
+**The pattern.** A whitepaper opens with a generic stock photo of "diverse business team meeting around laptop with charts." The image conveys nothing specific; readers tune it out within milliseconds.
+
+**Why it fails.** Long-form's value proposition includes signaling that the work is serious. Stock imagery undermines the signal: a serious piece would have commissioned specific visual work or skipped the hero image. Stock imagery says "we wanted a hero image and did not invest in one."
+
+**The cure options.**
+
+- Commission specific visual work. Custom illustration matched to the piece's argument. Branded data visualization based on the piece's findings. Scene photography directly related to the piece's case study.
+- Skip the hero image entirely. Long-form pieces can open without a hero image; many of the strongest editorial pieces do.
+- Use a content-specific opening visual. The first chart in the piece appears at the top, doing dual duty as hero image and load-bearing visual.
+
+The discipline. If the piece's hero image could be on any other piece on the same general topic, it is generic and should be cut or replaced.
+
+---
+
+## Chart conventions for long-form
+
+Charts in long-form pieces have specific expectations.
+
+**Title and caption.** Every chart should have a title that describes what the chart shows and a caption that explains the source of the data. Charts without titles or captions read as decoration.
+
+**Source attribution.** The data behind the chart should be cited. "Source: 2024 Industry Survey, n=412, methodology in appendix" or similar. Charts without source attribution are unverifiable.
+
+**Mobile readability.** Charts should be readable on mobile without horizontal scrolling. Wide charts should be redesigned for mobile or marked as "view on desktop for full detail." Charts that are unreadable on mobile lose mobile readers.
+
+**Color and contrast.** Charts should pass accessibility contrast guidelines (WCAG AA minimum). Color-coded charts need either patterns or labels for readers with color-blindness. Charts that rely on color alone fail accessibility.
+
+**Data integrity.** Truncated y-axes that exaggerate effects, cherry-picked time ranges, and apples-to-oranges comparisons violate the implicit chart contract. Long-form readers who notice deceptive charts lose trust in the entire piece.
+
+---
+
+## Diagram conventions for long-form
+
+Diagrams should make structure visible without becoming the main attraction.
+
+**Simplicity.** A diagram with 30 boxes and 50 arrows is a diagram nobody reads. Diagrams should be visually parse-able in seconds. Complex topics may need multiple simple diagrams rather than one comprehensive one.
+
+**Labeling.** Every box, arrow, and group should be labeled clearly. Diagrams with unlabeled elements assume the reader can infer the labels from context, which often fails.
+
+**Reading order.** Diagrams should have an obvious reading order (top to bottom, left to right, or numbered steps). Diagrams without obvious reading order leave readers uncertain how to traverse them.
+
+**Mobile rendering.** Wide diagrams that work on desktop become unreadable on mobile. Either redesign for mobile, accept that mobile readers will scroll, or split into multiple smaller diagrams.
+
+---
+
+## Sidebar conventions
+
+Sidebars should be visually distinct from the main thread but not overwhelming.
+
+**Length.** Most sidebars run 100-300 words. Sidebars longer than 500 words probably should have been their own section in the main thread or their own piece.
+
+**Visual treatment.** Background color or border that distinguishes the sidebar from main prose. Different typography weight or font (where the design system supports it).
+
+**Skip-readability.** Sidebars should be skippable without losing the main argument. If the main argument depends on the sidebar's content, that content belongs in the main thread, not in a sidebar.
+
+---
+
+## Pull-quote discipline
+
+Pull quotes should be earned moments, not decoration.
+
+**Selection.** A pull quote is a sentence the writer wants to stand alone for emphasis. It should be a sentence whose weight justifies the visual treatment. Generic sentences pulled into pull-quote treatment dilute the device.
+
+**Frequency.** One or two pull quotes per long-form piece is typical. Three or four can work for very long pieces (8,000+ words). More than that and the device loses meaning.
+
+**Attribution within pull quotes.** Pull quotes from interviews or external sources need attribution; pull quotes of the writer's own sentences do not need attribution but should still earn the visual weight.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The six visual element types and their work, the earned-position rule, the production-tax discipline, the stock-image-header anti-pattern, the chart conventions, the diagram conventions, the sidebar and pull-quote discipline, the MVP-visuals approach.
+
+## Implementation choices that stay internal
+
+Specific design tokens for charts in the team's brand system. Specific charting libraries the team uses. Specific accessibility-checking automation. Specific design-review workflow for visual elements. Specific custom-illustration commissioning processes. Specific stock-photo blocklist or sourcing guidelines. The team's own visual-budget conventions per format. These vary by team, design capacity, and tooling.

--- a/skills/long-form-content-frameworks/references/citation-and-source-authority.md
+++ b/skills/long-form-content-frameworks/references/citation-and-source-authority.md
@@ -1,0 +1,130 @@
+# Citation and source authority
+
+Source hierarchy for long-form, citation density discipline, freshness norms, inline vs endnote conventions, and the citation-laundering anti-pattern.
+
+Long-form pieces cite more, and cite more authoritatively, than blog posts. The reader is investing 30+ minutes; the writer owes them claims they can verify. Pieces that fail at citation discipline read as if the writer wanted authority without paying the verification cost.
+
+---
+
+## Source hierarchy
+
+Sources are not interchangeable. The same claim cited from a peer-reviewed paper carries different weight than the same claim cited from a vendor blog post.
+
+**Tier 1: Primary research.** Original studies, datasets, interviews, the writer's own data work. The writer is producing the data, not citing it. Highest authority. Pieces with primary research signal that the writer or team did the work.
+
+**Tier 2: Authoritative secondary sources.** Peer-reviewed papers, government data (BLS, Census, equivalent), established research firms (Gartner, Forrester, Pew, IDC, etc.), primary reporting from credible outlets. The writer is citing rigorous secondary work where the source's reputation does the verification work.
+
+**Tier 3: Industry-credible sources.** Vendor research with disclosed methodology, reputable trade publications, recognized expert practitioners with track records. The writer is citing sources that practitioners in the field would recognize as substantive even if they are not academically rigorous.
+
+**Tier 4: Linked-aware secondary sources.** Reputable blogs, publications, and commentary where the source is verifying claims rather than just amplifying them. The writer is citing sources that did some level of verification work, even if the source is a blog post rather than a study.
+
+**Tier 5 and below: Avoid.** Other content marketing pieces (citation laundering), "studies show" claims with no link, anonymous "experts," reposts of reposts, vendor marketing pages cited as research, AI-generated synthesis cited as primary source.
+
+The discipline. Long-form arguments should cite from tiers 1-3 wherever possible. Tier 4 is fine for color and context but should not bear primary argumentative load. Tier 5 sources signal the writer did not do the verification work.
+
+---
+
+## Citation density
+
+Citations should be roughly proportional to claim density.
+
+**A piece making 30 falsifiable claims.** Roughly 30 citations or attributions to primary analysis. Each claim either points to a verifiable source or is identified as the writer's own analysis (in which case the analysis itself should be defended).
+
+**A piece making 5 strong claims with extensive elaboration.** May need only 5 citations if the elaboration is reasoning rather than fact-claim. Manifestos and position pieces often work this way: a small number of central claims, deeply argued, with citations supporting the claims rather than every elaboration.
+
+**The audit.** Mark every falsifiable claim in the piece. For each claim, check: is it cited, is it identified as the writer's own analysis, or is it floating? Floating claims are the failure mode. Either cite, attribute to the writer, or cut.
+
+**The over-citation failure.** Some long-form pieces cite every sentence as if academic rigor were the goal. The result reads as a literature review, not a piece of editorial writing. Citations should support the argument, not perform credibility theater.
+
+---
+
+## Source freshness
+
+Statistics older than 3 years for fast-moving topics need refresh or explicit acknowledgment.
+
+**Fast-moving topics.** Technology, marketing tactics, AI capabilities, software stacks, social platforms. A 2018 stat in a 2026 piece on these topics signals stale research unless the writer is citing it specifically as historical context.
+
+**Stable topics.** Behavioral psychology research, structural economics, mathematical results, established scientific consensus. A 2015 stat on these topics may be perfectly current.
+
+**The acknowledgment pattern.** When citing older data on a fast-moving topic deliberately, acknowledge it: "A 2018 survey, the most recent rigorous data on the question, found..." The acknowledgment signals the writer knows the data is old and chose to cite it anyway, with reasoning.
+
+**The hidden-stale-data failure.** Citing a "2024 study" that turns out to be a 2024 republication of 2019 data. Verify primary publication date before citing.
+
+---
+
+## Inline vs endnote citations
+
+Two conventions for how citations appear.
+
+**Inline links.** The cited source appears as a hyperlink within the prose. Reader clicks to verify. Common in editorial long-form, content marketing whitepapers, and most web-published research reports.
+
+- Strength: keeps reader momentum; the prose flows without numerical interruptions.
+- Weakness: harder to verify without leaving the page; less academically formal.
+
+**Endnote-style citations.** Numbered footnotes at the end of the piece, with each citation numbered in the prose. Common in academic-influenced research reports, policy whitepapers, and some long-form published with print-style conventions.
+
+- Strength: signals academic rigor; preserves the citation list for verification.
+- Weakness: interrupts reading flow; readers rarely follow endnotes in web reading.
+
+**The convention rule.** Pick one and stay consistent within the piece. Mixing conventions (some claims inline-linked, some endnoted) reads as inconsistent. The choice depends on audience expectations: B2B technical research often expects endnotes; editorial whitepapers usually expect inline.
+
+**Hybrid: inline + bibliography.** Inline links throughout the piece plus a "sources" or "further reading" section at the end. Common compromise. Works well when the piece has both casual references and core sources.
+
+---
+
+## The citation-laundering anti-pattern
+
+Citing other content marketing pieces as authoritative when the cited piece itself does not have primary support.
+
+**The pattern.** Piece A claims X with a citation. Piece B cites A as the source for X. Piece C cites B. The original claim X may have been weak, made-up, or misinterpreted; each successive citation amplifies the appearance of authority without adding verification.
+
+**How it happens.** A writer searching for support for a claim finds another content marketing piece making the same claim and links to it. The writer feels they have cited a source. The source is itself unsourced or weakly sourced. The chain of laundering can run several pieces deep.
+
+**The cure.** When citing, follow the chain back. If the cited piece does not have primary or authoritative-secondary support, do not cite it. Either find a primary source, or remove the claim, or attribute it as the writer's own observation.
+
+**Why it matters in long-form.** The reader is investing time. Citation laundering produces pieces that read as authoritative because of citation count but fall apart under verification. Readers who verify discover the laundering; readers who do not develop a slow-decaying trust in the writer.
+
+---
+
+## The own-analysis citation
+
+When the writer is making a claim from their own analysis rather than citing a source, the claim should be visibly the writer's analysis with the analytical work shown.
+
+**The pattern.** "Looking at the data across [scope], the pattern that emerges is X." The pattern claim is the writer's; the data is cited; the analytical work is described.
+
+**The discipline.** Own-analysis claims still need defensibility. The writer should be able to defend, if challenged: where the data came from, how the analysis was performed, what alternative interpretations were considered.
+
+**The hidden-claim failure.** Sentences that read as fact ("The reality is that programmatic SEO is dying") without acknowledgment that the claim is the writer's interpretation. If the claim is contested, frame it as the writer's view; if the claim is empirical, cite a source. The hidden middle (claim presented as fact when it is interpretation) is where readers lose trust.
+
+---
+
+## Quote attribution
+
+Long-form pieces often include quotes from named experts, executives, or practitioners.
+
+**Verification.** Every quote should be from a real person who actually said the words attributed to them. Hallucinated quotes (especially in AI-assisted long-form) are an ethical failure regardless of whether the position is plausibly something the named person might say. See `editorial-qa`'s fact-accuracy reference for the discipline.
+
+**Context.** Quotes work best when the person's role is identified, the context of the statement is clear (interview, public statement, prior writing), and the quote earns its place by saying something specific.
+
+**The throwaway-quote failure.** A generic quote ("Content is king," John Smith, CEO) that does not advance the argument. If the quote does not say something specific the prose alone cannot convey, cut it.
+
+---
+
+## Citation in research reports specifically
+
+Research reports have particularly strict citation expectations because they are claiming primary research authority.
+
+- **Methodology disclosed.** Sample size, recruitment method, dates, instrument design. Without these, the research is not verifiable.
+- **Sample limits acknowledged.** What the sample does and does not represent. A sample of 300 marketers in B2B SaaS does not represent "marketers"; the report should not claim it does.
+- **Statistical limits acknowledged.** Confidence intervals, margins of error, significance tests where applicable. Reports presenting cherry-picked data points without distribution context are weak research.
+- **Original data made available.** Where possible, the underlying data should be shareable for verification. Reports that hide the data behind the headline findings invite skepticism.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The source hierarchy and tier definitions, the citation-density principle, the freshness rule and acknowledgment pattern, the inline-vs-endnote convention rule, the citation-laundering anti-pattern, the own-analysis discipline, the quote-attribution rules, the research-report citation expectations.
+
+## Implementation choices that stay internal
+
+Specific citation management tools the team uses. Specific bibliography generators integrated with the team's writing system. Specific link-checking automation that catches dead links and stale data. Specific data-publication conventions for research reports the team produces. The team's own internal source-tier classification when sources are ambiguous. These vary by team and tooling.

--- a/skills/long-form-content-frameworks/references/closing-patterns.md
+++ b/skills/long-form-content-frameworks/references/closing-patterns.md
@@ -1,0 +1,161 @@
+# Closing patterns
+
+Five closings that work, four that fail, and the underlying frame: the closing is the writer's last opportunity to leave the reader with something specific. Closings that do not leave anything specific signal a writer who ran out of energy, and the piece is remembered accordingly.
+
+Long-form pieces with strong closings get shared, get linked, get remembered. Pieces with throat-clearing closings disappear after the last subhead. The closing is one of the most consequential 200-400 words of any long-form piece, and one of the easiest places for writers to under-invest.
+
+---
+
+## The underlying frame
+
+The closing has three jobs at once.
+
+1. **Resolve the piece.** Whatever the lede promised, the closing delivers (or acknowledges what was not delivered).
+2. **Leave the reader with something specific.** A specific call, a sharpened framing, a question to consider. The reader should be different at the closing than they were at the lede.
+3. **Earn the reader's attention for next time.** The closing is the reader's last impression. Readers who finish a piece with a strong closing think of the writer as someone who delivers; readers who finish a piece with a weak closing think of the writer as someone who runs out of energy.
+
+Closings that do all three are memorable. Closings that do none are forgettable. Closings that do one or two are common and produce pieces that are technically complete but emotionally flat.
+
+---
+
+## Pattern 1: The specific call
+
+**Shape.** What should the reader do, decide, or change as a result of reading this. Concrete, not generic.
+
+**Fits.** Most long-form pieces. Particularly strong for problem-solution archetype, manifestos, decision-guide research reports, long-form tutorials.
+
+**Worked example.** A 5,000-word whitepaper on content distribution closes: "If your team is producing content faster than you can distribute it, the bottleneck is not your production rate. It is your channel-fit decisions. Audit one piece you shipped in the last quarter against the channel-fit framework. Find the one channel where the audience-content match was strongest but the piece never reached that channel. That gap is where the next quarter's distribution work should focus."
+
+**Why it works.** The reader has a specific action. The action is grounded in the piece's framework, so the framework keeps working after the reading is over.
+
+**The discipline.** The call must be specific to the piece. Generic calls ("rethink your content strategy") signal that the writer did not commit to a specific recommendation.
+
+---
+
+## Pattern 2: The reframed thesis
+
+**Shape.** The opening claim restated with the weight the body has now earned, often inverted, sharpened, or made more specific.
+
+**Fits.** Layered-argument pieces. Whitepapers. Manifestos. Pieces where the body's evidence justifies a stronger version of the opening claim.
+
+**Worked example.** A whitepaper that opens "Most teams treating content marketing as a volume problem will continue to underperform" closes: "The volume problem is not actually a content problem. It is a strategy problem the team has chosen to express through content. Teams that solve the strategy problem produce less content and more value; teams that try to solve the strategy problem with more content produce more content and less value. The path forward is not better content production. It is harder strategy decisions."
+
+**Why it works.** The reframed thesis lands the argument with weight the lede could not have carried. The body has done the work; the closing collects the payoff.
+
+**The discipline.** The reframing must be earned by the body. Pieces that restate the lede unchanged are recapping; pieces that restate it with sharpened framing the body justifies are doing the closing's work.
+
+---
+
+## Pattern 3: The open question
+
+**Shape.** The question this piece's findings raise but do not answer, framed as the next investigation.
+
+**Fits.** Research reports. Analytical whitepapers. Pieces where the writer has gone as far as the available evidence allows but the topic continues.
+
+**Worked example.** A research report on AI search citation patterns closes: "The data is clear that statistics with named sources earn citations at 4x the rate of unsourced claims. The data does not tell us why. The hypothesis worth testing in the next research cycle: do AI engines weight named sources because they are training on a corpus that itself weights named sources, or because the engine providers have built explicit credibility-weighting into the retrieval logic? The answer matters because the answer changes how content programs should respond."
+
+**Why it works.** The reader is left with intellectual momentum. The piece does not pretend to have answered everything; it acknowledges what it did not answer and frames that as productive rather than as a limit.
+
+**The discipline.** The open question must be a real question, not a rhetorical one. "What does the future hold?" is rhetorical filler. "Is the citation pattern downstream of the training corpus or of explicit retrieval logic?" is a real question.
+
+---
+
+## Pattern 4: The personal reflection
+
+**Shape.** The writer's stake in the topic surfaced briefly. What the writer thinks the piece illustrates beyond its specific argument.
+
+**Fits.** Manifestos. Opinionated long-form. Pieces where the writer has personal authority on the topic. Some case studies where the writer was personally involved.
+
+**Worked example.** A manifesto on content marketing's drift toward generic AI-assisted output closes: "I have been writing about content for a decade. The pattern that worries me is not that AI is involved; the pattern that worries me is that teams have stopped noticing when their content stopped sounding like them. The discipline this piece argues for is not anti-AI. It is pro-craft. The teams holding the line on craft will be readable in five years. The teams not holding the line will not be."
+
+**Why it works.** The personal stake adds weight to the argument. The writer's investment in the topic is the closing's payoff: the reader sees that the argument is not abstract for the writer.
+
+**The discipline.** The personal reflection must be earned by the writer's actual position. Personal reflections from writers without a real stake feel performed.
+
+---
+
+## Pattern 5: The provocation
+
+**Shape.** A challenge to the reader, the field, or the consensus. Often paired with a refusal to soften the position.
+
+**Fits.** Manifestos. Position pieces. Long-form criticism. Pieces where the writer is staking out an unpopular or contested position deliberately.
+
+**Worked example.** A manifesto on programmatic SEO closes: "The teams that will survive the next three years of search-algorithm pressure are the ones that stop treating programmatic as a volume strategy and start treating it as a depth strategy. Most programmatic operations will not make this change. They will not survive. This piece is for the few that will."
+
+**Why it works.** The provocation establishes that the writer means it. The reader either accepts the provocation and reads the piece as a call to action, or rejects it and reads the piece as wrong; either response is engaged. The middle response (mild interest, no engagement) is what kills long-form's reach.
+
+**The discipline.** The provocation must be defensible. Provocations the body did not actually argue for read as posturing. Provocations the body argued for and the closing committed to with conviction read as serious.
+
+---
+
+## Failure 1: The recap closing
+
+**Shape.** "In this piece, we covered X, Y, Z. As we have seen, content is important and only getting more so..."
+
+**Why it fails.** Signals the writer ran out of energy. Recap is what the table of contents does; the closing should add weight, not summarize. Readers who just spent 30 minutes reading do not need the recap; they need the writer to land the argument.
+
+**The cure.** Cut the recap. Replace with one of the five working patterns. The closing is not a tour through what the piece said; it is the writer's final position.
+
+---
+
+## Failure 2: The "more research is needed" closing
+
+**Shape.** Most research reports default to "More research is needed in this area" as a closing.
+
+**Why it fails.** Signals the writer did not commit a position even when the data warranted one. "More research is needed" is the default closing of academic papers because academic papers have specific norms about hedging; editorial long-form does not have those norms, and the default reads as evasive.
+
+**The cure.** If the data does support a position, commit the position. If the data does not support a position, frame the closing as an open question (Pattern 3) rather than a generic call for more research.
+
+---
+
+## Failure 3: The throat-clear closing
+
+**Shape.** "As we have seen, [topic] is important. Going forward, [generic platitude about the topic continuing to evolve]. Teams that [generic recommendation] will be best positioned to [generic outcome]."
+
+**Why it fails.** Delivers no payload. Every word could appear in any other piece on the same topic. The reader's response is "I read 5,000 words for this?"
+
+**The cure.** Strip the closing of every generic phrase. What is left is usually nothing; rewrite from scratch with one of the working patterns.
+
+---
+
+## Failure 4: The CTA-as-closing
+
+**Shape.** The closing is "Book a demo with us today" or "Sign up for our newsletter" or "Download the full report."
+
+**Why it fails.** Breaks the editorial contract. Long-form readers who reached the closing have invested 30+ minutes in editorial content; pivoting to a sales call reads as bait-and-switch. Trust is damaged.
+
+**The cure.** If a CTA belongs in the piece, place it after the closing, visually distinct, framed as an offer rather than as the closing itself. The piece's editorial closing does its work first; the CTA appears afterward as a separate element.
+
+---
+
+## The closing audit
+
+A short framework for auditing a draft closing.
+
+1. **Does the closing leave the reader with something specific to do, decide, or think about?** If not, rewrite.
+2. **Could this closing appear at the end of any other piece on this topic?** If yes, the closing is generic. Rewrite to be specific to this piece.
+3. **Does the closing have approximate weight to the piece?** A 5,000-word piece with a 50-word closing under-invests; a 1,500-word piece with a 600-word closing over-invests.
+4. **Read the closing aloud. Does it have energy?** Closings that read as tired signal the writer was tired. The reader registers the energy. Rewrite when fresh.
+5. **Does the closing match one of the five working patterns?** If it matches one of the failure patterns, rewrite using a working pattern.
+
+---
+
+## When to write the closing first
+
+Some long-form writers write the closing first and write the body toward it.
+
+**The argument for closing-first.** Knowing where the piece lands clarifies what the body needs to argue. Writers who draft the body without knowing the closing often discover at the closing that the body did not actually support the planned closing, and have to rework substantial sections.
+
+**The argument against closing-first.** Some pieces' closings emerge from the body's argument; predetermining the closing constrains where the body can go. Research reports particularly may benefit from following the data and writing the closing once the analysis is complete.
+
+**The middle path.** Draft a target closing before writing the body. Revisit the target after the body draft. The target may stand, or the body may have produced a stronger closing than the target predicted.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five working patterns and the four failure patterns, the underlying frame, the closing audit, the closing-first discussion, and the CTA-vs-editorial-closing distinction.
+
+## Implementation choices that stay internal
+
+Specific draft-review tooling that flags closing patterns. Specific style guides on closing length and weight in the team's editorial system. Specific A/B testing of closing variants for engagement metrics. Specific conventions for whether and where CTAs appear after closings. These vary by team, audience, and analytics setup.

--- a/skills/long-form-content-frameworks/references/common-long-form-failures.md
+++ b/skills/long-form-content-frameworks/references/common-long-form-failures.md
@@ -1,0 +1,179 @@
+# Common long-form failures
+
+Eleven-plus failure patterns with diagnoses and cures. The patterns appear repeatedly across long-form drafts, regardless of topic, format, or writer experience. Diagnosing them early saves the rewrite work that catches them late.
+
+The pattern across most failures: writers reaching for length without doing the structural work that justifies it, and writers under-investing in the structural decisions that make long-form land.
+
+---
+
+## Failure 1: Bloggy-long
+
+**Symptom.** A 5,000-word piece reads as a 1,500-word piece stretched. Padding paragraphs. Recap sections. "Before we get into it" preludes. Bullet expansions of single ideas. The reader notices within 600 words and skims.
+
+**Diagnosis.** The writer chose length first and structural depth second. The piece needed to be longer than 1,500 words for SEO or marketing reasons but did not have 5,000 words of substantive content.
+
+**Cure.** Two options. Cut to actual substantive length (often 1,800-2,500 words). Or expand the structural depth: add original analysis, primary research, case study specificity, or comparative dimensions that justify the length.
+
+**Prevention.** Choose length based on substantive content, not based on competitor length or SEO targets. SEO algorithms are getting better at detecting padded length; the strategy of "outranking by being longer" is increasingly counterproductive.
+
+---
+
+## Failure 2: Academic-bloat
+
+**Symptom.** A 7,000-word whitepaper that is exhaustive but loses the thread. Every adjacent topic surveyed. Every definition restated. Every caveat documented. Reader respects the effort and skims for the parts they need.
+
+**Diagnosis.** The writer aimed for comprehensiveness rather than for argumentative load. The piece treats inclusion as the metric instead of treating each section's contribution as the metric.
+
+**Cure.** Apply the section-weight audit: which sections are actually load-bearing, which are surveying. Cut surveying sections that do not support specific claims in the load-bearing sections. Often takes 7,000 words to 4,500 with the argument intact.
+
+**Prevention.** Outline the argument before drafting. Each section should answer: what does this section contribute to the argument? If a section's answer is "comprehensive coverage" rather than a specific contribution, question whether the section earns its place.
+
+---
+
+## Failure 3: Throat-clearing lede
+
+**Symptom.** The lede took 800 words to get to the thesis. Multiple paragraphs of "content marketing has changed dramatically" before the piece's actual claim appears.
+
+**Diagnosis.** The writer was warming up. Drafts often have throat-clearing ledes; finished pieces should not.
+
+**Cure.** Cut the first 400-700 words of the lede. The piece's actual first sentence is usually the third or fourth paragraph of the throat-clearing draft.
+
+**Prevention.** After drafting, ask: where does the piece's specific argument actually start? Whatever appears before that point is throat-clearing and can usually be cut.
+
+---
+
+## Failure 4: Even-section padding
+
+**Symptom.** All H2s come within 10% of each other in word count. Each section running 800-1,000 words regardless of its argumentative load.
+
+**Diagnosis.** The writer treated section length as a quota. Long sections were padded; short sections were either padded or not deepened.
+
+**Cure.** Identify which sections are actually load-bearing. Let them grow. Cut filler from non-load-bearing sections.
+
+**Prevention.** Plan section weights in the outline based on argumentative load, not on parallel structure. Allow 2x or 3x weight differences between sections doing different amounts of work.
+
+---
+
+## Failure 5: Mid-piece sag
+
+**Symptom.** The piece sags around the 60% mark. Reader-attention analytics show drop-off at this point.
+
+**Diagnosis.** Standard mid-piece attention dip, untreated. No micro-thesis, no rhythm variation; the reader is exhausted from sustained density.
+
+**Cure.** Add a mid-piece micro-thesis at the section boundary nearest the midpoint. Insert a breathing section (anecdote, illustration, or reflective moment) into a stretch of argument-tight prose. Vary visual rhythm in the mid-piece section.
+
+**Prevention.** During outlining, mark the midpoint and plan the micro-thesis explicitly. During drafting, audit the middle third for rhythm variation.
+
+---
+
+## Failure 6: Recap closing
+
+**Symptom.** The closing repeated the introduction. "In this piece we covered X, Y, Z. As we have seen, content is important..."
+
+**Diagnosis.** The writer ran out of energy. The closing was drafted last, in fatigue, and it shows.
+
+**Cure.** Rewrite the closing using one of the five working patterns: specific call, reframed thesis, open question, personal reflection, or provocation.
+
+**Prevention.** Write the closing first, or revise the closing last with fresh attention. Closings deserve disproportionate effort because they are disproportionately consequential.
+
+---
+
+## Failure 7: Citation laundering
+
+**Symptom.** Citations are mostly other content marketing pieces rather than primary or authoritative-secondary sources.
+
+**Diagnosis.** The writer searched for support for claims and found other content marketing pieces making the same claims. Citing them feels like sourcing; it is not.
+
+**Cure.** Follow each citation chain back to the original. If the chain ends at a primary source, cite the primary source. If the chain ends at unsourced or weakly sourced content marketing, either find a primary source for the claim or cut the claim.
+
+**Prevention.** Default to Tier 1-3 sources (primary research, authoritative secondary, industry-credible). Only cite Tier 4 sources for color and context, never for argumentative load.
+
+---
+
+## Failure 8: Visual-count overrun
+
+**Symptom.** The piece commissioned 12 charts. The team is exhausted from production. Six months later, charts are stale because nobody updated them. Traffic is the same as it would have been with 4 charts.
+
+**Diagnosis.** Visual count exceeded production capacity and earned-position discipline.
+
+**Cure.** Cut to the visuals that bear argumentative load the prose alone cannot. Update them on a maintainable cadence. Future pieces budget visuals against capacity rather than against ideal-world maximalism.
+
+**Prevention.** Apply the MVP-visuals approach: which visuals are load-bearing, which would be nice to have, which would be decoration. Ship the load-bearing ones first; add others only if capacity permits.
+
+---
+
+## Failure 9: Generic case study
+
+**Symptom.** The case study has no specifics. "A leading enterprise SaaS company" rather than the company name. "Significant revenue growth" rather than the actual percentage. "Several months" rather than the timeline.
+
+**Diagnosis.** The case study format failed at its primary tax: specificity. Either the case was too confidential to share specifics, or the specifics were never gathered.
+
+**Cure.** Get specifics. Negotiate with the customer for what can be shared. If specifics genuinely cannot be shared, abandon the case study format and write a different format (general thought-leadership piece on the lessons learned, with the specific case relegated to background).
+
+**Prevention.** Do not commit to the case study format until specifics are confirmed shareable. Generic case studies fail the format and are less valuable than honest pieces about the lessons without claiming case-study authority.
+
+---
+
+## Failure 10: Diplomatic manifesto
+
+**Symptom.** The manifesto reads as diplomatic. "Both sides have valid points." "The answer probably lies somewhere in the middle." Hedge stacking on positions that should be specific.
+
+**Diagnosis.** The writer chose the manifesto format but could not commit to the conviction the format requires. Often reflects organizational risk-aversion: the manifesto's bold framing was approved but its actual conviction was edited out.
+
+**Cure.** Either rewrite to commit a position (the format demands it), or change the format. A diplomatic position paper that is not pretending to be a manifesto is fine; a manifesto that hedges is broken.
+
+**Prevention.** Before committing to the manifesto format, confirm the writer (and the organization) actually has a contested position to argue. If hedging is required, write a different format.
+
+---
+
+## Failure 11: Definitive guide with gaps
+
+**Symptom.** The "definitive" guide has obvious sub-topic gaps that the audience would notice. The piece claims comprehensiveness but does not deliver it.
+
+**Diagnosis.** The format implies coverage that the piece does not have. Either the gaps reflect topics the writer did not cover deliberately (and should have flagged), or the writer did not realize the gaps existed.
+
+**Cure.** Either fill the gaps or rename the piece. "The definitive guide to X" with gaps is broken; "A practitioner's guide to X" with the same content but without the comprehensiveness claim is fine.
+
+**Prevention.** Before claiming definitive-ness, audit against the audience's likely sub-topic expectations. Confirm coverage or change the framing.
+
+---
+
+## Failure 12: Wrong archetype
+
+**Symptom.** The piece is fighting itself. The writer is trying to argue layered evidence inside a narrative arc, or to survey a taxonomy inside a problem-solution shape. The reader senses the structural friction even when they cannot articulate it.
+
+**Diagnosis.** Archetype-format mismatch or archetype-topic mismatch. The writer chose an archetype that does not fit the work.
+
+**Cure.** Identify the natural archetype for the topic and the format. Restructure. This is often a substantial revision because the archetype is the spine; changing it changes how sections fit together.
+
+**Prevention.** Choose archetype before drafting. Confirm the archetype fits the format and the topic. Do not commit to draft until the archetype-format-topic combination is coherent.
+
+---
+
+## Failure 13: Format-tax unpaid
+
+**Symptom.** The piece is published in a long-form format but does not pay the format's specific tax. A whitepaper without original synthesis. A research report without primary research. A long-form tutorial with broken steps.
+
+**Diagnosis.** The writer reached for the format's authority without paying the cost the format demands.
+
+**Cure.** Either pay the tax (do the original work the format requires) or change the format. A piece published in the wrong format reads as a category error to readers familiar with the format.
+
+**Prevention.** Confirm the format-tax is payable before committing to the format. Format choice is a downstream decision from "what work is the team prepared to do."
+
+---
+
+## The cross-cutting pattern
+
+Most long-form failures share a single root: the writer chose length, format, or visual ambition first, and chose the structural and substantive depth second. The pieces that read as publication-quality are the ones where the inverse choice is made: substantive depth first, then length, format, and visual ambition follow from the depth.
+
+The fix for almost any long-form failure starts with the same audit: what is the piece actually doing, what is each section actually contributing, what does the format require, what does the topic need? When those questions get clear answers, the piece either earns its length or shrinks to a length that fits its substance.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The thirteen-plus failure patterns with diagnoses and cures, the cross-cutting pattern that connects most of them, the prevention discipline.
+
+## Implementation choices that stay internal
+
+Specific draft-review checklists the team uses. Specific failure-pattern detection in the team's editing tools. Specific reviewer training on the patterns. Specific case-study negotiation templates for getting customer specifics. The team's own conventions for archetype-format fit confirmation. These vary by team, format mix, and tooling.

--- a/skills/long-form-content-frameworks/references/format-decision-framework.md
+++ b/skills/long-form-content-frameworks/references/format-decision-framework.md
@@ -1,0 +1,139 @@
+# Format decision framework
+
+When each long-form format fits, what reader contract it implies, and the format-specific taxes that distinguish credible work from filler dressed in the format's clothes.
+
+Format selection is the first long-form decision. The wrong format produces predictable failure: a thinly-researched whitepaper reads as a blog post in formal clothing; a manifesto written diplomatically reads as a position paper that committed nothing. Each format has a reader contract. Failing the contract is what readers detect even when they cannot articulate why a piece is not landing.
+
+---
+
+## Case study
+
+**Reader contract.** "Show me what worked, what did not, and the specifics that let me apply lessons to my own situation."
+
+**Length norm.** 2,000 to 4,000 words. Shorter feels like a marketing snippet; longer feels padded unless the case is unusually rich.
+
+**Structural archetype tendency.** Problem-solution, sometimes narrative arc.
+
+**Format-specific tax.** Specifics. Real company names (or, where confidential, well-disclosed anonymization with enough context to verify the case is real). Real numbers. Real timelines. Real failures alongside successes. Generic case studies that read like marketing collateral fail because the format's value proposition was specificity.
+
+**Common failures.** Anonymized to the point of meaninglessness ("a leading enterprise SaaS company saw 3x growth"); uncritical success narrative with no failures or surprises; missing methodology (what was measured, how, over what period); no reflection (what would the team change, what limits the lesson's applicability).
+
+**When the format does not fit.** When the case is too thin to support 2,000+ words of specificity, write a short customer story instead. When the case is so confidential that real numbers cannot be shared, the case study format is the wrong choice.
+
+---
+
+## Whitepaper
+
+**Reader contract.** "Take me through your reasoning on this question with the rigor I would expect from a serious source. Make an argument I have not seen elsewhere."
+
+**Length norm.** 3,000 to 8,000 words.
+
+**Structural archetype tendency.** Layered argument or comparative analysis.
+
+**Format-specific tax.** Original synthesis. A whitepaper that surveys what other sources already said is not a whitepaper; it is a literature review. The whitepaper format implies the writer is contributing analysis, framing, or synthesis the reader cannot find elsewhere.
+
+**Common failures.** Survey of the field with no original argument; vendor-thinly-disguised pitch document; methodological hand-waving on the data the argument rests on; conclusion that hedges the position the introduction stated.
+
+**When the format does not fit.** When the writer does not have an original synthesis to contribute, write a different format. A survey-style "state of the industry" report is a research report, not a whitepaper. A vendor pitch is a pitch deck, not a whitepaper. Calling either a whitepaper to borrow the format's authority is the genre-mismatch failure mode.
+
+---
+
+## Research report
+
+**Reader contract.** "Show me the data, how you collected it, what it means."
+
+**Length norm.** 4,000 to 12,000 words. Often longer when methodology and full data appendices are included.
+
+**Structural archetype tendency.** Taxonomic survey or comparative analysis.
+
+**Format-specific tax.** Actual primary research. Survey data with disclosed methodology, sample sizes, dates, and limits. Interview data with sample composition disclosed. Original quantitative work the writer did or commissioned. Citing other firms' research and calling the result a research report fails the contract.
+
+**Common failures.** "We surveyed 300 marketers" with leading questions and no methodology disclosure; cherry-picked data points presented without distribution or variance; methodology paragraph that gestures at rigor without delivering it; findings overstated relative to the sample's actual representativeness.
+
+**When the format does not fit.** When primary research budget is unavailable. Calling a literature synthesis a research report is genre fraud; write a whitepaper or a definitive guide instead.
+
+---
+
+## Definitive guide
+
+**Reader contract.** "Be the canonical resource on this topic for the audience the piece names."
+
+**Length norm.** 4,000 to 10,000 words.
+
+**Structural archetype tendency.** Taxonomic survey.
+
+**Format-specific tax.** Actual comprehensiveness. A definitive guide that has obvious topic gaps fails the format. The audience the piece names matters: a definitive guide for senior practitioners and a definitive guide for newcomers are different pieces; trying to be definitive for both audiences usually fails both.
+
+**Common failures.** Comprehensive on the easy parts of the topic, thin on the hard parts; outdated when published because the format suggests timeless authority but the topic moves quickly; not actually definitive because key sub-topics are missing or treated as out-of-scope without justification.
+
+**When the format does not fit.** When the topic is too broad for a single piece to cover canonically (then write a hub: see `pillar-content-architecture`). When the topic is so specialized that "definitive" is a category of one and the format's value disappears.
+
+---
+
+## Manifesto
+
+**Reader contract.** "Tell me what you believe, why, and convince me. Take a position I can argue with."
+
+**Length norm.** 1,500 to 6,000 words.
+
+**Structural archetype tendency.** Layered argument or narrative arc.
+
+**Format-specific tax.** Conviction. The manifesto format demands the writer commit a position with weight. Diplomatic hedging produces a piece that reads as a manifesto in form but a position paper in substance. Readers detect the gap.
+
+**Common failures.** "Both sides have valid points" framings that the manifesto format does not support; hedge-stacked claims ("typically", "generally", "often") on positions that should be specific; closing that walks back the opening's strength; fear of alienating audience segments producing a piece that alienates everyone by committing to nothing.
+
+**When the format does not fit.** When the writer does not actually have a contested position to argue. Calling a survey of consensus views a manifesto is a category error. Write a whitepaper or a position paper if hedging is required.
+
+---
+
+## Ebook
+
+**Reader contract.** "Take me through a body of work as a sequence of related pieces."
+
+**Length norm.** 8,000 to 30,000+ words across multiple chapters.
+
+**Structural archetype tendency.** Narrative arc across chapters, with each chapter using its own archetype.
+
+**Format-specific tax.** Each chapter earns its place. A 12-chapter ebook with 3 chapters that should have been cut signals the format was reached for to add length, not because the work justified the format. Table of contents reading reveals the discipline: are the chapters distinct contributions, or is the ebook one argument padded into 12 pieces?
+
+**Common failures.** Repetitive chapters covering the same ground from slightly different angles; introduction and conclusion that are throat-clearing rather than load-bearing; missing connective tissue between chapters that leaves the reader uncertain how the chapters fit; no reason for the work to be an ebook rather than a long-form whitepaper.
+
+**When the format does not fit.** When the work fits in 6,000 words. Stretching a long-form whitepaper to ebook length usually weakens it. Write the long-form whitepaper.
+
+---
+
+## Long-form tutorial
+
+**Reader contract.** "Take me from where I am to where I want to be, step by step, and make sure every step works."
+
+**Length norm.** 3,000 to 8,000 words.
+
+**Structural archetype tendency.** Problem-solution with sequential steps.
+
+**Format-specific tax.** Every step works. Long-form tutorials fail catastrophically when one step is broken: the reader stops there, cannot continue, and the rest of the tutorial is wasted. The tutorial-tax is verification that each step in the sequence delivers the result the next step assumes.
+
+**Common failures.** Skipped steps that were obvious to the writer but blocking to the reader; outdated steps that worked when written but no longer (especially common with tutorials referencing fast-moving tools); broken sequences where step 6 assumes a configuration step 4 did not actually create.
+
+**When the format does not fit.** When the topic does not have a clean sequential path. Branching tutorials where the path varies by reader context are usually better as a hub of shorter pieces (see `pillar-content-architecture`) than as one long-form tutorial trying to handle every branch.
+
+---
+
+## The format-fit decision
+
+A short framework for choosing.
+
+1. **What is the reader contract?** What is the reader investing 30+ minutes to get? Specifics (case study)? Original analysis (whitepaper)? Original data (research report)? Comprehensive coverage (definitive guide)? Conviction (manifesto)? A body of work (ebook)? Sequential instruction (long-form tutorial)?
+2. **Can the team pay the format-specific tax?** If the format demands specifics and the case is too confidential to share specifics, the format does not fit. If the format demands conviction and the writer wants to hedge, the format does not fit.
+3. **Is there an original contribution?** Whitepapers, manifestos, and research reports particularly require original contribution. Definitive guides and tutorials can be valuable as comprehensive synthesis without original argument.
+4. **Does the audience expect this format?** Some audiences expect whitepapers (B2B technical), some manifestos (founder-led brands), some research reports (analyst-influenced markets). Format choice signals genre-fit to the audience.
+5. **Is the production capacity available?** Long-form tutorials with verified sequential steps cost meaningful verification time. Research reports cost primary-research budget. Format choice must match capacity, or the format-tax goes unpaid and the piece reads as the format-it-pretended-to-be.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The seven format definitions and their reader contracts. The format-specific taxes that distinguish credible work from filler dressed in the format. The decision framework that matches format to work. The genre-mismatch failure modes. The when-the-format-does-not-fit handling.
+
+## Implementation choices that stay internal
+
+Specific case study templates the team uses. Specific whitepaper layouts in the brand's design system. Specific research-report data presentation conventions matching the team's design tokens. Specific PDF production tooling. Specific gating workflow integrations with the team's marketing automation. Specific tutorial step-verification scripts that match the stack the tutorials cover. These vary by team, brand, and tooling; methodology applies regardless.

--- a/skills/long-form-content-frameworks/references/lede-patterns-for-long-form.md
+++ b/skills/long-form-content-frameworks/references/lede-patterns-for-long-form.md
@@ -1,0 +1,148 @@
+# Lede patterns for long-form
+
+Five patterns that work, four that fail, and the underlying frame: the first paragraph of a long-form piece is the writer's only sales pitch for the next 30+ minutes of the reader's attention.
+
+Long-form ledes do different work than blog-post ledes. A blog-post lede answers the user's likely query in the first 200 words for SEO. A long-form lede earns attention for the time investment ahead. Both can be true at once (an SEO-driven long-form piece needs to do both), but the long-form discipline is the harder of the two: the lede that answers a query in 200 words is not necessarily the lede that earns 30 minutes of reader attention.
+
+---
+
+## The underlying frame
+
+Treat the first 150-250 words of a long-form piece as the writer's pitch to the reader. The reader is deciding, paragraph by paragraph, whether the time investment is going to be worth it. The lede has to:
+
+- Establish that the writer has something specific to say (not a survey).
+- Set the thesis or central question the body will deliver.
+- Earn enough attention to get the reader past the first H2.
+
+If the lede does not do these three things, readers leave at the first H2 boundary, before the body has a chance to deliver.
+
+---
+
+## Pattern 1: The contested-claim opener
+
+**Shape.** A surprising or contested position stated cleanly, then the rest of the piece argues for it.
+
+**Fits.** Manifestos. Opinionated whitepapers. Position pieces. Long-form analysis where the writer has a specific view.
+
+**Example shape.** "Most teams treating content marketing as a volume problem will continue to underperform their budget through the end of the decade. The discipline that produces durable content programs is the one most teams skip: deciding what NOT to publish."
+
+**Why it works.** The reader's response is "wait, why?" The piece exists to answer that. The contested claim earns the reader's attention because the reader is now invested in seeing whether the argument holds.
+
+**The discipline.** The contested claim must actually be defensible across the piece. Lede claims that the body fails to support produce broken contracts; readers feel deceived.
+
+---
+
+## Pattern 2: The problem-with-stakes opener
+
+**Shape.** A problem stated with the stakes made tangible. The reader sees themselves or their situation in the problem and wants the solution.
+
+**Fits.** Case studies. Problem-solution pieces. Long-form tutorials. Manifestos with a clear opposition.
+
+**Example shape.** "Three months after the migration, organic traffic was down 38%, the team had spent four hundred hours on the project, and nobody could explain where the loss was coming from. The migration had been planned for six months. Every checklist item had been completed. And the search-console graph was still pointing the wrong direction."
+
+**Why it works.** Stakes ground the abstract. The reader feels the problem before reading any solution, which earns attention for the solution that follows.
+
+**The discipline.** The stakes must be real, not invented for dramatic effect. Inflated stakes ("the future of marketing is at stake") read as filler. Specific stakes ("the migration cost $400K and three quarters of trust with the executive team") read as honest.
+
+---
+
+## Pattern 3: The data-anomaly opener
+
+**Shape.** A piece of data that does not fit the consensus, framed as the question the piece will answer.
+
+**Fits.** Research reports. Analytical whitepapers. Evidence-driven long-form.
+
+**Example shape.** "The median programmatic SEO program in 2025 generated more than 80% of its traffic from fewer than 5% of its pages. The pattern held across e-commerce, B2B SaaS, marketplaces, and travel. This piece is about why."
+
+**Why it works.** The data point creates a specific question. The reader wants the answer. The body's job is to deliver the answer with the analytical depth the question deserves.
+
+**The discipline.** The data point must be load-bearing. If the body's argument does not actually flow from the opening data, the lede was decoration rather than scaffolding.
+
+---
+
+## Pattern 4: The scene opener
+
+**Shape.** A specific moment, person, or scene that grounds the abstract topic. The reader enters the piece through a concrete situation, and the abstract argument follows.
+
+**Fits.** Narrative-arc pieces. Magazine-style longform. Pieces where human stakes are part of the argument. Some manifestos.
+
+**Example shape.** "On a Tuesday morning in September 2024, two engineers stood in front of a whiteboard covered in arrows and tried to explain to the new VP what the data pipeline actually did. The VP had been at the company three weeks. The whiteboard had been there four years. Neither of them could finish a sentence without contradicting the other."
+
+**Why it works.** Specific scenes hold attention. Readers complete narrative-arc pieces at higher rates than other archetypes; the scene opener uses that pull from the first paragraph.
+
+**The discipline.** The scene must connect to the piece's argument. Scene openers that are decorative ("imagine you are a marketer in 2026...") rather than load-bearing waste reader attention on prelude.
+
+---
+
+## Pattern 5: The orientation opener
+
+**Shape.** What this piece covers, who it is for, what reading it costs and what it delivers. Orientation, not throat-clearing.
+
+**Fits.** Definitive guides. Long-form tutorials. Reference-type long-form where the reader's first question is "is this the right resource for me."
+
+**Example shape.** "This guide is for engineering leaders deciding whether to migrate from a service mesh to a sidecar-less alternative. It assumes familiarity with Kubernetes and basic mesh concepts. Reading it costs about 30 minutes. It will not cover the original arguments for adopting a mesh; that is a different question. It will cover the migration decision: when it makes sense, what to expect, what fails."
+
+**Why it works.** Reference-type readers self-select on relevance. The orientation opener saves the wrong reader's time and earns the right reader's attention. Pieces that the right reader does not finish often fail because the wrong readers came in and the right readers left.
+
+**The discipline.** The orientation must be honest. Guides that overpromise relevance ("for anyone interested in cloud infrastructure") draw wrong readers; guides that underpromise lose right readers.
+
+---
+
+## Failure 1: The throat-clear opener
+
+**Shape.** "Content marketing has changed dramatically over the past decade. In this article, we will explore how to..."
+
+**Why it fails.** Filler signal. The reader knows the piece is about content marketing because of the title; restating it wastes attention. The "in this article we will explore" frame is a tour, not an argument; readers respond to arguments more than to tours.
+
+**The cure.** Cut the throat-clear paragraphs entirely. The piece's actual first sentence is usually the third or fourth paragraph of the throat-clear draft.
+
+---
+
+## Failure 2: The dictionary-definition opener
+
+**Shape.** "According to Merriam-Webster, X is defined as..."
+
+**Why it fails.** Signals an unwillingness to commit a position. The reader assumes the writer does not have a specific framing of their own and is hiding behind the dictionary's framing. For long-form, this is fatal: long-form earns reader attention through specific framing.
+
+**The cure.** State the writer's framing. If the writer needs to disambiguate the term, do so in their own words after stating their position.
+
+---
+
+## Failure 3: The history-of-the-topic opener
+
+**Shape.** Three or four paragraphs of background before the argument starts.
+
+**Why it fails.** Long-form readers tolerate background but only after they know why they should care. Front-loading background means the reader leaves before the thesis lands. The history-of-the-topic opener typically reflects the writer's research process leaking into the piece structure: the writer learned the history while researching, so they put it first, even though the reader does not need it first.
+
+**The cure.** Move history into the body where it supports specific claims. Lead with the thesis or the question the piece answers.
+
+---
+
+## Failure 4: The "in this article we will discuss" tour opener
+
+**Shape.** "In this article, we will discuss A, then B, then C, then D, then conclude with E."
+
+**Why it fails.** Flattens the piece into an outline before the writer has earned attention. Tours signal a writer who is not confident the body will hold the reader, so they preview it. The preview itself is what loses the reader: outlines are less interesting than the argument they describe.
+
+**The cure.** Trust the body to deliver. If the piece needs a navigation aid, use a table of contents or jump links, not an opening tour.
+
+---
+
+## The lede audit
+
+A short framework for auditing a draft lede.
+
+1. **Does the first paragraph establish a specific position, problem, data point, scene, or orientation?** If it does general throat-clearing instead, cut.
+2. **By the end of the first 250 words, has the thesis or central question of the piece been stated?** If not, the lede is too long.
+3. **Does the lede earn the reader's next 30 minutes?** Read the lede as a stranger to the topic. Would you keep reading? If you would skim, the lede is filler.
+4. **Does the body deliver on the lede's promise?** Some failed ledes are technically fine but make promises the body does not keep. The audit happens after the body is drafted: does the lede's framing match what the piece actually argues?
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five patterns and the four failures, the underlying frame, the lede audit, the format-tendency mapping, and the lede-body integrity discipline.
+
+## Implementation choices that stay internal
+
+Specific lede templates the team has built. Specific draft-review tooling that flags throat-clearing language patterns automatically. Specific A/B testing of lede variants against engagement metrics. The team's own conventions for lede-length norms within the bands. These vary by team and tooling.

--- a/skills/long-form-content-frameworks/references/section-weight-calibration.md
+++ b/skills/long-form-content-frameworks/references/section-weight-calibration.md
@@ -1,0 +1,128 @@
+# Section weight calibration
+
+How long sections should be relative to each other, varying by format. The audit pattern that catches structural imbalance, and the underlying principle that section weight should match argumentative load.
+
+Most long-form pieces fail at section weight before they fail at any other dimension. A 6,000-word whitepaper with seven sections of similar length signals that the writer treated each H2 as a quota rather than as an argument-bearing unit. The pieces that read as publication-quality are the ones where some sections breathe and others compress, where argumentative load is reflected in word count, and where filler sections were cut rather than evened out.
+
+---
+
+## The underlying principle
+
+Section weight should match how much argumentative load the section is bearing.
+
+Throat-clearing introductions get cut or compressed. Setup sections that orient the reader without making the argument yet are short. Body sections that are doing the actual work of the piece are longest. Closings are specific and tight. When section weights deviate from this, the piece is either padded (sections doing too little for their length) or under-developed (sections doing too much for their length).
+
+The audit is straightforward. For each section, ask: what argumentative work is this section doing, and is the word count proportional to that work? Sections doing little work that take up much space are filler. Sections doing much work that take up little space are under-developed.
+
+---
+
+## Whitepaper / research report typical weights
+
+For a 5,000-word whitepaper or research report.
+
+- **Introduction.** 8-12%. Roughly 400-600 words. Thesis stated, scope set, why the piece exists.
+- **Methodology or framing.** 10-15%. Roughly 500-750 words. How the analysis works, what data the argument rests on, what the reader should know about how the writer arrived at the position.
+- **Body.** 60-70%. Roughly 3,000-3,500 words. Divided into 3-5 weighted sections. The actual argument or findings. The largest body sections are the load-bearing ones; smaller body sections support or transition.
+- **Implications.** 10-15%. Roughly 500-750 words. What the argument means for the reader's situation.
+- **Closing.** 3-5%. Roughly 150-250 words. Specific call, reframed thesis, or open question.
+
+---
+
+## Case study typical weights
+
+For a 3,000-word case study.
+
+- **Setup and context.** 15-20%. Roughly 450-600 words. The company, the problem, why the problem mattered, what was at stake.
+- **Solution narrative.** 50-60%. Roughly 1,500-1,800 words. What the team did, in sequence, with the decision points that mattered.
+- **Outcomes.** 15-20%. Roughly 450-600 words. Quantified results, what worked beyond expectations, what did not work as planned.
+- **Reflection.** 5-10%. Roughly 150-300 words. What the team would change, what limits the case's applicability.
+
+The case-study weight discipline. The setup and the outcomes can be roughly even; the solution narrative is the longest section because it is doing the most work; the reflection is short because it is concentrated honest assessment.
+
+---
+
+## Manifesto typical weights
+
+For a 3,500-word manifesto.
+
+- **Position.** 5-10%. Roughly 175-350 words. What is believed, stated early and clearly. Manifestos that bury the position lose readers before the argument starts.
+- **Argument.** 70-80%. Roughly 2,450-2,800 words. Why, with the layers building intensity. The argument's later layers should be more intense, more specific, or more confrontational than the earlier layers; intensity that flattens loses momentum.
+- **Call.** 10-15%. Roughly 350-525 words. What should change as a result of accepting the position, who should change it, what the writer asks of the reader.
+
+The manifesto weight discipline. Position is short and load-bearing. Argument is long and intensifies. Call is specific and demands action or position-taking from the reader.
+
+---
+
+## Definitive guide typical weights
+
+For a 7,000-word definitive guide.
+
+- **Introduction.** 5-8%. Roughly 350-560 words. What the guide covers, who it serves, what reading it costs and pays.
+- **Body across taxonomic sections.** 80-85%. Roughly 5,600-5,950 words. Each category in the taxonomy treated with parallel structure. The categories should be roughly even in length unless the taxonomy itself implies asymmetry (some categories are more important than others).
+- **Closing and additional resources.** 7-10%. Roughly 490-700 words. Synthesis, recommendation about which categories matter most, pointers to next steps.
+
+The definitive-guide weight discipline. Most of the weight is in the body categories. The introduction is short because the guide's value is in the taxonomy treatment, not in extended setup. The closing's value is synthesis, not recap.
+
+---
+
+## Long-form tutorial typical weights
+
+For a 5,000-word long-form tutorial.
+
+- **Setup.** 10-15%. Roughly 500-750 words. What the reader will achieve, what they need to start, what the success state looks like.
+- **Sequential steps.** 70-80%. Roughly 3,500-4,000 words. Each step its own subsection. Steps doing more work get more words; trivial steps stay short. The temptation to even out step lengths produces tutorials that feel padded on simple steps and rushed on hard ones.
+- **Troubleshooting and edge cases.** 10-15%. Roughly 500-750 words. What goes wrong, what to do about it, when the reader has likely diverged from the success path.
+
+The tutorial weight discipline. Steps are weighted by actual difficulty, not by parallel structure. The troubleshooting section is load-bearing because tutorials fail at the failure-points; documenting them is the difference between a tutorial that works and one that strands readers.
+
+---
+
+## Ebook typical weights
+
+For a 20,000-word ebook with 8 chapters.
+
+- **Introduction.** 3-5%. Roughly 600-1,000 words. Why the ebook exists, who it serves, how the chapters fit together.
+- **Each chapter.** 10-13%. Roughly 2,000-2,600 words per chapter. Chapter weights can vary; a load-bearing chapter at the center may run 3,500 words while a transitional chapter runs 1,500. The variation should reflect actual content load, not arbitrary balancing.
+- **Closing chapter or synthesis.** 5-8%. Roughly 1,000-1,600 words. What the body of work amounts to.
+
+The ebook weight discipline. Chapter weights match chapter load; introduction and closing earn their place by doing connective work the body chapters cannot.
+
+---
+
+## The 3x audit
+
+A practical heuristic for catching section-weight problems.
+
+Compare any two sections bearing similar argumentative load. If one is more than 3x the length of the other, the piece is structurally unbalanced. Three responses:
+
+1. **Split the long section.** If the long section is genuinely doing 3x the work, it is probably actually two or three sections that should be separated for the reader's navigation.
+2. **Deepen the short section.** If the long section's length is correct, the short section is probably under-developed and the argument it is making is being skipped.
+3. **Acknowledge the imbalance.** If the asymmetry reflects an actual content reality (one category in the taxonomy genuinely matters 3x as much as another), the piece can keep the imbalance but should signal it to the reader so the structure does not feel arbitrary.
+
+---
+
+## Common section-weight failures
+
+Patterns that show up repeatedly in long-form drafts.
+
+**Even-section padding.** All H2s come out within 10% of each other in word count. Signal: writer is treating section length as a quota. Cure: identify which sections are actually load-bearing and let them grow while cutting the filler ones back.
+
+**Front-loaded setup.** Introduction is 25% of the piece. Signal: writer was not confident enough in the thesis to commit it early; spent the first quarter of the piece warming up. Cure: cut the introduction by half, lead with the thesis.
+
+**Body imbalance.** One body section is 50% of the piece while three others are 10% each. Signal: either the long section is actually multiple sections that should be separated, or the short sections are filler that should be cut.
+
+**Missing closing.** Closing is 1-2% of the piece. Signal: writer ran out of energy. Cure: rewrite the closing to actual proportional weight; specific call, reframed thesis, or open question.
+
+**Throat-clearing across sections.** Each section starts with 100-200 words of "as we discussed in the previous section" before getting to the section's actual work. Signal: writer is over-managing reader navigation. Cure: trust the reader; cut the recap paragraphs.
+
+**Bullet inflation.** A section's word count comes mostly from bulleted lists where each bullet is one expanded sentence. Signal: writer is using bullets to inflate length without doing the integration work. Cure: rewrite the bullets as prose if the integration matters; cut to a tighter list if the items are genuinely parallel.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The underlying principle (weight matches argumentative load), the format-specific weight profiles, the 3x audit, the common section-weight failure patterns and their cures.
+
+## Implementation choices that stay internal
+
+Specific word-count tracking tools the team uses to audit drafts. Specific outline templates with weight targets per section in the team's writing system. Specific reviewer dashboards that surface section-weight imbalance for editorial review. The team's own conventions for which formats run shorter or longer than the typical bands. These vary by team and tooling.

--- a/skills/long-form-content-frameworks/references/structural-archetype-patterns.md
+++ b/skills/long-form-content-frameworks/references/structural-archetype-patterns.md
@@ -1,0 +1,145 @@
+# Structural archetype patterns
+
+Five archetypes that fit different long-form problems, with worked examples and the patterns for combining archetypes within a single piece.
+
+The archetype is the spine of a long-form piece. It determines how the argument unfolds, how the reader's attention is structured, and which structural moves feel natural versus which would jar. Selecting the wrong archetype produces a piece that fights itself: the writer trying to argue layered evidence inside a narrative arc, or to survey a taxonomy inside a problem-solution shape.
+
+---
+
+## Archetype 1: Problem-solution
+
+**Shape.** State the problem with weight. Develop why it matters and who is affected. Present the solution. Show how it works in detail. Address objections. Close with implications.
+
+**Fits.** Case studies. Long-form tutorials. Manifestos with a clear opposition. Pieces where the writer has a specific recommendation and a specific framing of what the recommendation answers.
+
+**Worked example: a 3,500-word case study.**
+
+- Setup: the company, the problem, why the problem mattered (15-20% of the piece).
+- The solution narrative: what the team did, in sequence, with the decision points that mattered (50-60%).
+- Outcomes: quantified results, what worked beyond expectations, what did not work as planned (15-20%).
+- Reflection: what the team would change, what limits the case's applicability (5-10%).
+
+**Strengths.** Direct, action-oriented, satisfies readers looking for "show me how to solve this." Clear forward momentum prevents reader drift.
+
+**Risks.** Feels formulaic when overused (every case study reading the same shape). Tempts oversimplification: real situations rarely fit a clean problem-solution arc, and forcing them to flattens the case's interest.
+
+---
+
+## Archetype 2: Narrative arc
+
+**Shape.** Beginning establishing characters and stakes. Middle developing complications. End resolving (or refusing to resolve) the central tension. Time progresses; events follow each other.
+
+**Fits.** Ebooks across chapters. Some case studies, particularly founder stories, transformation cases, multi-year initiatives. Magazine-style longform. Manifestos where the writer's own journey is part of the argument.
+
+**Worked example: a 6,000-word transformation case study.**
+
+- Opening: a specific scene that grounds the abstract topic (the Monday-morning meeting where the problem became inescapable).
+- Rising action: the situation getting worse before it gets better, the failed attempts, the false starts.
+- Turning point: the specific decision or insight that shifted the trajectory.
+- Resolution: what the new state looks like, what the team learned, what is still in progress.
+- Coda: the writer's broader observation about what the story illustrates.
+
+**Strengths.** Most engaging archetype for sustained attention. Readers complete narrative-arc pieces at higher rates than other archetypes. Memorable; readers tell other readers.
+
+**Risks.** Forced narrative on topics that are not stories. A whitepaper trying to be a narrative arc usually fails because the topic does not naturally have characters, complication, and resolution. The forcing is detectable.
+
+---
+
+## Archetype 3: Layered argument
+
+**Shape.** Position stated. Layer 1 evidence supporting the position. Layer 2 evidence, often deeper or addressing a different aspect. Layer 3, often counter-arguments or caveats. Synthesis tying the layers together.
+
+**Fits.** Whitepapers. Manifestos. Position pieces. Analytical long-form. Pieces where the writer is making a case that requires building support across multiple distinct kinds of evidence.
+
+**Worked example: a 5,000-word whitepaper.**
+
+- Position: the central claim, stated cleanly in the first 200 words (10%).
+- Layer 1: the structural argument (why the position follows from how the system works). 25%.
+- Layer 2: the empirical argument (what data supports the position). 25%.
+- Layer 3: counter-arguments engaged seriously and answered. 20%.
+- Synthesis: what the layers together imply, including implications the position-statement alone did not surface. 15%.
+- Closing: specific call or reframed thesis. 5%.
+
+**Strengths.** Rigorous, defensible, persuasive to skeptical readers. Readers engaging seriously with the position find their objections engaged in the counter-argument layer.
+
+**Risks.** Feels academic if the synthesis is weak. Layers that do not actually build to a synthesis read as three separate articles stacked. The audit: cut one layer; does the synthesis still work? If yes, that layer was filler.
+
+---
+
+## Archetype 4: Taxonomic survey
+
+**Shape.** A topic mapped into categories. Each category explored. Relationships among categories surfaced. Sometimes a recommendation about which categories matter most, often a synthesis about what the taxonomy reveals.
+
+**Fits.** Definitive guides. Research reports surveying a landscape. Long-form tutorials covering a topic with parallel rather than sequential structure. Comparative pieces.
+
+**Worked example: a 7,000-word definitive guide.**
+
+- Introduction: what the guide covers, who it serves, what reading it costs and pays (5-8%).
+- Taxonomy framing: how the topic divides, why these categories rather than other possible categories (8-12%).
+- Category 1, 2, 3, 4 (etc.): each treated with parallel structure (definition, examples, when-it-fits, how-it-works) so readers can navigate. 70-75% across all categories.
+- Synthesis: what the taxonomy reveals about the topic as a whole; which categories the writer thinks matter most and why. 7-10%.
+- Closing: what to do with the taxonomy. 3-5%.
+
+**Strengths.** Reference-friendly. Readers come back to taxonomic surveys multiple times to look up specific categories. SEO-friendly because each category often answers a discrete query.
+
+**Risks.** Feels like a list with subheads if the taxonomy is not actually load-bearing. The audit: does the taxonomy reveal something that a list of items would not? If no, the piece is a list pretending to be a taxonomy.
+
+---
+
+## Archetype 5: Comparative analysis
+
+**Shape.** Multiple options, frameworks, or positions. Defined axes of comparison. Each option scored or characterized along each axis. Tradeoffs surfaced. The writer's recommendation argued.
+
+**Fits.** Whitepapers comparing approaches. Decision-guide research reports. Technology comparisons. Evaluations. Pieces where the reader's question is "which of these should I choose."
+
+**Worked example: a 4,500-word technology comparison.**
+
+- Setup: the decision the reader is making, why it matters, who this comparison serves (8-10%).
+- Comparison axes: the dimensions the writer chose to compare on, with justification for why these axes (5-8%).
+- Each option treated along the axes: parallel structure so readers can compare at-a-glance. 50-60%.
+- Tradeoff synthesis: what the comparison reveals about which option fits which context. 15-20%.
+- Recommendation: the writer's view, with the conditions under which the recommendation holds. 8-10%.
+- Closing: how to decide. 3-5%.
+
+**Strengths.** Decision-useful. Readers facing the decision the comparison addresses get clear input. Pairs well with comparison tables and side-by-side data.
+
+**Risks.** Feels like a feature matrix if the analysis is shallow. The axes matter: shallow axes (price, speed, ease) produce shallow analysis. Deep axes (failure modes under load, what the platform optimizes for, what the platform forces you to give up) produce useful comparison.
+
+---
+
+## Combination patterns
+
+Most strong long-form pieces use one archetype as the spine and borrow from another for variation.
+
+**Layered argument with comparative-analysis sections.** A whitepaper arguing a position with a comparative-analysis section showing how the position handles edge cases that competing positions do not.
+
+**Taxonomic survey with problem-solution chapters.** A definitive guide where each category in the taxonomy includes a problem-solution treatment of how to apply it.
+
+**Narrative arc with layered-argument moments.** An ebook where the narrative carries the reader through a transformation while individual chapters argue for specific positions encountered along the way.
+
+**Problem-solution with taxonomic-survey frame.** A long-form tutorial that introduces a taxonomy of failure modes and then walks through the solution sequentially.
+
+**Comparative analysis with case-study illustration.** A whitepaper comparing approaches with a case study embedded for one of the approaches to ground the analysis.
+
+The discipline. One archetype as spine; another as variation. Pieces using three archetypes simultaneously fragment; pieces using one archetype rigidly feel formulaic.
+
+---
+
+## Selecting the archetype
+
+A short framework.
+
+1. **What is the reader's relationship to the question?** "Tell me how" suggests problem-solution. "Tell me what happened" suggests narrative arc. "Convince me" suggests layered argument. "Map the landscape" suggests taxonomic survey. "Help me decide" suggests comparative analysis.
+2. **What does the topic naturally have?** Topics with a clear protagonist, complication, and resolution naturally fit narrative arc. Topics with parallel categories naturally fit taxonomic survey. Topics with a contested position naturally fit layered argument or manifesto-flavored layered argument.
+3. **What does the format expect?** Case studies expect problem-solution or narrative arc; whitepapers expect layered argument or comparative analysis; definitive guides expect taxonomic survey. Format-archetype mismatch is detectable to readers even when they cannot articulate it.
+4. **What is the writer's strength?** Different writers have different archetype strengths. A writer who naturally argues should not force themselves into narrative-arc longform; a writer who naturally narrates should not force themselves into taxonomic surveys. Assign archetype to writer skill where possible.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five archetype shapes, the worked examples, the combination patterns, the selection framework, the format-archetype fit tendencies, the writer-skill matching consideration.
+
+## Implementation choices that stay internal
+
+Specific archetype templates the team has built for repeat formats. Specific section-length scaffolds the team uses. Specific document templates per archetype in the team's writing tool. Specific archetype tagging in the team's content calendar so editorial mix can be reviewed. The decision rubric the team uses for archetype assignment when multiple writers are working on the same format. These are team-specific operationalizations of the methodology.


### PR DESCRIPTION
Direction 7 Dispatch A. Tier 2 content shipped as a grouped dispatch: 4 skills on a single branch with separate commits per skill. Each skill includes 14-15 section SKILL.md (~3000 words) plus 9 reference files. Each reference includes the 'Methodology-level / Implementation choices' closing pattern. Methodology/implementation discipline applied throughout.

Skills (in commit order):
- long-form-content-frameworks
- content-refresh-system
- content-repurposing
- content-distribution

Catalog grows from 77 to 81 skills, 235 to 271 reference files. Content category grows from 8 to 12 entries.

Companion landing pages in rampstackco-app PR.