### PR TITLE
feat(skills): add remaining PM skills (5 skills, Direction 7 Dispatch B; closes Direction 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-81-blue.svg)](#the-81-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-86-blue.svg)](#the-86-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 81 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 86 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -35,7 +35,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 81-skill catalog](#the-81-skill-catalog)
+- [The 86-skill catalog](#the-86-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -63,8 +63,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **81 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
-- **271 reference files** (templates, checklists, decision matrices, worked examples)
+- **86 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
+- **315 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -253,11 +253,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 81-skill catalog
+## The 86-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 81 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 86 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -335,7 +335,7 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 38 | [`seo-site-health-audit`](skills/seo-site-health-audit/SKILL.md) | Triage Ahrefs Site Audit findings by SEO impact, not severity |
 | 39 | [`seo-rank-tracking`](skills/seo-rank-tracking/SKILL.md) | Setup, baseline, segmentation, alerting, dashboarding |
 
-### Product (10)
+### Product (13)
 
 | # | Skill | What it does |
 |---|---|---|
@@ -349,42 +349,45 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 47 | [`product-analytics-setup`](skills/product-analytics-setup/SKILL.md) | Instrument product analytics correctly: event taxonomy, properties, naming conventions, schema versioning, funnels, retention cohorts, North Star selection, and the instrumentation debt that compounds without discipline |
 | 48 | [`data-warehouse-experimentation`](skills/data-warehouse-experimentation/SKILL.md) | Run experiments out of the warehouse: SQL assignment, exposure logs, dbt metric definitions, statistical analysis, variance reduction with CUPED, sequential testing, and the operational tradeoffs vs platforms |
 | 49 | [`feature-launch-playbook`](skills/feature-launch-playbook/SKILL.md) | The operational discipline of launching a feature well: positioning, internal alignment, customer comms, sales enablement, support readiness, rollout strategy, monitoring, and post-launch measurement |
+| 50 | [`jtbd-framing`](skills/jtbd-framing/SKILL.md) | Jobs-to-be-Done framework. Job statements, struggling moments, hire/fire criteria, the difference between feature-thinking and job-thinking. Honest about where JTBD earns its keep and where it becomes performative |
+| 51 | [`okr-design`](skills/okr-design/SKILL.md) | OKR design discipline. Outcome statements, key results, scoring, mid-quarter recalibration. Distinguishes sandbagged OKRs (always hit, useless) from aspirational fantasy (impossible, demoralizing) from stretch OKRs (genuine ambition with quarterly accountability) |
+| 52 | [`beta-program-management`](skills/beta-program-management/SKILL.md) | Running betas that produce real signal. Participant selection, structured feedback, beta-to-GA decisions. Distinguishes soft-launch (no structure) from kitchen-sink (everyone in) from structured-beta (calibrated cohort with intentional feedback loops) |
 
 ### Development (4)
 
 | # | Skill | What it does |
 |---|---|---|
-| 50 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
-| 51 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
-| 52 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
-| 53 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
+| 53 | [`code-review-web`](skills/code-review-web/SKILL.md) | PR review, build error diagnosis, security and quality checks |
+| 54 | [`frontend-component-build`](skills/frontend-component-build/SKILL.md) | Component architecture, props design, accessibility from the start |
+| 55 | [`accessibility-audit`](skills/accessibility-audit/SKILL.md) | WCAG compliance audit with remediation plan |
+| 56 | [`performance-optimization`](skills/performance-optimization/SKILL.md) | Core Web Vitals, asset optimization, render performance |
 
 ### Quality assurance (1)
 
 | # | Skill | What it does |
 |---|---|---|
-| 54 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
+| 57 | [`qa-testing`](skills/qa-testing/SKILL.md) | Pre-launch QA, regression testing, cross-browser checks |
 
 ### Operations (9)
 
 | # | Skill | What it does |
 |---|---|---|
-| 55 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
-| 56 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
-| 57 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
-| 58 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
-| 59 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
-| 60 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
-| 61 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
-| 62 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
-| 63 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
+| 58 | [`launch-runbook`](skills/launch-runbook/SKILL.md) | Go-live runbook, DNS cutover, deploy day procedures |
+| 59 | [`incident-response`](skills/incident-response/SKILL.md) | Incident triage, comms, mitigation, escalation |
+| 60 | [`after-action-report`](skills/after-action-report/SKILL.md) | Post-mortems, retros, learnings documentation |
+| 61 | [`domain-strategy`](skills/domain-strategy/SKILL.md) | DNS architecture, redirects, registrars, multi-domain portfolios |
+| 62 | [`monitoring-and-alerting`](skills/monitoring-and-alerting/SKILL.md) | SLO design, uptime checks, alert routing, on-call rotations |
+| 63 | [`backup-and-disaster-recovery`](skills/backup-and-disaster-recovery/SKILL.md) | RPO/RTO targets, backup strategy, restoration drills |
+| 64 | [`security-baseline`](skills/security-baseline/SKILL.md) | HTTPS, security headers, CSP, secrets management, vulnerability scans |
+| 65 | [`email-deliverability`](skills/email-deliverability/SKILL.md) | DMARC, SPF, DKIM, sender reputation, deliverability monitoring |
+| 66 | [`media-asset-management`](skills/media-asset-management/SKILL.md) | Image pipelines, video hosting, asset libraries, format selection |
 
 ### Growth (2)
 
 | # | Skill | What it does |
 |---|---|---|
-| 64 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
-| 65 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
+| 67 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
+| 68 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
 ### Marketing (3)
 
@@ -392,37 +395,39 @@ Paid media discipline: strategy, creative, and performance analytics. Pairs with
 
 | # | Skill | What it does |
 |---|---|---|
-| 66 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
-| 67 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
-| 68 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
+| 69 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
+| 70 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
+| 71 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
 
-### Research (3)
+### Research (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 69 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 70 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 71 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 72 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 73 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 74 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 75 | [`discovery-research-synthesis`](skills/discovery-research-synthesis/SKILL.md) | Synthesizing customer interviews, research notes, and support tickets into actionable PM decisions. Distinguishes data-dump (no synthesis) from insight-theater (overpolished narrative) from actionable synthesis (decision-grade clarity) |
+| 76 | [`user-feedback-aggregation`](skills/user-feedback-aggregation/SKILL.md) | Collecting and synthesizing user feedback across channels into continuous decision signal. Triage discipline that distinguishes loudest-voice (whoever complains most) from averaged-noise (every signal weighted equally) from triaged-synthesis (weighted by source quality and decision relevance) |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 72 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 73 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 74 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 75 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 76 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 77 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 78 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 79 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 80 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 81 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 77 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 78 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 79 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 80 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 81 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 82 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 83 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 84 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 85 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 86 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/skills/beta-program-management/SKILL.md
+++ b/skills/beta-program-management/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: beta-program-management
 description: "Running closed and open betas that produce real signal. Beta participant selection, structured feedback collection, beta-to-GA decision criteria, and the difference between soft-launch (no structure, no signal), kitchen-sink (everyone in, no actionable feedback), and structured beta (calibrated cohort, intentional feedback loops, clear graduation criteria). Triggers on beta program, alpha test, beta cohort, beta participant, beta feedback, beta to GA decision, design partner, early access program, closed beta, open beta, RC release. Also triggers when a feature is approaching launch and the team needs structured pre-GA validation, when prior betas produced noise rather than signal, or when the team has soft-launched before but wants more structured feedback this time."
-category: project-management
+category: product
 catalog_summary: "Running betas that produce real signal. Participant selection, structured feedback, beta-to-GA decisions. Distinguishes soft-launch (no structure) from kitchen-sink (everyone in) from structured-beta (calibrated cohort with intentional feedback loops)"
-display_order: 14
+display_order: 13
 ---
 
 # Beta Program Management

--- a/skills/beta-program-management/SKILL.md
+++ b/skills/beta-program-management/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: beta-program-management
+description: "Running closed and open betas that produce real signal. Beta participant selection, structured feedback collection, beta-to-GA decision criteria, and the difference between soft-launch (no structure, no signal), kitchen-sink (everyone in, no actionable feedback), and structured beta (calibrated cohort, intentional feedback loops, clear graduation criteria). Triggers on beta program, alpha test, beta cohort, beta participant, beta feedback, beta to GA decision, design partner, early access program, closed beta, open beta, RC release. Also triggers when a feature is approaching launch and the team needs structured pre-GA validation, when prior betas produced noise rather than signal, or when the team has soft-launched before but wants more structured feedback this time."
+category: project-management
+catalog_summary: "Running betas that produce real signal. Participant selection, structured feedback, beta-to-GA decisions. Distinguishes soft-launch (no structure) from kitchen-sink (everyone in) from structured-beta (calibrated cohort with intentional feedback loops)"
+display_order: 14
+---
+
+# Beta Program Management
+
+A senior product leader's playbook for running betas that produce real signal. Closed and open betas, alpha programs, design partner programs, early access. Participant selection, structured feedback collection, beta-to-GA decision criteria, and the difference between soft-launch (no structure, no signal), kitchen-sink (everyone in, no actionable feedback), and structured beta (calibrated cohort, intentional feedback loops, clear graduation criteria).
+
+Most betas underperform. Teams ship a beta because they think they should run a beta; participants are recruited loosely or open-flooded; feedback is collected ad-hoc through whatever channels exist; the decision to graduate to GA happens on calendar rather than on signal. The beta produced activity but not learning; the team launches with the same uncertainty they had before the beta.
+
+This skill is the discipline that turns betas into decision input. Calibrated cohorts who match the post-launch user profile. Structured feedback that captures what the team needs to know. Mid-beta triage that uses what is being learned. Graduation criteria that distinguish "ready" from "we are tired of running the beta." The discipline is not bureaucratic; it is the difference between a beta that informs the GA launch and a beta that produces noise.
+
+The voice is the senior product leader who has run betas with real signal and watched plenty of betas produce nothing. Concrete, opinionated about what produces signal, willing to call out where beta programs slide into ceremony.
+
+When to use this skill: planning a beta for an upcoming launch, auditing why prior betas have not produced actionable signal, designing the beta participant experience, or deciding whether a feature is ready to graduate from beta to GA.
+
+---
+
+## What this skill is for
+
+This skill spans beta program design and execution. The PM and engineering distinction:
+
+- `feature-flagging` is rollout mechanics; the technical layer for controlling who gets which features.
+- **`beta-program-management` (this skill)** is participant management and feedback discipline; the human layer.
+- `feature-launch-playbook` is the full launch (post-GA); this skill is what happens BEFORE GA.
+- `experiment-design` is rigorous A/B testing; betas are softer, qualitative-leaning, smaller-N.
+- `user-feedback-aggregation` is ongoing feedback streams; beta feedback is bounded to the beta period.
+- `discovery-research-synthesis` is one-off discovery research; betas are validation-stage rather than discovery-stage.
+
+The audience: senior PMs, product directors, engineering leads coordinating with product, customer success and support running beta cohorts, anyone planning a closed or open beta.
+
+What is not in scope: the broader feature launch (covered by `feature-launch-playbook`); the technical rollout mechanics (covered by `feature-flagging`); the rigorous experimentation methodology (covered by `experiment-design`); the discovery-stage research that informs whether to build the feature in the first place.
+
+---
+
+## Soft-launch vs kitchen-sink vs structured-beta
+
+The keystone framing.
+
+**Soft-launch.** "We will just turn it on for some users." No structured participant selection, no defined feedback collection, no graduation criteria. The beta runs because the team wanted to ship the feature without the full launch ceremony. Output: the feature is in production for some users; the team has no organized way to learn from their experience; signal accumulates through whatever channels happen to surface it; mid-beta course-correction does not happen because there is no structure to surface what should be corrected.
+
+**Kitchen-sink.** Everyone gets in. The beta opens to whoever signs up. 5,000 beta users; 50 useful pieces of feedback; 4,950 silent users who provide no signal. Volume drowns signal. The team cannot tell which users matched the target post-launch profile. Feedback channels overflow; useful patterns get lost in noise; mid-beta triage cannot keep up. Output: a sense of "we ran a big beta" without the actionable feedback that smaller calibrated cohorts produce.
+
+**Structured-beta.** Calibrated cohort selected by participant criteria. Intentional feedback loops the cohort knows to use. Clear graduation criteria that distinguish "ready for GA" from "tired of the beta." Mid-beta triage that uses what is being learned. Output: the beta produces decision-grade signal; the GA launch ships with confidence; problems that would have surfaced in production get caught and addressed in beta.
+
+The litmus test. After the beta concludes, ask: what specifically did we learn from this beta that changed the GA launch? If the team can name 3-7 specific lessons, the beta was structured. If the team can only generally say "the beta went well," the beta was soft-launch or kitchen-sink.
+
+---
+
+## Beta type decisions
+
+Several axes of beta-type choice. The right combination depends on the launch context.
+
+**Closed vs open.**
+
+- Closed: invite-only. Participants are selected by criteria. Cohort is bounded.
+- Open: anyone can join. Cohort is self-selecting.
+- Closed produces calibrated signal; open produces volume signal that may not match the target user profile.
+
+**Alpha vs beta vs RC.**
+
+- Alpha: very early, internal or trusted-partner only, expectation of bugs.
+- Beta: more polished, broader cohort, expectation of feedback rather than crash discovery.
+- RC (release candidate): essentially launch-ready, last validation, expectation of production-grade quality.
+
+**Internal vs external.**
+
+- Internal: only employees use the feature.
+- External: real customers use the feature.
+- Internal betas catch only what employees would experience; external betas catch the full user-context complexity.
+
+**Time-bounded vs open-ended.**
+
+- Time-bounded: 4-week beta, 8-week beta, with a defined end.
+- Open-ended: beta runs until the team decides to graduate.
+- Time-bounded forces the graduation decision; open-ended risks beta-purgatory.
+
+The combination decision. A typical structured beta might be closed + beta + external + 6-week time-bounded. A design partner program might be closed + alpha + external + open-ended. An open early access might be open + beta + external + time-bounded. The combination should match the kind of signal the team needs.
+
+Detail in `references/beta-type-decisions.md`.
+
+---
+
+## Participant selection criteria
+
+The discipline that makes calibrated cohorts possible.
+
+**The criteria that work.**
+
+- **Match the post-launch user profile.** If the feature is for enterprise admins, beta participants should be enterprise admins, not curious individual users. The beta participant profile should resemble the target GA audience.
+- **Variety across relevant dimensions.** Not all participants identical. If the feature has segment-specific behavior, the cohort spans segments. If usage volume varies, the cohort includes high-volume and low-volume users.
+- **Feedback willingness.** Participants who agree to provide feedback through the structured channels. Soft commitment ("I will give feedback when I have time") is weaker than explicit commitment ("I will respond to weekly check-ins and complete the structured survey").
+- **Existing relationship strength.** Customers with strong existing relationships are more likely to engage substantively. Customers in churn-risk are less likely to engage; their feedback may also be less representative.
+
+**The criteria that fail.**
+
+- **Self-selection only.** Open beta sign-ups skew toward enthusiasts and tinkerers; their feedback may not represent the broader target user.
+- **Highest-paying customers only.** Skews toward enterprise patterns that may not generalize; misses smaller-team use cases.
+- **Internal employees only.** Misses the customer-context complexity; signals "we tested" without "real users tested."
+
+**The cohort size question.** Calibrated cohorts are usually 20-200 participants for closed external betas. Smaller (5-20) for design partner programs. Larger (200-2,000) for open early access. Beyond 2,000 the program is a soft-launch with beta branding.
+
+Detail in `references/participant-selection-criteria.md`.
+
+---
+
+## Beta cohort sizing
+
+How big is enough; when does signal saturate.
+
+**Saturation patterns.**
+
+- Critical feedback (bugs, crashes, broken flows) saturates quickly. 20-30 participants surface most critical issues in the first 2 weeks.
+- Behavioral feedback (how users actually use the feature) saturates more slowly. 50-100 participants needed to see usage patterns clearly.
+- Edge case feedback saturates slowly. 100+ participants needed; some edge cases never surface in beta.
+
+**Sizing decisions.**
+
+- For betas focused on bug discovery: 20-50 participants for 2-4 weeks. Beyond this, returns diminish.
+- For betas focused on behavioral signal: 50-200 participants for 4-8 weeks.
+- For betas focused on validating product-market fit assumptions: 100-500 participants over 8-12 weeks.
+- For betas focused on at-scale infrastructure validation: 500-2,000 participants over 4-8 weeks.
+
+**The "beta size matches signal need" principle.** Cohort size follows from what the team needs to learn. Larger is not always better; calibrated is.
+
+Detail in `references/cohort-sizing-patterns.md`.
+
+---
+
+## Onboarding beta participants
+
+How participants enter the beta and what they know going in.
+
+**The setup.**
+
+- Welcome communication that sets expectations: what the beta is, what feedback is expected, how long it runs, what happens at graduation.
+- NDAs where relevant (for unannounced features, design partner programs).
+- Feedback channel access: where participants give feedback, what format, what cadence.
+- Support escalation path: who participants contact when things break.
+- Compensation or incentive disclosure: free access to the feature post-GA, gift cards, swag, named recognition, etc.
+
+**The expectations contract.**
+
+- What the team commits to participants: communication cadence, response to feedback, transparent about graduation criteria.
+- What participants commit to the team: feedback through the structured channels, not sharing externally during NDA, willingness to engage in interviews if requested.
+
+**Common onboarding failures.**
+
+- Vague expectations. Participants do not know what feedback is wanted; ad-hoc venting fills the channels.
+- No NDA where appropriate. Beta features get screenshotted on social before the team is ready.
+- Missing support path. Participants hit issues, do not know who to contact, churn out of the beta.
+- No incentive clarity. Participants feel underrecognized; engagement decays.
+
+Detail in `references/beta-onboarding-templates.md`.
+
+---
+
+## Feedback collection patterns
+
+Structured channels that produce signal rather than noise.
+
+**Channels that work.**
+
+- **Structured surveys.** 5-15 question surveys at defined points (week 1, week 4, end of beta). Specific questions tied to the team's learning goals.
+- **Async feedback forms.** Participants submit specific feedback through a defined form. Fields prompt for use case, severity, expected vs actual behavior.
+- **Structured interviews.** 30-60 minute interviews with a subset of participants (5-15 per beta). Focused on usage patterns, decision moments, and qualitative depth.
+- **In-product feedback widgets.** Contextualized to the moment. The feedback is timestamped to the user's actual experience.
+- **Support tickets routed to beta-aware support.** Beta participants get faster, more contextualized support; the support interactions surface usage friction.
+
+**Channels that fail.**
+
+- **Slack channels for venting.** Beta participants vent in real time; signal mixes with noise; nobody synthesizes.
+- **"Reply to this email with feedback."** Returns long unstructured emails; synthesis is hard; useful patterns get lost.
+- **"Tell us what you think in the survey at the end."** End-of-beta surveys catch only what participants remember; in-the-moment friction is forgotten.
+
+**Channel mix discipline.** Most structured betas use 3-5 channels. Each channel surfaces different kinds of signal. The team synthesizes across channels.
+
+Detail in `references/feedback-collection-patterns.md`.
+
+---
+
+## Mid-beta triage and iteration
+
+How the team responds to feedback during the beta.
+
+**The principle.** Betas where the team responds to feedback during the beta produce stronger signal than betas where the team waits for the end.
+
+**The triage cadence.**
+
+- Weekly: review feedback across all channels. Categorize: critical bug, friction issue, feature request, positive signal, edge case.
+- Bi-weekly: surface patterns. What recurring feedback are we seeing? What signal is converging?
+- As-needed: critical issues get same-day response. Bugs that prevent core flows are not allowed to sit.
+
+**The iteration discipline.**
+
+- Critical bugs fixed during the beta. Beta participants experience the fixes; the post-fix experience informs the GA decision.
+- Friction issues prioritized for fixes during the beta where feasible; documented for the GA decision where not.
+- Feature requests captured for post-GA roadmap; not added during the beta unless they are graduation-blocking.
+- Positive signal validated; surfaces what works, informs marketing copy and onboarding for GA.
+
+**The communication discipline.** Participants are kept informed: "We received your feedback on X; we are addressing it in next week's beta update." Silence makes participants feel ignored; over-communication signals overhead. Calibrate.
+
+Detail in `references/mid-beta-triage-and-iteration.md`.
+
+---
+
+## Beta-to-GA decision criteria
+
+Graduation gates that distinguish "ready" from "tired of running the beta."
+
+**The criteria.**
+
+- **Critical bugs cleared.** No known crashes, data loss, or core-flow failures.
+- **Friction issues addressed or accepted.** Friction the team will not address by GA is documented and accepted as known limitation.
+- **Behavioral validation.** Beta participants are using the feature in the patterns the team expected. Unexpected patterns are understood (either incorporated into the GA experience or addressed).
+- **Performance under load.** The feature performs adequately at the scale GA will produce. (For infrastructure betas, this is the central criterion.)
+- **Documentation and support readiness.** Help docs reflect actual usage; support team is trained on common issues; escalation paths work.
+- **Positive signal sufficient.** Feedback is net-positive enough to launch with confidence. Not all participants delighted, but a substantial majority finding value.
+
+**The "we are tired of running the beta" anti-pattern.** Beta has run long enough that the team wants to graduate regardless of signal. The graduation decision happens on calendar rather than on criteria. Resist this; either the criteria are met (graduate) or they are not (extend or reset).
+
+**The "perpetual beta" anti-pattern.** Beta runs indefinitely because no firm graduation criteria were set. The team avoids the GA commitment by keeping the feature in beta. Force the graduation decision; if the feature is not ready for GA, identify what would make it ready or reconsider whether to ship at all.
+
+Detail in `references/beta-to-ga-graduation-criteria.md`.
+
+---
+
+## Beta wind-down and participant communication
+
+How the beta ends.
+
+**The graduation announcement.** Participants are told the feature is graduating. Specific date. What changes for them: continued access (typically yes), pricing changes (often beta participants get free access for some period), feature stability commitments (the GA version is what they will use going forward).
+
+**The transition.**
+
+- For most participants: nothing changes operationally. The feature stays available; the "beta" label drops.
+- Pricing transitions communicated explicitly if applicable.
+- Beta-only features that did not make GA are flagged. Participants who relied on those features are given alternatives or transition timelines.
+
+**The thank-you.** Beta participants invested time providing feedback. Recognition matters: named in changelog (with consent), gift cards or swag, advance access to future betas. The recognition strengthens future-beta recruitment.
+
+**The postmortem.** Internal review of what the beta produced. What was learned, what changed in the GA launch, what would be done differently in future betas. This feeds the team's beta program practice.
+
+Detail in `references/beta-wind-down-communication.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-beta-failures.md`.
+
+- "Our beta produced no signal." Soft-launch pattern; no structured selection or feedback collection.
+- "Our beta has 5,000 users and we cannot synthesize feedback." Kitchen-sink; cohort too large for the structured signal the team needs.
+- "Our beta participants never gave feedback." Onboarding contract was unclear or feedback channels were friction-laden.
+- "We graduated to GA on schedule but launched with critical bugs." Graduation criteria not enforced; calendar-driven graduation.
+- "Our beta has been running for 8 months with no graduation." Perpetual beta; no firm graduation criteria; graduation decision avoided.
+- "Beta participants vented on Twitter before the launch." NDA missing or unclear; trust violation early erodes participant willingness.
+- "The beta surfaced patterns we did not act on." Mid-beta triage missing; feedback collected but not used during the beta.
+- "The GA launch surprised us." Beta was not actually validating the GA experience; cohort or feedback structure was wrong.
+- "Beta participants felt ignored after providing feedback." Communication discipline missing; participants commit time and want to know it mattered.
+- "We ran a closed beta that was effectively employees only." Internal-only beta; missed customer-context complexity.
+
+---
+
+## The framework: 12 considerations for beta program management
+
+When designing or auditing a beta program, walk these 12 considerations.
+
+1. **Structured-beta, not soft-launch or kitchen-sink.** Calibrated cohort, intentional feedback, clear graduation.
+2. **Beta type matches signal need.** Closed/open, alpha/beta/RC, internal/external, time-bounded/open-ended.
+3. **Participants match the post-launch profile.** Match the user the GA serves.
+4. **Cohort size calibrated to signal need.** Smaller for bugs; larger for behavioral signal.
+5. **Onboarding contract clear.** Expectations on both sides documented.
+6. **Feedback channels structured.** 3-5 channels; signal not noise.
+7. **Mid-beta triage active.** Feedback acted on during the beta.
+8. **Communication keeps participants engaged.** Updates on what was heard and what is changing.
+9. **Graduation criteria explicit.** Critical bugs cleared, friction addressed, behavioral validation, performance under load, support readiness, positive signal.
+10. **Wind-down treats participants well.** Transition clarity, recognition, thank-you.
+11. **Postmortem feeds practice.** Each beta improves the next.
+12. **Honest decisions on graduation.** Either criteria met (graduate) or not (extend or reconsider). No tired-of-the-beta graduation.
+
+The output of the framework is a beta program that produces decision-grade signal, supports the GA launch, and treats participants well enough to recruit them for future betas.
+
+---
+
+## Reference files
+
+- [`references/beta-type-decisions.md`](references/beta-type-decisions.md) - Closed/open, alpha/beta/RC, internal/external, time-bounded/open-ended. The combination decision and how it matches signal need.
+- [`references/participant-selection-criteria.md`](references/participant-selection-criteria.md) - Criteria that produce calibrated cohorts. Common selection failures. The cohort size question.
+- [`references/cohort-sizing-patterns.md`](references/cohort-sizing-patterns.md) - Saturation patterns by feedback type. Sizing decisions for different beta goals. The size-matches-signal principle.
+- [`references/beta-onboarding-templates.md`](references/beta-onboarding-templates.md) - Welcome communication structure. NDAs, feedback channels, support paths, incentives. The expectations contract.
+- [`references/feedback-collection-patterns.md`](references/feedback-collection-patterns.md) - Structured surveys, async forms, interviews, in-product widgets, beta-aware support. Channels that work and fail. Channel mix discipline.
+- [`references/mid-beta-triage-and-iteration.md`](references/mid-beta-triage-and-iteration.md) - Triage cadence. Iteration discipline (what to fix during, what to defer). Communication with participants.
+- [`references/beta-to-ga-graduation-criteria.md`](references/beta-to-ga-graduation-criteria.md) - The six graduation criteria. The "tired of the beta" anti-pattern. Perpetual beta anti-pattern.
+- [`references/beta-wind-down-communication.md`](references/beta-wind-down-communication.md) - Graduation announcement, transition, recognition, postmortem. Treating participants well.
+- [`references/common-beta-failures.md`](references/common-beta-failures.md) - 10+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: betas earn their keep with structure
+
+A structured beta is one of the most useful product activities available. The cohort experiences the feature; the team learns from their experience; the GA launch ships with reduced uncertainty. The discipline pays back many times its cost.
+
+A soft-launch or kitchen-sink beta is one of the least useful. The team spends weeks running an activity that produces ambient activity without converting to learning. The GA launches with the same uncertainty the beta was supposed to address.
+
+The teams that earn returns on betas are the ones that take the structure seriously: cohorts calibrated to the GA profile, feedback channels designed for signal, mid-beta triage that uses what is being learned, graduation criteria that distinguish ready from tired, wind-down communication that treats participants well enough to recruit them again.
+
+When in doubt about whether a beta is ready, ask: are participants matched to the GA user, are feedback channels structured, is the team responding to feedback during the beta, are graduation criteria explicit and being applied honestly, will participants want to join the next beta? If yes to all of those, the beta is real. If no to any, the gap is where the beta will fail to convert participation into learning.

--- a/skills/beta-program-management/references/beta-onboarding-templates.md
+++ b/skills/beta-program-management/references/beta-onboarding-templates.md
@@ -1,0 +1,230 @@
+# Beta onboarding templates
+
+Welcome communication structure. NDAs, feedback channels, support paths, incentives. The expectations contract.
+
+Onboarding sets the tone for the beta. Done well, participants enter with clear expectations and stay engaged through the program. Done badly, participants drop off, fail to provide feedback, or violate confidentiality unintentionally.
+
+---
+
+## The welcome communication
+
+The first message participants receive after accepting the invitation.
+
+**What it covers.**
+
+- Welcome and thank-you for joining.
+- What the beta is: the feature, the goals, what is being validated.
+- Beta duration: start date, end date, what graduation looks like.
+- What is expected of participants: feedback channels, cadence, format.
+- What participants get: access to the feature, support, recognition or compensation, post-GA terms.
+- NDA reminder where applicable.
+- How to access the feature: links, accounts, configuration steps.
+- Who to contact: support escalation path, beta program manager.
+- First feedback prompt: what the team would like to hear about in the first week.
+
+**What it does not cover.**
+
+- A complete product manual. The participant should be able to use the feature; in-product guidance handles the detail.
+- Internal team structure or politics. Participants do not need to know who reports to whom.
+- Future roadmap. The beta is about this feature; future plans are separate communication.
+
+**Length.** 400-800 words for substantive features. Shorter for simpler features. The welcome should be readable in 3-5 minutes.
+
+**Tone.** Warm but professional. Beta participants are doing the team a favor; the welcome reflects that. Avoid corporate-stiff or overly casual.
+
+---
+
+## The expectations contract
+
+Both sides commit to specific behaviors.
+
+**What the team commits to.**
+
+- Communication cadence: regular updates (weekly or bi-weekly).
+- Response to feedback: critical issues addressed quickly; friction issues prioritized; feature requests captured.
+- Transparency: participants are told what is being changed based on feedback and what is being deferred.
+- Graduation criteria: explicit criteria, applied honestly.
+- Post-GA continuity: participants know what their access looks like after graduation (typically continued access; sometimes special pricing).
+
+**What participants commit to.**
+
+- Feedback through the structured channels (specific channels named).
+- Confidentiality where NDA applies (no public posts, screenshots, or sharing of beta features outside the participant's organization).
+- Reasonable engagement: not required to use the feature daily, but expected to use it enough to provide informed feedback.
+- Willingness to engage in interviews if requested (with the right to decline specific interviews).
+
+**The signed-or-implicit agreement.**
+
+- For substantial NDAs, participants sign an explicit agreement.
+- For lighter beta agreements, the welcome communication may be the implicit acceptance (participation implies agreement to terms).
+- The team should know which approach applies and apply it consistently.
+
+---
+
+## NDA considerations
+
+When NDAs are appropriate.
+
+**NDA appropriate.**
+
+- Unannounced features (the beta is essentially confidential).
+- Features that affect competitive positioning (the team does not want competitors to see the feature early).
+- Design partner programs with deep collaboration on feature shaping.
+- Enterprise features that touch sensitive customer data or workflows.
+
+**NDA not appropriate or unnecessary.**
+
+- Open public betas.
+- Features that have already been announced.
+- Features where the team welcomes public discussion (e.g., developer-tool launches that benefit from community feedback).
+
+**NDA enforcement reality.**
+
+- NDAs in open beta are essentially unenforceable. Pretending an open beta has NDA protection is theater.
+- Closed-beta NDAs are enforceable but require trust; the team should not invite participants who are likely to violate confidentiality.
+- For sensitive betas, the cohort selection itself is the primary control; NDAs are the legal backstop.
+
+**What an NDA covers.**
+
+- Confidentiality of the beta feature, its functionality, and the team's plans.
+- Restrictions on screenshots, public posts, recordings.
+- Term: typically until the feature is publicly announced or for a defined period.
+- Exceptions: feedback to the team is allowed; discussion within the participant's organization is usually allowed.
+
+---
+
+## Feedback channel access
+
+What participants need to know about how to give feedback.
+
+**Channel inventory.**
+
+- Structured surveys: when they will arrive, how long they take, how to access.
+- Async feedback forms: link, instructions, what fields to fill.
+- Interview signups: how to volunteer for interviews, what compensation if any.
+- In-product feedback widget: how to use, what context it captures.
+- Support routing: how beta participants flag issues to the support team.
+- Slack or community: if a beta-only channel exists, how to join and what tone is expected.
+
+**Channel discipline.**
+
+- Each channel serves a different purpose. The welcome communication explains which channel is for which feedback type.
+- Avoid duplicating channels (multiple Slack-like channels for the same feedback) or confusing channel mappings.
+
+---
+
+## Support paths
+
+How participants escalate issues.
+
+**The escalation map.**
+
+- Bug reports: filed through the structured form or support ticketing system tagged "beta."
+- Critical issues (crashes, data loss): escalation contact named explicitly; not buried in standard support queues.
+- Feature questions and how-to: routed to in-product help or beta program manager.
+- Account issues: standard support paths or beta-aware support reps.
+
+**Support team awareness.**
+
+- Support team should know the beta is running and how to handle beta-tagged tickets.
+- Beta-tagged tickets often deserve faster response than standard tickets (the participant is doing the team a favor; long support waits damage the relationship).
+- Common beta issues should be documented for the support team in advance.
+
+---
+
+## Incentive disclosure
+
+What participants get for joining.
+
+**Common incentives.**
+
+- Free access to the feature post-GA for some period.
+- Discounted pricing on the feature post-GA.
+- Beta-only feature flags or capabilities preserved post-GA.
+- Recognition (named in changelog, on website, in launch communications) with consent.
+- Gift cards, swag, or other compensation.
+- Direct access to product team during the beta (some participants value this most).
+
+**Disclosure discipline.**
+
+- The welcome communication names the incentives explicitly. No surprise reveals at the end.
+- Different participants may have different incentive packages (design partners often get more); each participant knows their package.
+- The incentives match the commitment level. Light betas have light incentives; design partner programs have substantive ones.
+
+**The "no incentive" pattern.**
+
+- Some betas offer no formal incentive beyond access to the feature.
+- This works for high-engagement audiences (developers, enthusiasts) where access itself is the incentive.
+- It does not work for audiences where the time investment is significant; participants need a reason to engage substantively.
+
+---
+
+## First-week onboarding
+
+What happens after the welcome message.
+
+**The first week's actions.**
+
+- Day 1: welcome arrives; participants get access; first-day checklist (set up, access feature, complete profile if applicable).
+- Day 2-3: first feedback prompt arrives. Could be an in-product widget triggered after first usage, or an email asking specifically about the first impression.
+- End of week 1: brief check-in. Are participants able to access? Have they used the feature? Any friction with onboarding itself?
+
+**Onboarding-specific friction.**
+
+- Beta participants who cannot access the feature in the first 24-48 hours often disengage. Access friction is the most consequential onboarding failure.
+- Documentation that does not match the actual experience (because the docs were written for a slightly different feature version) frustrates early.
+- Missing context about what the feature is for. Participants who do not know what the feature is meant to accomplish use it tentatively or not at all.
+
+---
+
+## Onboarding for different beta types
+
+Different beta types warrant different onboarding intensity.
+
+**Lightweight onboarding (open beta, RC validation).**
+
+- Email welcome with key information.
+- Self-service access.
+- In-product guidance handles most setup.
+
+**Standard onboarding (closed beta, structured cohort).**
+
+- More substantial welcome email.
+- Optional onboarding call for participants who request it.
+- Beta program manager available via direct channel.
+
+**Deep onboarding (design partner program, complex feature).**
+
+- Onboarding call with each participant or company.
+- Custom configuration support.
+- Direct channel to product team for ongoing collaboration.
+
+The onboarding intensity matches the beta type. Heavyweight onboarding for an open beta with 5,000 participants is impossible; lightweight onboarding for a 5-partner design program under-invests in the relationships.
+
+---
+
+## Common onboarding failures
+
+**Vague expectations.** Participants do not know what feedback is wanted; ad-hoc venting fills the channels.
+
+**Missing NDA where appropriate.** Beta features get screenshotted on social before the team is ready.
+
+**Missing support path.** Participants hit issues, do not know who to contact, churn out of the beta.
+
+**No incentive clarity.** Participants feel underrecognized; engagement decays.
+
+**Welcome communication too long or too short.** Too long: participants do not read; too short: participants miss critical context.
+
+**Access friction in first 24-48 hours.** Participants cannot get into the feature; many disengage permanently.
+
+**Onboarding intensity mismatched to beta type.** Heavy onboarding for an open beta wastes effort; light onboarding for a design partner program under-invests.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The welcome communication structure. The expectations contract for both sides. NDA considerations. Feedback channel access. Support paths. Incentive disclosure. First-week onboarding. Onboarding by beta type. Common failures.
+
+## Implementation choices that stay internal
+
+Specific welcome email templates. Specific NDA boilerplate. Specific support routing automation. Specific incentive packages and approval workflows. The team's own conventions for onboarding intensity. These vary by team and beta type.

--- a/skills/beta-program-management/references/beta-to-ga-graduation-criteria.md
+++ b/skills/beta-program-management/references/beta-to-ga-graduation-criteria.md
@@ -1,0 +1,239 @@
+# Beta-to-GA graduation criteria
+
+The six graduation criteria. The "tired of the beta" anti-pattern. The perpetual beta anti-pattern.
+
+Graduation is the decision that distinguishes a structured beta from beta theater. Honest graduation criteria, applied honestly, separate "ready for GA" from "we are tired of running the beta." Defining the criteria explicitly upfront prevents calendar-driven graduation decisions later.
+
+---
+
+## The six graduation criteria
+
+The criteria that should be met before graduating from beta to GA.
+
+### 1. Critical bugs cleared
+
+**The criterion.** No known crashes, data loss, or core-flow failures.
+
+**The validation.** Bug tracker shows no open critical issues. The beta cohort has not reported new critical issues in the past 1-2 weeks.
+
+**The exception.** Some critical issues may be acceptable if they affect a tiny segment that the GA can either exclude or address with documentation. Decisions to graduate with known issues should be explicit.
+
+### 2. Friction issues addressed or accepted
+
+**The criterion.** Friction issues are either fixed before GA or documented as known limitations the team is choosing not to address pre-GA.
+
+**The validation.** Each friction issue from the beta has a disposition: fixed, fix-in-progress (with timeline), accepted-for-now (with rationale), accepted-permanently (with rationale).
+
+**The honest disposition.** "Accepted for now" is honest if the team plans to address post-GA. "Accepted permanently" is honest if the team has decided the friction is not worth the engineering cost. Hidden friction that the team hopes nobody will notice is not honest.
+
+### 3. Behavioral validation
+
+**The criterion.** Beta participants are using the feature in patterns the team expected. Unexpected patterns are understood (either incorporated into the GA experience or addressed).
+
+**The validation.** Usage data from the beta cohort shows the feature being used in the ways the design assumed. Significant deviations are investigated; either the design is adjusted, or the GA experience is modified to support the actual usage pattern.
+
+**The unexpected-pattern handling.**
+
+- Pattern A: most beta participants are using the feature in a different way than the design assumed. The design is wrong; iterate before GA.
+- Pattern B: a subset of participants is using the feature in an unexpected way that suggests an additional use case. Capture for post-GA expansion; do not delay GA.
+- Pattern C: participants are not using the feature much at all. The feature may not be solving a real problem; reconsider whether to ship.
+
+### 4. Performance under load
+
+**The criterion.** The feature performs adequately at the scale GA will produce.
+
+**The validation.** Performance testing under projected GA load. Beta cohort performance was acceptable; the GA scale projection has been tested.
+
+**The infrastructure-validation focus.** For features where scale is the primary concern (data-processing features, real-time features, multi-tenant features), this criterion is the central one. RC betas often exist primarily to validate this.
+
+### 5. Documentation and support readiness
+
+**The criterion.** Help docs reflect actual usage; support team is trained on common issues; escalation paths work.
+
+**The validation.**
+
+- Help docs match the feature as it will ship at GA.
+- Support team has been briefed and has handled at least the simulated beta-tier ticket volume.
+- Common issues are documented for the support team's reference.
+- Escalation paths from support to engineering are tested.
+
+**The skip risk.** Teams often graduate before docs and support are ready. The GA launch then catches the support team off-guard; tickets pile up; users have a worse experience than they would have with proper readiness.
+
+### 6. Positive signal sufficient
+
+**The criterion.** Beta feedback is net-positive enough to launch with confidence.
+
+**The validation.**
+
+- Survey signal shows positive sentiment among beta participants.
+- Behavioral signal shows continued usage (participants are not just trying the feature once).
+- Participants would recommend the feature to others.
+
+**The "sufficient" calibration.** Not all participants need to be delighted. A substantial majority finding value, with the dissenting voices understood (segment misfit, expectations mismatch, unfixable friction), is sufficient. A divided cohort with no clear majority signal is not.
+
+---
+
+## The "tired of the beta" anti-pattern
+
+Graduation that happens because the team wants to be done with the beta.
+
+**The pattern.**
+
+- Beta has run for the planned duration.
+- Some criteria are met; some are not.
+- The team graduates anyway because "we have to ship at some point" or "the beta cannot run forever."
+
+**Why it fails.**
+
+- Unmet criteria mean the GA launches with known issues that are not yet addressed or acknowledged.
+- Support, marketing, and customer success encounter problems the beta would have caught if extended.
+- Trust degrades: customers experience friction the beta participants reported but the team did not fix.
+
+**The cure.**
+
+- Either extend the beta until criteria are met.
+- Or graduate with explicit acknowledgment of the unmet criteria (known issues, deferred work).
+- Or reset the beta if significant changes are needed.
+
+The discipline: the graduation decision is criteria-driven, not calendar-driven. Calendar pressure can inform whether to ship a smaller scope, but it should not produce graduation despite unmet criteria.
+
+---
+
+## The perpetual beta anti-pattern
+
+Graduation that does not happen because the beta drifts indefinitely.
+
+**The pattern.**
+
+- Beta runs without firm graduation criteria.
+- Issues keep surfacing; the team keeps fixing; the beta extends.
+- 6 months later, the beta is still running. The "perpetual beta" branding becomes a strategic stance ("everything is always evolving").
+- The GA commitment is avoided.
+
+**Why it fails.**
+
+- Beta participants experience indefinite uncertainty about the feature's status.
+- The team avoids the discipline of GA readiness; the feature stays in a less-mature state than it could be.
+- Marketing, support, and customer success cannot operate around a beta-forever feature.
+- Stakeholder trust degrades: the team is not shipping.
+
+**The cure.**
+
+- Force the graduation decision. Either the criteria are met (graduate) or they are not (decide what would make them met, set a timeline, commit).
+- "Perpetual beta" as a strategic stance is rare and usually a rationalization.
+- Some features genuinely need extended-beta status for valid reasons (regulatory complexity, unusual scale validation); these should be exceptions documented explicitly, not the default.
+
+---
+
+## Honest graduation patterns
+
+When graduation criteria are mostly but not fully met.
+
+**Graduation with known issues.**
+
+- Some criteria fully met; one or two have known gaps.
+- Graduate with explicit acknowledgment: "We are shipping with X known limitation; documented; will address in [timeline]."
+- Communicate the known issues to support, marketing, customer success.
+- Customers who hit the known issue are not surprised; they were warned.
+
+**Graduation with extended monitoring.**
+
+- Behavioral signal not fully validated due to cohort limitations.
+- Graduate with monitoring infrastructure that surfaces issues at GA scale.
+- Plan for fast iteration if monitoring catches issues post-GA.
+
+**Graduation with phased rollout.**
+
+- All criteria met for a subset of users; less certain for broader users.
+- Graduate to the validated subset first; expand the rollout in phases.
+
+These patterns preserve graduation discipline while accommodating real-world constraints.
+
+---
+
+## When NOT to graduate
+
+Conditions that warrant extending or resetting the beta.
+
+**Not to graduate.**
+
+- Critical bugs are unaddressed.
+- Major friction issues affect mainline usage.
+- Behavioral signal contradicts the design assumptions.
+- Performance under projected load is inadequate.
+- Documentation and support are not ready.
+- Beta sentiment is divided without clear positive signal.
+
+**The honest extension.**
+
+- Acknowledge the gap explicitly.
+- Define what would close the gap.
+- Set a new timeline.
+- Communicate to participants and stakeholders.
+
+**The reset.**
+
+- If the gap requires significant feature changes, end the current beta and start a new one with the changed feature.
+- Do not blend "old beta" and "new feature" data.
+
+---
+
+## Graduation decision-making
+
+Who decides graduation and how.
+
+**The decision-maker.** Typically the product manager who owns the feature, with input from engineering lead, design lead, and beta program manager.
+
+**The decision process.**
+
+- Beta program manager prepares a graduation review document: status against each criterion, known issues, recommendation.
+- Decision meeting (60-90 minutes): review the document, discuss any open questions, make the decision.
+- Decision recorded explicitly: graduate, extend, or reset.
+
+**Stakeholder visibility.** The decision is communicated to stakeholders (executives, marketing, sales, customer success) before participants are notified.
+
+**Graduation timing.** Once the decision is made, graduation typically takes 1-2 weeks to execute (final code, marketing prep, support readiness, participant communication).
+
+---
+
+## Graduation criteria for different beta types
+
+The criteria adapt to the beta type.
+
+**Closed beta with calibrated cohort.** All six criteria apply. The cohort is small enough to validate behavioral signal directly.
+
+**Open beta with large volume.** Behavioral signal validates at scale. Critical bugs and performance criteria are more central. Documentation and support readiness scale with the open-beta visibility.
+
+**RC validation.** Performance under load is the central criterion. Other criteria should already have been met in prior alpha or beta stages.
+
+**Design partner program.** The criteria apply but graduation often happens incrementally (specific design partners moving to GA terms while the program continues with new partners). Less of a single graduation moment.
+
+**Internal beta.** Customer-context criteria (behavioral validation, support readiness for external) may need to be validated at GA rather than during beta. Honest disclosure: the beta did not fully validate the customer experience.
+
+---
+
+## Common graduation failures
+
+**Calendar-driven graduation.** Graduate when the planned duration ends regardless of criteria.
+
+**Criteria not defined upfront.** Graduation decision happens without explicit criteria; subjective decision.
+
+**Hidden known issues.** Graduate with known issues that are not surfaced; customers and support discover them later.
+
+**Perpetual beta.** Indefinite extension; graduation decision avoided.
+
+**Premature graduation.** Graduate before behavioral signal has emerged or critical bugs are fully cleared.
+
+**No stakeholder notification.** Graduation happens; support, marketing, customer success encounter the GA launch unprepared.
+
+**No participant communication about graduation.** Beta participants are not told about graduation timing or what changes for them.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The six graduation criteria. The "tired of the beta" anti-pattern. The perpetual beta anti-pattern. Honest graduation patterns. When not to graduate. Graduation decision-making. Graduation criteria for different beta types. Common failures.
+
+## Implementation choices that stay internal
+
+Specific graduation review document templates. Specific decision-meeting formats. Specific stakeholder notification workflows. The team's own conventions for graduation timing. These vary by team and tooling.

--- a/skills/beta-program-management/references/beta-type-decisions.md
+++ b/skills/beta-program-management/references/beta-type-decisions.md
@@ -1,0 +1,228 @@
+# Beta type decisions
+
+Closed/open, alpha/beta/RC, internal/external, time-bounded/open-ended. The combination decision and how it matches signal need.
+
+Beta type is the upstream decision that constrains everything downstream: who participates, what feedback channels make sense, what graduation looks like. Getting the type wrong makes the rest of the program harder.
+
+---
+
+## Closed vs open
+
+The cohort-control axis.
+
+**Closed beta.** Invite-only. Participants are selected by the team based on criteria. Cohort is bounded.
+
+**Strengths.**
+
+- Calibrated cohort: the team knows who is in the beta and can match participants to the GA user profile.
+- Quality of feedback: invited participants typically engage more substantively than self-selected open-beta users.
+- NDA enforceability: closed cohorts can sign NDAs; open cohorts usually cannot.
+- Synthesis tractability: bounded cohort means feedback volume is manageable.
+
+**Weaknesses.**
+
+- Recruiting overhead: identifying and inviting participants is real work.
+- Limited diversity: the cohort reflects the team's recruiting choices; gaps in selection produce gaps in feedback.
+- Slower feedback volume: smaller cohorts produce less total feedback.
+
+**Open beta.** Anyone can join. Cohort is self-selecting.
+
+**Strengths.**
+
+- Volume: large numbers of participants quickly.
+- No recruiting overhead: participants opt in.
+- Marketing value: open betas can build pre-launch audience awareness.
+
+**Weaknesses.**
+
+- Self-selection bias: early adopters and enthusiasts skew the cohort; their feedback may not represent the broader target user.
+- Signal-to-noise ratio: most participants do not provide actionable feedback; the team must mine signal from volume.
+- NDA difficulty: open cohorts cannot reasonably enforce NDAs; the feature is essentially public.
+
+---
+
+## Alpha vs beta vs RC
+
+The polish axis.
+
+**Alpha.**
+
+- Very early. Significant bugs expected.
+- Internal users or trusted partners only.
+- Goal: surface fundamental issues before broader exposure.
+- Feedback orientation: bug discovery, fundamental flow validation.
+
+**Beta.**
+
+- More polished. Major bugs caught; remaining issues are friction or edge cases.
+- Broader cohort. External customers in calibrated cohorts.
+- Goal: validate the feature works for real users in real contexts.
+- Feedback orientation: usage patterns, friction, behavioral signal, edge cases.
+
+**RC (release candidate).**
+
+- Essentially launch-ready. Production-grade quality expected.
+- Cohort can be large (open beta or extended beta).
+- Goal: last validation before GA, performance at scale, infrastructure readiness.
+- Feedback orientation: scale issues, infrastructure issues, last-mile polish.
+
+**The progression.** Many features pass through all three (alpha → beta → RC) before GA. Some skip alpha (sufficient internal testing) or skip RC (the beta is the last validation). The decision depends on feature complexity and risk tolerance.
+
+---
+
+## Internal vs external
+
+The audience axis.
+
+**Internal beta.** Only employees use the feature.
+
+**Strengths.**
+
+- Fast feedback: employees are easy to recruit and follow up with.
+- High engagement: employees usually feel some ownership of company products.
+- NDA simplicity: confidentiality is implicit.
+
+**Weaknesses.**
+
+- Missing customer context: employees experience features differently than customers (familiarity, infrastructure context, motivations).
+- Bias toward team-known patterns: employees use products in ways the team designed for; customers often use products differently.
+- Limited signal: internal-only cannot validate customer-context complexity.
+
+**External beta.** Real customers use the feature.
+
+**Strengths.**
+
+- Real customer experience: feedback reflects how customers actually use the product.
+- Behavioral signal: usage patterns from real customers inform GA decisions.
+- Trust building: customers who beta-test become advocates.
+
+**Weaknesses.**
+
+- Requires customer relationship: cannot just turn the feature on for employees.
+- Recruiting overhead: identifying willing customers and managing the cohort.
+- Risk: bugs reaching customers can damage trust if not handled well.
+
+**The combination.** Most strong betas pass through both: internal alpha, then external beta. Some skip internal (when internal use cases differ enough from customer use cases that internal validation is misleading).
+
+---
+
+## Time-bounded vs open-ended
+
+The duration axis.
+
+**Time-bounded beta.** A defined end date. Common durations: 4 weeks, 6 weeks, 8 weeks, 12 weeks.
+
+**Strengths.**
+
+- Forces the graduation decision. The end date arrives; the team must decide ready or not.
+- Clarity for participants: they know how long they are committing.
+- Resource bounding: the team's beta-running effort is bounded.
+
+**Weaknesses.**
+
+- Calendar pressure can force premature graduation: "we are at the end date so we are graduating" regardless of signal.
+- Some signals need longer to surface: behavioral patterns may not be visible in 4 weeks.
+
+**Open-ended beta.** No defined end. The beta runs until the team decides to graduate.
+
+**Strengths.**
+
+- Signal-driven graduation: the team graduates when the criteria are met, regardless of calendar.
+- Allows long-running validation: behavioral signal can develop over months.
+- Suits design partner programs: ongoing relationships rather than time-bounded cohorts.
+
+**Weaknesses.**
+
+- Beta-purgatory risk: beta runs indefinitely because nobody forces the graduation decision.
+- Participant fatigue: open-ended commitments without clear duration drain engagement.
+- Resource drain: the team's beta-running effort is open-ended.
+
+**The default.** Most betas should be time-bounded. Open-ended is appropriate for design partner programs and specific extended-validation scenarios.
+
+---
+
+## The combination decision
+
+How to choose across the four axes.
+
+**Worked combinations.**
+
+**Standard structured beta:** closed + beta + external + time-bounded (6-8 weeks).
+
+- Use when: shipping a meaningful feature that needs validation before GA. Most common combination.
+
+**Alpha:** closed + alpha + internal + open-ended (typically 2-6 weeks of internal testing before external alpha).
+
+- Use when: very early feature; need to surface fundamental issues before exposing customers.
+
+**Design partner program:** closed + alpha or beta + external + open-ended.
+
+- Use when: building a feature with deep customer involvement; small set of partner customers (3-10) collaborating closely on shaping the feature.
+
+**Open early access:** open + beta or RC + external + time-bounded (4-12 weeks).
+
+- Use when: pre-GA marketing matters; the feature is sufficiently polished that early access can build audience; team can handle the volume.
+
+**RC validation:** open or closed + RC + external + time-bounded (2-4 weeks).
+
+- Use when: the feature is essentially launch-ready; need last validation at scale or in the production environment.
+
+**Internal-only RC:** closed + RC + internal + time-bounded.
+
+- Use when: the feature is for internal users (e.g., admin tools used by support team), or when external testing is impractical for the type of feature.
+
+---
+
+## When the combination decision goes wrong
+
+Common mismatches.
+
+**Open + alpha.** Open cohorts on an alpha-stage feature exposes customers to bugs the team has not caught. Damages trust. Cure: alpha should be closed; open up at beta stage when the feature is more polished.
+
+**Closed + RC.** Closed RCs miss the at-scale validation that RCs are meant to provide. The cohort is too small to surface scale issues. Cure: RCs are usually open or large-closed.
+
+**External + alpha + open-ended.** External customers commit to an alpha that has no end date and many bugs. Engagement decays. Cure: alpha should be internal or trusted-partner only; external alpha should be time-bounded and limited.
+
+**Open + beta + open-ended.** Volume cohort with no end date. The beta runs forever; participants lose interest; the team cannot synthesize. Cure: time-bound the beta; force graduation decision.
+
+---
+
+## Beta type for specific contexts
+
+Common contexts and the typical type combinations.
+
+**B2B SaaS feature launch.** Closed + beta + external + time-bounded. 20-200 participants from existing customer base, 6-8 weeks.
+
+**Consumer product launch.** Open + beta + external + time-bounded (or open + RC). 1,000-10,000+ participants, 4-8 weeks. Marketing value is part of the rationale.
+
+**Enterprise platform major release.** Closed + alpha + design-partner + open-ended initially, then closed + beta + extended cohort + time-bounded for validation.
+
+**Developer-tool launch.** Open + beta + external + time-bounded, with public roadmap and community feedback channels.
+
+**Internal tool launch.** Closed + alpha or beta + internal + time-bounded. The cohort is the internal users who will use the tool post-GA.
+
+**Compliance-impacting feature.** Closed + extended beta + external + carefully selected design partners. The validation needs to surface compliance edge cases before GA.
+
+---
+
+## Common beta-type failures
+
+**Defaulting to soft-launch.** Skipping beta-type decisions and just turning the feature on for some users. Decide the type explicitly.
+
+**Defaulting to open beta for everything.** Open volume substituted for calibrated cohorts. Open is right for some contexts; not for all.
+
+**Mismatching alpha/beta/RC to feature polish.** Calling something "beta" when it is alpha (too many bugs); calling something "RC" when it is beta (not yet production-grade).
+
+**Internal-only when external context matters.** Validates an internal experience that does not match what customers will encounter.
+
+**Open-ended without graduation criteria.** Beta drifts into perpetual beta because no firm end was set.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The four axes (closed/open, alpha/beta/RC, internal/external, time-bounded/open-ended). Strengths and weaknesses per axis. Worked combinations. Common mismatches. Beta type for specific contexts. Common failures.
+
+## Implementation choices that stay internal
+
+Specific platform feature-flagging configurations. Specific recruitment platforms and processes. Specific NDA templates. Specific time-bounding workflows. The team's own conventions for beta-type decisions in different contexts. These vary by team and tooling.

--- a/skills/beta-program-management/references/beta-wind-down-communication.md
+++ b/skills/beta-program-management/references/beta-wind-down-communication.md
@@ -1,0 +1,231 @@
+# Beta wind-down communication
+
+Graduation announcement, transition, recognition, postmortem. Treating participants well.
+
+The beta's wind-down is its closing impression. Done well, participants leave the beta engaged and willing to participate in future betas. Done badly, participants feel discarded after providing significant feedback.
+
+---
+
+## The graduation announcement
+
+Communication to participants when the beta graduates.
+
+**Timing.** 1-2 weeks before graduation, with confirmation at graduation.
+
+**Content.**
+
+- The feature is graduating to GA. Specific date.
+- What changes for participants.
+- What does not change.
+- Recognition or thank-you for participation.
+- Information about post-GA support, pricing, or special terms.
+- Any beta-specific features or terms that will not carry to GA.
+
+**Tone.** Warm, appreciative. Participants invested time; the announcement reflects that.
+
+**Length.** 300-600 words. Long enough to cover the necessary information; short enough to be readable.
+
+---
+
+## What changes for participants at graduation
+
+**Continued access.** Most beta participants retain access to the feature post-GA. The beta was their preview; GA continues their use.
+
+**Pricing transitions.** If the feature has paid tiers, participants need to know:
+
+- Does beta access include free use of the feature post-GA for some period?
+- Does the feature require an upgraded plan for full access?
+- Are there special pricing terms for beta participants (early-bird discount, lifetime grandfathering, etc.)?
+
+**Feature stability.** Communicate what level of stability participants should expect post-GA. Beta features sometimes have rough edges; GA implies stability commitments.
+
+**Support transition.** Beta-aware support routing typically ends at GA. Participants now use standard support channels.
+
+**Beta-only features.** Some features in the beta may not make GA (deprecated, simplified, removed). Participants who relied on those features need clear communication about alternatives.
+
+---
+
+## Recognition
+
+Beta participants invested time providing feedback. Recognition matters.
+
+**Forms of recognition.**
+
+- **Named in changelog or launch communications** (with consent).
+- **Gift cards or compensation** for substantial time investment.
+- **Swag** for closed-beta participants.
+- **Advance access to future betas.**
+- **Direct thank-you from product team**, often via personal email.
+- **Public acknowledgment** in marketing or community materials.
+
+**Calibration.**
+
+- Light betas: direct thank-you, possibly modest swag.
+- Standard betas: thank-you, swag, post-GA continued access on favorable terms.
+- Design partner programs: substantial recognition, sometimes including case studies, named partnerships, financial compensation.
+
+**The discipline.** Recognition matches the participant's investment. Light recognition for a heavy commitment feels dismissive; heavy recognition for a light commitment is unnecessary.
+
+---
+
+## The post-beta survey
+
+A final feedback collection at graduation.
+
+**Purpose.** Capture overall reflections on the beta experience and the feature.
+
+**Content.**
+
+- Overall feature satisfaction.
+- Likelihood to continue using post-GA.
+- Likelihood to recommend.
+- What worked well in the beta program (process feedback, not feature feedback).
+- What could be improved in future betas.
+- Optional open-ended reflections.
+
+**Length.** 5-10 questions, 5-10 minutes to complete.
+
+**Why it matters.** The post-beta survey closes the loop with participants and informs the team's beta-program practice. The process feedback is particularly valuable: future betas improve based on past feedback.
+
+---
+
+## The beta postmortem
+
+Internal review of what the beta produced.
+
+**Timing.** Within 1-2 weeks of graduation.
+
+**Participants.** Beta program manager, product manager, engineering lead, design lead, customer success lead, support lead.
+
+**Content.**
+
+- What was learned from the beta? (Patterns, behavioral validation, friction discovery.)
+- What changed in the GA launch as a result?
+- What worked well in the beta program (process)?
+- What did not work? What would the team do differently next time?
+- What patterns recur across multiple betas? Are there lessons for the broader practice?
+
+**Output.** A short postmortem document. Surfaces lessons. Informs future betas.
+
+**Why it matters.** Beta programs improve through accumulated learning. Without postmortems, the team repeats the same mistakes; with postmortems, the practice gets sharper over time.
+
+---
+
+## Recruiting for future betas
+
+The wind-down is a recruiting moment for future betas.
+
+**The pattern.** Participants who had a good beta experience are likely to participate in future ones. The wind-down communication can include an invitation: would they like to be considered for future betas?
+
+**The benefits.**
+
+- Builds a roster of engaged beta participants for future programs.
+- Reduces recruiting overhead for future betas.
+- Strengthens the participant relationship.
+
+**The discipline.** Do not over-commit; future betas should not be promised in ways that are not honored. The invitation is to be considered, not a guarantee.
+
+---
+
+## Handling beta-only features that do not make GA
+
+Sometimes beta features include capabilities that are removed or simplified at GA.
+
+**Why it happens.**
+
+- The feature scope was reduced based on beta findings.
+- Some capabilities did not perform well enough to ship at GA.
+- The team learned the capability was not load-bearing.
+
+**The communication.**
+
+- Surface the change explicitly. Do not silently remove.
+- Explain the reasoning where appropriate.
+- Provide alternatives or workarounds for participants who relied on the removed capability.
+- Acknowledge the impact on participants.
+
+**The participant impact.** Some participants may push back; their usage assumed the capability would persist. The team must decide whether to extend support, offer migration help, or accept the participant churn.
+
+---
+
+## Special cases: extended beta
+
+Some betas extend beyond their planned duration.
+
+**Communication for extension.**
+
+- Tell participants when the extension is decided, not when the original end date passes.
+- Explain why the extension is needed.
+- Give a specific new end date.
+- Acknowledge the participant impact (they committed to the original timeline).
+- Provide an option to opt out if the extension is significant.
+
+**Avoid.**
+
+- Silent extensions where the planned end passes without acknowledgment.
+- Multiple extensions that erode the timeline credibility.
+- Extensions framed as "no big deal" when they affect participants' ongoing time investment.
+
+---
+
+## Special cases: beta cancellation
+
+Sometimes the team decides not to graduate the feature to GA.
+
+**Why it happens.**
+
+- The beta revealed the feature does not work as intended.
+- Strategic shift redirected resources.
+- The feature would compete poorly at GA scale.
+
+**The communication.**
+
+- Be honest about the cancellation.
+- Acknowledge the participants' time investment.
+- Explain (at appropriate level of detail) why the cancellation.
+- Discuss what happens to participants' beta data, configurations, etc.
+- Recognize the participation despite the cancellation.
+
+**The participant impact.** Cancellation can frustrate participants who invested time. Honest communication and good recognition mitigate the impact.
+
+---
+
+## Long-term participant relationships
+
+Beta participants represent ongoing relationships, not transactional interactions.
+
+**The relationship investment.**
+
+- Participants who had a good beta experience may become advocates, references, case study subjects.
+- Future product strategy benefits from continued conversation with beta alumni.
+- Customer success can use beta participation as relationship signal.
+
+**The maintenance.** Periodic check-ins with notable beta participants strengthen relationships even outside formal beta programs. Light-touch communication (annual newsletter, occasional product updates, personalized outreach for major launches) maintains the connection.
+
+---
+
+## Common wind-down failures
+
+**Silent graduation.** Beta participants discover graduation through the public launch announcement rather than through advance communication.
+
+**Vague transition information.** Participants do not know what changes for them; uncertainty produces churn.
+
+**Insufficient recognition.** Heavy participation rewarded with thin thank-you; participants feel dismissed.
+
+**Missing post-beta survey.** Process feedback is lost; future betas do not improve.
+
+**No postmortem.** Internal lessons are lost; the team repeats mistakes.
+
+**Surprise feature removals.** Beta-only features removed without warning; participants discover at GA that capabilities they relied on are gone.
+
+**No invitation to future betas.** The relationship ends at graduation; future betas restart recruitment from scratch.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The graduation announcement structure. What changes for participants. Recognition forms and calibration. The post-beta survey. The beta postmortem. Recruiting for future betas. Handling beta-only feature removals. Extended betas. Beta cancellations. Long-term relationships. Common failures.
+
+## Implementation choices that stay internal
+
+Specific graduation announcement templates. Specific recognition packages and approval. Specific postmortem templates. Specific CRM tracking of beta alumni. The team's own conventions for relationship maintenance. These vary by team.

--- a/skills/beta-program-management/references/cohort-sizing-patterns.md
+++ b/skills/beta-program-management/references/cohort-sizing-patterns.md
@@ -1,0 +1,207 @@
+# Cohort sizing patterns
+
+Saturation patterns by feedback type. Sizing decisions for different beta goals. The size-matches-signal principle.
+
+Cohort size is a calibration decision, not a maximize-volume decision. Each beta has a specific signal need; the right cohort size is the smallest that produces that signal reliably.
+
+---
+
+## Saturation patterns by feedback type
+
+Different kinds of feedback saturate at different cohort sizes.
+
+**Critical bugs (crashes, data loss, broken core flows).**
+
+- Saturate fast: most surface in the first 1-2 weeks with 20-30 participants.
+- Beyond ~50 participants, additional volume produces few new critical bugs.
+- The cohort size for bug discovery: 20-50 participants is usually sufficient.
+
+**Friction issues (workflow interruptions, confusing flows, slow performance in specific cases).**
+
+- Saturate moderately: most surface in 2-4 weeks with 50-100 participants.
+- Volume helps surface friction in less-common usage patterns.
+- The cohort size for friction discovery: 50-200 participants typical.
+
+**Behavioral patterns (how users actually use the feature, what flows they follow, what features they ignore).**
+
+- Saturate slowly: 4-8 weeks with 100-500 participants needed for clear patterns.
+- Patterns require usage volume; small cohorts may not generate enough usage to see patterns.
+- The cohort size for behavioral signal: 100-500+ participants typical.
+
+**Edge cases (unusual configurations, rare usage contexts, specific environment combinations).**
+
+- Saturate very slowly: 500+ participants needed; some edge cases never surface in beta and are discovered post-GA.
+- Volume is the only way to surface low-frequency edge cases.
+- The cohort size for edge case discovery: 500-5,000+ participants; even at this scale, rare cases may slip through.
+
+**Performance under load (scale-related issues, infrastructure constraints, concurrent-use issues).**
+
+- Saturate when cohort exceeds the load threshold the issue requires.
+- 1,000-10,000+ participants for at-scale validation.
+- Often the central goal of RC betas.
+
+---
+
+## Sizing decisions for different beta goals
+
+The cohort size matches what the team needs to learn.
+
+**Goal: Catch critical bugs before GA.**
+
+- Cohort size: 20-50 participants.
+- Duration: 2-4 weeks.
+- Closed cohort, calibrated to GA user profile.
+- Most critical bugs surface fast; beyond this, returns diminish.
+
+**Goal: Validate behavioral assumptions about how users will use the feature.**
+
+- Cohort size: 100-300 participants.
+- Duration: 4-8 weeks.
+- Closed cohort with variety across usage patterns.
+- Behavioral patterns need usage volume to emerge clearly.
+
+**Goal: Validate product-market fit assumptions for a major new feature.**
+
+- Cohort size: 200-500 participants.
+- Duration: 8-12 weeks.
+- Closed cohort spanning segments.
+- Long enough duration to see retention and continued usage, not just initial engagement.
+
+**Goal: Validate at-scale infrastructure for a launch.**
+
+- Cohort size: 1,000-5,000+ participants.
+- Duration: 4-8 weeks.
+- Often open beta or large closed RC.
+- Volume is the point; calibration is less important than scale.
+
+**Goal: Build a design partner program for ongoing collaboration.**
+
+- Cohort size: 3-10 partners.
+- Duration: open-ended (months to years).
+- Highly calibrated cohort with strong relationships.
+- Depth over breadth; the program is qualitative collaboration, not at-scale validation.
+
+**Goal: Generate pre-launch marketing and audience.**
+
+- Cohort size: 1,000-10,000+ participants.
+- Duration: 4-12 weeks.
+- Open beta with marketing-driven recruitment.
+- The cohort serves both validation and pre-launch buzz.
+
+---
+
+## The size-matches-signal principle
+
+The cohort should be the smallest size that produces the signal the team needs.
+
+**Why "smaller is better when calibrated."**
+
+- Smaller cohorts produce more synthesizable feedback. The team can read every transcript, review every survey response, follow up with every participant who reports an issue.
+- Smaller cohorts make participant relationships stronger. Each participant feels seen; engagement is higher.
+- Larger cohorts produce volume that can drown signal. The team cannot synthesize 5,000 pieces of feedback as well as 50.
+
+**When larger is necessary.**
+
+- The team needs at-scale validation (load, concurrent users, edge cases).
+- The team needs marketing reach.
+- The team needs behavioral signal that requires substantial usage volume.
+
+**The discipline.** Default to the smallest cohort that produces the needed signal. Justify any larger size against specific signal needs.
+
+---
+
+## Cohort size and feedback channel design
+
+Larger cohorts require different feedback channel design than smaller ones.
+
+**For cohorts of 5-50.**
+
+- Direct channels work: email, dedicated Slack, structured interviews.
+- The team can engage with each participant individually.
+- Synthesis can include reviewing all feedback.
+
+**For cohorts of 50-500.**
+
+- Mixed channels: structured surveys + sample interviews + in-product feedback widgets.
+- Sampling required for synthesis: review all surveys, sample interviews and tickets.
+
+**For cohorts of 500-5,000.**
+
+- Aggregated channels: in-product feedback widgets, support ticket aggregation, automated surveys.
+- Heavy sampling: review aggregate patterns, sample individual feedback.
+
+**For cohorts of 5,000+.**
+
+- Volume aggregation: NPS-style scoring, automated categorization, statistical analysis of usage patterns.
+- Individual feedback rarely reviewed; patterns are the signal.
+
+The implication. Beta planning includes feedback channel design appropriate to cohort size. Mismatches (small cohort with aggregated channels, or large cohort with direct channels) produce friction.
+
+---
+
+## Adjusting cohort size mid-beta
+
+Sometimes the team realizes mid-beta that the cohort is wrong-sized.
+
+**Cohort too small.**
+
+- Symptom: feedback volume is insufficient to see patterns.
+- Cure: open recruitment for additional participants, applying the same selection criteria.
+- Caution: late additions have less time in the beta; their feedback covers less of the beta period.
+
+**Cohort too large.**
+
+- Symptom: feedback volume overwhelms synthesis capacity; the team is reactive rather than analytical.
+- Cure: usually do not reduce; instead, scale up synthesis capacity (more reviewers, more aggregation tooling). Reducing cohort feels like a betrayal to participants.
+- Prevention: better sizing decision upstream.
+
+**Cohort skewed.**
+
+- Symptom: feedback patterns reflect skew (one segment over-represented).
+- Cure: targeted recruitment to balance the cohort, or explicit acknowledgment of skew in synthesis.
+- The cohort cannot always be re-balanced quickly; sometimes the synthesis adjusts for the skew rather than the cohort.
+
+---
+
+## Cohort and beta duration
+
+Cohort size and duration interact.
+
+**Short beta (2-4 weeks).** Smaller cohort works because feedback saturates faster on critical issues. 20-100 participants typical.
+
+**Medium beta (4-8 weeks).** Mid-size cohort matches the duration. 50-300 participants typical.
+
+**Long beta (8+ weeks).** Larger cohort works because behavioral signal needs duration. 100-1,000+ participants.
+
+**The mismatch failures.**
+
+- Long beta with small cohort: insufficient volume; the duration produces no proportional signal.
+- Short beta with very large cohort: insufficient time; the volume produces no proportional learning.
+
+The matching. Beta duration and cohort size both follow from signal need; they should be consistent.
+
+---
+
+## Common cohort sizing failures
+
+**Defaulting to "more is better."** Large cohorts where small calibrated ones would produce stronger signal.
+
+**Sizing without reference to signal need.** Cohort size set arbitrarily; team cannot defend why this size.
+
+**Cohort size mismatched to duration.** Small cohort in a long beta produces sparse signal; large cohort in a short beta produces noise.
+
+**Cohort size mismatched to feedback channel design.** Direct channels with too many participants overwhelm; aggregated channels with too few participants under-utilize.
+
+**Mid-beta cohort changes without synthesis adjustment.** Cohort grows or shrinks; the synthesis approach does not adapt.
+
+**Confusing volume with signal.** Larger cohort numbers reported as success; the team did not actually learn proportionally more.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The saturation patterns by feedback type. Sizing decisions for different beta goals. The size-matches-signal principle. Cohort size and feedback channel design alignment. Adjusting cohort size mid-beta. Cohort and beta duration interaction. Common failures.
+
+## Implementation choices that stay internal
+
+Specific recruitment automation tooling. Specific aggregation tooling for large cohorts. Specific synthesis processes for different cohort sizes. The team's own conventions for sizing within the bands. These vary by team and tooling.

--- a/skills/beta-program-management/references/common-beta-failures.md
+++ b/skills/beta-program-management/references/common-beta-failures.md
@@ -1,0 +1,205 @@
+# Common beta failures
+
+Ten-plus failure patterns with diagnoses and cures. The cross-cutting pattern: most beta failures share a single root, which is treating beta as ceremony rather than as decision input.
+
+---
+
+## Failure 1: Our beta produced no signal
+
+**Symptom.** The beta ran. The team has nothing actionable to show for it. The GA launch will happen with the same uncertainty the beta was supposed to address.
+
+**Diagnosis.** Soft-launch pattern. No structured selection, no defined feedback collection, no graduation criteria.
+
+**Cure.** Restructure the beta. Define the cohort, channels, criteria, and triage cadence. If the current beta cannot be saved, plan a more structured beta for the next feature.
+
+**Prevention.** Plan beta structure at the start, not after the beta has been running.
+
+---
+
+## Failure 2: Our beta has 5,000 users and we cannot synthesize
+
+**Symptom.** Open beta or large cohort. Volume is high. The team is reactive rather than analytical. Synthesis cannot keep up.
+
+**Diagnosis.** Kitchen-sink. Cohort too large for the structured signal the team needs.
+
+**Cure.** Two paths. Scale up synthesis capacity (more reviewers, aggregation tooling). Or reduce the active cohort by focusing structured channels on a calibrated subset (e.g., select 200 active participants for interviews; let the rest contribute through aggregated channels).
+
+**Prevention.** Size cohort to match synthesis capacity. Larger cohorts require aggregated feedback infrastructure.
+
+---
+
+## Failure 3: Our beta participants never gave feedback
+
+**Symptom.** Few survey responses. Few in-product widget submissions. Few interview signups. The cohort is silent.
+
+**Diagnosis.** Onboarding contract was unclear or feedback channels were friction-laden. Participants did not know what was expected or could not easily give feedback.
+
+**Cure.** Re-engage. Send specific, prompted requests for feedback. Make the channels easier (in-product prompts, simpler forms). Communicate what is being heard from those who do respond.
+
+**Prevention.** Onboarding makes feedback expectations explicit. Channels are designed for low friction.
+
+---
+
+## Failure 4: We graduated to GA on schedule but launched with critical bugs
+
+**Symptom.** The GA launches. Critical issues that the beta cohort would have surfaced (or did surface but were not addressed) appear post-GA.
+
+**Diagnosis.** Graduation criteria were not enforced. The decision was calendar-driven; the team graduated before the criteria were met.
+
+**Cure.** Damage control: address the bugs quickly, communicate transparently, reset support expectations.
+
+**Prevention.** Graduation criteria are enforced honestly. The decision is criteria-driven, not calendar-driven. If criteria are not met, extend the beta or graduate with explicit acknowledgment of unmet criteria.
+
+---
+
+## Failure 5: Our beta has been running for 8 months with no graduation
+
+**Symptom.** Beta has run far longer than planned. No firm graduation date. The team has avoided the GA decision.
+
+**Diagnosis.** Perpetual beta. No firm graduation criteria; the team avoided commitment.
+
+**Cure.** Force the graduation decision. Define criteria explicitly. Decide: graduate now, graduate by a specific date, or reset the beta.
+
+**Prevention.** Time-bound the beta from the start. Define graduation criteria upfront. Force the decision when the criteria are met or when the time is up.
+
+---
+
+## Failure 6: Beta participants vented on Twitter before the launch
+
+**Symptom.** Beta participants posted screenshots, mentioned the feature publicly, or discussed the beta outside the cohort.
+
+**Diagnosis.** NDA missing or unclear. Trust violation early erodes participant willingness; broader visibility may damage launch plans.
+
+**Cure.** Damage control depending on impact. Reach out to participants individually. Adjust the launch plan if the leaked information affects positioning.
+
+**Prevention.** NDAs in place where appropriate. Confidentiality expectations explicit in onboarding. Cohort selection includes trust assessment.
+
+---
+
+## Failure 7: The beta surfaced patterns we did not act on
+
+**Symptom.** The beta produced clear feedback about specific issues. The GA launches without addressing them. Customers hit the same issues post-GA.
+
+**Diagnosis.** Mid-beta triage missing. Feedback was collected but not used during the beta.
+
+**Cure.** For the GA: address the issues quickly post-launch; communicate transparently. For future betas: implement the triage cadence and iteration discipline.
+
+**Prevention.** Weekly triage cadence. Categorization of feedback. Iteration on critical and high-impact items during the beta.
+
+---
+
+## Failure 8: The GA launch surprised us
+
+**Symptom.** Issues emerge at GA that the team did not anticipate from the beta. The beta did not actually validate the GA experience.
+
+**Diagnosis.** Cohort or feedback structure was wrong. The cohort did not match the GA user; the channels did not surface the kinds of issues the GA exposed.
+
+**Cure.** Address the surprises post-GA. Investigate the gap between beta and GA experience. Apply lessons to future betas.
+
+**Prevention.** Cohort calibrated to GA user. Channels designed to surface the kinds of signal the GA decision needs. Validation of the cohort-GA match before the beta starts.
+
+---
+
+## Failure 9: Beta participants felt ignored after providing feedback
+
+**Symptom.** Participants gave feedback. The team did not communicate what was heard or addressed. Participants disengaged.
+
+**Diagnosis.** Communication discipline missing. Participants commit time and want to know it mattered.
+
+**Cure.** Re-engage with appreciation and specific acknowledgment. For future participants, tighten the communication discipline.
+
+**Prevention.** Weekly or bi-weekly updates to participants. Updates reference specific feedback. Participants who give substantive feedback receive direct acknowledgment.
+
+---
+
+## Failure 10: We ran a closed beta that was effectively employees only
+
+**Symptom.** The "external beta" included primarily employees, employees' family members, or very-friendly customers. Not actual representative customers.
+
+**Diagnosis.** Internal-only beta with external branding. Missed the customer-context complexity.
+
+**Cure.** Run a true external beta before GA, even if shorter. Apply lessons to future cohort selection.
+
+**Prevention.** Cohort selection includes "are these actually external customers using the product in real conditions?" Internal-leaning cohorts get flagged in cohort review.
+
+---
+
+## Failure 11: Cohort and channels mismatched
+
+**Symptom.** Small cohort with aggregated channels (no signal extracted from the small volume). Or large cohort with direct channels (overwhelmed synthesis).
+
+**Diagnosis.** Cohort size and channel design did not align.
+
+**Cure.** Adjust mid-beta if possible: scale synthesis for large cohorts, deepen direct channels for small ones.
+
+**Prevention.** Cohort size and channel design decided together. Mismatches caught at planning.
+
+---
+
+## Failure 12: Feedback collected but not synthesized
+
+**Symptom.** Surveys completed; widgets submitted; interviews recorded. The beta ends; the team has not synthesized the feedback into patterns or recommendations.
+
+**Diagnosis.** Synthesis was treated as optional or postponed. Without synthesis, the feedback never produced decisions.
+
+**Cure.** Allocate synthesis time post-beta. Apply discovery-research-synthesis discipline (see that skill). Produce the synthesis even if delayed.
+
+**Prevention.** Plan synthesis as part of the beta timeline. Allocate explicit time and ownership.
+
+---
+
+## Failure 13: Wind-down treated participants poorly
+
+**Symptom.** Participants graduated to GA without clear transition information. Recognition was thin or missing. Future-beta recruitment is harder because alumni are unenthused.
+
+**Diagnosis.** Wind-down communication missed key elements. Recognition was insufficient for the time invested.
+
+**Cure.** Reach out individually to participants who feel underrecognized. Adjust future wind-down templates.
+
+**Prevention.** Wind-down communication template covers all elements (transition, recognition, post-survey, future beta invitation).
+
+---
+
+## Failure 14: No postmortem
+
+**Symptom.** Beta ends; team moves on. Lessons from this beta do not inform future ones. Patterns recur across multiple betas because nobody surfaced them.
+
+**Diagnosis.** Postmortem was skipped. The beta program does not improve.
+
+**Cure.** Run a delayed postmortem if feasible. Establish postmortem as a non-negotiable step.
+
+**Prevention.** Postmortem on the timeline. Owner identified. Lessons documented and applied.
+
+---
+
+## Failure 15: Beta scope crept
+
+**Symptom.** Mid-beta, additional capabilities were added based on participant requests. The beta validated a different feature than the original.
+
+**Diagnosis.** Scope creep during the beta. Feature requests were absorbed into the live beta.
+
+**Cure.** Reset the beta if the changes are significant. Capture for post-GA roadmap rather than addressing during the beta.
+
+**Prevention.** Triage discipline rejects scope-expanding feature requests during the beta. Capture for post-GA; do not add.
+
+---
+
+## The cross-cutting pattern
+
+Most beta failures share a single root: treating beta as ceremony rather than as decision input.
+
+Ceremony focuses on running a beta because betas are expected: invite participants, collect feedback, ship the GA. The beta is a stage gate, not a learning loop.
+
+Decision input focuses on what the beta needs to inform: which decisions, what signal will inform them, what cohort and channels will produce that signal. The beta is structured around the decision it serves.
+
+The fix for almost any beta failure starts with the same question: what specifically did the team need to learn from this beta, and how is the beta structured to produce that learning? When the answers are clear, the beta becomes load-bearing. When the answers are vague, the beta becomes ceremony.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The fifteen failure patterns with diagnoses and cures. The cross-cutting ceremony-vs-decision pattern.
+
+## Implementation choices that stay internal
+
+Specific failure-pattern detection. Specific reviewer training. Specific intervention patterns. The team's own conventions for catching failures early. These vary by team.

--- a/skills/beta-program-management/references/feedback-collection-patterns.md
+++ b/skills/beta-program-management/references/feedback-collection-patterns.md
@@ -1,0 +1,295 @@
+# Feedback collection patterns
+
+Structured surveys, async forms, interviews, in-product widgets, beta-aware support. Channels that work and fail. Channel mix discipline.
+
+The feedback collection design is what determines whether the beta produces signal or noise. Structured channels capture usable data; ad-hoc venting channels produce volume that does not synthesize.
+
+---
+
+## Structured surveys
+
+Surveys at defined points in the beta.
+
+**The structure.**
+
+- 5-15 questions per survey.
+- Mix of structured questions (Likert scale, multiple choice) and 1-2 open-ended questions.
+- Tied to specific learning goals: each question has a reason for being there.
+- Sent at defined points: end of week 1, mid-beta, end of beta.
+
+**Strong survey questions.**
+
+- "On a scale of 1-7, how likely are you to use this feature daily?" (closed-ended; quantitative signal)
+- "What's the most useful thing you've done with this feature so far?" (open-ended; surfaces use cases)
+- "What was confusing or frustrating in your first week?" (open-ended; surfaces friction)
+- "Compared to how you did this task before, is this feature better, worse, or about the same?" (specific comparison)
+
+**Weak survey questions.**
+
+- "Do you like the feature?" (binary; not actionable)
+- "What features would you like next?" (out of beta scope; produces wishlist)
+- "How can we improve?" (too open-ended; produces unfocused responses)
+
+**Why structured surveys work.**
+
+- Quantitative signal aggregates. Mid-beta NPS or satisfaction trend lines surface signal.
+- Open-ended questions tied to specific topics produce focused qualitative data.
+- Participants understand what is being asked; response rates are higher than for vague open-ended surveys.
+
+---
+
+## Async feedback forms
+
+Forms participants fill when they encounter specific issues.
+
+**The structure.**
+
+- Always-available link or in-product entry point.
+- Form fields prompt for specific information: use case, severity, expected vs actual behavior, screenshots if applicable.
+- Auto-routes to the team's tracking system (issue tracker, feedback aggregation tool).
+
+**Strong form fields.**
+
+- "What were you trying to do?" (use case context)
+- "What did you expect to happen?" (mental model)
+- "What actually happened?" (observed behavior)
+- "How blocking is this?" (severity)
+- "Steps to reproduce" (when applicable)
+
+**Why async forms work.**
+
+- Captures issues at the moment they happen.
+- Structured fields produce consistent data across submissions.
+- Synthesis is easier when each submission has the same information shape.
+
+---
+
+## Structured interviews
+
+30-60 minute interviews with a subset of participants.
+
+**The structure.**
+
+- 5-15 interviews per beta, depending on cohort size.
+- Mid-beta or near end of beta.
+- Discussion guide tied to the team's learning goals.
+- Recorded with permission; transcribed for synthesis.
+
+**Strong interview prompts.**
+
+- "Walk me through the last time you used this feature. What were you trying to do?"
+- "What was the most useful thing about it? What was the most frustrating?"
+- "How did you decide to use this instead of [alternative]?"
+- "Looking back, what do you wish was different?"
+
+**Why structured interviews work.**
+
+- Depth that surveys cannot capture.
+- Specific moments and decisions surface in conversation that participants would not write into surveys.
+- The qualitative data complements the quantitative survey data.
+
+**Cross-reference `discovery-research-synthesis`** for the broader interview discipline. Beta interviews are validation-stage; the interviewing methodology is similar.
+
+---
+
+## In-product feedback widgets
+
+Feedback collection contextualized to the moment.
+
+**The structure.**
+
+- Trigger: button or prompt within the beta feature.
+- Captures: what the user was doing (page or context), brief feedback text, optional rating.
+- Routes to the team's tracking system.
+
+**Strong in-product widget design.**
+
+- Triggered after specific moments (completing the feature's primary action, abandoning a flow).
+- Brief: 1-3 fields max.
+- Optional severity or sentiment rating.
+- Captures the page or context automatically.
+
+**Why in-product widgets work.**
+
+- Capture friction at the moment, not weeks later.
+- Context is preserved automatically.
+- Low friction encourages submissions.
+
+---
+
+## Beta-aware support tickets
+
+Support tickets routed to a beta-aware support team.
+
+**The structure.**
+
+- Beta participants flagged in the support system.
+- Tickets from beta participants get special handling: tagged "beta," routed to support reps trained on the feature, given priority response.
+- Common beta issues documented for the support team in advance.
+
+**Strong beta-support practices.**
+
+- Faster response than standard tickets (the participant is doing the team a favor).
+- Support reps escalate beta issues to product team where the issue affects beta program decisions.
+- Patterns across tickets surface to the beta program manager.
+
+**Why beta-aware support works.**
+
+- Surfaces issues participants encounter "in the wild," not just the issues they choose to flag through formal channels.
+- Captures the support burden of the feature, which informs GA support readiness.
+
+---
+
+## Channels that fail
+
+Common feedback channels that produce noise rather than signal.
+
+**Beta-only Slack channels for venting.**
+
+- Participants vent in real time.
+- Mixes critical signal with casual chat.
+- Nobody synthesizes.
+- High-engagement participants drown out quieter ones.
+- Cure: structured channels instead, or use Slack for community building rather than feedback collection.
+
+**"Reply to this email with feedback."**
+
+- Returns long unstructured emails.
+- Synthesis is hard; useful patterns get lost.
+- Cure: structured forms or surveys.
+
+**End-of-beta survey only.**
+
+- Catches only what participants remember at the end.
+- In-the-moment friction is forgotten.
+- Cure: surveys at multiple points; in-product widgets for moment-of capture.
+
+**"Tell us anything."**
+
+- Unfocused open-ended prompts produce unfocused responses.
+- Participants do not know what is wanted; many do not respond.
+- Cure: specific prompts tied to what the team needs to learn.
+
+---
+
+## Channel mix discipline
+
+Most structured betas use 3-5 channels. Each surfaces different signal.
+
+**Typical channel mix.**
+
+- 1 structured survey at end of week 1 (quantitative + first-impression qualitative).
+- 1 structured survey at mid-beta (quantitative trend + behavior signal).
+- Always-available async feedback form (specific issues as they arise).
+- 5-10 structured interviews near end of beta (qualitative depth).
+- In-product feedback widget (in-the-moment friction).
+- Beta-aware support routing (issues participants choose to escalate).
+
+**The synthesis.** The team synthesizes across channels. Patterns that appear in multiple channels are stronger; signals from a single channel are weaker.
+
+**Channel mix calibration.**
+
+- Smaller cohorts (5-50): more interviews, less aggregation.
+- Larger cohorts (100-500): more surveys and aggregation, fewer interviews.
+- Largest cohorts (500+): heavy aggregation, sampling for interviews.
+
+---
+
+## Feedback synthesis cadence
+
+How feedback gets reviewed during the beta.
+
+**Weekly synthesis.**
+
+- 1-2 hours weekly during the beta.
+- Review feedback across all channels for the week.
+- Categorize: critical bug, friction, feature request, positive signal, edge case.
+- Surface patterns: what recurring feedback are we seeing?
+
+**Bi-weekly pattern review.**
+
+- 1-2 hours bi-weekly.
+- Look at patterns across the past 2-4 weeks.
+- Identify converging signal: which patterns are strengthening?
+- Decide: what to fix during the beta vs what to defer to post-GA roadmap.
+
+**End-of-beta synthesis.**
+
+- Substantial work: 1-2 weeks of synthesis depending on cohort size.
+- Apply discovery-research-synthesis discipline (see that skill).
+- Output: beta synthesis document with patterns, implications, and graduation recommendation.
+
+---
+
+## Feedback signal quality
+
+Not all feedback is equally valuable.
+
+**High-signal feedback.**
+
+- Specific moments of friction with reproducible context.
+- Patterns across multiple participants.
+- Behavioral data showing what users actually do (vs what they say).
+- Comparison to alternatives (what users tried before, why they switched).
+
+**Lower-signal feedback.**
+
+- One-off complaints with no pattern.
+- Hypothetical preferences ("it would be nice if...").
+- Wishlist features unrelated to the beta scope.
+- Venting without specific context.
+
+**The discipline.** Synthesis weights higher-signal feedback. Lower-signal feedback gets noted but does not drive decisions.
+
+---
+
+## Feedback volume management
+
+Managing the flow of feedback as the beta runs.
+
+**Volume signals.**
+
+- Critical issues surface fast: most appear in the first 2 weeks.
+- Friction issues surface continuously through the beta.
+- Behavioral signal accumulates; visible by mid-beta.
+
+**Volume management.**
+
+- The team's synthesis capacity bounds usable volume. Beyond that capacity, additional feedback produces less actionable signal.
+- For larger cohorts, aggregate channels (surveys, in-product widgets) scale better than direct channels (Slack, email).
+
+**Burnout risk.**
+
+- Beta program managers reading 100+ feedback items per week burn out.
+- Triage is the discipline: not all feedback gets equal attention.
+- Critical and pattern feedback gets full attention; one-off venting gets noted briefly.
+
+---
+
+## Common feedback collection failures
+
+**Single-channel reliance.** Only one feedback channel; misses signal that other channels would have caught.
+
+**Channels not tied to learning goals.** Feedback collected without clear purpose; synthesis cannot tell what to do with it.
+
+**Noisy channels (Slack venting).** High volume, low signal-to-noise ratio.
+
+**End-of-beta only.** Misses in-the-moment friction; relies on participant memory.
+
+**Vague prompts.** Open-ended questions without focus; produces unfocused responses.
+
+**No mid-beta synthesis.** Feedback collected but not reviewed until end; opportunities to address issues during the beta missed.
+
+**Feedback channels that conflict.** Multiple Slack channels for the same purpose; participants confused about where to post.
+
+**No closing the loop.** Participants give feedback; team never tells them what was heard or changed; engagement decays.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+Channels that work (structured surveys, async forms, interviews, in-product widgets, beta-aware support). Channels that fail. Channel mix discipline. Feedback synthesis cadence. Signal quality discipline. Volume management. Common failures.
+
+## Implementation choices that stay internal
+
+Specific survey tools and templates. Specific feedback form integrations. Specific in-product widget implementations. Specific support ticketing systems. The team's own conventions for channel selection. These vary by team and tooling.

--- a/skills/beta-program-management/references/mid-beta-triage-and-iteration.md
+++ b/skills/beta-program-management/references/mid-beta-triage-and-iteration.md
@@ -1,0 +1,216 @@
+# Mid-beta triage and iteration
+
+Triage cadence. Iteration discipline (what to fix during the beta, what to defer). Communication with participants.
+
+Betas where the team responds to feedback during the beta produce stronger signal than betas where the team waits for the end. Mid-beta triage turns a static validation into an iterative one.
+
+---
+
+## The triage cadence
+
+How the team reviews feedback during the beta.
+
+**Weekly triage (1-2 hours).**
+
+- Review feedback across all channels for the week.
+- Categorize each piece: critical bug, friction issue, feature request, positive signal, edge case.
+- Tag for action: fix this week, fix later in the beta, defer to post-GA, no action needed (one-off).
+- Identify any critical issues warranting immediate response.
+
+**Bi-weekly pattern review (1-2 hours).**
+
+- Look at patterns across the past 2-4 weeks.
+- Identify converging signal: which patterns are strengthening, which are not surfacing in volume?
+- Surface decisions: what to address in the remaining beta period.
+
+**As-needed escalation.**
+
+- Critical issues (data loss, security, broken core flows) get same-day response regardless of cadence.
+- The triage cadence does not delay critical-issue response.
+
+---
+
+## Categorization
+
+Each piece of feedback gets categorized.
+
+**Categories.**
+
+- **Critical bug.** Crashes, data loss, broken core flows, security issues. Must be fixed before GA.
+- **Friction issue.** Workflows that are confusing, slow, or sub-optimal but functional. Fix during beta where feasible; document otherwise.
+- **Feature request.** Capability the participant wants that is outside beta scope. Capture for post-GA roadmap; do not add during beta.
+- **Positive signal.** What is working well; what users find valuable. Surfaces what to preserve in GA and what to highlight in marketing.
+- **Edge case.** Unusual configurations or contexts. Note for post-GA monitoring; address only if affecting many participants.
+- **One-off.** Single observation without pattern. Note briefly; do not action.
+
+**Why categorization matters.**
+
+- Different categories have different action paths. Treating all feedback the same overwhelms triage.
+- The categorization is the basis for the iteration decisions.
+
+---
+
+## What to fix during the beta
+
+The team should fix some things during the beta and defer others.
+
+**Fix during the beta.**
+
+- Critical bugs that prevent participants from using the feature. The beta cannot validate the feature if participants cannot use it.
+- Friction issues that are clearly addressable and significantly affect participant experience. Fixing them produces stronger end-of-beta signal.
+- Issues that, if unfixed, will surface again post-GA at higher cost.
+- Issues that participants are about to escalate publicly (if NDA-relevant) or that damage trust if left.
+
+**Defer to post-GA.**
+
+- Feature requests outside beta scope.
+- Friction issues that affect a small subset of users in ways the team can document.
+- Polish work that does not block the GA decision.
+- Edge cases that do not affect mainline usage.
+
+**The "what changes the GA decision" test.** If fixing this issue affects whether the team can ship to GA, fix it. If it does not affect the GA decision, capture it for post-GA roadmap.
+
+---
+
+## The iteration discipline
+
+Mid-beta iteration adds value but has constraints.
+
+**The discipline.**
+
+- Iterate on the feature, not the beta scope. Adding features to the beta mid-way confuses participants and dilutes signal.
+- Fix critical and high-impact friction; capture rather than fix lower-impact issues.
+- Communicate iteration to participants: when they see a fix or change, they know it came from their feedback.
+
+**The "do not redesign mid-beta" rule.**
+
+- Significant feature changes mid-beta produce two betas: the pre-change beta and the post-change beta. Neither is fully validated.
+- If significant changes are needed, end the current beta, redesign, and start a new beta. Do not blend them.
+
+**The "no creep" discipline.**
+
+- Mid-beta is not the time to add capabilities outside the beta's original scope.
+- Feature requests get captured for post-GA, not added to the beta.
+- The beta's signal depends on consistency; scope creep undermines the validation.
+
+---
+
+## Communication with participants
+
+Mid-beta communication keeps participants engaged.
+
+**The cadence.**
+
+- Weekly or bi-weekly updates to participants.
+- Format: short email or in-product notification.
+- Content: what was heard, what is being addressed, what is being deferred, what to expect next week.
+
+**Strong update content.**
+
+- "We heard your feedback about the configuration friction in step 3. We pushed a fix this week; please let us know if it is improved."
+- "Several of you reported the dashboard load time is slow at scale. We are investigating; we expect a fix in the next 1-2 weeks."
+- "We are seeing strong positive signal on the new export functionality. We will expand the format options in the next iteration."
+- "Several of you requested integrations beyond the beta scope. We have captured these for post-GA roadmap."
+
+**Why communication matters.**
+
+- Participants who see their feedback acted on engage more substantively.
+- Participants who feel ignored decay.
+- Communication signals to participants that the team is listening.
+
+**Common communication failures.**
+
+- Silence between welcome and end of beta. Participants feel ignored.
+- Generic updates that do not reference specific feedback. Feels performative.
+- Over-communication. Daily updates are too much; participants tune out.
+- Updates that promise more than the team will deliver. Erodes trust when promises are not kept.
+
+---
+
+## The mid-beta health check
+
+A specific mid-beta milestone.
+
+**The milestone.** Roughly the midpoint of the beta. The team takes stock of where the beta is.
+
+**The questions.**
+
+- Is the feedback volume what was expected? If not, what is causing the difference?
+- Are critical issues surfacing or has the team caught them all in the first part of the beta?
+- Are behavioral patterns emerging? What do they suggest for the GA experience?
+- Are participants engaged? Are some segments dropping off?
+- Is the trajectory toward graduation criteria? Where are gaps?
+
+**The output.**
+
+- Adjustments to the beta operations: more triage, more communication, additional cohort recruitment if needed.
+- Surfaced concerns about graduation: are the criteria reachable in the remaining beta time?
+- Surfaced wins: what is going well that the team can build on for GA.
+
+---
+
+## Mid-beta participant churn
+
+Some participants will drop off during the beta.
+
+**Why participants churn.**
+
+- The feature did not match their use case (they expected something different).
+- They lost interest or got busy.
+- They hit critical friction early and gave up.
+- They felt ignored after providing feedback.
+
+**The response.**
+
+- Investigate churn. A subset of churn is normal; high churn is signal.
+- For participants who churned because of friction: address the friction; possibly re-engage them.
+- For participants who churned because of misfit: the cohort may have been miscalibrated; learn for future betas.
+- For participants who felt ignored: tighten the communication discipline; thank them for prior feedback even if they have stopped engaging.
+
+**Replacement recruitment.**
+
+- For betas that need a specific cohort size for signal, replace churned participants if possible.
+- Late-recruited replacements have less time in the beta; their feedback covers less of the beta period.
+- Sometimes accepting churn and a smaller-than-planned cohort is the right call.
+
+---
+
+## Triage anti-patterns
+
+Common ways triage decays.
+
+**Triage skipping.** No formal triage cadence; feedback accumulates without categorization or action.
+
+**Triage as logging.** Feedback gets categorized but never actioned. The categorization is documentation theater.
+
+**Triage by loudest voice.** Loudest participants get attention; quieter ones with similar feedback do not. Skews the synthesis.
+
+**Triage by easiness.** Easy fixes get prioritized regardless of impact. Important harder fixes get deferred indefinitely.
+
+**Triage without communication.** Internal triage happens but participants are not told. They feel ignored.
+
+**Triage that absorbs feature requests.** Participants request features outside scope; the team adds them mid-beta; scope creeps; signal dilutes.
+
+---
+
+## Common iteration failures
+
+**No iteration during the beta.** Feedback is collected; the team waits for end of beta; opportunities to address issues during the beta are missed.
+
+**Excessive iteration.** Significant feature changes mid-beta. The beta becomes two different betas; neither validates the GA experience cleanly.
+
+**Iteration without communication.** The team fixes issues; participants do not know; engagement decays.
+
+**Iteration on participant requests outside scope.** Scope creep; the beta validates a different feature than the original.
+
+**No closing the loop.** Iterations happen; participants are not told their feedback drove the change; the connection between feedback and improvement is invisible.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The triage cadence. The categorization scheme. What to fix during the beta vs defer. The iteration discipline. The "do not redesign mid-beta" rule. Communication with participants. The mid-beta health check. Mid-beta churn handling. Common failures.
+
+## Implementation choices that stay internal
+
+Specific triage tools and trackers. Specific communication templates. Specific health-check formats. The team's own conventions for what counts as critical vs friction. These vary by team and tooling.

--- a/skills/beta-program-management/references/participant-selection-criteria.md
+++ b/skills/beta-program-management/references/participant-selection-criteria.md
@@ -1,0 +1,212 @@
+# Participant selection criteria
+
+Criteria that produce calibrated cohorts. Common selection failures. The cohort size question.
+
+Participant selection determines what the beta can produce. Calibrated cohorts produce decision-grade signal; misaligned cohorts produce noise that does not represent the GA user. Selection is upstream of every other beta decision.
+
+---
+
+## Criteria that produce calibrated cohorts
+
+**Match the post-launch user profile.** If the feature is for enterprise admins, beta participants should be enterprise admins, not curious individual users.
+
+- Worked example: a feature for product managers at growth-stage SaaS companies. Beta participants should be PMs at growth-stage SaaS companies. Not designers, engineers, or PMs at very-early or very-late stage companies.
+- The matching dimensions depend on the feature: role, company size, industry, usage volume, tenure, technical sophistication.
+
+**Variety across relevant dimensions.** Not all participants identical.
+
+- If the feature has segment-specific behavior, the cohort spans segments.
+- If usage volume varies, the cohort includes high-volume and low-volume users.
+- If geography matters (compliance, latency, language), the cohort spans relevant geographies.
+- The variety should match the GA user diversity.
+
+**Feedback willingness.** Participants who agree to provide feedback through structured channels.
+
+- Soft commitment ("I will give feedback when I have time") is weaker than explicit commitment ("I will respond to weekly check-ins and complete the structured survey").
+- Recruiting should make the feedback expectation explicit. Participants who agree are more likely to engage; participants who decline are honest about their availability.
+
+**Existing relationship strength.** Customers with strong existing relationships are more likely to engage substantively.
+
+- Champion users, design partners, customers with active customer success relationships engage more.
+- Customers in churn-risk are less likely to engage; their feedback may also be less representative (the relationship is already strained).
+
+**Real usage of the broader product.** Beta participants who use the broader product actively can give grounded feedback. Participants who signed up only for the beta and do not use the product otherwise often give surface-level feedback.
+
+---
+
+## Criteria that produce miscalibrated cohorts
+
+**Self-selection only.** Open beta sign-ups skew toward enthusiasts and tinkerers.
+
+- Skews toward users who try every new feature; their feedback may not represent the broader target user.
+- Misses users who would adopt at GA but who do not seek out beta sign-ups.
+
+**Highest-paying customers only.** Skews toward enterprise patterns.
+
+- Misses smaller-team and individual use cases.
+- Enterprise feedback may emphasize features that smaller customers do not need.
+
+**Internal employees only.** Misses customer-context complexity.
+
+- Employees experience features differently than customers (familiarity, infrastructure, motivations).
+- Internal-only validation produces "we tested" without "real customers tested."
+
+**Whoever happens to be available.** No selection criteria; the cohort is whoever the team can recruit quickly.
+
+- The cohort may not match the GA user; signal does not transfer to the GA decision.
+
+**Champion users only.** All beta participants are existing strong advocates.
+
+- Enthusiastic feedback may overstate readiness; missing the friction non-champion users would hit.
+
+---
+
+## Variety calibration
+
+How to ensure the cohort spans the relevant dimensions.
+
+**The dimension audit.**
+
+- For the feature being beta'd, identify the dimensions that affect user experience.
+- Common dimensions: role, company size, industry vertical, usage volume, geographic region, technical sophistication, tenure with the product.
+- Decide which dimensions matter most for this feature.
+
+**Cohort composition.**
+
+- For each high-priority dimension, ensure the cohort includes representation across the values.
+- If role matters: cohort includes participants in each relevant role.
+- If usage volume matters: cohort includes high-volume, mid-volume, low-volume users.
+- If industry varies meaningfully: cohort spans industries.
+
+**Worked example.** A feature for product managers using analytics tools.
+
+- Role dimension: cohort is all PMs (no other roles).
+- Usage dimension: high-volume PMs (active daily users) + mid-volume PMs (weekly users). Skip low-volume because they likely will not use the feature meaningfully.
+- Company size dimension: 10-50 employee, 50-200 employee, 200-500 employee. Skip enterprise (different feature priorities).
+- Tenure dimension: PMs who have used the product 3+ months (so they have established workflows the new feature will integrate into). Skip new users.
+
+The cohort composition is intentional; each participant fits multiple criteria.
+
+---
+
+## The cohort size question
+
+How many participants are enough.
+
+**The calibration is signal-need-driven.**
+
+- Bug discovery saturates fast: 20-30 participants surface most critical issues in 2-4 weeks.
+- Behavioral signal saturates slower: 50-100 participants needed to see usage patterns clearly.
+- Edge case discovery: 100-500+ participants needed; some edge cases never surface in beta.
+
+**Common cohort sizes by beta type.**
+
+- Design partner program: 3-10 participants.
+- Closed alpha: 10-30 participants.
+- Closed beta: 50-200 participants.
+- Open beta: 500-5,000+ participants.
+- RC validation: 1,000-10,000+ participants.
+
+**The "more is better" anti-pattern.** Teams default to large cohorts thinking volume produces signal. In practice, larger-than-needed cohorts produce volume without proportional signal increase, while making feedback synthesis harder.
+
+**The "smaller produces calibrated" principle.** A 50-person calibrated cohort often produces stronger signal than a 5,000-person uncalibrated one. Pick the smallest cohort that produces the signal needed.
+
+---
+
+## The recruitment process
+
+How participants get selected.
+
+**Sources.**
+
+- Existing customer base: customer success identifies candidates matching the criteria.
+- Sales pipeline: late-stage prospects who could become customers and provide feedback.
+- Past beta participants: customers who participated in prior betas and proved engaged.
+- Public sign-up forms (for open betas): with screening criteria applied to actual selection.
+- Partner referrals: customers who recommend other customers fitting the profile.
+
+**The screening.**
+
+- Define the criteria explicitly (role, dimension values, feedback willingness).
+- Apply the screening to candidates: who fits the criteria?
+- For closed betas, decide which subset of fitting candidates to invite (cohort sizing).
+- For open betas with screening, the sign-up form captures qualifying information; the team selects from sign-ups.
+
+**The invitation.**
+
+- Personalized invitations engage better than mass invitations.
+- The invitation explains: what the beta is, what is expected, what participants get, how long it runs.
+- Acceptance is opt-in; participants who decline are honest.
+
+**The capacity.**
+
+- Recruiting takes real time. A 50-participant closed beta may take 2-4 weeks of recruiting work depending on customer base and selection criteria.
+- Plan recruiting time as part of the beta timeline.
+
+---
+
+## The diversity-vs-control tradeoff
+
+Calibrated cohorts can over-control diversity in ways that miss valuable signal.
+
+**The tradeoff.**
+
+- Tightly-defined selection criteria produce a cohort that is uniform along the criteria. Reduces variety; may miss signal from users who differ.
+- Loosely-defined criteria produce more diverse cohorts but make the cohort less calibrated to the GA user.
+
+**The middle path.**
+
+- Define the must-have criteria (role, key segment markers).
+- Allow variety in the optional dimensions (industry, geography, tenure).
+- The cohort is calibrated on what matters and varied on what does not.
+
+---
+
+## When recruitment fails
+
+What to do when selection criteria cannot be met.
+
+**Insufficient candidates fitting criteria.**
+
+- Reconsider whether the criteria are too narrow.
+- Extend recruiting time if feasible.
+- Accept a smaller cohort that fully fits the criteria, rather than a larger cohort that includes mismatches.
+
+**Candidates fitting criteria decline to participate.**
+
+- Investigate why. Is the beta commitment too heavy? The compensation insufficient? The timing wrong?
+- Adjust the offer; re-invite.
+- If still insufficient, consider whether the beta plan is realistic given customer engagement willingness.
+
+**Cohort skew despite intentional selection.**
+
+- Some dimensions skew despite efforts (e.g., one industry over-represented because that industry is more receptive).
+- Acknowledge the skew explicitly in synthesis. Patterns from the over-represented dimension may not generalize.
+
+---
+
+## Common selection failures
+
+**No criteria.** Whoever happens to be available joins. Cohort does not represent GA user.
+
+**Self-selection only.** Open sign-ups skew the cohort.
+
+**Only champions.** Cohort over-represents enthusiasts; misses friction non-champions hit.
+
+**Internal employees only.** Misses customer-context complexity.
+
+**Single-dimension calibration.** Cohort uniform on one dimension (role) but mismatched on others (usage, segment).
+
+**Recruiting too late.** Beta starts before the cohort is calibrated; recruitment continues mid-beta; signal is muddled.
+
+**Enterprise-only.** Cohort over-represents large customers; misses smaller use cases.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The criteria for calibrated cohorts. The criteria for miscalibrated cohorts. Variety calibration with worked example. The cohort size question. The recruitment process. The diversity-vs-control tradeoff. When recruitment fails. Common selection failures.
+
+## Implementation choices that stay internal
+
+Specific recruiting tools and CRM integration. Specific screening surveys. Specific outreach templates. Specific tracking of cohort composition. The team's own conventions for selection criteria within different beta types. These vary by team and customer base.

--- a/skills/discovery-research-synthesis/SKILL.md
+++ b/skills/discovery-research-synthesis/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: discovery-research-synthesis
 description: "Turning research artifacts into actionable PM insight. Customer interviews, user research notes, support ticket reviews, sales call transcripts, survey data, in-app feedback, all synthesized into the decisions they are meant to inform. The discipline of moving from raw discovery data to clear product direction without losing signal in the synthesis or fabricating insight that was not actually there. Triggers on research synthesis, customer interview synthesis, user research analysis, discovery readout, research insights, sales call analysis, support ticket analysis, qualitative data analysis. Also triggers when a team has done research but cannot turn it into decisions, when synthesis is producing pretty decks but no roadmap movement, or when an upcoming PM decision needs to be grounded in research already conducted."
-category: project-management
+category: research
 catalog_summary: "Synthesizing customer interviews, research notes, and support tickets into actionable PM decisions. Distinguishes data-dump (no synthesis) from insight-theater (overpolished narrative) from actionable synthesis (decision-grade clarity)"
-display_order: 11
+display_order: 4
 ---
 
 # Discovery Research Synthesis

--- a/skills/discovery-research-synthesis/SKILL.md
+++ b/skills/discovery-research-synthesis/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: discovery-research-synthesis
+description: "Turning research artifacts into actionable PM insight. Customer interviews, user research notes, support ticket reviews, sales call transcripts, survey data, in-app feedback, all synthesized into the decisions they are meant to inform. The discipline of moving from raw discovery data to clear product direction without losing signal in the synthesis or fabricating insight that was not actually there. Triggers on research synthesis, customer interview synthesis, user research analysis, discovery readout, research insights, sales call analysis, support ticket analysis, qualitative data analysis. Also triggers when a team has done research but cannot turn it into decisions, when synthesis is producing pretty decks but no roadmap movement, or when an upcoming PM decision needs to be grounded in research already conducted."
+category: project-management
+catalog_summary: "Synthesizing customer interviews, research notes, and support tickets into actionable PM decisions. Distinguishes data-dump (no synthesis) from insight-theater (overpolished narrative) from actionable synthesis (decision-grade clarity)"
+display_order: 11
+---
+
+# Discovery Research Synthesis
+
+A senior PM's playbook for turning research artifacts into decisions. Customer interviews, user research notes, support ticket reviews, sales call transcripts, survey data, in-app feedback, all synthesized into the product direction they are meant to inform.
+
+Most discovery research never produces decisions. The team conducts interviews; the transcripts pile up; a researcher hands product the raw artifacts (data-dump) or builds a polished readout deck (insight-theater); the deck gets a 30-minute review meeting and is never referenced again. Two months later the team is making the same product decisions that the research was supposed to inform, with the same gut-feel inputs the research was supposed to displace.
+
+The discipline is in the synthesis. Synthesis is where research earns its keep: where transcripts become tagged observations, observations cluster into patterns, patterns get named, named patterns surface product implications, and implications drive specific decisions. Without that sequence, research is performance art.
+
+This skill covers one-off discovery research projects: a 12-week customer development sprint, a sales-call review for an onboarding redesign, a support-ticket audit informing a roadmap quarter. Different from `user-feedback-aggregation`, which covers ongoing feedback streams; different from `jtbd-framing`, which is a specific framing technique often applied within synthesis but narrower in scope.
+
+The voice is the senior PM or staff product researcher who has run synthesis well and seen plenty of teams fail at it. Honest about where polish becomes performance and where pattern-naming slides into pattern-fabrication.
+
+When to use this skill: synthesizing a recent batch of customer interviews, auditing why prior research has not produced product decisions, designing the synthesis output for a multi-week discovery sprint, or establishing the synthesis discipline a team currently lacks.
+
+---
+
+## What this skill is for
+
+This skill spans research-to-decision synthesis. The PM-skill distinction:
+
+- **`discovery-research-synthesis` (this skill)** is one-off research synthesis: turning a discrete batch of artifacts into a discrete set of decisions.
+- `user-feedback-aggregation` is ongoing feedback streams: continuous synthesis across always-on channels (support, NPS, in-app, sales).
+- `jtbd-framing` is a framing technique often applied during synthesis; this skill is broader.
+- `pm-spec-writing` is downstream: specs use synthesized insights as input.
+- `roadmap-planning` is downstream: roadmap uses synthesized priorities as input.
+- `experiment-design` is the quantitative-validation discipline that often follows qualitative synthesis.
+
+The audience: senior PMs, product directors, in-house product teams, agencies running discovery work for clients, researchers handing off to product teams.
+
+What is not in scope: conducting the research itself (interview design, recruiting, moderation), the broader discovery strategy that decides which research to commission, or the long-running feedback channels that user-feedback-aggregation covers.
+
+---
+
+## Data-dump vs insight-theater vs actionable-synthesis
+
+The keystone framing. Two failure modes plus the discipline.
+
+**Data-dump.** Research artifacts handed to the product team raw. "Here are 47 transcripts and a spreadsheet of tags; figure it out." No synthesis, no signal-finding, no implications drawn. The product team either does the synthesis itself (often badly, often months later) or skips it (the most common outcome). Output: a research investment that produced artifacts but not insight.
+
+**Insight-theater.** Overpolished synthesis dressed as insight. Pretty quote walls, designed personas, branded readout decks, no decision-driving conclusions. The research deck that gets a 30-minute review and never gets referenced. Synthesis that performed for the executive audience but did not inform the product audience. Cost: real research budget converted into a slide deck; the organization "did the research" without doing the research.
+
+**Actionable-synthesis.** Synthesis that drives decisions. Each pattern has a "so what" attached; each finding leads to a product implication; the document gets referenced in roadmap discussions, spec drafts, prioritization debates. The synthesis is short, opinionated, and load-bearing. Six months later, team members can quote the patterns that shaped what shipped and what got cut.
+
+The litmus test. Three months after a synthesis ships, can team members name the decisions the synthesis informed? If yes, the synthesis was actionable. If team members remember the deck but cannot name the decisions, it was insight-theater. If nobody remembers anything because the synthesis never happened, it was data-dump.
+
+---
+
+## Discovery research types
+
+Five common research types, each with different artifacts and synthesis needs.
+
+**Customer interviews.** 30-90 minute structured or semi-structured conversations. Transcripts plus moderator notes plus recordings. Highest-quality qualitative data; most expensive to collect; most rewarding to synthesize when done well. Typical batch: 8-15 interviews per discovery cycle.
+
+**Support ticket reviews.** Auditing recent support tickets for patterns. Lower per-artifact richness than interviews; higher volume; surfaces the friction users actually hit (not just what they say in interviews). Typical batch: 100-500 tickets per audit.
+
+**Sales call analysis.** Recording or transcript review of recent sales calls. Surfaces objections, pricing-conversation patterns, competitive mentions, and the gap between marketing positioning and what sales actually leads with. Typical batch: 15-30 calls per audit.
+
+**Survey data.** Quantitative responses with optional qualitative comments. Best for validating qualitative patterns at scale; weak as primary discovery (surveys reveal what users say, not what they do). Typical batch: 100-2,000 responses.
+
+**In-app feedback.** Users submitting feedback through in-product channels. Volume is high; quality varies; signal lives in patterns across many low-effort submissions. Typical batch: ongoing; synthesized in periodic audits.
+
+Different research types compose. A discovery cycle often pairs interviews (depth) with support ticket review (volume) with survey data (validation at scale). The synthesis combines them.
+
+Detail in `references/research-types-and-when-each-fits.md`.
+
+---
+
+## The synthesis sequence
+
+Six stages from raw artifacts to decisions. Skipping stages is where synthesis fails.
+
+**1. Transcribe and prepare.** Convert artifacts into a synthesizable format. Interview recordings to transcripts; sales calls to summaries; support tickets to a tagged dataset. The prep work is unglamorous; teams that skip it never reach the later stages.
+
+**2. Tag at the artifact level.** Read each transcript or ticket and tag it with the topics, problems, and quotes that surface. First-pass tagging is descriptive: what did this person say, what problem did they hit, what were they trying to do. Tags are messy; that is fine.
+
+**3. Cluster across artifacts.** Group tags into themes. Multiple users mentioned the same friction; multiple tickets reference the same workflow; multiple interviews returned to the same struggling moment. The clusters surface the patterns.
+
+**4. Name patterns.** Each cluster becomes a named pattern. The naming is the work: a pattern named badly disappears into the synthesis; a pattern named well becomes the framing the team references. "Onboarding configuration friction" is a pattern name; "users had trouble" is not.
+
+**5. Infer product implications.** For each pattern, what does this imply for the product? Implications are the bridge from observation to decision. A pattern without an implication is a finding; a pattern with an implication is actionable input.
+
+**6. Name the so-what.** For each implication, the specific decision it informs. "Should we prioritize the onboarding redesign in Q2?" The so-what is what makes the synthesis decision-grade.
+
+The sequence is non-negotiable. Teams that skip tagging and jump to pattern naming hallucinate patterns; teams that skip implications produce findings without product direction; teams that skip so-what produce documentation, not synthesis.
+
+Detail in `references/synthesis-sequence-walkthrough.md`.
+
+---
+
+## Tagging and clustering discipline
+
+The middle stages of the synthesis sequence have specific failure modes.
+
+**Tag at the artifact level first; do not pre-design the taxonomy.** Tags emerge from the artifacts. Teams that arrive with a pre-built tag taxonomy ("we will tag for usability, performance, pricing, support") force artifacts into categories that may not fit the data, and miss patterns the taxonomy did not anticipate.
+
+**Allow tag proliferation; collapse later.** Early tagging may produce 80-150 tags across a batch. That is correct. The clustering stage collapses them. Premature consolidation ("we had 4 onboarding tags; let me merge them") loses distinctions that turn out to matter.
+
+**Cluster on patterns, not on tag overlap.** Two tags that co-occur in many artifacts may or may not be the same pattern. Cluster on the underlying observation: are these the same struggling moment, or do they share a tag because the tag was loose?
+
+**Name the cluster after clustering, not before.** The cluster name comes from the data, not from a hypothesis. Teams that arrive with named clusters and slot data into them produce confirmation; teams that name clusters from the data produce discovery.
+
+**Tag dissent and contradictions explicitly.** Some users will contradict the dominant pattern. Those contradictions are signal: either there is a sub-segment with different needs, or the pattern is weaker than the volume suggests. Tag the dissent so the synthesis can address it.
+
+Detail in `references/tagging-and-clustering-discipline.md`.
+
+---
+
+## Pattern naming
+
+The work that distinguishes synthesis from documentation.
+
+**A pattern name is not a category label.** "Onboarding" is a category. "Users abandon configuration before reaching the success state because the third configuration step requires data they do not have on hand" is a pattern. The pattern names the specific behavior the data reveals.
+
+**The name should make the implication legible.** A reader who sees only the pattern name should be able to guess the product implication. If the name is too abstract, the reader cannot reach the implication; if the name is too concrete, the synthesis becomes a list of micro-observations.
+
+**Avoid category bloat.** Synthesis with 30 named patterns is usually under-clustered: many of those patterns are variations on a smaller number of underlying patterns. Synthesis with 4 named patterns is often the right number; 6-8 is common; more than 12 is usually category bloat.
+
+**Avoid naming the obvious.** "Users want fast performance" is not a pattern; it is a truism. A pattern is a specific observation that the product team did not already know. If the pattern name reads as something everyone could have said before the research, the pattern is not a pattern.
+
+**Name with conviction.** Hedged pattern names ("users sometimes seem to maybe struggle with...") signal a researcher who did not commit to what the data showed. Patterns named with conviction are more useful even if they overstate slightly; they invite challenge and produce decisions.
+
+Detail in `references/pattern-naming-patterns.md`.
+
+---
+
+## From pattern to product implication
+
+The bridge from observation to decision.
+
+**Pattern-to-implication is the writer's analytical work, not what the user said.** Users do not state product implications; they describe their experience. The PM doing synthesis interprets the pattern and proposes the implication. The interpretation is where synthesis adds value beyond transcription.
+
+**Each pattern can have multiple implications.** A pattern about onboarding friction might imply a redesign of the configuration flow, or default-data pre-population, or staged onboarding. The synthesis surfaces the options; the prioritization decision picks one.
+
+**Implications should be falsifiable.** A vague implication ("we should improve onboarding") is not actionable. A specific implication ("staged onboarding that defers the third configuration step until after the user reaches the first success state") is. Specific implications can be debated, scoped, prioritized.
+
+**Implications should acknowledge cost.** Patterns suggest solutions; solutions cost product capacity. Synthesis that implies 30 product changes without acknowledging that delivering them all is impossible is not synthesis; it is a wishlist.
+
+**Some patterns imply not-acting.** Sometimes the pattern reveals friction the team should not address: it affects too few users, it represents segment misfit, addressing it would compromise other priorities. Naming the not-act implication is honest synthesis.
+
+Detail in `references/from-pattern-to-product-implication.md`.
+
+---
+
+## Writing for decisions, not deck performance
+
+Synthesis output should be optimized for decision use, not for presentation.
+
+**Document, not deck.** Deck format is poor for synthesis: slides cannot carry argument density; readers cannot reference slides later; decks decay into icons and bullet points. A short document (4-12 pages) carries more usable synthesis than a 60-slide deck.
+
+**Lead with patterns and implications; relegate evidence to appendix.** A reader scanning for decision input wants the patterns and implications first. Evidence (quotes, ticket excerpts, data tables) supports the patterns but does not lead. Decks that lead with quote walls have inverted the reader's needs.
+
+**One section per pattern.** Each pattern gets a short section: pattern name, evidence summary (2-3 sentences with link to full evidence in appendix), implication, so-what decision input.
+
+**Be opinionated.** Synthesis that hedges every pattern reads as a researcher avoiding accountability. Synthesis that commits positions invites challenge and produces decisions. The PM doing synthesis is making a recommendation; readers can disagree, but disagreement is the point.
+
+**Include a decision-input section.** What does this synthesis recommend the team do? Where should priorities shift? Which roadmap items does this validate, which does it challenge? The decision-input section is the synthesis's reason for existing.
+
+Detail in `references/writing-for-decisions-not-decks.md`.
+
+---
+
+## The synthesis review and validation loop
+
+How the synthesis gets pressure-tested before it drives decisions.
+
+**Internal review with the research participants where possible.** Show the synthesis to a subset of the research participants. Do they recognize themselves and their experiences in the patterns? Misrecognition signals the synthesis fabricated patterns or projected interpretations the data did not support.
+
+**Adjacent-team review.** Show the synthesis to product, engineering, support, sales. Do the patterns match what they observe in their domains? Adjacent teams catch synthesis errors that the research team missed.
+
+**Quantitative validation where possible.** Patterns from qualitative synthesis can often be validated at scale through analytics, survey, or in-app data. The pattern says X; does the data confirm X happens at the frequency and severity the pattern implies? See `experiment-design` and `product-analytics-setup` for the quantitative methodology.
+
+**The "challenge the synthesis" session.** A specific session where adjacent teams try to find the patterns the synthesis missed, the implications the synthesis overstated, the decisions the synthesis is railroading. Productive disagreement strengthens the synthesis.
+
+**Iterate before publishing.** Synthesis goes through revision based on the review loop. Synthesis that ships in the first draft state usually carries unacknowledged blind spots.
+
+Detail in `references/synthesis-review-and-validation.md`.
+
+---
+
+## When to halt and gather more data
+
+Synthesis sometimes reveals that the research did not collect enough.
+
+**Pattern thinness.** A pattern surfaces in 2-3 artifacts but the synthesis would need 5-8 to commit a position. Either name the pattern as tentative pending more data, or pause synthesis and gather more research.
+
+**Segment under-representation.** The research overrepresents one user segment and underrepresents another that matters for the decision. Patterns from the represented segment may not apply to the underrepresented one.
+
+**Contradictory clusters.** Two clusters point in opposite directions and the data does not resolve the contradiction. Often signals a sub-segment difference that the research did not investigate enough.
+
+**Decision time pressure.** Synthesis revealing data gaps but the decision has to ship before more research can happen. Honest path: name the data gap explicitly in the synthesis, make the recommendation with the gap acknowledged, plan the follow-up research that would validate or revise.
+
+**The "we have enough" trap.** Teams that have invested in research often want to declare the data sufficient even when the synthesis reveals gaps. The discipline is naming gaps even when uncomfortable.
+
+Detail in `references/when-to-gather-more-data.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-discovery-synthesis-failures.md`.
+
+- "We did the research but never made decisions from it." Data-dump or insight-theater; synthesis sequence skipped or stopped at findings.
+- "Our synthesis deck got a polite review and was never referenced again." Insight-theater; output was performative rather than load-bearing.
+- "We have 30 named patterns and no clear priorities." Category bloat; under-clustering; cure: re-cluster to 4-8 underlying patterns.
+- "Every pattern reads as something we already knew." The synthesis named truisms, not patterns. Re-examine the data for what was actually surprising.
+- "The patterns contradict each other and we cannot reconcile them." Often segment misfit; consider whether the contradictions reveal sub-segments with different needs.
+- "Research participants did not recognize themselves in our synthesis." Synthesis fabricated patterns or projected interpretations not in the data. Restart with closer evidence-tracking.
+- "The synthesis is detailed but the team cannot tell what to do." Implications missing or vague; cure: each pattern gets a specific falsifiable implication.
+- "We hedged every pattern and the synthesis reads as wishy-washy." Hedge stacking; the synthesis avoided commitment. Rewrite with conviction.
+- "Our quote walls were impressive but the deck was 60 slides." Insight-theater; cure: 8-page document with quotes in appendix.
+- "The synthesis recommended 20 product changes; we shipped one." Wishlist synthesis; did not acknowledge cost; cure: prioritize within the synthesis.
+- "Adjacent teams disagreed with our patterns and we did not engage." Review loop skipped; cure: make adjacent-team review non-negotiable before shipping.
+
+---
+
+## The framework: 12 considerations for discovery synthesis
+
+When designing or auditing a synthesis output, walk these 12 considerations.
+
+1. **Actionable-synthesis, not data-dump or insight-theater.** Synthesis that drives decisions.
+2. **Research types matched to questions.** Interviews, support, sales calls, surveys, in-app combined deliberately.
+3. **The synthesis sequence: transcribe, tag, cluster, name, imply, so-what.** No stage skipped.
+4. **Tags emerge from artifacts; taxonomy not pre-designed.**
+5. **Tag proliferation allowed; clustering collapses.**
+6. **Patterns named with conviction; not categories or truisms.**
+7. **Each pattern produces a specific falsifiable product implication.**
+8. **Each implication has a so-what tied to a real decision.**
+9. **Output is a document, not a deck.** Patterns lead; evidence in appendix.
+10. **Synthesis is opinionated.** Hedges flagged; conviction shown.
+11. **Review loop before publish.** Participants, adjacent teams, quantitative validation where available.
+12. **Data gaps named, not buried.** Where research did not support a position, the synthesis says so.
+
+The output of the framework is a synthesis the team can act on: short, opinionated, evidence-grounded, decision-driving, accountable to challenge.
+
+---
+
+## Reference files
+
+- [`references/research-types-and-when-each-fits.md`](references/research-types-and-when-each-fits.md) - Five research types with synthesis implications. Composition patterns across types within a discovery cycle.
+- [`references/synthesis-sequence-walkthrough.md`](references/synthesis-sequence-walkthrough.md) - The six-stage sequence with worked example. Stage outputs, common skip-failures, time investment per stage.
+- [`references/tagging-and-clustering-discipline.md`](references/tagging-and-clustering-discipline.md) - Tag-at-artifact-level discipline, allow tag proliferation, cluster on patterns not overlap, name after clustering, tag dissent.
+- [`references/pattern-naming-patterns.md`](references/pattern-naming-patterns.md) - Pattern names that work and fail. Avoiding category bloat, naming-with-conviction, the implication-legibility test.
+- [`references/from-pattern-to-product-implication.md`](references/from-pattern-to-product-implication.md) - The bridge from pattern to implication. Falsifiability, multi-implication patterns, cost acknowledgment, the not-act implication.
+- [`references/writing-for-decisions-not-decks.md`](references/writing-for-decisions-not-decks.md) - Document over deck, patterns lead, evidence appendix, opinionated voice, decision-input section.
+- [`references/synthesis-review-and-validation.md`](references/synthesis-review-and-validation.md) - Participant review, adjacent-team review, quantitative validation, the challenge-the-synthesis session, iteration before publish.
+- [`references/when-to-gather-more-data.md`](references/when-to-gather-more-data.md) - Pattern thinness, segment under-representation, contradictory clusters, decision time pressure, the we-have-enough trap.
+- [`references/common-discovery-synthesis-failures.md`](references/common-discovery-synthesis-failures.md) - 11+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: synthesis is where research earns its keep
+
+Discovery research is one of the most expensive activities a product team commissions. The expense is mostly hidden: customer time, researcher time, the opportunity cost of the discovery cycle itself, the management overhead of recruiting and scheduling. Most of that expense gets spent before synthesis even begins.
+
+The teams that earn returns on the research investment are the teams that take synthesis seriously: the sequence is run end-to-end, the patterns are named with conviction, the implications are falsifiable, the so-what ties to specific decisions, the output is a load-bearing document the team references for months. The teams that do not earn returns produce data-dumps or insight-theater; their research becomes documentation of work done rather than the input to work to come.
+
+When in doubt about whether a synthesis is ready, ask: are the patterns named with conviction, do they reach product implications, do the implications tie to specific decisions, has the synthesis been reviewed by participants and adjacent teams, are the data gaps named honestly? If yes to all of those, the synthesis is real. If no to any, the gap is where the research investment will fail to convert into decisions.

--- a/skills/discovery-research-synthesis/references/common-discovery-synthesis-failures.md
+++ b/skills/discovery-research-synthesis/references/common-discovery-synthesis-failures.md
@@ -1,0 +1,193 @@
+# Common discovery synthesis failures
+
+Eleven-plus failure patterns with diagnoses and cures. The cross-cutting pattern: most synthesis failures share a single root, which is treating synthesis as documentation work rather than as decision work.
+
+---
+
+## Failure 1: We did the research but never made decisions from it
+
+**Symptom.** Discovery cycle completed; transcripts and notes filed; the team's roadmap discussions in the following months never reference the research.
+
+**Diagnosis.** Data-dump or insight-theater pattern. Synthesis sequence either skipped entirely (data-dump) or stopped at findings without reaching decisions (insight-theater).
+
+**Cure.** Run the synthesis sequence end-to-end on the existing artifacts. Even months after the original research, retroactive synthesis can produce decisions the original research was meant to inform.
+
+**Prevention.** Before commissioning the next research cycle, name the decisions the research is intended to inform. Build the synthesis sequence into the discovery plan, not as an afterthought.
+
+---
+
+## Failure 2: Our synthesis deck got a polite review and was never referenced again
+
+**Symptom.** A polished readout deck. A 30-minute presentation. Positive feedback in the meeting. Six months later nobody references the synthesis in product decisions.
+
+**Diagnosis.** Insight-theater. Output was performative rather than load-bearing. Optimized for the presentation moment, not for reference use.
+
+**Cure.** Convert the deck content into a document with patterns leading, evidence in appendix, decision-input section. Recirculate as a reference document.
+
+**Prevention.** Future synthesis ships as documents, not decks. The presentation is a deck if needed; the synthesis is the document.
+
+---
+
+## Failure 3: We have 30 named patterns and no clear priorities
+
+**Symptom.** The synthesis lists many patterns. The team agrees they are interesting but cannot prioritize. The synthesis fails to drive a roadmap shift.
+
+**Diagnosis.** Category bloat. Under-clustering produced inflation. Many of the 30 patterns are variations on a smaller number of underlying patterns.
+
+**Cure.** Re-cluster. Take the pattern list back to the clustering stage and look for the 4-8 underlying patterns the data actually supports. Synthesize from the consolidated list.
+
+**Prevention.** Cap pattern count at 4-8 for typical synthesis. When more than 8 patterns emerge, that is a signal to recluster, not to ship with bloat.
+
+---
+
+## Failure 4: Every pattern reads as something we already knew
+
+**Symptom.** The synthesis names patterns that read as truisms. Team members who attended the readout could have produced the patterns without the research.
+
+**Diagnosis.** Pattern names captured truisms rather than the specific observations the research surfaced. The analytical work of pattern naming was skipped.
+
+**Cure.** Re-examine the data for what was actually surprising. Often the strongest patterns surface in the contradictions, the unexpected sub-segments, the workarounds users built. Pattern names should commit positions the team would not have committed before the research.
+
+**Prevention.** During pattern naming, apply the "what the team did not know" test. Patterns that read as common-knowledge are probably under-named.
+
+---
+
+## Failure 5: The patterns contradict each other and we cannot reconcile them
+
+**Symptom.** Two patterns point in opposite directions. The synthesis is silent on the contradiction or hand-waves it.
+
+**Diagnosis.** Often segment misfit: different segments have different needs, and the synthesis did not surface the segment distinction. Sometimes context misfit: different use contexts produce different patterns.
+
+**Cure.** Re-examine the data for the segment or context dimension that explains the contradiction. The contradiction often becomes the most valuable finding once explained.
+
+**Prevention.** Tag dissent and contradictions explicitly during the tagging stage. Surface them through clustering. Address them in synthesis rather than burying them.
+
+---
+
+## Failure 6: Research participants did not recognize themselves in our synthesis
+
+**Symptom.** When shown the synthesis, participants say "I did not say that" or "this does not match my experience."
+
+**Diagnosis.** Synthesis fabricated patterns or projected interpretations not in the data. The pattern naming reached for what the team wanted to find rather than what the participants actually said.
+
+**Cure.** Restart with closer evidence-tracking. Each pattern should be traceable to specific moments in specific artifacts. Patterns that cannot be traced are projections, not observations.
+
+**Prevention.** Build participant review into the synthesis process. Synthesis that participants do not recognize fails the validation; revise before publishing.
+
+---
+
+## Failure 7: The synthesis is detailed but the team cannot tell what to do
+
+**Symptom.** Patterns are clear and well-supported. The team agrees on the patterns. The team cannot derive the product implications.
+
+**Diagnosis.** Implications missing or vague. The synthesis stopped at observations without bridging to product responses.
+
+**Cure.** Add implications to each pattern. Each implication should be specific, falsifiable, cost-acknowledged, and tied to a specific decision.
+
+**Prevention.** The synthesis sequence's implication stage is non-negotiable. Synthesis that ships without implications is incomplete.
+
+---
+
+## Failure 8: We hedged every pattern and the synthesis reads as wishy-washy
+
+**Symptom.** "Users may sometimes occasionally seem to indicate." Every claim caveated. The synthesis avoids commitment.
+
+**Diagnosis.** Hedge stacking. The researcher did not commit to what the data showed.
+
+**Cure.** Rewrite with conviction. Name patterns as if the data supports them. If the data does not support the position, name a smaller position the data does support; do not hedge an oversized claim.
+
+**Prevention.** During pattern naming, apply the conviction test. Hedge stacking signals a pattern that should either be sharpened or dropped.
+
+---
+
+## Failure 9: Our quote walls were impressive but the deck was 60 slides
+
+**Symptom.** Beautiful quote pulls; designed personas; 60 slides. Readers admired the deck. Few remember the patterns.
+
+**Diagnosis.** Insight-theater. Evidence dominated; analysis receded. Quote walls without analytical bridge.
+
+**Cure.** Restructure as a document. Patterns lead; evidence in appendix. Quote walls converted into evidence-summary paragraphs supporting each pattern.
+
+**Prevention.** The format choice is upstream. Default to documents; reserve decks for short executive summaries paired with substantive documents.
+
+---
+
+## Failure 10: The synthesis recommended 20 product changes; we shipped one
+
+**Symptom.** Synthesis presents many implications. Team picks the easiest or most-vocal one to ship. The rest sit in the synthesis document unaddressed.
+
+**Diagnosis.** Wishlist synthesis. Implications did not acknowledge cost or prioritize within themselves. The synthesis offloaded prioritization to the team without giving them a starting point.
+
+**Cure.** Re-prioritize within the synthesis. Each implication gets a cost note. The synthesis recommends a sequence: which implications to address now, which to defer, which to drop. The team has a starting point for prioritization.
+
+**Prevention.** During implication writing, surface cost. The synthesis owner uses available context to estimate cost; pairs with engineering for harder estimates. Cost-blind synthesis is incomplete.
+
+---
+
+## Failure 11: Adjacent teams disagreed with our patterns and we did not engage
+
+**Symptom.** Synthesis ships. Support team says "this does not match what we see in tickets." Sales team says "our prospects say something different." The synthesis fails to align with the teams closest to the customer.
+
+**Diagnosis.** Adjacent-team review skipped or compressed. The synthesis reached publication without surfacing perspectives the research team did not have.
+
+**Cure.** Pause publication. Run the adjacent-team review even after the fact. Revise based on inputs.
+
+**Prevention.** Build adjacent-team review into the synthesis workflow. Make it non-negotiable. The teams closest to the customer have ground-truth observations the research team needs.
+
+---
+
+## Failure 12: Data gaps buried in the synthesis
+
+**Symptom.** Synthesis presents conclusions where the data did not support them. The recommendations sound confident; the data is thin in places the synthesis did not name.
+
+**Diagnosis.** The we-have-enough trap. Sunk-cost reasoning suppressed honest gap-naming.
+
+**Cure.** Audit each pattern for data sufficiency. Where gaps exist, name them explicitly. Where recommendations rest on under-supported patterns, downgrade or hedge them honestly.
+
+**Prevention.** The synthesis owner's job is to be honest about what the data can and cannot support. The team relies on the synthesis owner for this honesty.
+
+---
+
+## Failure 13: Synthesis sequence stages skipped
+
+**Symptom.** Synthesis arrives at "patterns" without going through the tagging and clustering stages. Patterns feel imposed on the data rather than emerging from it.
+
+**Diagnosis.** Stages skipped. Researcher jumped to pattern-naming based on impressions from reading transcripts.
+
+**Cure.** Restart the sequence from tagging. Patterns from skipped sequences are usually projections; tagging-grounded patterns are observations.
+
+**Prevention.** The sequence is non-negotiable. Every synthesis runs through transcribe, tag, cluster, name, imply, so-what.
+
+---
+
+## Failure 14: Synthesis owner became defensive in the review
+
+**Symptom.** Adjacent teams raise concerns; synthesis owner argues against each one; the review session produces no revisions; synthesis ships unchanged.
+
+**Diagnosis.** Defensive review posture. The owner treated review as defense of the synthesis rather than as input to it.
+
+**Cure.** Owner takes notes; does not defend in the moment; revises based on inputs over the following days. Reviewer concerns surface in the revision; the synthesis improves.
+
+**Prevention.** Establish the review session's purpose explicitly: input, not approval. The synthesis owner's job in the session is to listen.
+
+---
+
+## The cross-cutting pattern
+
+Most synthesis failures share a single root: treating synthesis as documentation work rather than as decision work.
+
+Documentation work prioritizes capturing the research; producing a deliverable; performing for an audience. Output: artifacts that look like synthesis but do not drive decisions.
+
+Decision work prioritizes producing direction; committing positions; informing prioritization. Output: synthesis that team members reference for months, that drives roadmap shifts, that earns the research investment.
+
+The fix for almost any synthesis failure starts with the same question: what decision is this synthesis supposed to inform? When the answer is clear, the synthesis becomes load-bearing. When the answer is "we should document the research," the synthesis fails as decision input.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The fourteen failure patterns with diagnoses and cures. The cross-cutting documentation-vs-decision pattern.
+
+## Implementation choices that stay internal
+
+Specific reviewer training on synthesis-failure detection. Specific automation that flags synthesis structures (e.g., document length checks, hedge-frequency analysis). Specific reviewer dashboards. The team's own conventions for catching synthesis failures pre-publish. These vary by team.

--- a/skills/discovery-research-synthesis/references/from-pattern-to-product-implication.md
+++ b/skills/discovery-research-synthesis/references/from-pattern-to-product-implication.md
@@ -1,0 +1,192 @@
+# From pattern to product implication
+
+The bridge from observation to decision. Implications are where synthesis adds value beyond transcription.
+
+A pattern without an implication is a finding. A finding describes the world; an implication proposes action. Synthesis stops at findings; actionable synthesis reaches implications.
+
+---
+
+## Implications are the writer's analytical work, not what the user said
+
+**The principle.** Users describe their experience; PMs interpret what experience implies for the product.
+
+**Why this matters.** A common synthesis failure is presenting implications as if they came from users. "Users want X" treated as an implication. But users do not always know what would actually solve their problem; they describe symptoms, not solutions.
+
+**Worked example.** A pattern: "Users abandon configuration step 3 because credit card details are not accessible during signup."
+
+- What users said: "I had to stop and find my credit card."
+- What users want (per their own description): "Make signup not require credit card details."
+- What the implication actually is (PM analytical work): defer the credit-card-requiring step to after first success state, OR remove the credit card requirement at signup, OR allow signup without credit card and request it before paid features.
+
+The implication options surface from analytical interpretation, not from user prescription. Users said the symptom; the PM proposes the system response.
+
+**The discipline.** Frame implications as the team's analytical position grounded in the pattern, not as user requests. "The pattern implies X" rather than "Users want X."
+
+---
+
+## Each pattern can have multiple implications
+
+**The principle.** Synthesis surfaces options; the prioritization decision picks one.
+
+**Worked example.** A pattern: "Free users hit the upgrade prompt before experiencing paid value."
+
+Possible implications:
+
+- Delay the upgrade prompt until after the user has experienced the value-realization moment.
+- Show the upgrade prompt earlier but reframe it as exploratory rather than transactional.
+- Add a value-realization moment earlier in the free experience to align with the existing prompt timing.
+- Remove the upgrade prompt entirely; let users discover paid features through usage.
+
+Each implication is a different product response. The synthesis presents the options; the team's prioritization debate picks one (or sequences several).
+
+**Why multi-implication matters.** Single-implication synthesis presents the synthesizer's preferred solution as if it were the only solution. Multi-implication synthesis surfaces options the team can debate.
+
+**The presentation.** Per pattern, surface 2-4 candidate implications. Acknowledge tradeoffs between them. Recommend if the data supports a recommendation; otherwise present the options for prioritization.
+
+---
+
+## Implications should be falsifiable
+
+**The principle.** A vague implication cannot be acted on or debated. A specific implication can.
+
+**Vague implications.**
+
+- "We should improve onboarding."
+- "Pricing should be reconsidered."
+- "Mobile experience needs attention."
+
+These are too vague to drive decisions. The team agrees to "improve onboarding" without committing to any specific change.
+
+**Falsifiable implications.**
+
+- "Defer configuration step 3 to after first success state."
+- "Add a value-realization moment within the first 90 seconds of signup."
+- "Make the homepage hero copy lead with B2B use cases."
+
+These commit specific positions. The team can debate them, scope them, kill them, prioritize them.
+
+**The test.** For each implication, ask: could the team disagree with this and explain why? If the implication is vague enough that disagreement is impossible, the implication is too vague to be useful.
+
+---
+
+## Implications should acknowledge cost
+
+**The principle.** Patterns suggest solutions; solutions cost product capacity. Synthesis that ignores cost produces wishlists.
+
+**The pattern that fails.** Synthesis recommends 30 product changes without acknowledging that delivering them all is impossible. The team takes one or two; the rest sit. The synthesis produced no actionable input because the team had no help prioritizing.
+
+**The pattern that works.** Each implication includes an estimated cost dimension and a recommendation about whether the cost is justified.
+
+- "Defer configuration step 3 (medium engineering cost; high expected impact on signup conversion)."
+- "Pre-populate step 3 with sensible defaults (low engineering cost; medium expected impact)."
+- "Remove credit card requirement entirely (high cost across systems; uncertain impact)."
+
+The cost annotations help the team prioritize without re-doing the synthesis work.
+
+**The discipline.** PMs doing synthesis usually have enough context to estimate cost roughly. If they do not, they can pair with engineering to estimate. Cost-blind synthesis is incomplete.
+
+---
+
+## Some patterns imply not-acting
+
+**The principle.** Sometimes the pattern reveals friction the team should not address.
+
+**When not-acting is honest.**
+
+- The friction affects too few users to justify the engineering cost.
+- The friction reveals segment misfit; the affected users are not the team's target.
+- Addressing the friction would compromise other priorities or product positioning.
+- The friction is real but the proposed solutions are worse than the problem.
+
+**Worked example.** A pattern: "Enterprise users want admin controls that small-team users do not need."
+
+Implications:
+
+- Build the admin controls (high cost, expands target market).
+- Build the admin controls only for the enterprise tier (medium cost, segment-specific).
+- Do not build (acknowledges enterprise as not the target segment).
+
+If the team is committed to small-team users as the target market, the not-act implication is honest; building enterprise admin controls would dilute focus.
+
+**The naming discipline.** When the synthesis recommends not-acting, name it explicitly. "The pattern is real but the recommended response is to not address it because [reason]." Buried not-act implications get overlooked; the team adds the unaddressed friction to the next quarter's roadmap because nobody surfaced the not-act case.
+
+---
+
+## Implications that bridge to specific decisions
+
+**The principle.** The strongest implications point to a specific decision the team is making.
+
+**Implication-to-decision mapping.**
+
+- Implication: "Defer configuration step 3."
+  - Decision input: should the Q2 roadmap include the onboarding redesign? (Yes, with this approach.)
+- Implication: "Add B2B-leading homepage hero."
+  - Decision input: should the homepage redesign be prioritized this quarter? (Yes, with positioning shift.)
+- Implication: "Do not address enterprise admin controls."
+  - Decision input: should enterprise tier be in this year's roadmap? (No; small-team focus continues.)
+
+**Why decision-mapping matters.** Implications floating free of decisions produce a list the team must connect to its prioritization work themselves. Implications mapped to decisions produce direct input.
+
+---
+
+## Implication strength and confidence
+
+**The principle.** Not all implications are equally well-supported.
+
+**Strong implications.**
+
+- Pattern is supported by multiple research types (interviews + tickets + survey).
+- Implication has a clear analytical bridge from the pattern.
+- Cost is reasonable relative to expected impact.
+- Decision input is clear.
+
+**Weaker implications.**
+
+- Pattern is supported by limited evidence (3 interviews; thin volume).
+- Implication is one of several plausible options without clear analytical bridge.
+- Cost is uncertain.
+- Decision input is hedged.
+
+**The discipline.** Synthesis labels implications by strength. Strong ones get presented as recommendations; weaker ones as options for further investigation. The team can prioritize confidently when it knows which implications carry weight.
+
+---
+
+## Common pattern-to-implication failures
+
+**Implications that restate the pattern.** "The pattern shows X. The implication is X." No analytical bridge; no value added.
+
+**Wishlist implications.** Synthesis recommends 30 changes; the team cannot prioritize; one or two ship; the rest sit.
+
+**Implications buried in narrative.** The synthesis discusses the pattern at length; the implication is one sentence at the end. Readers miss it.
+
+**No cost acknowledgment.** Implications presented as if all are equal cost; team has to do the cost analysis itself.
+
+**Skipping the not-act implication.** Synthesis recommends action on every pattern; some patterns warrant not-acting; the synthesis fails to surface this honestly.
+
+**Implications that prescribe specific designs.** Implications should propose product responses, not detailed designs. Detailed designs are for spec writing; implications are the upstream input.
+
+---
+
+## The implication-quality audit
+
+A short framework for auditing implications.
+
+1. Is each implication an analytical proposition, not a user request?
+2. Are multiple candidate implications surfaced where appropriate?
+3. Is each implication specific enough to be falsifiable?
+4. Does each implication acknowledge cost?
+5. Where the data supports not-acting, is that surfaced honestly?
+6. Does each implication map to a specific decision?
+7. Is implication strength labeled?
+
+Synthesis that passes this audit converts research into decisions. Synthesis that fails it produces findings that look like decisions but do not drive them.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The implication-as-analytical-work principle. Multi-implication patterns. Falsifiability. Cost acknowledgment. The not-act implication. Decision mapping. Implication strength. Common failures. The audit.
+
+## Implementation choices that stay internal
+
+Specific document templates that surface implications. Specific cost-estimation conventions. Specific cross-functional review patterns for cost validation. The team's own conventions for implication-strength labeling. These vary by team.

--- a/skills/discovery-research-synthesis/references/pattern-naming-patterns.md
+++ b/skills/discovery-research-synthesis/references/pattern-naming-patterns.md
@@ -1,0 +1,178 @@
+# Pattern naming patterns
+
+Pattern naming is the work that distinguishes synthesis from documentation. A pattern named badly disappears into the synthesis; a pattern named well becomes the framing the team references for months.
+
+The naming is not formatting. It is analytical work that surfaces what the data actually shows. Most synthesis underperforms because the pattern names did not do this work.
+
+---
+
+## A pattern name is not a category label
+
+**The principle.** Categories describe topics; patterns describe specific observations the data reveals.
+
+**Examples.**
+
+- Category: "Onboarding."
+- Pattern: "Users abandon configuration step 3 because it requires data they do not have on hand at signup time."
+
+- Category: "Pricing."
+- Pattern: "Free users hit the upgrade prompt before they have experienced the paid value, producing churn instead of conversion."
+
+- Category: "Mobile."
+- Pattern: "New users on mobile cannot complete onboarding without switching to desktop because two configuration screens are not mobile-functional."
+
+**Why categories fail as pattern names.** Categories are containers. The synthesis with category-named patterns is a list of containers, not a list of observations. Readers cannot tell what the data showed; only what topic it concerned.
+
+**The test.** Does the pattern name commit a position about what the data reveals, or does it merely name a topic the data covered? Position-committing names are patterns; topic-naming labels are categories.
+
+---
+
+## The name should make the implication legible
+
+**The principle.** A reader who sees only the pattern name should be able to guess the product implication.
+
+**Examples that pass the test.**
+
+- "Users abandon configuration step 3 because credit card details are not accessible during signup."
+  - Implication a reader can guess: defer configuration step 3 to after first success state, or remove credit card requirement at signup.
+- "Sales prospects assume the product is for B2C because the homepage hero shows consumer use cases."
+  - Implication a reader can guess: revise homepage positioning to lead with B2B use cases.
+
+**Examples that fail the test.**
+
+- "Onboarding has issues."
+- "Users have feedback about pricing."
+- "There is mobile-related friction."
+
+**Why implication-legibility matters.** Synthesis exists to drive decisions. Pattern names that obscure implications force readers to do the analytical work themselves; many readers will not, and the synthesis fails to inform decisions.
+
+---
+
+## Avoid category bloat
+
+**The principle.** Strong synthesis has 4-8 named patterns. Synthesis with 30 patterns is usually under-clustered: many of those are variations on a smaller number of underlying patterns.
+
+**Diagnosis of bloat.**
+
+- Look at the pattern list. Are some patterns sub-cases of others? If yes, the under-cluster is producing inflation.
+- Are there patterns that always co-occur with other patterns? If yes, they may be the same pattern viewed from different angles.
+- Are there patterns supported by 1-2 artifacts only? If yes, they may be noise being elevated to pattern status.
+
+**The cure.** Re-cluster. Take the 30-pattern list back to clustering and look for the 4-8 underlying patterns the data actually supports.
+
+**Why bloat fails.** Synthesis with 30 patterns produces no decision direction: the team cannot prioritize 30 things. Synthesis with 4-8 patterns surfaces what to focus on.
+
+---
+
+## Avoid naming the obvious
+
+**The principle.** A pattern is a specific observation that the product team did not already know. Pattern names that read as truisms ("users want fast performance") are not patterns.
+
+**The truism trap.**
+
+- "Users want better performance."
+- "Users find some aspects confusing."
+- "Pricing is a consideration in the decision."
+- "Mobile usage is increasing."
+
+These are descriptive of the universe; they do not describe what the research revealed.
+
+**The cure.** For each pattern name, ask: would this name have been just as accurate without the research? If yes, the pattern is a truism. The research must have surfaced something more specific; rewrite the name to capture it.
+
+**The "what the team did not know" test.** Strong pattern names commit a position the team would not have made before the research. Weak pattern names commit positions the team already held.
+
+---
+
+## Name with conviction
+
+**The principle.** Hedged pattern names ("users sometimes seem to maybe struggle with...") signal a researcher who did not commit to what the data showed. Patterns named with conviction are more useful even if they overstate slightly.
+
+**Hedging vs precision.**
+
+- Hedged: "Some users may experience occasional difficulty in some configuration steps."
+- Precise: "Users abandon configuration step 3 in 40% of signup attempts."
+
+The precise name is also commitment-bearing: it claims a specific behavior at a specific frequency. If the data does not support 40%, the name is wrong; the researcher should restate. The hedged name avoids being wrong by avoiding being specific.
+
+**Why conviction matters.** Synthesis that hedges every pattern reads as a researcher avoiding accountability. Readers cannot debate hedged patterns; they cannot prioritize them; they cannot act on them. Conviction-named patterns invite challenge, which strengthens synthesis.
+
+**The discipline.** Name as if the data fully supports the position. If it does not, name a smaller position the data does support. Do not pad an under-supported position with hedging.
+
+---
+
+## Pattern naming structures that work
+
+Several structures recur across strong synthesis.
+
+**The behavioral observation: "Users [do specific action] because [specific cause]."**
+
+Example: "Users abandon configuration step 3 because credit card details are not accessible during signup."
+
+This structure forces specificity in both behavior and cause.
+
+**The contradiction: "Users [say X] but [do Y]."**
+
+Example: "Users in interviews report wanting more configuration options, but in support tickets request defaults that match their actual usage."
+
+This structure surfaces the gap between stated preference and revealed preference.
+
+**The segment difference: "[Segment A] [does X], while [Segment B] [does Y]."**
+
+Example: "Free users hit the upgrade prompt before experiencing paid value, while paid users encounter it after the value-realization moment."
+
+This structure surfaces sub-segment patterns the research revealed.
+
+**The mismatch: "[Team's framing] does not match [user's framing]."**
+
+Example: "Marketing positions the product as B2C-friendly; sales prospects evaluating for B2B use assume the product is consumer-only based on the homepage."
+
+This structure surfaces positioning gaps.
+
+**The frequency-specific: "[Specific behavior happens at frequency X across segment Y]."**
+
+Example: "30% of new users hit the configuration friction within 5 minutes of signup; the friction correlates with day-7 churn."
+
+This structure pairs qualitative observation with quantitative validation.
+
+---
+
+## The pattern-name editing pass
+
+Strong synthesis runs a final editing pass focused only on pattern names.
+
+**For each pattern name, the editing questions.**
+
+1. Is this a category or a pattern?
+2. Can a reader guess the implication from the name alone?
+3. Is this a truism or a specific observation?
+4. Does the name commit a position with conviction?
+5. Does the name match what the data actually shows (no overstatement)?
+6. Could this be split into multiple patterns or merged with another?
+
+**The editing investment.** 1-2 hours of focused name-editing on a 4-8 pattern set. The investment pays off in synthesis usability.
+
+---
+
+## Common pattern-naming failures
+
+**Categories disguised as patterns.** "Onboarding patterns" as a section heading; nothing in the section actually names a pattern.
+
+**Patterns that hedge into nothing.** "Users may sometimes experience difficulty"; the name commits no position.
+
+**Truism patterns.** "Users want fast performance"; the name describes the universe, not the data.
+
+**Vague specificity.** "Configuration step 3 is problematic"; specific enough to seem like a pattern, vague enough to not be one.
+
+**Pattern bloat.** 30 named patterns; the synthesis loses focus and produces no priorities.
+
+**Patterns named without evidence ties.** Synthesis where readers cannot trace each pattern to specific artifacts and quotes. Patterns become assertions rather than observations.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The category-vs-pattern distinction. The implication-legibility test. The avoid-bloat principle. The avoid-truism principle. The conviction principle. The pattern-name structures that work. The editing pass. Common naming failures.
+
+## Implementation choices that stay internal
+
+Specific document templates that surface pattern names prominently. Specific reviewer rubrics for editing pattern names. Specific A/B testing of pattern name variants for clarity. The team's own conventions for pattern count within the bands. These vary by team.

--- a/skills/discovery-research-synthesis/references/research-types-and-when-each-fits.md
+++ b/skills/discovery-research-synthesis/references/research-types-and-when-each-fits.md
@@ -1,0 +1,221 @@
+# Research types and when each fits
+
+Five common discovery research types, what each surfaces, what synthesis they support, and how to compose them within a single discovery cycle.
+
+Research-type selection is upstream of synthesis. The wrong types collected for the question produce data that synthesis cannot rescue. The right types collected, even at modest scale, produce synthesis that drives decisions.
+
+---
+
+## Customer interviews
+
+**Format.** 30-90 minute conversations, structured or semi-structured. Often one-on-one, sometimes in pairs or small groups for specific contexts.
+
+**Artifacts.** Recordings, transcripts, moderator notes, sometimes follow-up email exchanges.
+
+**What this surfaces.**
+
+- Why users do what they do (motivation, context, constraints).
+- The struggling moments and workarounds users have built.
+- The mental model behind user behavior.
+- The trade-offs users are weighing that the team did not anticipate.
+- The vocabulary users actually use (often different from internal product language).
+
+**What this does not surface.**
+
+- What users actually do in practice (interview self-report differs from behavioral data).
+- Patterns that emerge only at scale (a single interview is one data point).
+- Pricing willingness to pay (interview answers about price are notoriously unreliable).
+
+**Synthesis implications.**
+
+- Highest per-artifact richness; warrants careful per-transcript tagging.
+- Best paired with other research types that quantify the qualitative patterns.
+- Pattern thinness risk: 8-15 interviews surfaces patterns; 3-5 surfaces hypotheses that need more validation.
+
+**Typical batch size.** 8-15 interviews per discovery cycle. Larger batches saturate (most patterns emerge by interview 8-10 in a focused topic).
+
+---
+
+## Support ticket reviews
+
+**Format.** Audit of recent support tickets, often spanning a defined time window or a defined product area.
+
+**Artifacts.** Tagged ticket dataset, agent-conversation transcripts, sometimes recorded support calls.
+
+**What this surfaces.**
+
+- The friction users actually hit (revealed by ticket volume).
+- The vocabulary users use to describe broken experiences.
+- The disconnect between intended user flow and actual user behavior.
+- Repeated workflows that produce confusion or errors.
+- Documentation and onboarding gaps.
+
+**What this does not surface.**
+
+- Why users got there (the ticket starts at the problem; the path before is not visible).
+- The experience of users who did not contact support (silent struggling).
+- Users who succeed without friction.
+
+**Synthesis implications.**
+
+- Lower per-artifact richness; higher volume; signal lives in patterns across many tickets.
+- Best for surfacing concrete friction points; weak for understanding motivation.
+- Often pairs with interviews (interviews explain why; tickets document where).
+
+**Typical batch size.** 100-500 tickets per audit, often filtered by topic or product area.
+
+---
+
+## Sales call analysis
+
+**Format.** Recording or transcript review of recent sales calls. Often pairs with sales team feedback on patterns they hear repeatedly.
+
+**Artifacts.** Call recordings, sales notes, CRM-tagged objections, deal-stage data.
+
+**What this surfaces.**
+
+- Objections prospects raise (what makes the sale hard).
+- Pricing-conversation patterns and price sensitivity by segment.
+- Competitive mentions (which competitors are top-of-mind, what differentiation prospects ask about).
+- The gap between marketing positioning and what sales actually leads with.
+- Use cases prospects describe (sometimes different from how marketing describes the product).
+- Words prospects use to describe their situation (vocabulary signal).
+
+**What this does not surface.**
+
+- Existing-customer experience (sales calls are pre-purchase).
+- Why prospects who did not buy did not buy (lost-deal analysis is a separate research mode).
+
+**Synthesis implications.**
+
+- Pairs well with positioning and pricing decisions.
+- Useful for marketing-product alignment work.
+- Sales teams often have synthesis hypotheses already; the research either confirms or challenges those.
+
+**Typical batch size.** 15-30 calls per audit.
+
+---
+
+## Survey data
+
+**Format.** Quantitative responses to structured questions, often with optional qualitative comments.
+
+**Artifacts.** Response dataset, segmented by audience attributes.
+
+**What this surfaces.**
+
+- The frequency and severity of patterns identified through other research.
+- Segment differences (do Pro users and Free users have different needs).
+- Quantitative validation of qualitative hypotheses.
+- Aggregate satisfaction or NPS-style sentiment.
+
+**What this does not surface.**
+
+- Why users responded the way they did (closed-ended responses do not explain).
+- Patterns that the survey questions did not anticipate (surveys cannot find what they did not ask about).
+- Behavior (surveys reveal what users say, not what they do).
+
+**Synthesis implications.**
+
+- Best as validation of qualitative patterns at scale, not as primary discovery.
+- Survey design biases (leading questions, response order effects, satisficing) compromise data; treat with skepticism.
+- Open-ended comments are often the highest-value section of a survey.
+
+**Typical batch size.** 100-2,000 responses, depending on segment specificity.
+
+---
+
+## In-app feedback
+
+**Format.** Users submitting feedback through in-product channels (feedback widgets, NPS prompts, post-task surveys, error-state feedback forms).
+
+**Artifacts.** Submitted feedback corpus, often timestamped and contextualized by where in the product the feedback was triggered.
+
+**What this surfaces.**
+
+- Friction at the moment users encounter it (high context fidelity).
+- Patterns across many low-effort submissions.
+- Feature requests grounded in specific usage moments.
+- Bugs and broken experiences not captured by support.
+
+**What this does not surface.**
+
+- Users who did not bother to submit feedback (silent majority).
+- Why users hit the friction (the feedback names the problem; not always the cause).
+- Patterns from users who do not actively use the feedback channels.
+
+**Synthesis implications.**
+
+- Volume varies widely; some products see high in-app feedback volume, others minimal.
+- Often pairs with support tickets (similar surface area; different submission channels).
+- Useful as ongoing signal; this skill is more about the periodic-audit case (`user-feedback-aggregation` covers continuous synthesis).
+
+**Typical batch size.** Ongoing; synthesized in periodic audits over defined windows.
+
+---
+
+## Composition across types
+
+Strong discovery cycles combine research types deliberately.
+
+**The pair-and-validate pattern.**
+
+- Interviews (depth, ~12 conversations) provide qualitative patterns.
+- Support tickets (volume, ~300 tickets) document where friction surfaces in practice.
+- Survey (validation, ~500 responses) quantifies the patterns at scale.
+- Synthesis weaves all three: interview patterns ground the why, tickets ground the where, survey grounds the how-many.
+
+**The triangulate-the-decision pattern.**
+
+- A specific decision (should we redesign onboarding) gets evidence from three sources.
+- Interviews surface the experience of recent signups.
+- Sales calls surface what prospects say onboarding will look like.
+- Support tickets surface what new users actually hit.
+- Synthesis converges three perspectives on the same decision.
+
+**The single-type sufficiency pattern.**
+
+- Some discovery questions only need one type. A pricing review might need only sales call analysis. A support-volume reduction effort might need only ticket analysis.
+- Discipline: do not commission research types that will not contribute to the decision.
+
+**The wrong-pairs to avoid.**
+
+- Interviews + survey only, with no behavioral data: both are self-report; both can be wrong in the same direction.
+- Survey only, no qualitative: the survey assumes the questions are right.
+- Sales calls only, no customer voice: the prospect view is one segment; existing-customer voice may differ.
+
+---
+
+## Research-type pitfalls per type
+
+**Interview pitfalls.** Recruiting bias (the easiest-to-recruit users are not always representative). Leading questions. Confirming the team's prior hypothesis rather than challenging it. Small-batch over-generalization.
+
+**Support ticket pitfalls.** Survivorship bias (only users who contacted support are visible; users who silently churned are not). Tag quality (poor tagging compounds in synthesis). Time-window choice (a window that misses recent product changes can mislead).
+
+**Sales call pitfalls.** Stage selection (early-stage discovery calls and late-stage closing calls reveal different things). Sales-team interpretation (sales reps' framings can color how calls are tagged). Anonymization vs detail (privacy needs can erase the specifics that matter).
+
+**Survey pitfalls.** Response bias (who responds is not representative of who is asked). Question wording. Ordering effects. Satisficing (respondents click through without engaging). Falsely-precise quantitative output from low-quality data.
+
+**In-app feedback pitfalls.** Channel bias (the kinds of users who submit in-app feedback differ from those who do not). Volume-driven prioritization (loudest categories get attention; quieter ones get missed).
+
+---
+
+## When to commission what
+
+A short framework.
+
+1. **Decision driving the research.** What product decision is this research meant to inform?
+2. **Best research type for that decision.** Discovery (interviews lead), validation (survey or quantitative leads), friction-mapping (support and in-app feedback lead), positioning (sales call analysis leads).
+3. **Composition.** Which secondary types triangulate the primary?
+4. **Capacity.** What can be collected within the time and budget the decision allows?
+5. **Existing data check.** Has the team already collected research that would answer the question? Mining existing artifacts often produces value before commissioning new research.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five research types and what each surfaces. The composition patterns. The wrong-pairs to avoid. The pitfalls per type. The when-to-commission framework. The principle that research-type selection is upstream of synthesis quality.
+
+## Implementation choices that stay internal
+
+Specific recruiting platforms and incentive structures. Specific transcription tooling. Specific support-ticket platforms and their tagging schemas. Specific survey tools and statistical-significance configurations. Specific in-app feedback widgets and integration patterns. The team's own conventions for sample sizes within the bands. These vary by team, budget, and tooling.

--- a/skills/discovery-research-synthesis/references/synthesis-review-and-validation.md
+++ b/skills/discovery-research-synthesis/references/synthesis-review-and-validation.md
@@ -1,0 +1,177 @@
+# Synthesis review and validation
+
+How synthesis gets pressure-tested before it drives decisions. Review and validation surface synthesis errors that the research team missed: fabricated patterns, projected interpretations, missing dissent, segment misreads.
+
+The discipline is making review non-negotiable. Synthesis that ships without review carries unacknowledged blind spots; review compresses those blind spots before the synthesis becomes the team's working document.
+
+---
+
+## Internal review with research participants where possible
+
+**The principle.** Show the synthesis to a subset of the research participants. Do they recognize themselves and their experiences in the patterns?
+
+**Why participant review matters.**
+
+- Participants are the only authoritative source on whether the synthesis represents their experience.
+- Misrecognition signals fabrication: the synthesis projected interpretations the data did not support, or named patterns that did not match what participants actually said.
+- Recognition validates the synthesis: participants endorse the patterns as accurate representations.
+
+**The mechanics.**
+
+- Send the synthesis (or relevant excerpts) to 3-5 research participants for review.
+- Ask: "Do these patterns reflect your experience? Anything missing? Anything the synthesis got wrong?"
+- Build participant recognition into the research design from the start (with consent for follow-up review).
+
+**The exception.** Some research types (large-scale survey, anonymous in-app feedback) do not support participant review at the individual level. For those, validation depends on aggregate quantitative checks (the next section).
+
+**The honest disclosure.** When participant review surfaces misrecognition, the synthesis revises rather than dismissing the feedback. Synthesis that dismisses participant pushback is reverting to confirmation bias.
+
+---
+
+## Adjacent-team review
+
+**The principle.** Show the synthesis to product, engineering, support, sales. Do the patterns match what they observe in their domains?
+
+**Why adjacent-team review matters.**
+
+- Adjacent teams have ground-truth observations the research did not access. Support sees the friction users hit every day; sales hears prospect objections; engineering knows which problems are technically tractable.
+- Adjacent teams catch synthesis errors that the research team missed: patterns that contradict what support handles daily, implications that ignore engineering constraints.
+- Adjacent teams' alignment with synthesis affects whether the synthesis drives decisions: if support disagrees with the support-related patterns, the synthesis loses authority.
+
+**The mechanics.**
+
+- Share the synthesis with relevant adjacent-team leads for review.
+- Hold a structured review session where adjacent teams can challenge, validate, or extend the patterns.
+- Capture adjacent-team observations as inputs to synthesis revision.
+
+**Common adjacent-team feedback patterns.**
+
+- Support: "Your synthesis names X as a pattern, but support tickets show Y is also load-bearing and not in the synthesis."
+- Sales: "Prospects do say what your synthesis claims, but the patterns you missed are the pricing-conversation friction."
+- Engineering: "The implication you propose has a constraint the synthesis did not account for."
+
+The synthesis revises in light of these inputs.
+
+---
+
+## Quantitative validation where possible
+
+**The principle.** Patterns from qualitative synthesis can often be validated at scale through analytics, survey, or in-app data.
+
+**The validation pattern.**
+
+- Synthesis says: "Users abandon configuration step 3 because credit card details are not accessible at signup."
+- Quantitative validation: pull analytics on configuration step 3 abandonment rate. Does the data confirm 40% abandonment that the pattern implies? Does abandonment correlate with the credit card requirement (versus other possible causes)?
+- If the data confirms: the pattern is strongly supported.
+- If the data does not confirm: the pattern needs revision; the qualitative signal may not generalize.
+
+**Why validation matters.**
+
+- Qualitative patterns can overstate frequency; small-sample interview signal does not always match large-sample reality.
+- Quantitative validation grounds synthesis in scaled data without requiring the synthesis to be quantitative-only.
+- Validation reveals which patterns are strong enough to act on and which need more investigation.
+
+**See `experiment-design`** for rigorous A/B testing as quantitative validation. **See `product-analytics-setup`** for the instrumentation that makes validation possible.
+
+**The honest disclosure.** When quantitative validation contradicts qualitative patterns, the synthesis adjusts. Patterns the analytics does not support get downgraded or removed. Synthesis that ignores quantitative pushback in favor of qualitative claims is unrigorous.
+
+---
+
+## The "challenge the synthesis" session
+
+**The principle.** A specific session where adjacent teams try to find what the synthesis missed, overstated, or railroaded.
+
+**The session structure.**
+
+- Synthesis owner presents the patterns and implications (15-30 minutes).
+- Adjacent-team participants challenge: "What patterns did the research miss? What implications overstate the data? What decisions is the synthesis trying to railroad?"
+- Synthesis owner takes notes; does not defend; the session is for surfacing concerns, not for resolution in the moment.
+- Synthesis owner revises based on the inputs over the following days; revised synthesis circulates back.
+
+**Why this works.**
+
+- Productive disagreement strengthens synthesis. The team that surfaces concerns is contributing to better synthesis, not undermining the research investment.
+- The session creates space for honest pushback that quieter review formats sometimes suppress.
+- The session signals that synthesis is open to challenge, which strengthens the team's trust in the synthesis once it ships.
+
+**The anti-pattern.** Synthesis owners who treat the session as defense of the synthesis rather than as input to the synthesis. The owner pushes back on every challenge; adjacent teams disengage; synthesis ships unrevised.
+
+**The discipline.** The synthesis owner's job in the session is to listen and capture, not to defend. Defense happens in the revision; pushback happens later, after considering the input.
+
+---
+
+## Iterate before publishing
+
+**The principle.** Synthesis goes through revision based on the review loop. Synthesis that ships in first-draft state usually carries unacknowledged blind spots.
+
+**The iteration cycle.**
+
+- First draft from the synthesis owner.
+- Participant review (where possible).
+- Adjacent-team review (always).
+- Challenge-the-synthesis session.
+- Revision based on inputs.
+- Final review by senior product leader for clarity and quality.
+- Publication.
+
+**Time investment.** The review-and-iteration loop adds 1-2 weeks to the synthesis timeline. That investment is small relative to the cost of publishing synthesis with blind spots that produce wrong decisions.
+
+**Common iteration outputs.**
+
+- Patterns split (the original pattern was actually two patterns adjacent teams distinguished).
+- Patterns merged (the original separation was not load-bearing).
+- Patterns revised (the framing did not match the data on closer review).
+- Implications expanded (additional implications surfaced during review).
+- Implications narrowed (some implications overstepped what the data supports).
+- Decision input refined (the original was too vague to drive decisions).
+
+---
+
+## When the review loop reveals the synthesis cannot be saved
+
+**The honest case.** Sometimes review surfaces synthesis problems too deep to fix in revision: patterns built on insufficient data, projections the data did not support, framing that adjacent teams flatly contradict.
+
+**The response.**
+
+- Stop. Do not publish synthesis with known significant problems.
+- Re-examine: was the underlying research adequate? Was the synthesis sequence run completely? Were the patterns named with conviction or projected?
+- Restart from where the breakdown happened. Often returns to clustering or pattern-naming.
+- Sometimes returns to gathering more research. The honest case is acknowledging that the discovery cycle did not produce sufficient input for reliable synthesis.
+
+**The cost calibration.** Restarting synthesis costs PM time. Publishing flawed synthesis costs the team's trust in research output, plus the wrong decisions the flawed synthesis drives. The latter is usually more expensive.
+
+---
+
+## What review does not do
+
+**Review does not validate every synthesis.** Some synthesis fails review and should not ship; some passes with revision; some passes with minor adjustment. Review is the discipline that distinguishes the cases.
+
+**Review does not eliminate disagreement.** Adjacent teams may continue to disagree even after review. The synthesis owner makes the final call after considering inputs. Disagreement preserved in the published synthesis is fine and honest; pretended consensus is not.
+
+**Review does not slow shipping artificially.** A 1-2 week review loop on substantive synthesis is appropriate. Quick-turn synthesis (short audits, focused interview batches) can run a lighter review (asynchronous comments from 2-3 reviewers; adjacent-team check; ship).
+
+---
+
+## Common review-and-validation failures
+
+**Skipping participant review.** Synthesis ships without participants ever seeing the patterns; participants would have caught misrecognitions; the synthesis carries projection.
+
+**Skipping adjacent-team review.** The team most likely to know the data is wrong did not see the synthesis before publication.
+
+**Defensive review sessions.** The synthesis owner argues against challenges instead of capturing them; the session produces defense rather than input.
+
+**Quantitative validation skipped.** The qualitative patterns went unchallenged by available analytics data; the synthesis overstates patterns the data does not support.
+
+**Iteration compressed to one round.** First draft + one review + ship. Most synthesis benefits from two rounds of revision: first round on substance, second round on presentation.
+
+**Review feedback dismissed.** Adjacent teams raise concerns; synthesis owner notes them but does not revise. Synthesis ships as if the feedback did not happen.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The participant review pattern. The adjacent-team review pattern. Quantitative validation. The challenge-the-synthesis session. Iteration discipline. The cannot-be-saved escalation. What review does and does not do. Common review failures.
+
+## Implementation choices that stay internal
+
+Specific reviewer pairings and roles. Specific session formats and facilitation. Specific revision tracking. Specific publication conventions. Specific quantitative validation pipelines. The team's own conventions for review-loop length. These vary by team.

--- a/skills/discovery-research-synthesis/references/synthesis-sequence-walkthrough.md
+++ b/skills/discovery-research-synthesis/references/synthesis-sequence-walkthrough.md
@@ -1,0 +1,229 @@
+# Synthesis sequence walkthrough
+
+The six-stage synthesis sequence with worked example. Stage outputs, common skip-failures, time investment per stage.
+
+The sequence is non-negotiable. Teams that skip stages produce findings that look like synthesis but are not: untagged transcripts, unclustered tags, unnamed patterns, patterns without implications, implications without decisions. Each stage builds on the previous; skipping any stage breaks the chain.
+
+---
+
+## The six stages
+
+1. **Transcribe and prepare.** Convert artifacts into a synthesizable format.
+2. **Tag at the artifact level.** First-pass descriptive tagging.
+3. **Cluster across artifacts.** Group tags into themes.
+4. **Name patterns.** Each cluster becomes a named pattern.
+5. **Infer product implications.** What does each pattern imply.
+6. **Name the so-what.** The decision input.
+
+---
+
+## Stage 1: Transcribe and prepare
+
+**The work.** Convert artifacts into a format you can read, mark up, and search.
+
+**Outputs.**
+
+- Interview transcripts, time-stamped, speaker-labeled.
+- Support ticket dataset, exported to a workable format with relevant fields (subject, body, resolution, tags, dates).
+- Sales call summaries or transcripts.
+- Survey data with open-ended responses extracted into a reviewable format.
+
+**Time investment.** Often underestimated. A 60-minute interview takes 60-90 minutes to transcribe (with AI tools) plus 30-60 minutes to clean. Eight interviews: 12-20 hours of prep before tagging starts.
+
+**Common skip-failures.**
+
+- Skipping transcription on the assumption that the recordings are sufficient. Reality: tagging from audio is impractical at any meaningful batch size.
+- Cleaning to the point of distortion (removing the messy parts that contain signal).
+- Skipping speaker labels (collapsed dialog loses critical context).
+
+**The unglamorous-but-essential principle.** Teams that skip prep work never reach the later stages because the artifacts are not workable. The investment in prep pays back across every later stage.
+
+---
+
+## Stage 2: Tag at the artifact level
+
+**The work.** Read each transcript or ticket and tag it with topics, problems, quotes, and observations.
+
+**Outputs.**
+
+- Tagged artifacts (transcripts, tickets, etc.) with descriptive tags inline.
+- A tag list (often 80-150 tags per batch by the end of this stage).
+- Quote pulls (specific sentences worth referencing later).
+
+**Approach.**
+
+- First-pass tagging is descriptive: what did this person say, what problem did they hit, what were they trying to do.
+- Allow tag proliferation. Do not force consolidation in this stage; that is for clustering.
+- Tag dissent and contradictions explicitly. "User reports liking the onboarding" alongside other users reporting friction is signal; tag it.
+- Mark quotes worth pulling. Synthesis output includes evidence; the evidence comes from quotes selected during tagging.
+
+**Time investment.** Per artifact: 30-90 minutes for an interview transcript, 1-3 minutes per support ticket, 15-30 minutes per sales call. A typical batch (12 interviews + 200 tickets + 20 sales calls) might run 25-40 hours of focused tagging work.
+
+**Common skip-failures.**
+
+- Pre-designing the tag taxonomy and forcing artifacts into it.
+- Tagging from memory after reading the transcript rather than during reading.
+- Premature consolidation (collapsing tags during this stage instead of later).
+- Skipping the contradictions (only tagging the dominant pattern).
+
+**The artifact-level discipline.** Each tag is grounded in a specific moment in a specific artifact. Tags floating free of evidence are a stage-2 failure that compounds in later stages.
+
+---
+
+## Stage 3: Cluster across artifacts
+
+**The work.** Group tags into themes that surface the patterns the data reveals.
+
+**Outputs.**
+
+- A cluster list (often 6-15 clusters from the 80-150 tags).
+- Per-cluster tag membership.
+- Per-cluster artifact source list (which artifacts contributed to this cluster).
+
+**Approach.**
+
+- Cluster on the underlying observation, not on tag overlap. Two tags that co-occur may not be the same pattern.
+- Iterate: first-pass clustering will reveal that some tags belong in multiple clusters; some clusters are too broad; some need to split.
+- Use the artifact-source list to test cluster strength. A cluster with 8 supporting artifacts is stronger than one with 2.
+- Track the dissent: which clusters have countervailing evidence the synthesis must address.
+
+**Time investment.** 4-8 hours of clustering work for a batch this size. Often done collaboratively with another reviewer to surface alternative groupings.
+
+**Common skip-failures.**
+
+- Clustering on assumed categories rather than emergent themes.
+- Stopping at first-pass clustering without iterating.
+- Ignoring artifact-source counts (clusters with thin support get weighted equally with strong ones).
+- Forcing every tag into a cluster (some tags are noise; that is fine).
+
+---
+
+## Stage 4: Name patterns
+
+**The work.** Each cluster becomes a named pattern that captures what the underlying observation actually is.
+
+**Outputs.**
+
+- A pattern list (typically 4-8 patterns from a strong synthesis).
+- Per-pattern name, evidence summary, and source-artifact list.
+
+**Approach.**
+
+- Pattern name is specific enough that a reader can guess the implication.
+- Pattern names commit a position: name what the data shows, not a category the data sits in.
+- Avoid truisms: pattern names that read as something everyone could have said before the research are not patterns.
+- Limit pattern count: 4-8 strong patterns serve synthesis better than 15 weak ones.
+
+**Time investment.** 2-4 hours of pattern-naming work. Often the highest-impact stage; investment in good pattern names pays off in implications and decisions.
+
+**Common skip-failures.**
+
+- Pattern names that are category labels (Onboarding, Pricing, Support).
+- Pattern names that are truisms (Users want fast performance).
+- Hedge-stacked pattern names (Users sometimes seem to occasionally maybe).
+- Too many patterns (under-clustering manifests as pattern bloat).
+
+See `pattern-naming-patterns.md` for detail.
+
+---
+
+## Stage 5: Infer product implications
+
+**The work.** For each pattern, name what this implies for the product.
+
+**Outputs.**
+
+- Per-pattern implication list (often 1-3 implications per pattern).
+- Per-implication: specific, falsifiable, cost-acknowledged.
+
+**Approach.**
+
+- Each pattern can have multiple implications. Surface the options; do not pre-prioritize.
+- Implications are the writer's analytical work, not what users said. Users describe experience; PMs interpret what experience implies.
+- Make implications falsifiable. "We should improve onboarding" is not an implication; "Move the third configuration step to after first success state" is.
+- Acknowledge cost. Implications that ignore implementation cost produce wishlists.
+- Some patterns imply not-acting. Naming the not-act implication is honest synthesis.
+
+**Time investment.** 3-6 hours of implication work.
+
+**Common skip-failures.**
+
+- Vague implications that cannot be acted on or debated.
+- Wishlist implications that do not acknowledge cost.
+- Skipping the not-act implication when it would be honest.
+- Implications that are restatements of the pattern (no analytical bridge).
+
+See `from-pattern-to-product-implication.md` for detail.
+
+---
+
+## Stage 6: Name the so-what
+
+**The work.** For each implication, the specific decision it informs.
+
+**Outputs.**
+
+- Per-implication so-what statement tied to a real decision.
+- An overall recommendation section: what should change as a result of this synthesis.
+
+**Approach.**
+
+- Map each implication to a decision the team is making (or should make).
+- Be specific: "Should the Q2 roadmap include the onboarding redesign?" rather than "Onboarding should be considered."
+- Surface the synthesis's overall recommendation: where to invest, where to deprioritize, where to gather more data before deciding.
+- Acknowledge the decisions the synthesis cannot resolve: data gaps, contested patterns, decisions outside the synthesis's scope.
+
+**Time investment.** 2-4 hours of so-what work.
+
+**Common skip-failures.**
+
+- So-whats that are too abstract to drive decisions.
+- Skipping the overall recommendation section (each pattern stands alone; the synthesis does not aggregate).
+- Buried data gaps (the synthesis presents conclusions where the data did not support them).
+
+---
+
+## Worked example
+
+A discovery cycle with 12 customer interviews + 250 support tickets + a sales call audit, focused on a possible onboarding redesign.
+
+**Stage 1 (prep).** 18 hours. Interview transcripts cleaned; ticket dataset extracted; sales call transcripts pulled.
+
+**Stage 2 (tagging).** 32 hours. 110 tags emerged across the artifacts. Quote pulls captured.
+
+**Stage 3 (clustering).** 6 hours. Clusters emerged: configuration-step friction, value-state delay, onboarding length, mobile-context onboarding, role-based mismatch, support-deflectable confusion. Six clusters with varying artifact support.
+
+**Stage 4 (pattern naming).** 3 hours. Six patterns named, including:
+
+- "Users abandon configuration step 3 because it requires data they do not have on hand at signup time."
+- "Free users reach the success state at half the rate of paid users because the configuration burden is the same but the value reveal is gated."
+- "New users on mobile cannot complete onboarding without switching to desktop because two configuration screens are not mobile-functional."
+
+**Stage 5 (implications).** 4 hours. Per-pattern implications. Example for the configuration-step pattern:
+
+- Implication: defer configuration step 3 to after first success state, with a "complete your setup" prompt later.
+- Cost: medium engineering investment; affects existing flows for users who completed step 3 historically.
+- Alternative implication: pre-populate step 3 with sensible defaults from step 2 data where possible.
+- Not-act implication: keep the current flow but improve docs (probably insufficient given the friction severity).
+
+**Stage 6 (so-what).** 3 hours. Decision input: yes, prioritize onboarding redesign in Q2; staged-onboarding approach; mobile parity is a sub-track within the redesign; configuration-step deferral is the headline change.
+
+**Total synthesis time.** 66 hours over the six stages. Roughly 1.5-2 weeks of focused synthesis work for one PM.
+
+---
+
+## Time-investment patterns
+
+Synthesis sequences that go shorter than this are usually skipping stages. Sequences that go longer are usually over-investing in tagging or under-deciding in implications. The 60-80 hour range for a substantial discovery synthesis is typical.
+
+Programs that have not budgeted synthesis time often discover it after research ships and the synthesis stalls. The discipline is budgeting synthesis at the start of the discovery cycle, not as an afterthought.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The six-stage sequence with stage outputs and time investments. The worked example. The non-negotiability of the sequence. Common skip-failures per stage.
+
+## Implementation choices that stay internal
+
+Specific transcription tools. Specific tagging tools (spreadsheet, dedicated qualitative analysis software, AI-assisted tagging). Specific clustering visualization. Specific document templates per output. Specific time-tracking conventions for synthesis budgeting. These vary by team and tooling.

--- a/skills/discovery-research-synthesis/references/tagging-and-clustering-discipline.md
+++ b/skills/discovery-research-synthesis/references/tagging-and-clustering-discipline.md
@@ -1,0 +1,140 @@
+# Tagging and clustering discipline
+
+The middle stages of the synthesis sequence have specific failure modes. Tagging and clustering done badly produces bad patterns; tagging and clustering done well produces patterns that drive decisions.
+
+The discipline is in five principles that apply across both stages.
+
+---
+
+## Principle 1: Tag at the artifact level first; do not pre-design the taxonomy
+
+**The pattern.** Tags emerge from the artifacts. The researcher reads each transcript and tags what is actually there.
+
+**The anti-pattern.** Researchers arrive at tagging with a pre-built taxonomy: "we will tag for usability, performance, pricing, support." Artifacts get forced into the categories. Patterns the taxonomy did not anticipate get missed.
+
+**Why pre-built taxonomies fail.**
+
+- The taxonomy reflects what the team already thinks; tagging confirms what the team already thinks; synthesis does not reveal anything new.
+- Artifacts that do not fit the taxonomy categories get skipped or shoehorned in.
+- Tags that emerge in the data but were not in the taxonomy do not get captured.
+
+**The exception.** Some categorical metadata is fine to apply consistently (user segment, source channel, recency). The semantic tagging that drives synthesis should still emerge from the data.
+
+**The recovery.** Mid-tagging, if the team realizes the pre-built taxonomy is constraining, it can be discarded and tagging restarted with descriptive tags emerging from artifacts. Better to restart than to publish synthesis grounded in a constraining taxonomy.
+
+---
+
+## Principle 2: Allow tag proliferation; collapse later
+
+**The pattern.** First-pass tagging produces 80-150 tags across a batch. That is correct. Premature consolidation loses distinctions that turn out to matter.
+
+**The anti-pattern.** Researchers consolidating tags during the tagging stage. "We had four onboarding tags; let me merge them into one." The merge happens before the researcher has seen whether the four tags actually represent different patterns.
+
+**Why proliferation matters.**
+
+- Some distinctions only become visible after seeing many artifacts. Two tags that seem similar at artifact 3 may turn out to be different patterns by artifact 12.
+- Granular tags can always be collapsed in the clustering stage; collapsed tags cannot be unmerged once the tagging is done.
+- Proliferation supports the discovery posture; consolidation supports the confirmation posture.
+
+**The volume calibration.** A batch of 12 interviews + 250 tickets + 20 sales calls might end with 80-150 tags. Fewer than that often signals premature consolidation; more than that may signal undisciplined tagging.
+
+---
+
+## Principle 3: Cluster on patterns, not on tag overlap
+
+**The pattern.** Two tags that co-occur in many artifacts may or may not be the same pattern. Cluster on the underlying observation, not on statistical co-occurrence.
+
+**The anti-pattern.** Tools that auto-cluster by co-occurrence. They produce statistical groupings that do not always match the patterns the researcher needs.
+
+**Why pattern-clustering matters.**
+
+- "Slow onboarding" and "configuration friction" might co-occur because both are common; that does not mean they are the same pattern. They might be the same (configuration is what makes onboarding feel slow) or different (there is friction in configuration AND there is a perception of length independent of configuration).
+- The researcher's interpretation of the artifact-level tags is what surfaces the pattern; tools can suggest groupings but cannot determine them.
+
+**The work.** For each candidate cluster, ask: are the underlying observations the same, or do they share a tag because the tag was loose? If the latter, split the cluster.
+
+---
+
+## Principle 4: Name the cluster after clustering, not before
+
+**The pattern.** The cluster name comes from the data after the clustering work is done.
+
+**The anti-pattern.** Researchers arriving with named clusters and slotting data into them. The clusters become hypothesis-confirmation rather than discovery.
+
+**Why post-cluster naming matters.**
+
+- Pre-named clusters bias the clustering: tags get assigned to clusters they fit linguistically rather than substantively.
+- Post-cluster naming reveals patterns the team did not anticipate (the highest-value patterns).
+- The naming itself is part of the synthesis work; rushing the naming compresses the analytical work into a label without thought.
+
+**The discipline.** First-pass clustering produces unnamed clusters. The researcher then names each cluster based on what the underlying observations actually show. Names emerge after the clustering, not before.
+
+---
+
+## Principle 5: Tag dissent and contradictions explicitly
+
+**The pattern.** Some users will contradict the dominant pattern. Those contradictions are signal: either there is a sub-segment with different needs, or the pattern is weaker than the volume suggests.
+
+**The anti-pattern.** Tagging only the dominant pattern; ignoring the contradictions; or tagging contradictions but not following them through to clustering and synthesis.
+
+**Why dissent matters.**
+
+- Contradictions reveal sub-segments. "Most users find configuration confusing; experienced users find it efficient" might mean the pattern is segment-specific, not universal.
+- Contradictions reveal pattern strength. A pattern with no countervailing evidence is suspicious; a pattern with some dissent that the synthesis can explain is stronger.
+- Synthesis that ignores dissent reads as researcher confirmation bias.
+
+**The discipline.** Each major pattern in synthesis has a "but consider" section: contradictions in the data, segment differences, edge cases. The synthesis is more honest with these sections; readers trust patterns that engage their counterevidence.
+
+---
+
+## Tagging tactics that work
+
+A short list of tactics that improve tagging quality.
+
+**Read the artifact end-to-end before tagging.** Tagging while reading on first pass produces fragmentary tags. Reading first, then tagging on a second pass, produces tags grounded in the artifact's full context.
+
+**Tag specific moments, not summaries.** "User struggles" is a summary. "User abandons configuration step 3 because credit card details are not accessible during signup" is a specific moment. Specific moments support stronger pattern naming later.
+
+**Pull quotes during tagging.** Synthesis output includes evidence; the evidence comes from quotes selected during tagging. Marking quote-worthy moments during tagging prevents re-reading later.
+
+**Tag motivation alongside behavior.** "User clicked X" is behavior; "User clicked X because they thought it would Y" is motivation. Motivation tags surface what users were trying to accomplish, which informs implications more than behavior alone.
+
+**Tag emotional valence sparingly.** "User was frustrated" is fine; tagging every artifact for emotional state produces noise.
+
+---
+
+## Clustering tactics that work
+
+**Iterate clustering at least twice.** First-pass clustering is rough; second-pass clustering refines; third-pass clustering catches what the first two missed.
+
+**Use artifact-source counts.** A cluster supported by 8 artifacts is stronger than one supported by 2. The source count does not determine pattern importance, but it informs synthesis weighting.
+
+**Test cluster boundaries.** Take a tag from one cluster and ask: could this fit in another cluster instead? If yes, the cluster boundaries are unclear; refine.
+
+**Surface the leftovers.** Tags that do not fit any cluster are signal. They might be noise (one-off observations not generalizing). They might be edge-case patterns worth naming separately. They might point to a cluster the researcher missed.
+
+**Cluster collaboratively where possible.** A second reviewer surfaces alternative groupings the first reviewer did not see. Two reviewers usually produces better clustering than one.
+
+---
+
+## Common tagging-and-clustering failures
+
+**Tagging by memory, not by reading.** Researchers reading transcripts and then tagging from recall. Loses specifics; produces general tags that cluster poorly.
+
+**Tag exhaustion.** Researchers running through too many artifacts in one session, tag quality decaying as fatigue sets in. Reduce session length; pace the tagging across days.
+
+**Confirming the team's prior hypothesis.** Researchers entering tagging with a hypothesis the research is meant to confirm. Tags get assigned to support the hypothesis; counterevidence gets minimized.
+
+**Cluster collapsing to fit a target count.** Researchers feeling they should have N clusters and forcing the data to that count. Either over-collapsing (losing distinctions) or under-collapsing (preserving noise as signal).
+
+**Skipping the dissent.** Tagging only the dominant pattern; clustering only the supporting tags. Synthesis publishes patterns without their counterevidence; reviewers later catch the gap.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five principles (tag at artifact level, allow proliferation, cluster on patterns, name after clustering, tag dissent). The tagging tactics. The clustering tactics. The common failures.
+
+## Implementation choices that stay internal
+
+Specific tagging tools (spreadsheet, dedicated qualitative analysis software, AI-assisted tagging). Specific clustering visualization. Specific session-length conventions for tagging. Specific reviewer pairings. The team's own conventions for tag-count thresholds. These vary by team and tooling.

--- a/skills/discovery-research-synthesis/references/when-to-gather-more-data.md
+++ b/skills/discovery-research-synthesis/references/when-to-gather-more-data.md
@@ -1,0 +1,212 @@
+# When to gather more data
+
+Synthesis sometimes reveals that the research did not collect enough. The discipline is naming gaps explicitly and deciding whether to halt synthesis, ship with named gaps, or restart with more research.
+
+The discomfort of acknowledging gaps is the source of bad synthesis. Teams that have invested in research want to declare the data sufficient even when the synthesis reveals it was not. The discipline is honesty about what the research can and cannot support.
+
+---
+
+## Pattern thinness
+
+**The signal.** A pattern surfaces in 2-3 artifacts but the synthesis would need 5-8 to commit a position.
+
+**Why it happens.**
+
+- The discovery cycle had a defined batch size; some patterns emerged with limited support.
+- The pattern is real but rare; the research did not encounter enough cases to characterize it.
+- The pattern is segment-specific; the research overrepresented other segments.
+
+**The honest options.**
+
+- Name the pattern as tentative pending more data. Synthesis ships with this pattern flagged as preliminary; the team treats it as a hypothesis rather than a finding.
+- Pause synthesis to gather more research. If the pattern is decision-load-bearing, the additional research investment may be worthwhile.
+- Drop the pattern. If the pattern is not decision-relevant or the data is too thin to be useful, do not include it. Inflating thin patterns to fill space is a synthesis failure.
+
+**The dishonest option to avoid.** Naming the thin pattern as if it had full support. Readers cannot distinguish well-supported from thinly-supported patterns; decisions get made as if all patterns are equal weight; the team gets surprised when the thin-pattern decisions do not pan out.
+
+---
+
+## Segment under-representation
+
+**The signal.** The research overrepresents one user segment and underrepresents another that matters for the decision.
+
+**Why it happens.**
+
+- Recruiting bias produces segment skew (the easiest-to-recruit users are usually a specific segment).
+- The research was scoped before the team realized which segments mattered most for the decision.
+- Available research artifacts (existing tickets, prior interviews) skew toward certain segments.
+
+**The honest options.**
+
+- Synthesize for the represented segment; flag explicitly that the patterns may not apply to underrepresented segments.
+- Pause to recruit and conduct research with the underrepresented segment.
+- Use existing data sources (analytics, support data) to validate patterns in the underrepresented segment indirectly.
+
+**Worked example.** A discovery cycle on B2B onboarding interviews 12 users, all from companies of 50-500 employees. The synthesis surfaces strong patterns for that segment. The product team is also considering enterprise (1000+ employees) and small business (1-50). The synthesis should:
+
+- Name patterns for the 50-500 segment with confidence.
+- Acknowledge that enterprise and small business patterns are not represented.
+- Recommend either separate research for the missing segments or scoping the decision to the segment the data covered.
+
+---
+
+## Contradictory clusters
+
+**The signal.** Two clusters point in opposite directions and the data does not resolve the contradiction.
+
+**Why it happens.**
+
+- Sub-segment differences the research did not investigate explicitly.
+- Different use contexts producing different needs (mobile vs desktop, new vs returning users).
+- One cluster reflects what users say; the other reflects what users do; the contradiction is real and revealing.
+
+**The honest options.**
+
+- Investigate the contradiction. Often the contradiction itself becomes the most valuable finding: it surfaces a sub-segment or context distinction the team did not anticipate.
+- Pause synthesis to gather targeted research that resolves the contradiction.
+- Ship synthesis with the contradiction named and the recommendation to gather more data before committing decisions in this area.
+
+**Worked example.** Interviews with new users surface that they want simpler onboarding. Support tickets from new users in the same week surface frequent requests for more configuration options during onboarding. The contradiction may reveal:
+
+- New users say "simpler" but mean "fewer required steps before value"; configuration options are fine if not blocking.
+- The interview sample skewed casual users; the support tickets came from power users.
+- The contradiction needs more investigation before driving onboarding redesign.
+
+---
+
+## Decision time pressure
+
+**The signal.** Synthesis revealing data gaps but the decision has to ship before more research can happen.
+
+**Why it happens.**
+
+- Roadmap commitments do not flex for data gaps.
+- The decision is upstream of work that has already been committed.
+- The cost of waiting exceeds the value of additional data.
+
+**The honest path.**
+
+- Name the data gap explicitly in the synthesis. Do not pretend the gap does not exist.
+- Make the recommendation with the gap acknowledged. "Given current data, we recommend X. The gap that may revise this recommendation is Y."
+- Plan the follow-up research that would validate or revise the recommendation.
+- Build instrumentation that will validate the recommendation post-launch (so the team can detect if the recommendation was wrong).
+
+**The path to avoid.** Pretending the data is sufficient when it is not. Synthesis under time pressure that treats partial data as complete data produces decisions the team will not be able to recover from cleanly when the gap surfaces later.
+
+---
+
+## The "we have enough" trap
+
+**The pattern.** Teams that have invested in research want to declare the data sufficient even when the synthesis reveals gaps.
+
+**Why it happens.**
+
+- Sunk-cost reasoning: the team has spent the research budget; restarting feels like waste.
+- Timeline pressure: the research was scheduled before synthesis; more research means schedule slip.
+- Status concerns: declaring the research insufficient feels like admitting the discovery work was inadequate.
+
+**Why it produces bad synthesis.**
+
+- The data gaps still exist whether or not the team acknowledges them. Decisions made on incomplete data still suffer from the incompleteness.
+- Synthesis that papers over gaps trains the team to treat synthesis as performative rather than load-bearing.
+- The next discovery cycle will repeat the same scoping mistakes because the team did not name them honestly.
+
+**The discipline.**
+
+- Naming gaps is the synthesis owner's job. The team relies on the synthesis owner to be honest about what the research can and cannot support.
+- The cost of naming gaps is short-term discomfort; the cost of pretending they do not exist is bad decisions.
+- "We have enough" should be the conclusion of synthesis review, not the assumption.
+
+---
+
+## When more research is the right call
+
+**The criteria.**
+
+- The decision is load-bearing for product direction.
+- The gap is large enough that synthesis would be misleading without addressing it.
+- The cost of additional research is bounded and feasible.
+- The cost of deciding now and being wrong is high.
+
+**Examples that warrant more research.**
+
+- A pricing decision where current research underrepresents the segment that drives revenue.
+- An onboarding redesign where the synthesis cannot distinguish what new users want from what they need.
+- A positioning shift where existing-customer voice is in the data but prospect voice is missing.
+
+**Examples that do not warrant more research.**
+
+- Minor decisions where the gap's resolution would not change the recommendation materially.
+- Decisions where the cost of waiting exceeds the value of additional data.
+- Decisions that can be reversed easily based on post-launch data.
+
+---
+
+## When to ship synthesis with named gaps
+
+**The criteria.**
+
+- Decision time pressure makes more research infeasible.
+- The gap is named honestly so the team can weigh the recommendation accordingly.
+- Post-launch instrumentation will detect if the recommendation was wrong.
+
+**The discipline.**
+
+- The named gap is in the synthesis prominently, not buried.
+- The recommendation acknowledges what the gap might change.
+- The follow-up research plan is specific and committed.
+
+**Worked example.** "Recommendation: prioritize the onboarding redesign in Q2. Caveat: our research underrepresents enterprise users; if enterprise represents a significant share of new signups, the redesign should include enterprise-specific paths we have not validated. Follow-up: enterprise-specific user research in Q1 to validate the redesign approach for that segment before Q2 ships."
+
+---
+
+## When to drop the pattern entirely
+
+**The criteria.**
+
+- The supporting data is too thin to commit a position even tentatively.
+- The pattern, if false, would mislead the team in directions hard to recover from.
+- The pattern is not load-bearing for the synthesis's primary recommendations.
+
+**The discipline.**
+
+- Some thin patterns warrant dropping rather than flagging. Not every observation needs to make it into the synthesis.
+- Dropping is honest synthesis; inflating is not.
+
+---
+
+## Common gather-more-data failures
+
+**Inflating thin patterns.** Patterns supported by 2 artifacts presented as if supported by 12. Readers cannot distinguish strength.
+
+**Hiding segment gaps.** Synthesis presents recommendations as universal when they apply only to the segment researched.
+
+**Pretending contradictions resolved.** Synthesis writes around the contradiction rather than naming it; readers later discover it on their own.
+
+**Decision-pressure denial.** Synthesis treats time pressure as if it makes data complete. The decision is made; the wrong-decision cost is paid later.
+
+**The "we have enough" trap.** Sunk cost and status protect the synthesis from honest gap-naming.
+
+**Endless research.** The opposite failure: every gap triggers more research; synthesis never ships; the team paralyzes on data-gathering.
+
+---
+
+## The data-sufficiency calibration
+
+A short framework.
+
+1. **Is the gap load-bearing for the recommendations?** If yes, address it. If no, name and proceed.
+2. **Is more research feasible within the decision timeline?** If yes, gather. If no, ship with named gaps.
+3. **Can post-launch instrumentation catch wrong decisions?** If yes, ship-with-instrumentation is reasonable. If no, more caution warranted.
+4. **What is the cost of being wrong vs cost of waiting?** Compare; choose the lower-cost path.
+5. **Is the team's commitment to follow-up research credible?** If named gaps will trigger real follow-up, ship-with-gaps works. If named gaps will be ignored, gather now.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The pattern thinness signal. Segment under-representation. Contradictory clusters. Decision time pressure. The we-have-enough trap. When more research is and is not the right call. When to ship with named gaps. When to drop patterns. Common gather-more-data failures. The data-sufficiency calibration.
+
+## Implementation choices that stay internal
+
+Specific recruiting pipelines for follow-up research. Specific instrumentation for post-launch validation. Specific synthesis-revision workflows when gaps are named. The team's own conventions for "thin pattern" thresholds. These vary by team.

--- a/skills/discovery-research-synthesis/references/writing-for-decisions-not-decks.md
+++ b/skills/discovery-research-synthesis/references/writing-for-decisions-not-decks.md
@@ -1,0 +1,207 @@
+# Writing for decisions, not decks
+
+Synthesis output should be optimized for decision use, not for presentation. The format choice (document vs deck), the structure (patterns lead, evidence appendix), the voice (opinionated), and the closing (decision input section) compose to produce synthesis the team actually references.
+
+---
+
+## Document, not deck
+
+**The principle.** Deck format is poor for synthesis.
+
+**Why decks fail.**
+
+- Slides cannot carry argument density. A pattern, its evidence summary, its implications, and its decision input do not fit on one slide; spreading them across slides loses coherence.
+- Readers cannot reference slides later. A pattern needs to be findable; decks decay into icons and bullet points that are hard to search and cite.
+- Decks are presentation artifacts; synthesis needs to be a reference artifact that the team uses for months.
+- The deck format encourages summarization that loses precision.
+
+**Why documents work.**
+
+- A 4-12 page document can carry the pattern, evidence, implications, and decision input in connected prose.
+- Documents are searchable, linkable, and citable.
+- Documents accommodate density without overwhelming; readers can scan headings and dive into sections.
+- Documents read as load-bearing analytical work; decks read as presentation.
+
+**The exception.** A short executive summary deck (5-8 slides) can pair with a substantive document. The deck summarizes; the document carries the work.
+
+**The discipline.** If the synthesis is being optimized for a single 30-minute readout meeting, the format will fail when the team needs to reference the synthesis in week 6 of execution. Optimize for the reference use, not the presentation moment.
+
+---
+
+## Lead with patterns and implications; relegate evidence to appendix
+
+**The principle.** Readers scanning for decision input want patterns and implications first.
+
+**The reader's question.** "What does this synthesis tell me to do?" Patterns and implications answer it. Evidence supports the answer but is not the answer.
+
+**The structure that works.**
+
+- Executive summary (1 page): the patterns, the recommendations, the decision input.
+- Pattern sections (1-3 pages per pattern): pattern name, evidence summary in 2-3 sentences, implications, decision input.
+- Recommendations section (1 page): overall synthesis recommendation; what should change.
+- Appendix: detailed evidence, quote pulls, methodology notes, full transcripts or links to them.
+
+**The structure that fails.**
+
+- Decks that lead with quote walls. Readers admire the quotes; they do not extract decisions.
+- Documents that bury the patterns under methodology and background. Readers stop reading before reaching the patterns.
+- Synthesis that mixes evidence and analysis throughout. Readers cannot tell where observation ends and recommendation begins.
+
+**The discipline.** Each pattern section is short (2-4 paragraphs of synthesis text); evidence linked or summarized briefly; the appendix is where evidence depth lives. Readers who want depth follow the link; readers who want decisions stay in the body.
+
+---
+
+## One section per pattern, parallel structure
+
+**The principle.** Synthesis with 4-8 patterns has 4-8 parallel sections, each with the same structure.
+
+**Per-section structure.**
+
+- Pattern name (the heading).
+- Evidence summary (2-3 sentences naming the artifacts and the dominant signals).
+- Implication (1-3 implications with cost notes).
+- Decision input (specific decision the implication informs).
+
+**Why parallel structure works.**
+
+- Readers learn the structure from the first section and can scan subsequent ones.
+- Comparison across patterns is easier when each is presented the same way.
+- Editing for completeness is easier (each section either has the elements or it does not).
+
+**The variation.** Some patterns warrant longer treatment (richer evidence, more complex implications); some are shorter. Length variation is fine; structural variation is not.
+
+---
+
+## Be opinionated
+
+**The principle.** Synthesis that hedges every pattern reads as a researcher avoiding accountability.
+
+**Hedged synthesis.**
+
+- "Users may sometimes occasionally seem to indicate possible difficulty."
+- "It might be considered to potentially explore some adjustments."
+- "There could be benefits to investigating opportunities."
+
+These commit nothing. Readers cannot debate or decide on hedged synthesis.
+
+**Opinionated synthesis.**
+
+- "Users abandon configuration step 3 in 40% of signup attempts because credit card details are not accessible at signup."
+- "The Q2 roadmap should prioritize the onboarding redesign over the dashboard expansion."
+- "The not-act recommendation is to defer enterprise admin controls until small-team segment growth stabilizes."
+
+These commit positions. Readers can disagree; disagreement produces decisions.
+
+**The discipline.** Write synthesis as a recommendation. The PM doing synthesis is making analytical claims; readers may push back, but pushback is the point. Hedging avoids pushback by avoiding claim.
+
+**The exception for honest uncertainty.** When the data genuinely does not support a position, name the uncertainty explicitly: "The evidence supports two possible interpretations; we recommend gathering more data before deciding." This is honest uncertainty, not hedging. Hedging is dressing up uncertainty as if it were synthesis.
+
+---
+
+## Include a decision-input section
+
+**The principle.** What does this synthesis recommend the team do?
+
+**The section's role.** The decision-input section connects the synthesis to the team's prioritization work. Without it, the synthesis presents patterns and implications but does not aggregate them into recommendations.
+
+**What the section addresses.**
+
+- Where should priorities shift based on this synthesis?
+- Which roadmap items does the synthesis validate? Which does it challenge?
+- Which decisions can the team make now with this synthesis as input?
+- Which decisions need more research before making?
+- What is the synthesis's overall view of where the product should focus?
+
+**The section's voice.** Direct, specific, opinionated. The team can disagree, but the section should commit a recommendation.
+
+**The discipline.** Without this section, synthesis is a collection of patterns; with this section, synthesis is decision input. The section is what makes the synthesis load-bearing for the team's strategic work.
+
+---
+
+## Length calibration
+
+**The principle.** Synthesis should be as short as possible without losing the load-bearing content.
+
+**Typical lengths.**
+
+- Discovery cycle synthesis from a meaningful research batch: 6-12 pages.
+- Smaller-scale synthesis from a single research type (e.g., support audit alone): 3-6 pages.
+- Quick-turn synthesis from a focused interview batch: 2-4 pages.
+
+**Length anti-patterns.**
+
+- Synthesis padded to 30+ pages. Readers stop reading; the load-bearing content gets lost.
+- Synthesis compressed to 1 page. Density too high; specifics get lost.
+- Synthesis stretched across multiple documents without clear primacy. Readers do not know which document is the synthesis.
+
+**The discipline.** Edit for length. Each pattern section should be tight; each implication should be specific; the recommendation should be concise. Readers will engage with a 6-page synthesis they can finish in 20 minutes; readers will skim a 30-page synthesis and miss the recommendations.
+
+---
+
+## The reference-after-shipping test
+
+**The principle.** Synthesis that gets referenced months after publication has earned its keep.
+
+**The test.** Six months after a synthesis ships, can the team:
+
+- Name the patterns the synthesis surfaced?
+- Cite the synthesis in roadmap discussions?
+- Use the synthesis as input for related decisions that came up after publication?
+
+**Failures the test reveals.**
+
+- Synthesis nobody can name suggests insight-theater (presented but not absorbed).
+- Synthesis nobody references suggests document-shelf-syndrome (filed away after readout).
+- Synthesis the team contradicts in later decisions suggests the synthesis was not load-bearing in their actual prioritization work.
+
+**Recovery.** When prior synthesis fails the test, the next synthesis should adjust: shorter, more opinionated, more directly tied to specific decisions. Each round of synthesis should be more usable than the prior.
+
+---
+
+## Visual elements in synthesis documents
+
+**The discipline.** Visuals should carry argumentative load the prose alone cannot.
+
+**Visuals that work.**
+
+- A pattern-to-implication-to-decision diagram showing how the synthesis connects to product work.
+- A frequency chart for patterns supported by quantitative data.
+- A segment comparison table where patterns differ across segments.
+- An evidence map showing artifact-source distribution per pattern.
+
+**Visuals that fail.**
+
+- Stock images decorating section breaks.
+- Quote walls without context.
+- Word clouds (rarely informative).
+- Persona illustrations (decorative; not synthesis output).
+
+**The frequency.** Visual elements every 2-3 pages of synthesis is typical. More than that risks decoration; fewer is fine if the prose carries the work.
+
+---
+
+## Common synthesis-writing failures
+
+**Format choice.** Deck instead of document; the synthesis decays into bullets that lose precision.
+
+**Buried recommendations.** Patterns are clear; the recommendation is one sentence on page 11. Readers miss it.
+
+**Hedge-stacking.** Every claim caveated; readers cannot extract a position.
+
+**No decision-input section.** Synthesis presents patterns; team has to aggregate them into decisions on their own; usually does not.
+
+**Length excess.** 30 pages of synthesis where 8 would have served. Readers skim; load-bearing content gets lost.
+
+**Length compression.** 1 page of synthesis where 6 were needed. Density too high; specifics lost.
+
+**Quote-wall presentation.** Evidence dominates; analysis recedes; readers admire the quotes and miss the synthesis.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The document-not-deck principle. The patterns-lead-evidence-appendix structure. The parallel-section discipline. The opinionated voice. The decision-input section. Length calibration. The reference-after-shipping test. Visual element discipline. Common failures.
+
+## Implementation choices that stay internal
+
+Specific document templates and styles. Specific document hosting (Notion, Coda, Google Docs, Confluence). Specific link conventions for evidence. Specific reviewer workflows. Specific archive practices. The team's own conventions for synthesis length within the bands. These vary by team and tooling.

--- a/skills/jtbd-framing/SKILL.md
+++ b/skills/jtbd-framing/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: jtbd-framing
 description: "The Jobs-to-be-Done framework as applied product methodology. Job statements, struggling moments, hire and fire criteria, the difference between feature-thinking and job-thinking. Honest about where JTBD adds clarity (discovery, prioritization, positioning) and where it becomes performative ritual (job-statement workshops that do not drive decisions, persona-theater disguised as JTBD). Triggers on jobs-to-be-done, JTBD, job statements, struggling moments, hire criteria, fire criteria, switch triggers, functional emotional social jobs, outcome-driven innovation. Also triggers when a team is over-relying on feature-request lists or persona archetypes that do not drive product decisions, when a positioning conversation needs the framing JTBD provides, or when discovery is producing outputs that do not connect to product strategy."
-category: project-management
+category: product
 catalog_summary: "Jobs-to-be-Done framework. Job statements, struggling moments, hire/fire criteria, the difference between feature-thinking and job-thinking. Honest about where JTBD earns its keep and where it becomes performative"
-display_order: 12
+display_order: 11
 ---
 
 # Jobs-to-be-Done Framing

--- a/skills/jtbd-framing/SKILL.md
+++ b/skills/jtbd-framing/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: jtbd-framing
+description: "The Jobs-to-be-Done framework as applied product methodology. Job statements, struggling moments, hire and fire criteria, the difference between feature-thinking and job-thinking. Honest about where JTBD adds clarity (discovery, prioritization, positioning) and where it becomes performative ritual (job-statement workshops that do not drive decisions, persona-theater disguised as JTBD). Triggers on jobs-to-be-done, JTBD, job statements, struggling moments, hire criteria, fire criteria, switch triggers, functional emotional social jobs, outcome-driven innovation. Also triggers when a team is over-relying on feature-request lists or persona archetypes that do not drive product decisions, when a positioning conversation needs the framing JTBD provides, or when discovery is producing outputs that do not connect to product strategy."
+category: project-management
+catalog_summary: "Jobs-to-be-Done framework. Job statements, struggling moments, hire/fire criteria, the difference between feature-thinking and job-thinking. Honest about where JTBD earns its keep and where it becomes performative"
+display_order: 12
+---
+
+# Jobs-to-be-Done Framing
+
+A senior product leader's playbook for the Jobs-to-be-Done framework as applied methodology. Job statements, struggling moments, hire and fire criteria, the difference between feature-thinking and job-thinking. Honest about where JTBD adds clarity and where it becomes performative ritual.
+
+JTBD has become one of the more cited and less practiced frameworks in product. Teams cite it in strategy docs, run job-statement workshops, produce wall-sized artifacts, and continue building from feature requests and persona archetypes the next quarter. The methodology gets the credit; the practice gets skipped.
+
+This skill is JTBD as applied product methodology. The framework's actual contribution: surfacing what users are trying to ACCOMPLISH (the job) rather than treating users as preference-aggregators (feature requests) or demographic archetypes (persona theater). When the framing is grounded in struggling moments and hire/fire criteria, it produces decisions; when it stops at the job-statement worksheet, it produces ritual.
+
+This skill is honest about both modes. JTBD genuinely earns its keep in discovery, prioritization, and positioning when applied with rigor. It becomes ceremony when teams treat job statements as deliverables rather than as analytical tools.
+
+The voice is the senior product leader who has used JTBD well and watched plenty of teams use it badly. Concrete, opinionated about what the framework actually contributes, willing to call out where it gets oversold.
+
+When to use this skill: applying JTBD to a discovery cycle, replacing persona-driven prioritization with job-driven prioritization, reframing positioning around what users hire the product to do, or auditing whether existing JTBD work in the org is driving decisions.
+
+---
+
+## What this skill is for
+
+This skill spans JTBD as a framing technique within product work. The PM-skill distinction:
+
+- `discovery-research-synthesis` is broader synthesis discipline; JTBD is one framing technique within it.
+- **`jtbd-framing` (this skill)** is the specific JTBD methodology, its strengths, and its failure modes.
+- `pm-spec-writing` is downstream: specs reference jobs as input.
+- `creative-direction` is positioning territory; JTBD informs positioning but does not replace creative direction.
+- `roadmap-planning` is downstream: roadmap can be organized around jobs rather than features.
+
+The audience: senior PMs, product directors, product strategists, agencies running discovery and positioning work, in-house teams considering or already using JTBD.
+
+What is not in scope: other product strategy frameworks (Wardley mapping, North Star, OKRs); the broader synthesis discipline (`discovery-research-synthesis` covers it); the demographic-persona work that sometimes gets confused with JTBD.
+
+---
+
+## Feature-request-list vs persona-theater vs job-framing
+
+The keystone framing.
+
+**Feature-request-list.** "Users want X, Y, Z." Treats users as preference-aggregators. The product team builds the most-requested features. Output: a product that satisfies stated preferences but misses what users were actually trying to accomplish. Users do not always know what would solve their problem; they describe symptoms, not solutions. Feature-list-driven products often improve incrementally without becoming meaningfully better.
+
+**Persona-theater.** Demographic personas with cute names. "Marketing Manager Maria, 35, urban, Pinterest user, drinks oat milk lattes." Decorative, not decision-driving. Persona characteristics rarely correlate with what the user needs from the product; demographic detail substitutes for behavioral insight. Personas in the wild often live as wall posters that nobody references in actual prioritization debates.
+
+**Job-framing.** Users hire products to do jobs. The job is what the user is trying to accomplish, not who the user is or what features they request. The framing surfaces struggling moments (when do users feel pulled toward an alternative); hire criteria (what makes them adopt a product); fire criteria (what makes them switch away). Output: product decisions grounded in user motivation rather than user description.
+
+The litmus test. Take a product decision the team is debating. Can JTBD ground the decision? "Should we build feature X?" Reframed: "What job would feature X help users do? What job is currently done badly that this addresses?" If the JTBD framing produces clearer arguments on both sides, the framing is earning its keep. If the JTBD framing just adds vocabulary without resolving the debate, the framing is ritual.
+
+---
+
+## The job statement structure
+
+The canonical structure: "When [situation], I want to [motivation], so I can [outcome]."
+
+**Situation.** The context, trigger, or moment when the job becomes active. Not a demographic; a moment.
+
+- "When my team is rolling out a new feature and I need to communicate it to customers..."
+- "When I am preparing the quarterly board deck..."
+- "When I get a customer escalation outside of business hours..."
+
+**Motivation.** What the user is trying to do in that situation.
+
+- "...I want to write a clear announcement that explains what changed and why it matters..."
+- "...I want to assemble revenue and engagement data into a coherent narrative..."
+- "...I want to triage and respond without disrupting my evening too much..."
+
+**Outcome.** What success looks like; what the user is trying to achieve by doing the job.
+
+- "...so I can ship the rollout without flooding support with confusion."
+- "...so I can answer the board's likely questions before they ask them."
+- "...so I can address the customer's concern while still being present at home."
+
+The structure forces specificity at all three levels. Vague situations, vague motivations, or vague outcomes produce job statements that drive nothing.
+
+Detail in `references/job-statement-structure-patterns.md`.
+
+---
+
+## Identifying struggling moments
+
+Jobs become visible at struggling moments: when the user's current solution is failing them, when the alternative tools they have feel inadequate, when they would actively prefer a different way of doing the job.
+
+**The signal.** Users describe friction in their current approach. They describe workarounds. They describe wishing they had something better. They describe specific moments when the current approach broke down.
+
+**The methodology.** Discovery interviews surface struggling moments through specific prompts: "Walk me through the last time you did X." "What was hardest about that?" "What would you have done differently if you could?" Specific recent moments produce richer data than abstracted descriptions of "how I usually do this."
+
+**The pattern recognition.** Across many users, struggling moments cluster. The same kinds of friction recur. The clusters reveal the jobs that are not currently being done well in the market.
+
+**The pitfall.** Teams that interview without grounding in specific moments produce abstracted job descriptions that cannot drive decisions. "Users want to be more productive" is not a struggling moment; "I lost an hour on Tuesday assembling the board metrics from three different dashboards because none of them had the slice I needed" is.
+
+Detail in `references/identifying-struggling-moments.md`.
+
+---
+
+## Hire and fire criteria
+
+Why users adopt a product (hire), why they switch away (fire). The two questions ground the framework in real decisions users make.
+
+**Hire criteria.**
+
+- The struggling moment the user is trying to solve.
+- The alternatives they considered or tried first.
+- What made the chosen product the answer (vs the alternatives).
+- The expected job output: what the user expected to accomplish with the product.
+
+**Fire criteria.**
+
+- The struggling moment that recurred even with the chosen product.
+- The alternative that started looking better.
+- What tipped the user from "considering switching" to "switching."
+- The job output that the chosen product failed to deliver consistently.
+
+**Why hire/fire matters.**
+
+- Hire criteria reveal what the product needs to be excellent at to win adoption.
+- Fire criteria reveal what the product needs to maintain to retain users.
+- The two are often different: features that win adoption are not always the features that prevent churn.
+
+**The methodology.** Customer interviews surface hire/fire through specific prompts: "What were you doing before you adopted X?" "What made you switch?" "If you switched away from X tomorrow, what would the trigger be?" Recent switch decisions are particularly rich; users remember the specific moment.
+
+Detail in `references/hire-and-fire-criteria.md`.
+
+---
+
+## Functional, emotional, and social dimensions of jobs
+
+Jobs have three dimensions. Strong JTBD work surfaces all three; weak work treats jobs as functional only.
+
+**Functional dimension.** What the user is mechanically trying to accomplish.
+
+- "Assemble the quarterly board deck."
+- "Track team OKR progress."
+- "Onboard a new engineer to the codebase."
+
+**Emotional dimension.** How the user feels (or wants to feel) doing the job.
+
+- "Confident that the deck represents the team's actual progress, not a polished version."
+- "In control of the OKR check-in cadence, not behind on it."
+- "Helpful to the new engineer without becoming their full-time guide."
+
+**Social dimension.** How the user wants to be perceived doing the job.
+
+- "Seen by the board as a competent leader who knows the numbers."
+- "Seen by direct reports as someone who follows through on commitments."
+- "Seen by the new engineer as a senior who invested in their onboarding."
+
+**Why three dimensions matter.**
+
+- Products that win on functional alone often lose to alternatives that also serve emotional and social.
+- Some product decisions hinge on emotional dimensions ("the user wants to feel in control"); functional analysis alone misses these.
+- Social dimensions inform positioning more than functional descriptions do.
+
+**The discipline.** For each job statement, ask the three dimensions explicitly. Most early job statements are functional-only; the addition of emotional and social often reveals what the product actually needs to address.
+
+Detail in `references/functional-emotional-social-dimensions.md`.
+
+---
+
+## Where JTBD adds clarity vs where it becomes ritual
+
+The honest framing.
+
+**Where JTBD genuinely earns its keep.**
+
+- **Discovery.** When research is grounded in struggling moments and hire/fire decisions, JTBD surfaces the user motivation that feature-list discovery misses. Discovery interviews structured around jobs produce richer data than ones structured around feature preferences.
+- **Prioritization.** When the team is debating which work to prioritize, jobs ground the debate in what users are trying to accomplish. "Does this work help users do an important job better?" cuts through the politics of feature-request prioritization.
+- **Positioning.** When marketing or sales is articulating what the product does, jobs frame the product as a way of accomplishing something the customer cares about, rather than as a feature list.
+
+**Where JTBD becomes ritual.**
+
+- **Job-statement workshops as deliverables.** The team runs a workshop, produces a wall of job statements, and never references the artifacts in subsequent decisions. The workshop became the deliverable; the analytical work did not happen.
+- **Job statements substituted for personas without analytical rigor.** "We have JTBD now" but the team treats job statements as named characters (Job Bob, Job Alice) instead of as analytical tools.
+- **Mandatory JTBD for every product question.** Every meeting starts with "what's the job?" Even when the question does not benefit from the framing. The methodology becomes a tax rather than a tool.
+- **JTBD as compliance.** The org adopts JTBD because a leadership book or conference talk endorsed it; teams produce JTBD artifacts to show they are using the framework; nobody actually uses the framework to decide.
+
+**The honest signal.** If the team can show how a recent product decision was different because of JTBD analysis, the framework is earning its keep. If the team uses JTBD vocabulary but cannot trace decisions to JTBD analysis, the framework is ritual.
+
+---
+
+## Applying JTBD to discovery, prioritization, positioning
+
+The three modes where JTBD genuinely contributes.
+
+**Discovery.** Structure interviews around recent struggling moments, hire decisions, and fire decisions. Gather job statements after the interviews from the data, not before. Cluster jobs across users. Name jobs from the clusters. Pair with `discovery-research-synthesis` for the broader synthesis discipline.
+
+Detail in `references/applying-jtbd-to-discovery.md`.
+
+**Prioritization.** When evaluating roadmap candidates, frame each candidate by the job(s) it addresses. Ask: which jobs is the product currently doing badly? Which candidates address those jobs vs adjacent or unrelated work? Pair with `roadmap-planning` for the broader prioritization discipline.
+
+Detail in `references/applying-jtbd-to-prioritization.md`.
+
+**Positioning.** When articulating what the product is for, lead with the job rather than the features. "Help product teams synthesize discovery research into decisions" is a job framing; "AI-powered research synthesis with collaboration tools" is a feature framing. Pair with `creative-direction` and `brand-discovery` for the broader positioning work.
+
+Detail in `references/applying-jtbd-to-positioning.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-jtbd-failures.md`.
+
+- "We did the JTBD workshop but nothing changed in our roadmap." Job-statement workshop as deliverable; no analytical work after the workshop.
+- "Our job statements all sound the same." Generic job statements; not grounded in specific struggling moments. Re-ground in interview data.
+- "Our jobs read like feature requests." "When I am using product X, I want feature Y" is not a job; the job is what the user was trying to accomplish, independent of the product.
+- "We have personas and jobs and they contradict each other." Personas are demographic; jobs are situational. They do not have to align; if they conflict, jobs usually carry more decision weight.
+- "JTBD says we should build everything." Without prioritization across jobs, JTBD identifies many opportunities and does not pick. Pair with prioritization discipline.
+- "We dropped JTBD because it became theater." Common; the recovery is JTBD as analytical tool, not JTBD as ritual. Use the framework where it earns its keep; do not force it everywhere.
+- "Our job statements are functional only." Add emotional and social dimensions; many product decisions hinge on the latter two.
+- "We cannot agree on the job." Often signals different segments with different jobs. Surface the segment differences.
+- "Our marketing copy uses JTBD vocabulary but our product does not." Positioning-product gap; the marketing claim is not load-bearing in product decisions.
+
+---
+
+## The framework: 12 considerations for JTBD framing
+
+When applying JTBD or auditing JTBD work, walk these 12 considerations.
+
+1. **Job-framing, not feature-list or persona-theater.** Users hire products to accomplish jobs.
+2. **Job statement structure: situation, motivation, outcome.** Specific at all three levels.
+3. **Struggling moments ground the jobs.** Specific recent moments, not abstractions.
+4. **Hire criteria identified.** What makes users adopt the product over alternatives.
+5. **Fire criteria identified.** What makes users switch away (or would).
+6. **Functional, emotional, social dimensions surfaced.** All three; not functional only.
+7. **Jobs derived from data, not workshop output.** Job statements emerge from interview data, not from whiteboard sessions.
+8. **JTBD applied where it earns its keep.** Discovery, prioritization, positioning. Not as ritual.
+9. **Segment differences in jobs surfaced.** When the same product is hired for different jobs by different segments.
+10. **Decisions traceable to JTBD analysis.** Each major decision can be explained through the job framing.
+11. **JTBD vocabulary not substituted for analytical work.** Vocabulary without analysis is ritual.
+12. **Honest assessment of where JTBD does not help.** Some questions do not benefit from the framing; force-fitting produces ritual.
+
+The output of the framework is product decisions grounded in user motivation rather than user description, with the framing applied where it adds clarity and held back where it would become ritual.
+
+---
+
+## Reference files
+
+- [`references/job-statement-structure-patterns.md`](references/job-statement-structure-patterns.md) - The situation/motivation/outcome structure with worked examples. Common structural failures (vague situations, motivation as feature request, outcome as feature output).
+- [`references/identifying-struggling-moments.md`](references/identifying-struggling-moments.md) - Discovery prompts that surface struggling moments. Pattern recognition across users. The specific-moment vs abstraction distinction.
+- [`references/hire-and-fire-criteria.md`](references/hire-and-fire-criteria.md) - Methodology for surfacing hire and fire criteria. Why the two are often different. Recent-switch interview discipline.
+- [`references/functional-emotional-social-dimensions.md`](references/functional-emotional-social-dimensions.md) - Three dimensions per job. Why functional-only fails. Worked examples per dimension. Positioning implications of social dimension.
+- [`references/applying-jtbd-to-discovery.md`](references/applying-jtbd-to-discovery.md) - Discovery interview structure around jobs. Job clustering. Naming jobs from data. Pair with discovery-research-synthesis.
+- [`references/applying-jtbd-to-prioritization.md`](references/applying-jtbd-to-prioritization.md) - Prioritizing roadmap candidates by jobs. Identifying which jobs are done badly. Pair with roadmap-planning.
+- [`references/applying-jtbd-to-positioning.md`](references/applying-jtbd-to-positioning.md) - Job-led positioning vs feature-led positioning. Lead with what the product helps users accomplish. Pair with creative-direction.
+- [`references/common-jtbd-failures.md`](references/common-jtbd-failures.md) - 9+ failure patterns with diagnoses and cures. The cross-cutting pattern: JTBD as ritual vs JTBD as analytical tool.
+
+---
+
+## Closing: jobs over features
+
+The Jobs-to-be-Done framework is one of the most useful product methodologies available when applied with rigor, and one of the most performative when applied as ritual. The difference is in whether the framework drives decisions or decorates documentation.
+
+Jobs over features is a real shift in product thinking. Feature-list discovery treats users as preference-aggregators; persona archetypes treat users as demographic categories; job-framing treats users as people trying to accomplish things, where the product is one tool they hire (or fire) for the job.
+
+The teams that benefit from JTBD are the ones that take the analytical work seriously: grounding jobs in struggling moments, identifying hire and fire criteria, surfacing functional-emotional-social dimensions, deriving jobs from data, and applying the framing where it earns its keep. The teams that adopt JTBD vocabulary without the analytical work produce ritual.
+
+When in doubt about whether a JTBD application is real or ritual, ask: can a recent product decision be traced to the JTBD analysis, or did the JTBD work happen in parallel with decisions that were made on other grounds? If the former, JTBD is doing its work. If the latter, the framework is decoration.

--- a/skills/jtbd-framing/references/applying-jtbd-to-discovery.md
+++ b/skills/jtbd-framing/references/applying-jtbd-to-discovery.md
@@ -1,0 +1,211 @@
+# Applying JTBD to discovery
+
+How JTBD shapes discovery interview structure, job clustering, and naming jobs from data. Pairs with `discovery-research-synthesis` for the broader synthesis discipline.
+
+JTBD's strongest contribution to discovery is structural: interviews grounded in struggling moments and hire/fire decisions produce richer data than interviews that ask about feature preferences or use cases.
+
+---
+
+## Structuring discovery interviews around jobs
+
+The JTBD discovery interview structure differs from feature-elicitation interviews.
+
+**Feature-elicitation interview pattern.**
+
+- "What problems are you trying to solve?"
+- "What features would help?"
+- "What is your ideal product?"
+
+This structure produces user-prescribed solutions: feature requests, ideal-product fictions, and abstracted preferences. The data is hard to act on because users do not always know what would actually help.
+
+**JTBD interview pattern.**
+
+- "Walk me through the last time you did [task]. What happened? What was hardest?"
+- "What were you doing before you adopted [current solution]? What made you switch?"
+- "Tell me about a recent time when [task] went badly. What was different about that time?"
+- "If you switched away from [current solution] tomorrow, what would the trigger be?"
+
+This structure grounds the data in specific moments and real decisions. Users describe their experience; the PM doing synthesis interprets what the experience implies.
+
+---
+
+## Interview prompts that work
+
+**Recent specific moments.**
+
+- "Walk me through the most recent time you did [task]."
+- "What was the last week when [task] cost you more time than usual?"
+- "When was the last time [task] surprised you in a bad way?"
+
+**Hire decision prompts.**
+
+- "Tell me about the moment you decided to start using [product]."
+- "What were you doing before? What made you switch?"
+- "What alternatives did you consider? What ruled them out?"
+
+**Fire decision prompts (for users who switched).**
+
+- "Tell me about the moment you decided to switch away from [product]."
+- "What was the alternative starting to look better? What tipped you?"
+- "Looking back, why didn't you switch sooner?"
+
+**Workaround prompts.**
+
+- "What's something you do that takes longer than it should?"
+- "What workarounds have you built?"
+- "When was the last time you accepted a worse outcome because the better path was too painful?"
+
+---
+
+## Interview prompts that fail
+
+**Hypothetical prompts.**
+
+- "What would your ideal product look like?" (produces fiction)
+- "If you had a magic wand, what would you change?" (produces wishlist)
+- "What features would you like?" (produces feature lists)
+
+**Abstracted prompts.**
+
+- "How do you usually do [task]?" (produces averaged descriptions)
+- "What's your typical experience?" (loses the specifics)
+- "What kind of user are you?" (produces self-categorization)
+
+**Leading prompts.**
+
+- "Don't you find [feature] frustrating?" (confirms the team's hypothesis)
+- "Wouldn't it be great if [feature]?" (produces agreement, not data)
+
+---
+
+## The interview length and depth
+
+JTBD interviews benefit from depth. Surface answers come quickly; deeper jobs surface in the second half of an interview.
+
+**Typical structure.**
+
+- Minutes 0-15: warm-up, general context, what the user does and how their work fits together.
+- Minutes 15-45: the recent specific moments, walk-throughs, struggling moments. The richest data emerges here.
+- Minutes 45-60: hire and fire decisions, alternatives considered, switch decisions.
+- Minutes 60-75 (when warranted): emotional and social dimensions, how the user wants to be perceived doing the work.
+- Minutes 75-90: closing prompts, what the user wishes was different, what they would have done differently.
+
+**The depth payoff.** Users open up after 30-40 minutes. The struggling moments they describe in the second half are usually richer than the first-half answers. Cutting interviews short at 45 minutes loses the depth.
+
+**The 90-minute upper bound.** Beyond 90 minutes, fatigue degrades data quality. Schedule for 90; complete in 60-75; leave room for the depth without forcing it.
+
+---
+
+## Job clustering from interview data
+
+After interviews, jobs emerge through clustering (per the synthesis sequence in `discovery-research-synthesis`).
+
+**The clustering work.**
+
+- Tag struggling moments and hire/fire decisions across interviews.
+- Cluster moments that share underlying jobs (the user was trying to accomplish the same thing).
+- Each cluster becomes a candidate job.
+- Name the job from the cluster, not from a pre-built list.
+
+**Common clustering patterns.**
+
+- Multiple users described the same kind of friction in similar contexts. The cluster becomes one job.
+- Multiple users described different surface-level frictions but the same underlying motivation and outcome. The cluster reveals a job that surfaces differently across users.
+- One user's described moment is unique. May be an edge case, may be a job worth surfacing as smaller-segment.
+
+---
+
+## Naming jobs from data
+
+Jobs are named from the cluster, not from a pre-built taxonomy.
+
+**The naming process.**
+
+- Read the cluster's contributing moments.
+- Identify the situation, motivation, and outcome that recurred.
+- Write the job statement: "When [situation], I want to [motivation], so I can [outcome]."
+- Test the statement against the source moments: does it capture what users were trying to accomplish?
+
+**The iteration discipline.** First-pass job statements are usually too narrow or too broad; refine through iteration.
+
+**Worked example.** A cluster of moments around quarterly board prep:
+
+- Multiple users described assembling data from multiple sources.
+- Multiple described uncertainty about whether they had the right slice.
+- Multiple described the time pressure and the disruption to other work.
+- Multiple described wanting to walk into the board with confidence.
+
+First-pass job statement: "When preparing the board deck, I want to assemble data from multiple sources, so I can present numbers correctly."
+
+Second-pass refinement: "When preparing for quarterly business reviews, I want to assemble cross-source data into a coherent narrative I can defend, so I can answer the board's questions confidently without spending the night before reconciling spreadsheets."
+
+The second pass captures the situation more specifically (quarterly business reviews, not just any board deck), the motivation more specifically (coherent narrative I can defend, not just data assembly), and the outcome more specifically (answer questions confidently without grinding the night before, not just present numbers correctly).
+
+---
+
+## How many jobs emerge from typical discovery
+
+Strong discovery cycles often surface 3-8 jobs across the research batch.
+
+**Smaller numbers (1-2 jobs).** May indicate the discovery scope was narrow (only one user task investigated) or the synthesis under-clustered.
+
+**Mid numbers (3-8 jobs).** Typical for substantive discovery cycles. Jobs cover the major user motivations the research surfaced.
+
+**Larger numbers (10+ jobs).** May indicate over-clustering (each cluster is small and the overall synthesis is fragmented) or genuine breadth (the research investigated multiple distinct user contexts).
+
+The discipline. Job count should reflect the underlying patterns the data reveals, not a target number. Force-fitting to 7 jobs because "that feels right" produces synthesis that does not match the data.
+
+---
+
+## Pairing JTBD discovery with quantitative validation
+
+Qualitative job patterns often warrant quantitative validation.
+
+**The pattern.**
+
+- Job statement claims a specific frequency or severity ("users hit this friction in 40% of attempts").
+- Quantitative data validates: analytics shows configuration step abandonment rate; survey data confirms the segment proportion; product instrumentation captures the in-the-moment frequency.
+- If validation confirms: the job statement is strongly supported.
+- If validation contradicts: revise the job statement to reflect the data.
+
+**Pair with `experiment-design`** for rigorous validation methodology and `product-analytics-setup` for the instrumentation that makes validation possible.
+
+---
+
+## When JTBD discovery does not fit
+
+Some discovery does not benefit from JTBD framing.
+
+**Greenfield categories.** When the product is a category-defining product, users may not have struggling moments because the alternative is not having the capability at all. JTBD framing is useful but may need to be supplemented with broader product strategy.
+
+**Highly novel use cases.** When users have not yet developed mental models for the use case (e.g., new technology categories), struggling moments may not exist because the activity itself does not exist. Discovery may need to focus on adjacent activities and what users would do if the new capability existed.
+
+**Pure positioning research.** When the discovery is about how to position an existing product, hire and fire criteria interviews are useful, but emotional and social dimensions of positioning matter as much as the JTBD-framed jobs.
+
+**The discipline.** JTBD is a tool, not a mandate. When the discovery question fits the framework, use it. When it does not fit cleanly, supplement with other discovery techniques.
+
+---
+
+## Common JTBD-discovery failures
+
+**Eliciting feature lists instead of jobs.** Interview prompts ask "what features do you want" rather than "what are you trying to accomplish." Restructure prompts.
+
+**Pre-built job taxonomy.** Researchers arriving with named jobs and slotting interview data into them. Jobs should emerge from data; pre-built taxonomies confirm what the team already thinks.
+
+**Skipping struggling moments.** Interviews capture preferences and use-cases without grounding in specific friction events. Add struggling-moment prompts.
+
+**Skipping hire/fire decisions.** Interviews ask about current usage but not about adoption or switch decisions. Add hire and fire prompts.
+
+**Job statements written from intuition rather than data.** Researchers writing jobs based on what they think users are trying to do, without grounding in interview clusters.
+
+**Force-fitting all data to JTBD.** Some interview data does not fit the JTBD framing cleanly; the team forces it in anyway. Better: surface what JTBD captures and supplement with other framings for the rest.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The interview structure that grounds in jobs. Prompts that work and fail. Interview length and depth. Job clustering from interview data. Naming jobs from data. Typical job counts. Pairing with quantitative validation. When JTBD discovery does not fit. Common failures.
+
+## Implementation choices that stay internal
+
+Specific interview templates. Specific recording and tagging tools. Specific synthesis tooling for job clustering. Specific recruitment criteria. The team's own conventions for interview cadence and batch sizing. These vary by team.

--- a/skills/jtbd-framing/references/applying-jtbd-to-positioning.md
+++ b/skills/jtbd-framing/references/applying-jtbd-to-positioning.md
@@ -1,0 +1,201 @@
+# Applying JTBD to positioning
+
+Job-led positioning vs feature-led positioning. Lead with what the product helps users accomplish. Pairs with `creative-direction` and `brand-discovery` for the broader positioning work.
+
+JTBD's contribution to positioning is the lead message: positioning that names the job the product helps users accomplish creates affinity in ways feature lists do not. The functional, emotional, and social dimensions of jobs all inform positioning differently.
+
+---
+
+## Job-led vs feature-led positioning
+
+The two positioning approaches.
+
+**Feature-led positioning.**
+
+- "AI-powered analytics with collaborative dashboards and integrations."
+- "Cloud-native CRM with automation and reporting."
+- "Project management software with timelines, kanban, and integrations."
+
+Characteristics: lists features; competes on feature comparison; gets compared head-to-head with alternatives that have similar feature lists; produces buyer behavior of feature-checklist evaluation.
+
+**Job-led positioning.**
+
+- "Help product teams synthesize discovery research into decisions."
+- "The CRM your sales team will actually use because it stays out of their way."
+- "Run the project, not the project management tool."
+
+Characteristics: names what the product helps users accomplish; competes on outcome rather than feature parity; produces buyer behavior of job-fit evaluation; harder to copy because the positioning is built on understanding the job.
+
+**The trade-off.** Feature-led positioning is easier to write and easier for buyers to evaluate. Job-led positioning is harder to write but produces stronger affinity and is more durable to feature-parity competition.
+
+---
+
+## When job-led positioning works
+
+Job-led positioning works best when:
+
+- The product addresses a job that users currently do badly with alternatives.
+- The job has emotional or social dimensions that the positioning can serve.
+- The user can recognize themselves in the job description.
+- The market category is mature enough that feature comparison is no longer differentiating.
+
+Job-led positioning is less effective when:
+
+- The product is a new category and users do not yet recognize the job.
+- The product is a commodity where job-fit is similar across alternatives.
+- The buyer is not the user, and the buyer evaluates on different criteria than job-fit.
+
+---
+
+## The lead message structure
+
+The lead message is the first thing prospects encounter (homepage hero, ad headline, sales pitch opener).
+
+**Job-led lead message structure.**
+
+- "[Product/category] for [user trying to do job in situation], so [outcome]."
+- "[Action verb describing the job] without [the friction users currently encounter]."
+- "[Outcome the product produces] for [user in situation]."
+
+**Worked examples.**
+
+- "Help product teams synthesize discovery research into decisions, not deck performance."
+- "Run quarterly business reviews without spending Sunday night reconciling spreadsheets."
+- "Onboard new engineers without becoming their full-time guide."
+
+Each example names a job, an outcome, and either a contrast (without the friction) or a quality (the way the product accomplishes the job).
+
+---
+
+## Functional, emotional, social in positioning
+
+Positioning leans on different dimensions of the job for different effects.
+
+**Functional dimension in positioning.**
+
+- "[Product] does [job]." Direct and informative; lower-affinity.
+- Worked example: "Synthesize discovery research from interview transcripts and support tickets."
+
+Functional dimension positioning is useful for product details, not for lead messages. Lead messages on functional alone compete on feature comparison.
+
+**Emotional dimension in positioning.**
+
+- "[Product] lets you do [job] feeling [desired emotional state]."
+- Worked example: "Run discovery cycles feeling in control, not buried in transcripts."
+
+Emotional dimension positioning creates affinity. Users recognize the emotional state they want and connect with positioning that names it.
+
+**Social dimension in positioning.**
+
+- "[Product] for [user identity]."
+- Worked example: "For PMs who run discovery seriously."
+
+Social dimension positioning creates identity affinity. Users want to belong to the kind of users the positioning describes. This dimension is often the strongest for positioning because it is hardest to copy and creates the most durable affinity.
+
+**The composition.** Strong positioning often combines all three dimensions: a functional lead with emotional and social undertones. "Run discovery cycles for PMs who take synthesis seriously, without burying yourself in transcripts." Functional (run discovery cycles), social (PMs who take synthesis seriously), emotional contrast (without burying yourself in transcripts).
+
+---
+
+## Avoiding job-positioning that misses
+
+Job-led positioning fails when the named job does not match the user's actual situation.
+
+**The pattern.** Marketing crafts a job-led message that sounds compelling but does not match how target users describe their work. Users do not recognize themselves; the positioning underperforms.
+
+**Worked failure example.** A productivity SaaS positions as "Eliminate the chaos in your day."
+
+The pattern. The job named (eliminating chaos) is too abstract; users describe specific frictions ("I cannot find the right meeting notes when I need them; I spend 20 minutes a day reconciling calendar conflicts; I miss commitments because tasks are scattered across tools"). The positioning is generic; users cannot recognize their specific situation.
+
+**The cure.** Ground positioning in specific job statements that emerged from user research. The positioning should sound like users describing their own work, not like marketing describing users.
+
+---
+
+## Positioning testing for JTBD-led messages
+
+Job-led positioning benefits from user testing.
+
+**The test.** Show the positioning to target users. Ask:
+
+- "Does this describe your work?"
+- "Would you keep reading this?"
+- "What product would you expect to be behind this positioning?"
+
+**What good responses look like.**
+
+- "Yes, that's exactly what I do." (positive recognition)
+- "I would want to see what this is." (interest signal)
+- "It sounds like a [accurate product description]." (the positioning communicates accurately)
+
+**What bad responses look like.**
+
+- "I'm not sure this applies to me." (mismatch)
+- "It sounds generic." (not specific enough to the job)
+- "I expect this to be a [different product type]." (positioning misleads)
+
+**The iteration.** Positioning often improves through 2-3 rounds of testing and revision. The ground-truth from target users surfaces the gap between what marketing wrote and what users recognize.
+
+---
+
+## Positioning across multiple jobs
+
+Many products serve multiple jobs. Positioning must decide whether to lead with one job or surface multiple.
+
+**Lead-with-one approach.**
+
+- Pick the most differentiating, most strategically important job.
+- Lead with that job in the primary positioning.
+- Surface other jobs in secondary positioning (feature pages, segment-specific pages).
+
+**Worked example.** A productivity SaaS that serves task management, team coordination, and reporting jobs:
+
+- Primary positioning leads with team coordination (the most strategic, most differentiating job).
+- Feature pages address task management for users who land there.
+- Reporting positioning lives on a dedicated page for evaluators looking specifically for that job.
+
+**Lead-with-many approach.**
+
+- The product genuinely serves several jobs equally; leading with one would mislead.
+- Use a multi-job message: "[Product] for [job A], [job B], and [job C]."
+- Risk: looks like a feature list dressed in job language.
+
+**The discipline.** Most products benefit from leading with one job and supplementing. Lead-with-many positioning often collapses into "do everything" messaging that creates no specific affinity.
+
+---
+
+## Positioning for jobs vs positioning for users
+
+JTBD positioning leads with jobs; persona positioning leads with user identity.
+
+**Job-led positioning.** "Help product teams synthesize discovery research into decisions."
+
+**Persona-led positioning.** "For senior product managers at high-growth SaaS companies."
+
+The two can compose. Strong positioning often pairs job and identity: "Help senior PMs at high-growth SaaS companies synthesize discovery research into decisions."
+
+**The discipline.** Lead with the job (what the user is trying to do); add identity (who the user is) to create the affinity layer. Identity-only positioning is persona theater; job-only positioning may not create enough affinity. Job + identity is often the strongest form.
+
+---
+
+## Common JTBD-positioning failures
+
+**Job-led messages that are too abstract.** "Eliminate the chaos in your day" is job-flavored but does not name a specific job. Replace with the specific job from research.
+
+**Feature-led messages dressed in job language.** "Use our analytics to make better decisions" is feature-led; "make better decisions" is too generic to be a job.
+
+**Job-led positioning that does not match user vocabulary.** Marketing wrote the positioning without grounding in user research; users do not recognize the language.
+
+**Lead-with-many positioning that becomes "do everything."** Multiple jobs surfaced equally; positioning loses specificity.
+
+**Positioning ignores the social dimension.** Strong positioning often leans on social dimension; positioning that omits it competes only on functional and emotional.
+
+**Positioning not user-tested.** Marketing crafts the positioning in isolation; target users have not validated that they recognize themselves in it.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The job-led vs feature-led distinction. When job-led works and does not. The lead message structure. Functional, emotional, social in positioning. Avoiding job-positioning that misses. Positioning testing methodology. Positioning across multiple jobs. Job vs persona positioning. Common failures.
+
+## Implementation choices that stay internal
+
+Specific positioning frameworks the team uses. Specific copy templates. Specific A/B testing setups for positioning variants. Specific user-testing methodologies. The team's own conventions for primary vs secondary positioning. These vary by team and brand discipline.

--- a/skills/jtbd-framing/references/applying-jtbd-to-prioritization.md
+++ b/skills/jtbd-framing/references/applying-jtbd-to-prioritization.md
@@ -1,0 +1,206 @@
+# Applying JTBD to prioritization
+
+Prioritizing roadmap candidates by jobs. Identifying which jobs are done badly. The framing that cuts through feature-list politics.
+
+JTBD's contribution to prioritization is grounding the debate in user motivation rather than feature requests or stakeholder volume. Pairs with `roadmap-planning` for the broader prioritization discipline.
+
+---
+
+## The job-led prioritization frame
+
+Each roadmap candidate gets evaluated by the jobs it addresses.
+
+**The questions.**
+
+- Which jobs is the product currently doing badly?
+- Which roadmap candidates address those jobs vs adjacent or unrelated work?
+- Which jobs matter most to the product's strategy and user base?
+- What is the cost of addressing each candidate vs the value of the job improvement?
+
+**Why this frame works.**
+
+- It grounds prioritization in what users are trying to accomplish, not in what features they happen to have requested.
+- It cuts through stakeholder politics: a roadmap candidate's value is measured against jobs, not against who is requesting it.
+- It makes "we should not build this" defensible: candidates that do not address a load-bearing job get deprioritized clearly.
+
+**The compose-with-strategy discipline.** Job-led prioritization is downstream of strategy. The team needs to know which jobs matter for the product's market position; not all jobs are equally strategic. Pair with broader strategy work for the upstream framing.
+
+---
+
+## Identifying jobs the product does badly
+
+The starting point for job-led prioritization.
+
+**The methodology.**
+
+- For each major job the product is meant to serve, evaluate how well it currently does the job.
+- Use multiple inputs: user research (struggling moments, fire criteria), support data (where users hit friction), competitive analysis (where alternatives are stronger), in-product analytics (where users abandon).
+- Score or rank jobs by how well they are currently served. Jobs done badly are candidates for prioritization investment.
+
+**Worked example.** A team productivity SaaS evaluating four core jobs:
+
+- Job A (creating tasks): well-served. Low priority for new investment.
+- Job B (collaborating on tasks across teams): partially served. Some friction; alternatives are stronger; users describe workarounds.
+- Job C (reporting on team progress): poorly served. High struggling-moment frequency; users export to spreadsheets; competitive products do this better.
+- Job D (integrating with external tools): partially served. Friction at scale; mid-size customers describe pain.
+
+The badly-served jobs (B, C, D) are candidates for prioritization. Job A is not a fertile area for new investment.
+
+---
+
+## Mapping roadmap candidates to jobs
+
+Each roadmap candidate gets associated with the jobs it addresses.
+
+**The mapping.**
+
+- Roadmap candidate: "Build cross-team task assignment with permissions."
+  - Job addressed: Job B (collaborating across teams).
+  - Job impact: addresses the core friction users describe; closes the gap with stronger alternatives.
+
+- Roadmap candidate: "Add custom report builder."
+  - Job addressed: Job C (reporting on team progress).
+  - Job impact: enables the reporting users currently export to spreadsheets to do.
+
+- Roadmap candidate: "Build mobile app for task creation."
+  - Job addressed: Job A (creating tasks) on mobile context.
+  - Job impact: extends a well-served job to a context where it currently is not served. Useful but not addressing a struggling job.
+
+- Roadmap candidate: "Redesign sidebar navigation."
+  - Job addressed: unclear. Possibly across multiple jobs.
+  - Job impact: hard to evaluate without clarification on which job this serves.
+
+**The fourth example signals a problem.** Roadmap candidates that do not clearly address a specific job often get prioritized on internal preferences rather than user value. The job mapping forces clarity: what job does this candidate serve, and how badly is that job currently being done?
+
+---
+
+## The "no job, no priority" discipline
+
+Roadmap candidates that do not clearly address a job tied to user motivation often should not be prioritized.
+
+**The pattern.**
+
+- Candidate: "Migrate to a new internal framework."
+  - Job addressed: none directly; serves engineering velocity.
+  - Disposition: may be valuable for engineering reasons; do not prioritize on user-job grounds. If the team values engineering velocity, prioritize it on that basis explicitly.
+
+- Candidate: "Add dark mode."
+  - Job addressed: weak (some users describe preference).
+  - Disposition: low job-priority unless dark mode addresses an emotional dimension of jobs the team is also addressing.
+
+- Candidate: "Improve admin permissions."
+  - Job addressed: depends on which segment is asking. For enterprise: addresses fire criteria around compliance. For small teams: weak job impact.
+  - Disposition: prioritize for the segment whose job it serves; do not generalize.
+
+**The discipline.** Surface the job each candidate addresses (or does not). Candidates that do not serve jobs may still be valuable but should be prioritized on different grounds. The candidates the team can defend on jobs are the ones with the clearest user-value case.
+
+---
+
+## Prioritization across jobs
+
+Different jobs have different strategic weights. The roadmap should reflect the strategy.
+
+**The questions.**
+
+- Which jobs are most load-bearing for the product's market position?
+- Which jobs are most differentiated from competitors? (Where addressing the job better produces lasting advantage.)
+- Which jobs serve the segments the strategy is targeting?
+- Which jobs are growing in importance based on market trends?
+
+**Worked example.** A team productivity SaaS in mid-market growth:
+
+- Job B (cross-team collaboration): high strategic weight. Mid-market customers grow into multi-team workflows; the product needs to scale with them.
+- Job C (reporting): high strategic weight. Mid-market customers need reporting that small-team customers did not require.
+- Job D (integration): medium strategic weight. Important for retention; less differentiating than B and C.
+- Job A (task creation): low strategic weight for new investment. Already served; not where competitors are winning.
+
+The strategic weighting biases the roadmap: B and C get more capacity than D; D gets more than A.
+
+---
+
+## The "what job is this serving" review for in-flight work
+
+Job-led prioritization applies to existing work, not just new candidates.
+
+**The review.**
+
+- Take in-flight roadmap items.
+- For each, ask: what job is this serving? How well does the work address that job?
+- Items that cannot articulate a clear job may be candidates for re-scoping or cancellation.
+
+**The honest case.** Many roadmap programs accumulate work that started for reasons unrelated to user jobs (engineering preference, executive request, "we said we would"). The job review surfaces these and creates space to reconsider.
+
+**The kindness.** The review is not aimed at blame; sometimes work was committed before the team had the JTBD framing. The cure is reconsidering, not punishing.
+
+---
+
+## Avoiding the JTBD-prioritization-religion failure
+
+JTBD as prioritization framework can become rigid in ways that hurt the team.
+
+**Patterns to avoid.**
+
+- Mandatory job-mapping for every roadmap item, including small bug fixes. The framework becomes overhead for low-value items.
+- Treating job-impact estimates as precise numbers. Job-impact is often qualitative; pretending precision misleads.
+- Over-weighting JTBD to the exclusion of other prioritization inputs. Strategic, technical, and operational considerations matter alongside jobs.
+
+**The discipline.** Use JTBD where it adds clarity to prioritization debates. Do not force the framework where it adds overhead without value.
+
+---
+
+## Worked prioritization example
+
+A quarterly roadmap review at a team productivity SaaS.
+
+**Available capacity.** 5 large initiatives.
+
+**Candidates with job mapping.**
+
+1. Cross-team task assignment with permissions (Job B; high impact; high strategic weight).
+2. Custom report builder (Job C; high impact; high strategic weight).
+3. Mobile app for task creation (Job A on mobile; medium impact; low strategic weight).
+4. Sidebar redesign (no clear job; serves general usability).
+5. Slack integration upgrade (Job D; medium impact; medium strategic weight).
+6. Onboarding redesign (multiple jobs; high impact on hire criteria for new customers).
+7. Admin role overhaul (Job D for enterprise; high impact for that segment; matches enterprise expansion strategy).
+8. Migration to new search backend (technical; serves multiple jobs indirectly).
+
+**Prioritization decision (5 of 8).**
+
+- Cross-team task assignment (1): yes. Top job priority.
+- Custom report builder (2): yes. Top job priority.
+- Onboarding redesign (6): yes. High hire-criteria impact.
+- Admin role overhaul (7): yes. Enterprise strategy alignment.
+- Migration to new search backend (8): yes. Technical foundation; serves multiple jobs.
+
+**Deferred.**
+
+- Mobile app for task creation (3): Job A is well-served on desktop; mobile is convenient but not high-priority.
+- Sidebar redesign (4): no clear job. Reconsider for next cycle if a specific job emerges.
+- Slack integration upgrade (5): Job D is medium-priority; can wait a quarter.
+
+**The defense.** The decisions can be explained on jobs and strategy. Stakeholders who pushed for items that did not make the cut can hear a clear rationale. The cut items can be reconsidered next quarter against jobs at that point.
+
+---
+
+## Common JTBD-prioritization failures
+
+**Job-mapping all candidates without segmenting strategic weight.** Jobs treated as equal; the team picks based on impact estimates that obscure which jobs actually matter for strategy.
+
+**No job assigned to many candidates.** The team treats job mapping as optional; non-mapped candidates get prioritized on volume of requests or stakeholder preference.
+
+**Job-impact precision theater.** Numerical scores for job impact (Job B: 8/10) when the underlying assessment is qualitative. Decisions look quantitative but are not.
+
+**Forcing all decisions through JTBD.** Some decisions (technical migrations, strategic bets) do not benefit from JTBD framing. Force-fitting produces bad decisions.
+
+**JTBD as cover for predetermined prioritization.** The team ranks items by JTBD theater after deciding what to prioritize on other grounds. The framework becomes documentation rather than decision input.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The job-led prioritization frame. Identifying jobs done badly. Mapping candidates to jobs. The "no job, no priority" discipline. Strategic weighting across jobs. The in-flight work review. Avoiding JTBD-religion. Worked prioritization example. Common failures.
+
+## Implementation choices that stay internal
+
+Specific roadmap-tracking tools. Specific scoring rubrics for job impact. Specific stakeholder-review formats. Specific job-strategic-weight reviews. The team's own conventions for prioritization meetings. These vary by team and tooling.

--- a/skills/jtbd-framing/references/common-jtbd-failures.md
+++ b/skills/jtbd-framing/references/common-jtbd-failures.md
@@ -1,0 +1,166 @@
+# Common JTBD failures
+
+Nine-plus failure patterns with diagnoses and cures. The cross-cutting pattern: most JTBD failures share a single root, which is treating JTBD vocabulary as a substitute for analytical work.
+
+---
+
+## Failure 1: We did the JTBD workshop but nothing changed in our roadmap
+
+**Symptom.** A workshop was held. Job statements were produced. The wall has Post-its. The next quarter's roadmap looks the same as the prior quarter's.
+
+**Diagnosis.** Job-statement workshop as deliverable. The workshop became the artifact; the analytical work that should have followed never happened.
+
+**Cure.** Treat job statements as analytical input, not as workshop output. Re-evaluate roadmap candidates against the jobs. Apply the "no job, no priority" discipline. The roadmap should look different than it would have looked without the JTBD work; if it does not, the work is ritual.
+
+**Prevention.** Do not run JTBD workshops as standalone events. Pair the workshop with prioritization or positioning work that uses the job statements as input. Without downstream application, the workshop produces ritual.
+
+---
+
+## Failure 2: Our job statements all sound the same
+
+**Symptom.** Multiple job statements share similar situations, motivations, or outcomes. They are hard to distinguish.
+
+**Diagnosis.** Generic job statements; not grounded in specific struggling moments. The statements were written from intuition rather than from interview data.
+
+**Cure.** Re-ground in interview data. Each job should be traceable to specific moments in specific interviews. Statements that cannot be traced are projections; rewrite from the ground up.
+
+**Prevention.** Job statements emerge from clustering, not from whiteboard sessions. The clustering work surfaces the distinctions; whiteboard sessions tend to produce homogeneous statements.
+
+---
+
+## Failure 3: Our jobs read like feature requests
+
+**Symptom.** Job statements describe what users want from the product, not what users are trying to accomplish.
+
+**Examples that fail.**
+
+- "When using the dashboard, I want to see all my metrics on one screen."
+- "When in the settings page, I want to configure permissions easily."
+
+The motivations and outcomes describe product features, not job-doing.
+
+**Diagnosis.** Product-bound job statements. The motivation is bound to the product; the outcome is feature output.
+
+**Cure.** Apply the product-independence test. The motivation should make sense without naming any specific product. If the user is "in the dashboard," they are using a product; the underlying job is what they are trying to accomplish that brought them to the dashboard.
+
+**Prevention.** During job-statement writing, check each statement: could this make sense if the user had no product to use? If no, rewrite the motivation and outcome to describe the underlying job.
+
+---
+
+## Failure 4: We have personas and jobs and they contradict each other
+
+**Symptom.** The team has both demographic personas and JTBD job statements. Decisions get made differently depending on which framework the conversation invokes.
+
+**Diagnosis.** Personas are demographic; jobs are situational. They serve different purposes. Conflict often signals confusion about which framework drives which decisions.
+
+**Cure.** Decide the role of each framework. JTBD is usually better for product decisions (what to build, how to prioritize); demographic personas are sometimes useful for marketing audience targeting (who to advertise to). Use each where it adds clarity; do not require both for every decision.
+
+**Prevention.** When introducing JTBD, surface the relationship to existing personas. If personas are not driving decisions, consider deprecating them. If personas are useful for specific marketing work, keep them but separate from product decision-making.
+
+---
+
+## Failure 5: JTBD says we should build everything
+
+**Symptom.** Job statements identify many job-improvement opportunities. The team cannot pick. The roadmap becomes a list of all the jobs to address.
+
+**Diagnosis.** Without prioritization across jobs, JTBD identifies opportunities but does not pick. The framework is doing its discovery work; it is not doing prioritization work.
+
+**Cure.** Pair JTBD with strategic weighting (which jobs matter most for the strategy?), capacity constraints (what can the team actually deliver?), and impact estimation (which job improvements move the needle most?). JTBD informs prioritization but does not replace prioritization frameworks.
+
+**Prevention.** When applying JTBD to roadmap prioritization, surface the strategic-weight question explicitly. Some jobs matter more than others; the team's strategy decides which ones.
+
+---
+
+## Failure 6: We dropped JTBD because it became theater
+
+**Symptom.** The team adopted JTBD; produced workshop artifacts; never used them in decisions; and concluded JTBD does not work.
+
+**Diagnosis.** JTBD as ritual produced ritual. The framework was applied without the analytical work.
+
+**Cure.** Reintroduce JTBD as analytical tool, not as ritual. Apply where it earns its keep (discovery, prioritization, positioning). Skip the artifacts that decorate without informing decisions. Demonstrate the value through specific decisions JTBD informed.
+
+**Prevention.** When introducing JTBD, frame it as a tool for specific decisions, not as a methodology to be adopted org-wide. Start with one application (one discovery cycle, one prioritization debate) and show value before expanding.
+
+---
+
+## Failure 7: Our job statements are functional only
+
+**Symptom.** Job statements describe mechanical tasks. The product strategy prioritizes functional features. The product wins on functional dimension and loses to alternatives on emotional and social.
+
+**Diagnosis.** Functional-only synthesis. The interview prompts and synthesis stayed at the functional dimension; emotional and social dimensions were not surfaced.
+
+**Cure.** Re-interview a subset of users with emotional and social prompts. Add the dimensions to existing job statements. Re-evaluate strategy considering all three dimensions.
+
+**Prevention.** Interview structure should explicitly prompt for all three dimensions. Synthesis should surface all three. Single-dimension job statements are usually a sign that prompts or synthesis missed dimensions.
+
+---
+
+## Failure 8: We cannot agree on the job
+
+**Symptom.** Different team members describe the user's job differently. The team debates the framing; the framing does not converge.
+
+**Diagnosis.** Often signals different segments with different jobs. The team is right that there is more than one job; they are wrong to think there should be one consensus job.
+
+**Cure.** Surface the segment differences. The same product may serve different jobs for different segments. Naming the segments and their distinct jobs resolves the disagreement and improves strategy.
+
+**Prevention.** When defining jobs, ask explicitly: do all target users share this job, or does it differ across segments? Often the answer is "differs"; surface the segments rather than forcing consensus.
+
+---
+
+## Failure 9: Our marketing copy uses JTBD vocabulary but our product does not
+
+**Symptom.** Marketing positioning describes the job the product helps users accomplish. The product itself is built around feature-list thinking. Users adopt expecting one experience and encounter another.
+
+**Diagnosis.** Positioning-product gap. The marketing claim is not load-bearing in product decisions; product decisions are still made on feature-list grounds.
+
+**Cure.** Either align product decisions to the JTBD positioning (apply JTBD to prioritization), or revise the positioning to match what the product actually does. The mismatch erodes trust over time.
+
+**Prevention.** When introducing JTBD-led positioning, simultaneously apply JTBD to product strategy. Positioning that describes what the product is becoming should drive what the product becomes.
+
+---
+
+## Failure 10: JTBD vocabulary substituted for analytical work
+
+**Symptom.** The team uses JTBD language ("the job," "struggling moment," "hire criteria") in conversations but cannot trace decisions to specific JTBD analyses.
+
+**Diagnosis.** Vocabulary without analysis is ritual. The framework provides language; the language does not produce decisions on its own.
+
+**Cure.** Audit recent decisions: which were grounded in JTBD analysis (specific job statements, specific hire/fire criteria, specific user research)? Which used JTBD vocabulary as decoration around decisions made on other grounds? Re-anchor in analytical work.
+
+**Prevention.** When the team uses JTBD vocabulary, surface the underlying analytical work explicitly. "What job is this serving?" should produce a specific job statement traceable to research, not a hand-wavy answer.
+
+---
+
+## Failure 11: Force-fitting JTBD where it does not help
+
+**Symptom.** Every product question gets framed in JTBD. Even questions where the framing adds no clarity.
+
+**Diagnosis.** JTBD as mandate. The framework gets applied universally; tax for the team; signal-to-noise drops.
+
+**Cure.** Use JTBD where it earns its keep. Some questions (technical migrations, infrastructure decisions, urgent bug fixes) do not benefit from JTBD framing. Apply other frameworks where they fit better; apply JTBD where it fits.
+
+**Prevention.** Establish that JTBD is one tool among many. Frame the question first; then pick the framework. Do not start with the framework and look for questions to apply it to.
+
+---
+
+## The cross-cutting pattern
+
+Most JTBD failures share a single root: treating JTBD vocabulary as a substitute for analytical work.
+
+The vocabulary is easy: "job," "struggling moment," "hire criteria," "fire criteria," "functional, emotional, social dimensions." Teams adopt the vocabulary and signal that they have adopted JTBD.
+
+The analytical work is hard: structured interviews, struggling-moment grounding, clustering across users, naming jobs from data, surfacing all three dimensions, applying the framework to specific decisions, validating that the analysis informs decisions.
+
+When the vocabulary is adopted without the analytical work, JTBD produces ritual. When the analytical work is done with discipline, JTBD produces decisions and the vocabulary is incidental.
+
+The fix for almost any JTBD failure starts with the same question: where is the analytical work happening, and what decisions is it informing? If the answers are clear, the framework is doing its job. If the answers are vague, the framework is ritual.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The eleven failure patterns with diagnoses and cures. The cross-cutting vocabulary-vs-analysis pattern. The discipline of using JTBD where it earns its keep.
+
+## Implementation choices that stay internal
+
+Specific JTBD-application audits. Specific reviewer training on failure detection. Specific tooling that surfaces JTBD ritual vs analytical use. The team's own conventions for catching ritual before it spreads. These vary by team.

--- a/skills/jtbd-framing/references/functional-emotional-social-dimensions.md
+++ b/skills/jtbd-framing/references/functional-emotional-social-dimensions.md
@@ -1,0 +1,201 @@
+# Functional, emotional, and social dimensions of jobs
+
+Jobs have three dimensions. Strong JTBD work surfaces all three; weak work treats jobs as functional only. The omission of emotional and social dimensions is one of the most common JTBD failure modes.
+
+---
+
+## The three dimensions
+
+### Functional
+
+What the user is mechanically trying to accomplish.
+
+**Worked examples.**
+
+- "Assemble the quarterly board deck."
+- "Track team OKR progress."
+- "Onboard a new engineer to the codebase."
+- "Prepare a customer-facing announcement for a feature launch."
+- "Reconcile vendor payments at month-end."
+
+**Characteristics.**
+
+- Describable in task language.
+- Often the easiest dimension to surface in interviews.
+- Often the dimension product teams default to.
+
+---
+
+### Emotional
+
+How the user feels (or wants to feel) doing the job.
+
+**Worked examples.**
+
+- "Confident that the deck represents the team's actual progress, not a polished version."
+- "In control of the OKR check-in cadence, not behind on it."
+- "Helpful to the new engineer without becoming their full-time guide."
+- "Comfortable that the announcement will not surprise anyone in a way that lands badly."
+- "Confident that the reconciliation is correct without spending the whole week verifying."
+
+**Characteristics.**
+
+- Describes the user's internal experience.
+- Often surfaces through how users describe what went well or badly.
+- Distinguishes products that feel good to use from products that work mechanically but feel exhausting.
+
+---
+
+### Social
+
+How the user wants to be perceived doing the job.
+
+**Worked examples.**
+
+- "Seen by the board as a competent leader who knows the numbers."
+- "Seen by direct reports as someone who follows through on commitments."
+- "Seen by the new engineer as a senior who invested in their onboarding."
+- "Seen by customers as transparent and proactive, not evasive."
+- "Seen by audit as someone whose work the team can trust without re-checking."
+
+**Characteristics.**
+
+- Describes how the user wants others to perceive their work.
+- Often the most overlooked dimension.
+- Drives positioning more than the other two dimensions.
+
+---
+
+## Why three dimensions matter
+
+Products that win on functional alone often lose to alternatives that also serve emotional and social.
+
+**Worked example.** Two analytics tools serving the same functional job.
+
+- Tool A: technically thorough, full-featured, hard to learn, intimidating-feeling. Functional excellence; weak emotional dimension.
+- Tool B: focused on the specific job, faster to confidence, feels manageable. Slightly less functional power; stronger emotional dimension.
+
+For users who could complete the job with either, Tool B often wins. The emotional dimension (feeling in control, confidence) tipped the decision even though Tool A's functional dimension was technically stronger.
+
+**Worked example, social dimension.** A board reporting tool serving CFOs.
+
+- Tool A: produces correct numbers; layout is utilitarian.
+- Tool B: produces the same numbers; layout signals "this CFO knows their numbers" through design.
+
+The social dimension (how the CFO is perceived presenting from this tool) tips many decisions. Tool B is hired in part because it makes the CFO look good in front of the board.
+
+---
+
+## Surfacing emotional and social dimensions in interviews
+
+Emotional and social dimensions often surface only when the interview prompts for them.
+
+**Functional prompts.** "Walk me through the task. What did you do?"
+
+**Emotional prompts.** "How did you feel doing this? What was the most stressful part? When did you feel relieved?"
+
+**Social prompts.** "Who else was watching this work? How did you want to come across to them? What did you do specifically because of how it would look?"
+
+**The interview discipline.** Surface all three dimensions; do not assume the functional dimension is the whole job. Many users will not volunteer emotional or social dimensions; the prompts surface them.
+
+---
+
+## When functional alone is sufficient
+
+Some jobs are dominantly functional and the emotional/social dimensions are minor.
+
+**Worked example.** A backup utility that runs in the background. The functional dimension (data is backed up correctly) is the whole job; the user does not have an emotional relationship with the tool and is not perceived doing it.
+
+**The discipline.** Some products are appropriately functional-only. The team's job is to recognize when the dimensions matter and when they do not. Force-fitting emotional and social dimensions onto purely functional jobs produces false signal.
+
+---
+
+## Functional-only failure mode
+
+The most common JTBD failure: surfacing only the functional dimension.
+
+**The pattern.** Job statements describe what the user is mechanically doing; the team prioritizes functional features; the product wins on functional excellence and loses on emotional and social.
+
+**The cure.** Re-interview a subset of users with emotional and social prompts. Add the dimensions to existing jobs. Re-evaluate strategy considering all three dimensions.
+
+**The signal.** Products that are technically excellent but lose to "lesser" alternatives often have an emotional or social dimension the strategy missed. Investigate.
+
+---
+
+## Emotional dimension and product feel
+
+The emotional dimension shows up in product feel: the way using the product makes users feel.
+
+**Examples of emotional dimensions in product design.**
+
+- A complex configuration interface vs a guided wizard. Both can be functionally equivalent; the wizard often serves the emotional dimension of "feeling in control rather than overwhelmed."
+- An error message that explains and offers recovery vs one that just reports the failure. Both can be technically accurate; the explaining one serves the emotional dimension of "feeling supported rather than stuck."
+- A success state that celebrates the milestone vs one that proceeds silently. Both can be functionally complete; the celebrating one serves the emotional dimension of "feeling progress rather than grinding."
+
+**The discipline.** Product designers often instinctively address emotional dimensions; the JTBD work makes this explicit and prioritizable. Emotional dimension can be a deliberate strategy choice rather than a designer's intuition.
+
+---
+
+## Social dimension and positioning
+
+The social dimension informs positioning more than the other dimensions.
+
+**Examples of social dimensions in positioning.**
+
+- "Used by senior engineers at companies that ship reliable software." (positions the user as a senior engineer at a reliable company.)
+- "The board reporting tool CFOs at high-growth startups trust." (positions the CFO as someone who works for a high-growth startup.)
+- "Built for product teams that ship every week." (positions the product manager as part of a high-velocity team.)
+
+**Why social dimension is positioning-relevant.**
+
+- Users want to be perceived as belonging to the kind of teams the positioning describes.
+- Positioning that names the social dimension creates affinity; positioning that names only functional features competes on feature comparison.
+- The social dimension is durable; functional dimensions can be matched, social dimensions are harder to copy.
+
+**The discipline.** Positioning work should explicitly identify the social dimension of the jobs the product serves. Positioning that ignores social dimension misses one of the strongest tools available.
+
+---
+
+## Worked synthesis combining all three dimensions
+
+A job statement enriched with all three dimensions:
+
+**Job:** "When my team is rolling out a new feature and I need to communicate it to customers, I want to write a clear announcement that explains what changed and why it matters, so I can ship the rollout without flooding support with confusion."
+
+**Functional dimension:** Write the announcement, distribute it to customers, prepare support for incoming questions.
+
+**Emotional dimension:** Confident that the announcement will land well, not anxious that it will trigger a wave of confused tickets, in control of the rollout rather than reactive to its fallout.
+
+**Social dimension:** Seen by the team as someone who handles rollouts smoothly, seen by customers as a brand that communicates clearly about changes, seen by support team as someone whose announcements reduce their workload rather than create it.
+
+**Product implications.** A tool that helps with this job needs to:
+
+- Functionally: support drafting, distribution, and support-team coordination.
+- Emotionally: provide confidence-inducing review (preview tools, sentiment checks, changelog patterns).
+- Socially: produce announcements that carry the brand voice the user wants associated with their rollouts.
+
+The three-dimensional analysis surfaces product needs the functional analysis alone would miss.
+
+---
+
+## Common dimension-related failures
+
+**Functional-only synthesis.** Job statements describe mechanical tasks; strategy prioritizes functional features; product loses on feel.
+
+**Decorative emotional dimension.** Adding "feels good" without specifying which emotional state the product should support. The dimension exists on paper but does not drive design decisions.
+
+**Missing social dimension.** Strategy and positioning work that ignores how users want to be perceived. Positioning ends up generic; product fails to create affinity.
+
+**Force-fitting all three to every job.** Some jobs are functional-dominant. Adding emotional and social dimensions where they do not matter produces noise.
+
+**Treating dimensions as separate jobs.** Functional, emotional, and social dimensions are aspects of the same job, not separate jobs. Treating them separately produces fragmented strategy.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The three dimensions and their characteristics. Worked examples per dimension. Interview prompts per dimension. The functional-only failure mode. Emotional dimension and product feel. Social dimension and positioning. Worked three-dimensional synthesis. Common failures.
+
+## Implementation choices that stay internal
+
+Specific interview prompt templates per dimension. Specific synthesis templates that capture all three. Specific design-review patterns that check for emotional dimension. Specific positioning frameworks that lead with social dimension. These vary by team and design practice.

--- a/skills/jtbd-framing/references/hire-and-fire-criteria.md
+++ b/skills/jtbd-framing/references/hire-and-fire-criteria.md
@@ -1,0 +1,189 @@
+# Hire and fire criteria
+
+Why users adopt a product (hire), why they switch away (fire). The two questions ground JTBD in real decisions users make.
+
+Hire and fire criteria are the JTBD methodology's most actionable contribution to product strategy. They surface what the product needs to be excellent at to win adoption (hire) and what the product needs to maintain to retain users (fire). The two are often different; products that win on hire criteria can lose on fire criteria.
+
+---
+
+## Hire criteria
+
+What makes a user adopt a product.
+
+**The components.**
+
+- The struggling moment the user is trying to solve.
+- The alternatives they considered or tried first.
+- What made the chosen product the answer (vs the alternatives).
+- The expected job output: what the user expected to accomplish with the product.
+
+**Worked example.** A PM user adopting a new analytics tool:
+
+- Struggling moment: "I was spending hours every week assembling product metrics from three different sources before standup, and I was always uncertain whether I had the right slice."
+- Alternatives considered: "Continued the manual spreadsheet approach. Tried to extend the existing BI tool. Considered building an internal dashboard."
+- Why this product won: "It connected to all three sources out of the box, the slice I needed was a 30-second config, and the team could share the same view."
+- Expected job output: "I would walk into standup with the metrics ready, with no manual reconciliation work the night before."
+
+**The discovery prompt.** "Tell me about the moment you decided to start using [product]. What were you doing before? What made you switch?"
+
+---
+
+## Fire criteria
+
+What makes a user switch away.
+
+**The components.**
+
+- The struggling moment that recurred even with the chosen product.
+- The alternative that started looking better.
+- What tipped the user from "considering switching" to "switching."
+- The job output that the chosen product failed to deliver consistently.
+
+**Worked example.** A PM user switching away from an analytics tool:
+
+- Struggling moment: "Once we hit cross-source aggregations the basic config could not handle, I was back to manual workarounds."
+- Alternative looking better: "A team I respect started using a different tool that handled cross-source natively."
+- Tipping point: "When I had to rebuild a report three weeks in a row because the workaround broke whenever the source schemas changed."
+- Failed job output: "The 30-second-config promise did not hold for the analyses that mattered most."
+
+**The discovery prompt.** "If you switched away from [product] tomorrow, what would the trigger be? What would the alternative need to do that [product] does not?"
+
+For users who have actually switched: "What was the moment you decided to switch away?"
+
+---
+
+## Why hire and fire are often different
+
+Hire criteria reveal what the product needs to be excellent at to win adoption. Fire criteria reveal what the product needs to maintain to retain users. The asymmetry is consequential.
+
+**Examples of the asymmetry.**
+
+- A product that wins adoption with a fast onboarding (hire criterion) can lose users to depth limitations once they get past onboarding (fire criterion). The product needs both: fast onboarding AND depth that handles harder cases.
+- A product that wins adoption with a single integration (hire criterion) can lose users when their tooling stack expands and the product does not keep up (fire criterion). The product needs both: a strong landing integration AND breadth as users grow.
+- A product that wins adoption with a low price (hire criterion) can lose users when their budget expands and competitors offer more value at higher tiers (fire criterion). The product needs both: accessible entry AND value at higher tiers.
+
+**The implication.** Strategy work that focuses only on hire criteria builds for adoption. Strategy work that focuses only on fire criteria builds for retention. Mature strategy addresses both, often through different parts of the product or different lifecycle stages.
+
+---
+
+## Recent-switch interview discipline
+
+Users who recently switched (in either direction) are particularly rich for JTBD interviews.
+
+**Why recent switches matter.**
+
+- The user remembers the specific moment of the switch decision; older switches get smoothed into abstractions.
+- The user remembers the alternatives they considered, the criteria they used, the moment of tipping.
+- The data is grounded in real decisions, not hypothetical preferences.
+
+**The recruiting target.** Users who switched in the last 30-90 days are the highest-value recruits for hire/fire interviews. Users who switched 6+ months ago provide weaker data.
+
+**The interview structure.**
+
+- Walk through the situation that prompted the switch consideration.
+- Identify the alternatives evaluated.
+- Surface the criteria the user used to evaluate.
+- Identify the tipping moment.
+- Compare expected vs realized outcomes after the switch.
+
+---
+
+## Hire and fire across segments
+
+Different segments often have different hire and fire criteria.
+
+**Worked example.** A team productivity SaaS:
+
+- Small-team segment: hire criterion is "fast setup; works without admin"; fire criterion is "team grew and the product feels limiting."
+- Mid-size segment: hire criterion is "supports our existing roles and permissions"; fire criterion is "missing reporting and audit features as we standardize."
+- Enterprise segment: hire criterion is "compliance and security pass our review"; fire criterion is "vendor responsiveness during incidents."
+
+**The discipline.** Surface segment differences in hire and fire criteria explicitly. A product that wins on small-team hire criteria but loses on mid-size fire criteria has a known retention pattern that strategy must address.
+
+---
+
+## The "why didn't you switch sooner" question
+
+A specific prompt that reveals the friction barrier to switching.
+
+**The prompt.** "Looking back, why didn't you switch sooner?"
+
+**What it surfaces.**
+
+- The switching cost the user had to overcome (data migration, team retraining, contract obligations).
+- The alternatives that almost won earlier but did not (and why).
+- The accumulated frustration that finally broke through the inertia.
+
+**Why it matters.**
+
+- High switching costs protect incumbents. Users tolerate friction longer when switching is expensive.
+- The pattern of frustration accumulation reveals which fire criteria are load-bearing (the ones users finally cannot tolerate).
+- The almost-won alternatives reveal what would have been compelling enough earlier.
+
+---
+
+## Hire and fire criteria for non-switching users
+
+Not every user has switched. Some users are at the start of their relationship with the product; others have used it for years without considering alternatives.
+
+**For new users:** focus on hire criteria. The recent decision is the adoption decision; the fire criteria are hypothetical.
+
+**For long-tenured users:** focus on fire criteria. The hypothetical "what would make you switch" reveals the latent fire criteria even without a switch event. The product can use these to address fire risks before they become switch events.
+
+**For users who tried and abandoned:** rich data. They evaluated, found the product wanting, and stuck with the prior alternative. The reasons reveal both hire criteria the product failed and fire criteria for the alternative they kept.
+
+---
+
+## Patterns across hire criteria
+
+Common patterns in hire criteria across product domains.
+
+**Speed-to-value.** Users hire products that get them to first value quickly. Long onboarding loses adoption races; fast onboarding wins.
+
+**Specific job fit.** Users hire products that look like they will solve the specific job. Generic products that "could be used for many things" lose to specific products that "solve this exact problem."
+
+**Confidence in continuity.** Users hire products they trust will be there in 2 years. Established products win on this; startups have to compensate with other criteria.
+
+**Workflow continuity.** Users hire products that fit their existing workflows. Products that demand workflow change face higher hire bars.
+
+**Recommendation chain.** Users hire products that someone they trust recommended. Word-of-mouth is often a stronger hire criterion than feature comparison.
+
+---
+
+## Patterns across fire criteria
+
+Common patterns in fire criteria across product domains.
+
+**Reliability degradation.** Users fire products that become unreliable. A product that ships bugs faster than it ships fixes loses users.
+
+**Scaling friction.** Users fire products that get harder to use as they grow. The product that was great for 5 users may be painful at 50.
+
+**Vendor responsiveness.** Users fire products whose vendors stop responding. Support quality, account management, and incident response all matter.
+
+**Pricing trajectory.** Users fire products whose pricing escalates faster than the value they get. Enterprise tiers that gate basic functionality drive fire decisions.
+
+**Competitive pressure.** Users fire products when alternatives reach feature parity plus advantage. Products that stop innovating lose to products that overtake them.
+
+---
+
+## Common hire-and-fire failures
+
+**Asking only about hire.** The team interviews about adoption decisions but never about switch decisions. The strategy biases toward adoption; retention concerns surface late.
+
+**Asking only about fire.** The team focuses on churn analysis without understanding hire criteria. New customer acquisition struggles because the team does not know what wins adoption.
+
+**Treating hire and fire as the same.** The team assumes the criteria match. Strategy ends up optimized for hire-with-no-fire-attention or vice versa.
+
+**Hypothetical-only fire data.** Long-tenured users describing what they "would" switch over. Useful but weaker than real-switch data.
+
+**Ignoring segment differences.** Hire and fire criteria collapsed across segments. Strategy that works for one segment fails for another.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The hire and fire criteria components. Why they are often different. The recent-switch interview discipline. Hire and fire across segments. The "why didn't you switch sooner" question. Hire and fire for non-switching users. Patterns across hire and fire criteria. Common failures.
+
+## Implementation choices that stay internal
+
+Specific interview templates for hire and fire interviews. Specific recruitment criteria for recent switchers. Specific synthesis tooling for hire and fire data. The team's own conventions for hire-fire balance in strategy work. These vary by team and research practice.

--- a/skills/jtbd-framing/references/identifying-struggling-moments.md
+++ b/skills/jtbd-framing/references/identifying-struggling-moments.md
@@ -1,0 +1,176 @@
+# Identifying struggling moments
+
+Jobs become visible at struggling moments: when the user's current solution is failing them, when alternatives feel inadequate, when they would prefer a different way of doing the job.
+
+The struggling moment is the JTBD methodology's most direct contribution to discovery research. Most discovery interviews surface preferences and feature requests; well-structured JTBD interviews surface struggling moments, which produce richer data and clearer jobs.
+
+---
+
+## What a struggling moment is
+
+A specific moment in time when:
+
+- The user encountered friction in trying to accomplish something.
+- The current approach failed them or felt inadequate.
+- They considered or wished for an alternative.
+- They built a workaround or accepted suboptimal output.
+
+**Strong struggling-moment examples.**
+
+- "Last Tuesday I lost an hour assembling the board metrics from three different dashboards because none of them had the slice I needed. I ended up exporting CSVs and combining them manually, and then second-guessing whether I had pulled the right data."
+- "When the customer escalation came in at 9pm, I was at dinner and tried to triage from my phone, but the support tool's mobile experience was unusable. I had to go back to my laptop and the whole evening was disrupted."
+- "Last quarter I spent the whole onboarding week pair-programming with the new engineer because our docs assumed knowledge they did not have, and I could not point them anywhere that would work without me there."
+
+Each example names a specific time, a specific friction, and the workaround or impact.
+
+**Weak struggling-moment examples.**
+
+- "I wish dashboards were better." (general; not a moment)
+- "It would be nice if the support tool was more mobile-friendly." (preference; not a friction-in-context)
+- "Onboarding new engineers takes a lot of time." (abstracted; no specific moment)
+
+---
+
+## Discovery prompts that surface struggling moments
+
+Specific prompts produce specific data.
+
+**Prompts that work.**
+
+- "Walk me through the last time you did [task]. What was hardest about it?"
+- "What was the most recent time you wished you had a better way of doing [task]?"
+- "When was the last time [task] went badly? What happened?"
+- "Describe the last time you considered switching from [current tool] to something else. What triggered that?"
+- "What's something you do that takes longer than it should? When was the last time it cost you?"
+
+The prompts share two characteristics: they ground in recent specific moments, and they invite the user to describe friction without pre-judging it.
+
+**Prompts that fail.**
+
+- "What features would you like to see?" (produces feature requests, not jobs)
+- "How do you usually do [task]?" (produces abstracted descriptions, not moments)
+- "Are you satisfied with [tool]?" (produces preferences, not behaviors)
+- "What would your dream solution look like?" (produces fiction, not data)
+
+---
+
+## The recency bias as a feature
+
+JTBD interviewing exploits recency. Recent moments are remembered with specifics; older moments get smoothed into abstractions.
+
+**The methodology.** Ask about the last time, the most recent occurrence, the situation that happened this week. Users can recall details from recent moments that they cannot recall from older ones. The details are where the job lives.
+
+**The trade-off.** Recent moments may not represent the dominant pattern; the most recent occurrence may be an outlier. The mitigation is interview volume: 8-15 interviews each grounded in recent moments produce a pattern; one interview grounded in one moment is one data point.
+
+---
+
+## Pattern recognition across users
+
+Across many users, struggling moments cluster. The same kinds of friction recur. The clusters reveal the jobs that are not currently being done well.
+
+**The clustering work.**
+
+- Across interviews, struggling moments get tagged with what the user was trying to accomplish, what failed, what alternative they wished for.
+- Tags cluster: multiple users describe the same kind of friction in similar contexts.
+- Each cluster suggests a job: the underlying thing users were trying to do that the cluster's friction was blocking.
+
+**Worked example.** Across 12 interviews with PM users:
+
+- Multiple users describe assembling data from multiple dashboards before quarterly business reviews.
+- Multiple describe building Excel exports because their dashboard tool does not produce the right slice.
+- Multiple describe second-guessing whether the data they assembled is correct.
+- Multiple describe the time pressure and disruption these workarounds create.
+
+The cluster suggests a job: "When preparing for quarterly business reviews, I want to assemble cross-source data into a coherent narrative I can defend, so I can answer the board's questions confidently without spending the night before reconciling spreadsheets."
+
+The job emerges from the moments; the moments came from the prompts.
+
+---
+
+## Distinguishing struggling moments from venting
+
+Not every friction users describe is a struggling moment for product purposes.
+
+**Struggling moments.**
+
+- Specific friction that interferes with the user accomplishing something they care about.
+- The friction is reproducible (other users encounter similar friction in similar contexts).
+- The friction has a workaround or alternative the user has tried.
+
+**Venting that is not a struggling moment.**
+
+- General complaint without specific friction context ("everything is too slow").
+- Preference for cosmetic differences ("I do not like the color").
+- One-off issues with no pattern across users.
+
+**The discipline.** Tag specific friction; do not over-weight venting. The struggling moments that drive product decisions are the ones with reproducible context across users.
+
+---
+
+## The "what would you have done differently" question
+
+A specific prompt that surfaces both struggling moments and the implicit alternative.
+
+**The prompt.** "If you could have done [task] any way you wanted, how would you have done it?"
+
+**What it surfaces.**
+
+- The user's mental model of the ideal approach.
+- The gap between current tools and the user's mental model.
+- Sometimes the alternative tools the user has used or considered.
+
+**What it does not surface.**
+
+- Always-correct product solutions. Users often describe alternatives that would not actually work; the value is in understanding their mental model, not adopting their proposed solution.
+
+**The interpretation.** The user's described "would have done differently" is informative about the gap, not prescriptive about the fix. Synthesis interprets the gap and proposes product responses; users do not directly produce the responses.
+
+---
+
+## When users do not have struggling moments
+
+Sometimes the interview reveals that the user is not struggling with the area the team is researching. They have a workable approach; they would not change it; the friction the team thought existed does not exist for this user.
+
+**The honest interpretation.** The team's hypothesis about a job that needs better tooling may be wrong, or this user may not be in the target segment for the job, or the job may be done well enough by existing solutions that there is no struggle.
+
+**The discipline.** Surface this finding rather than discounting it. "Some users are not struggling here" is data; ignoring it because it does not match the team's hypothesis is confirmation bias.
+
+---
+
+## Struggling moments by product type
+
+Different product domains surface different kinds of struggling moments.
+
+**Tools that fit into existing workflows.** Struggling moments are workflow disruptions: the moment the existing tool failed and the user had to switch to a workaround.
+
+**Tools that change workflows.** Struggling moments are transition points: the moment the user realized the old workflow was unsustainable and considered changing it.
+
+**Consumer products.** Struggling moments are often emotional: the moment the user felt frustrated, blocked, or in conflict with their own goals.
+
+**B2B platforms.** Struggling moments often involve coordination: the moment the user could not align with a colleague, customer, or vendor because the tooling did not support the coordination.
+
+The discipline. Tailor interview prompts to the kind of struggling moment most likely in the product domain; do not assume one prompt works for all domains.
+
+---
+
+## Common struggling-moment failures
+
+**Eliciting preferences instead of moments.** "What features do you wish existed?" produces preferences. Reframe: "What's the last task that took longer than it should have?"
+
+**Abstracting moments to patterns prematurely.** Users describing "what I usually do" instead of specific recent moments. Bring them back to the last specific time.
+
+**Ignoring countervailing data.** Users who do not struggle in the researched area. Their data is signal; do not discard it.
+
+**Treating venting as struggling moments.** General complaint without specific context does not produce jobs.
+
+**Over-relying on the "wish" question.** Users describe ideal alternatives that do not necessarily reflect what would work; treat as gap-revealing data, not as product specs.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+What a struggling moment is and is not. Discovery prompts that work and fail. The recency bias as a feature. Pattern recognition across users. Distinguishing struggling moments from venting. The "what would you have done differently" question. When users do not struggle. Domain-specific struggling moment patterns. Common failures.
+
+## Implementation choices that stay internal
+
+Specific interview templates and discussion guides. Specific recording and tagging conventions. Specific recruitment criteria for who the team interviews. The team's own conventions for interview length and structure. These vary by team and research practice.

--- a/skills/jtbd-framing/references/job-statement-structure-patterns.md
+++ b/skills/jtbd-framing/references/job-statement-structure-patterns.md
@@ -1,0 +1,198 @@
+# Job statement structure patterns
+
+The canonical structure: "When [situation], I want to [motivation], so I can [outcome]." Each level demands specificity. Vague levels produce job statements that drive nothing.
+
+---
+
+## The three levels
+
+### Situation
+
+The context, trigger, or moment when the job becomes active.
+
+**Strong situation patterns.**
+
+- "When my team is rolling out a new feature and I need to communicate it to customers..."
+- "When I am preparing the quarterly board deck the night before the meeting..."
+- "When I get a customer escalation outside of business hours..."
+- "When a new engineer joins my team mid-quarter..."
+
+**Weak situation patterns.**
+
+- "When I am at work..." (too broad)
+- "As a marketing manager..." (demographic, not situational)
+- "Whenever I need to communicate..." (lacks the specific trigger)
+
+**Why specificity matters.** Situations name the moment when the job activates. Different situations can produce different jobs even for the same user; collapsing situations together loses the patterns.
+
+---
+
+### Motivation
+
+What the user is trying to do in that situation.
+
+**Strong motivation patterns.**
+
+- "...I want to write a clear announcement that explains what changed and why it matters..."
+- "...I want to assemble revenue and engagement data into a coherent narrative..."
+- "...I want to triage the escalation and respond without disrupting my evening too much..."
+- "...I want to onboard the new engineer to our codebase without becoming their full-time guide..."
+
+**Weak motivation patterns.**
+
+- "...I want to do my job better..." (too vague)
+- "...I want to use feature X..." (motivation is a feature, not a goal)
+- "...I want to be more productive..." (universal; not actionable)
+
+**Why specificity matters.** Motivations name what the user is trying to accomplish in their own words. The motivation should describe the job the user is doing, not the product the user is using. "I want to use Slack to communicate" is not a motivation; "I want to coordinate with the team on the rollout" is.
+
+**The product-independence test.** A good motivation should make sense without naming any specific product. If the motivation is bound to the product, it has slid into feature framing.
+
+---
+
+### Outcome
+
+What success looks like; what the user is trying to achieve by doing the job.
+
+**Strong outcome patterns.**
+
+- "...so I can ship the rollout without flooding support with confusion."
+- "...so I can answer the board's likely questions before they ask them."
+- "...so I can address the customer's concern while still being present at home."
+- "...so the new engineer can ship their first PR within two weeks without depending on me for every question."
+
+**Weak outcome patterns.**
+
+- "...so I can succeed." (too vague)
+- "...so I can use the feature." (outcome is feature use, not user goal)
+- "...so I can be efficient." (universal; not specific)
+
+**Why specificity matters.** Outcomes name what success looks like in the user's terms. Different outcomes for the same situation+motivation can produce different jobs. The outcome anchors the job in the user's success criteria, not the product's metrics.
+
+---
+
+## Worked examples across product domains
+
+### B2B SaaS for engineering teams
+
+- "When a production incident is detected and I am the on-call engineer, I want to identify the root cause and roll back if needed, so I can restore service before the SLO breach without escalating unnecessarily."
+
+### Consumer fitness app
+
+- "When I have 30 minutes between meetings and I want to use the time well, I want to do a workout that fits the time budget and uses the equipment I have at hand, so I can stay consistent without skipping when life gets busy."
+
+### Internal tools for finance teams
+
+- "When the month-end close is starting and I need to reconcile vendor payments, I want to identify discrepancies and document explanations, so the auditors can review without follow-up questions."
+
+### Creator-tools SaaS
+
+- "When I am editing a podcast episode the day before publication, I want to remove background noise and balance audio levels across speakers, so the episode sounds professional without spending another two hours on mastering."
+
+Each example specifies the moment, what the user is trying to do, and what success looks like. Each is product-independent at the motivation level: the user is trying to accomplish the job regardless of which tool they use.
+
+---
+
+## Common structural failures
+
+### Vague situations
+
+**Failure.** "When I am at work..."
+
+**Diagnosis.** The situation does not name the trigger that activates the job. Most users are at work most of the time; the situation should name the specific moment.
+
+**Cure.** Re-ground in interview data. What was the user actually doing when this job became urgent? Use that moment.
+
+---
+
+### Motivation as feature request
+
+**Failure.** "...I want to use the dashboard..."
+
+**Diagnosis.** Motivation is a feature, not a goal. The user does not want to use the dashboard; they want to accomplish something the dashboard supports.
+
+**Cure.** Ask the why-question. Why does the user want to use the dashboard? What are they trying to learn from it? The answer is the motivation.
+
+---
+
+### Outcome as feature output
+
+**Failure.** "...so I can see the metrics."
+
+**Diagnosis.** Outcome is feature output, not user success. Seeing the metrics is intermediate; the user wants something the metrics enable.
+
+**Cure.** Ask another why. Why does the user want to see the metrics? What does seeing the metrics enable? The answer is the outcome.
+
+---
+
+### Demographic as situation
+
+**Failure.** "As a marketing manager..."
+
+**Diagnosis.** Demographic, not situational. Different marketing managers in different moments have different jobs.
+
+**Cure.** Replace with the specific moment. "When the marketing manager is preparing the quarterly campaign retrospective..."
+
+---
+
+### Universal as motivation or outcome
+
+**Failure.** "...I want to be more productive, so I can be efficient."
+
+**Diagnosis.** Universal language; could apply to any user, any job. Says nothing.
+
+**Cure.** Specificity at both motivation and outcome. What kind of productivity? What does productivity enable? The specifics are the job.
+
+---
+
+## Multiple jobs per situation
+
+A single situation can produce multiple jobs. Different motivations or outcomes within the same situation are different jobs.
+
+**Worked example.**
+
+Situation: "When I am preparing the quarterly board deck..."
+
+Job A: "...I want to assemble revenue and engagement data into a coherent narrative, so I can answer the board's likely questions before they ask them."
+
+Job B: "...I want to flag the risks I want the board to engage with, so I can get their input on the calls I cannot make alone."
+
+Both jobs share the situation but have different motivations and outcomes. They may need different product responses.
+
+The discipline. Do not collapse multiple jobs into one because they share a situation. The motivation and outcome distinguish them.
+
+---
+
+## Job statements vs alternatives in JTBD literature
+
+The "When... I want to... so I can..." format is the most widely used job statement structure. Other formats exist (outcome statements in outcome-driven innovation, struggle statements in switch interviews). They each name the same fundamental thing: the user's situation, motivation, and success criteria.
+
+This skill uses the When/I-want-to/So-I-can structure because it is the most teachable and the most consistently understood. Teams familiar with other JTBD lineages can translate; the underlying principles are the same.
+
+**The structure-vs-substance discipline.** The structure is a scaffold for analytical work. Job statements written in the right structure but without grounding in interview data are still ritual. Job statements written in slightly different structures but grounded in interview data and driving decisions are still jobs.
+
+---
+
+## The job statement editing pass
+
+Strong JTBD work runs an editing pass focused on job-statement quality.
+
+**Per job statement, the editing questions.**
+
+1. Is the situation specific (a moment, not a demographic)?
+2. Is the motivation product-independent and goal-directed?
+3. Is the outcome the user's success criterion, not a feature output?
+4. Is the statement specific enough that another team could distinguish it from related jobs?
+5. Could the team use this job statement to evaluate a product decision?
+
+**The editing investment.** 1-2 hours per round of revisions on a typical job-statement set. The investment pays off in clarity for downstream applications (discovery, prioritization, positioning).
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The three-level structure (situation, motivation, outcome). Strong vs weak patterns at each level. The product-independence test for motivation. Common structural failures and their cures. Multiple-jobs-per-situation discipline. The structure-vs-substance principle. The editing pass.
+
+## Implementation choices that stay internal
+
+Specific job-statement templates in the team's writing system. Specific document conventions for job-statement libraries. Specific A/B testing of statement variants in interview prompts. The team's own conventions for how many job statements per discovery cycle. These vary by team.

--- a/skills/okr-design/SKILL.md
+++ b/skills/okr-design/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: okr-design
 description: "OKR design as actually shipped, not as conference-talk theory. Outcome statements that drive decisions, key results that measure the right thing, scoring discipline, mid-quarter recalibration, and the difference between sandbagged OKRs (always 100%) and aspirational OKRs (always 30%) and stretch OKRs (genuine ambition with quarterly accountability). Triggers on OKR design, OKR setting, key result design, OKR scoring, mid-quarter recalibration, OKR cascading, outcomes vs outputs, quarterly planning, goal setting. Also triggers when a team's OKRs are always hit and producing no learning, when OKRs are demoralizing because they were set as fantasy, or when the team uses OKR vocabulary but the practice has decayed."
-category: project-management
+category: product
 catalog_summary: "OKR design discipline. Outcome statements, key results, scoring, mid-quarter recalibration. Distinguishes sandbagged OKRs (always hit, useless) from aspirational fantasy (impossible, demoralizing) from stretch OKRs (genuine ambition with quarterly accountability)"
-display_order: 13
+display_order: 12
 ---
 
 # OKR Design

--- a/skills/okr-design/SKILL.md
+++ b/skills/okr-design/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: okr-design
+description: "OKR design as actually shipped, not as conference-talk theory. Outcome statements that drive decisions, key results that measure the right thing, scoring discipline, mid-quarter recalibration, and the difference between sandbagged OKRs (always 100%) and aspirational OKRs (always 30%) and stretch OKRs (genuine ambition with quarterly accountability). Triggers on OKR design, OKR setting, key result design, OKR scoring, mid-quarter recalibration, OKR cascading, outcomes vs outputs, quarterly planning, goal setting. Also triggers when a team's OKRs are always hit and producing no learning, when OKRs are demoralizing because they were set as fantasy, or when the team uses OKR vocabulary but the practice has decayed."
+category: project-management
+catalog_summary: "OKR design discipline. Outcome statements, key results, scoring, mid-quarter recalibration. Distinguishes sandbagged OKRs (always hit, useless) from aspirational fantasy (impossible, demoralizing) from stretch OKRs (genuine ambition with quarterly accountability)"
+display_order: 13
+---
+
+# OKR Design
+
+A senior product leader's playbook for OKR design as actually shipped, not as conference-talk theory. Outcome statements that drive decisions, key results that measure the right thing, scoring discipline, mid-quarter recalibration, and the practical disciplines that distinguish OKRs from quarterly to-do lists or impossible-fantasy goal-setting.
+
+OKRs are accountability infrastructure. When designed well, they produce a quarterly rhythm of ambitious goal-setting, mid-quarter learning, end-of-quarter scoring, and adjustment for the next quarter. When designed badly, they become a tax on the team that produces no signal: sandbagged OKRs that always hit 100% (no ambition, no learning), aspirational fantasy OKRs that nobody can hit (demoralizing, ignored after week 2), or vague OKRs that the team scores generously regardless of outcome.
+
+This skill is OKR design as practical methodology. The teams that benefit from OKRs are the ones that hold the discipline: outcomes over outputs, key results that actually measure the outcome, scoring honestly even when uncomfortable, recalibrating mid-quarter when warranted, and using the OKR review cadence to drive learning rather than performance theater.
+
+The voice is the senior product leader who has run OKRs in healthy organizations and watched the practice decay in others. Concrete, opinionated about what actually works, willing to call out the failure modes that conference talks gloss over.
+
+When to use this skill: designing OKRs for the next quarter, auditing why current OKRs are not driving decisions, recalibrating an OKR practice that has decayed, or onboarding a team to OKRs that has never used them.
+
+---
+
+## What this skill is for
+
+This skill spans OKR design and the operational rhythm around them. The PM-skill distinction:
+
+- **`okr-design` (this skill)** is outcomes (results to be achieved).
+- `roadmap-planning` is outputs (features and initiatives sequenced).
+- `feature-launch-playbook` is post-ship execution.
+- `product-analytics-setup` is measurement infrastructure (the metrics that key results depend on).
+- `experiment-design` is the discipline for testing whether specific initiatives produce outcomes.
+- `discovery-research-synthesis` informs which outcomes to pursue.
+
+The audience: senior PMs, product directors, engineering leaders, executives setting org-wide OKRs, in-house teams operating in OKR-driven cultures.
+
+What is not in scope: the broader strategic planning that decides which outcomes matter (other strategy frameworks); the execution of specific initiatives toward OKRs (covered by roadmap-planning, pm-spec-writing, feature-launch-playbook); the analytics infrastructure (covered by product-analytics-setup, analytics-strategy).
+
+---
+
+## Sandbagged vs aspirational-fantasy vs stretch
+
+The keystone framing.
+
+**Sandbagged.** OKRs designed to hit 100%. The key results target outcomes the team is already on track to deliver. End of quarter: 100% scores across the board. The team celebrates; nobody learns anything. Output: an OKR practice that produces no signal. The team has the same OKRs every quarter dressed in different vocabulary because nothing pushes them past where they would have gone anyway.
+
+**Aspirational-fantasy.** OKRs that nobody can hit. 1000% growth in 90 days. Demoralizing, performative, ignored after week 2. Teams that ship aspirational-fantasy OKRs typically discover by week 6 that no realistic effort path produces the targets; they disengage; the OKRs become decoration on the planning doc that nobody references.
+
+**Stretch.** Genuine ambition with quarterly accountability. Designed to hit 60-70% on average. Hits and misses both teach something. The 60% case ("we hit 60% of our key results") is informative about what the team can deliver in a quarter; the 100% case is rare and usually signals sandbagging in retrospect; the 30% case signals either fantasy or the team encountered something unexpected (which is also informative).
+
+The litmus test. Look at the team's last four quarters of OKRs. If the average score is 95%+, the OKRs are sandbagged. If the average is below 30%, they are fantasy. If the average is 50-75%, the design is in the stretch zone. Adjust upcoming OKRs to bring the practice into stretch territory.
+
+---
+
+## Objective design
+
+Objectives are outcome statements. They name what the team is trying to achieve in the quarter.
+
+**Strong objective characteristics.**
+
+- Outcome-focused, not output-focused. "Improve activation for new sign-ups" is an outcome; "Ship the new onboarding flow" is an output.
+- Specific to the quarter. Vague aspirations ("be more user-focused") do not focus quarterly work.
+- Inspiring without being fantasy. The team should feel pulled toward the objective, not crushed by it.
+- Few in number. Most teams should have 2-4 objectives per quarter; more than 5 dilutes focus.
+
+**Worked examples.**
+
+- "Improve activation for new sign-ups so that more reach the value-realization moment within the first week."
+- "Make the support experience deflect predictable issues so the team can focus on harder cases."
+- "Establish enterprise-readiness foundations so we can serve the segment we are targeting next year."
+
+**Weak objective characteristics.**
+
+- Output-disguised-as-outcome. "Ship the activation redesign" is an output; the objective should be the result the redesign is meant to produce.
+- Too vague. "Improve user experience" is too broad to focus quarterly work.
+- Too tactical. "Refactor the auth service" is a tactical decision, not a quarterly objective.
+- Too many. 8 objectives produces no focus; the team works on too many things and excels at none.
+
+Detail in `references/objective-design-patterns.md`.
+
+---
+
+## Key result design
+
+Key results measure progress toward the objective. They are the quantitative or testable indicators that show whether the objective is being achieved.
+
+**Strong key result characteristics.**
+
+- Measurable. There is a specific number or testable threshold.
+- Outcome-aligned. Achieving the key result actually moves the objective forward.
+- Within team influence. The team can affect the key result through their work.
+- Time-bounded. The measurement window is the quarter (or appropriate sub-window).
+
+**Worked example.** Objective: "Improve activation for new sign-ups."
+
+Strong key results:
+
+- "Increase the percentage of new sign-ups reaching the value-realization moment within their first week from 32% to 45%."
+- "Reduce the median time-to-first-value from 4.2 days to under 2 days."
+- "Reach 80% completion rate on the onboarding flow (up from 64%)."
+
+Each key result is measurable, ties to activation, the team can influence it through onboarding redesign work, and is time-bounded to the quarter.
+
+**Weak key results.**
+
+- Vague: "Improve activation significantly."
+- Output: "Ship 5 onboarding redesign initiatives." (counts work done, not outcomes produced.)
+- Outside influence: "Increase total signups by 50%." (signups are mostly upstream of activation work.)
+- Vanity: "Reach 1M users." (impressive number; not directly tied to activation outcome.)
+
+**The 3-5 key results rule.** Most objectives benefit from 3-5 key results. One key result is fragile (single measurement may not capture the outcome); 6+ key results dilute focus.
+
+Detail in `references/key-result-design-patterns.md`.
+
+---
+
+## Cascading OKRs across the org
+
+When and how to cascade OKRs from leadership to teams.
+
+**The trade-off.**
+
+- Cascaded OKRs ensure team work aligns with company priorities. The product team's objective derives from the company's objective; the engineering team's objective derives from the product team's.
+- Strict cascading produces top-down OKRs that miss bottom-up insight. The team closer to the work sometimes knows what to prioritize better than the layer above.
+- Too-loose cascading produces team OKRs that do not connect to company priorities; teams optimize locally without contributing to org goals.
+
+**The middle path.**
+
+- Company-level OKRs set quarterly. Team-level OKRs set with reference to company OKRs but with team-level autonomy on how to contribute.
+- Each team's OKRs explicitly identify which company OKRs they ladder up to.
+- Some team OKRs may be team-specific (technical debt, infrastructure, experimentation infrastructure) without direct company-OKR ladders. Surface these explicitly so the team's full work is visible.
+
+**When to cascade strictly.** Early-stage companies aligning around a small number of company priorities. Times of strategic shift where the org needs to move in a coordinated direction.
+
+**When to cascade loosely.** Mature organizations with established team mandates. Cross-functional teams where strict cascading would over-constrain.
+
+**The honest disclosure.** Cascading is harder than conference talks suggest. Most orgs over-cascade in the first few cycles and learn to relax it; some never learn and produce OKRs that are increasingly performative as they propagate down.
+
+Detail in `references/cascading-okrs-decisions.md`.
+
+---
+
+## Scoring discipline
+
+End-of-quarter scoring is where OKR practice succeeds or decays.
+
+**The 0.0-1.0 scale.** Each key result scores from 0.0 (no progress) to 1.0 (fully achieved). The objective scores as the average of its key results.
+
+**The 60-70% target.** Stretch OKRs are designed so that the average score across the team's OKRs is 0.6-0.7. Higher average suggests sandbagging; lower suggests fantasy or unexpected disruption.
+
+**Scoring honesty.**
+
+- Score the actual outcome, not the effort. The team that worked hard but did not move the metric scores low; the team that got lucky and moved the metric without much effort scores high. The score reflects outcome.
+- Do not round up. A key result at 0.55 is 0.55, not 0.6. Honest scoring produces honest signal.
+- Acknowledge what changed mid-quarter. Some misses reflect priority shifts; surface those without using them as excuses.
+
+**What 100% means.** 100% scores warrant scrutiny. Either the OKR was sandbagged (under-set), the team had a great quarter (informative), or the team is rounding up. Investigate which.
+
+**What 30% means.** 30% scores warrant scrutiny. Either the OKR was fantasy (over-set), the team encountered unexpected disruption (informative), or the work was deprioritized mid-quarter (also informative). Investigate which.
+
+**The compensation question.** OKRs work best when not directly tied to compensation. When OKRs determine bonuses, sandbagging incentives become severe; teams set OKRs they know they can hit. Most healthy OKR cultures separate goal-setting from compensation.
+
+Detail in `references/scoring-discipline.md`.
+
+---
+
+## Mid-quarter recalibration
+
+When OKRs should change vs when teams should adapt.
+
+**The default.** OKRs hold for the quarter. Teams adapt their tactics to the OKR; OKRs do not change to match what the team is doing.
+
+**When to recalibrate.**
+
+- Strategic shift. The company's strategy changed materially mid-quarter; OKRs that no longer reflect the strategy are no longer the right targets.
+- Major external disruption. A market change, regulatory event, or significant outage warrants resetting the quarter's targets.
+- Information that invalidates the OKR. The team learned mid-quarter that the metric they were targeting does not actually represent the outcome.
+
+**When NOT to recalibrate.**
+
+- The team is not on track. OKRs that are missing should remain as set; the miss is the signal.
+- The OKR is uncomfortable. Teams uncomfortable with stretch OKRs should not lower them mid-quarter to feel better.
+- Easier OKRs would feel achievable. The temptation to swap hard OKRs for easy ones is sandbagging in slow motion.
+
+**The recalibration discipline.** Recalibration should be rare (1-2 quarters out of 8). Frequent recalibration signals OKR design failure: either too aggressive or not strategically aligned. The recalibration itself should be transparent: surface what changed, why, and what the new targets are.
+
+Detail in `references/mid-quarter-recalibration.md`.
+
+---
+
+## The OKR review cadence
+
+OKRs benefit from a structured review rhythm.
+
+**Weekly check-ins.**
+
+- Team reviews progress on each key result. 15-30 minutes.
+- Surfaces blockers, dependencies, signal that the trajectory is off.
+- Not for adjusting OKRs; for adjusting tactics to keep moving toward them.
+
+**Mid-quarter review.**
+
+- Roughly week 6 of the quarter. 60-90 minutes.
+- Honest assessment of trajectory: which key results are on track, which are off.
+- Decision point for any recalibration (rare; should not be the default outcome).
+- Surface external dependencies that affect end-of-quarter outcomes.
+
+**End-of-quarter review.**
+
+- Score each key result honestly.
+- Identify what produced the scores: tactical choices, external factors, OKR design decisions.
+- Inform next-quarter OKR design with the lessons.
+
+**Quarterly retrospective.**
+
+- Distinct from the scoring review. The retrospective examines the OKR practice itself: were the OKRs the right ones, did the cadence work, what should change.
+- Often combined with the next-quarter OKR setting session.
+
+Detail in `references/review-cadence-templates.md`.
+
+---
+
+## OKRs vs roadmap items vs metrics
+
+Three concepts often conflated. Each serves a different purpose.
+
+**OKRs.** Outcome targets for the quarter. "Improve activation for new sign-ups" is an OKR; "Increase first-week activation rate from 32% to 45%" is a key result.
+
+**Roadmap items.** Initiatives the team is building or doing. "Onboarding redesign" is a roadmap item. Roadmap items contribute to OKRs but are not the OKRs themselves.
+
+**Metrics.** Ongoing measurements the team tracks. "First-week activation rate" is a metric. Metrics inform key results (which are quarterly targets on metrics) and are tracked continuously regardless of whether the team has an OKR aimed at them.
+
+**The relationship.**
+
+- OKR: "Improve activation for new sign-ups."
+- Key result: "First-week activation rate from 32% to 45%."
+- Metric: "First-week activation rate" (tracked continuously).
+- Roadmap items contributing: "Onboarding redesign," "Welcome email sequence revision," "Activation triage automation."
+
+**Common conflations.**
+
+- Treating roadmap items as OKRs. "Ship the onboarding redesign" as an OKR; the OKR should be the outcome the redesign is meant to produce.
+- Treating every metric as needing an OKR. Some metrics matter for the team to track without setting quarterly targets on them.
+- Treating OKRs as roadmap commitments. OKRs name outcomes; the team is committed to pursuing them but may shift tactics; treating OKRs as roadmap commitments locks in tactics that may need to change.
+
+Detail in `references/okrs-vs-roadmap-vs-metrics.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-okr-failures.md`.
+
+- "Our OKRs are always 100% and produce no signal." Sandbagged. Set with stretch ambition; expect 60-70% scores.
+- "Our OKRs are always 30% and demoralizing." Fantasy. Recalibrate to genuine stretch; investigate whether the targets are achievable in any realistic effort path.
+- "Our key results measure work, not outcomes." Output-disguised-as-outcome. Rewrite key results to measure the result, not the work.
+- "We have 12 OKRs and the team is working on 47 things." Too many OKRs; cap at 2-4 objectives, 3-5 KRs each.
+- "Our OKRs are vague." Lack measurable targets; rewrite key results with specific numbers and thresholds.
+- "Our cascading produces team OKRs that do not match team work." Strict cascading mismatched to team mandate; loosen cascading or change team mandate.
+- "We never recalibrate even when the strategy shifts." Recalibration too tightly avoided; surface strategic-shift criteria and use them.
+- "We recalibrate every quarter." Recalibration too easy; OKR design is failing; investigate.
+- "Our weekly check-ins became status reports." Tactical-discussion missing; reform the check-in format.
+- "Our scoring rounds up." Scoring discipline missing; commit to honest scoring.
+- "OKRs and bonuses are tied; people sandbag." Predictable; decouple OKRs from compensation.
+
+---
+
+## The framework: 12 considerations for OKR design
+
+When designing or auditing OKRs, walk these 12 considerations.
+
+1. **Stretch, not sandbagged or fantasy.** 60-70% average score target.
+2. **Objectives are outcomes, not outputs.** What we are trying to achieve.
+3. **Few objectives, well-focused.** 2-4 per team per quarter.
+4. **Key results are measurable.** Specific numbers or testable thresholds.
+5. **Key results are outcome-aligned.** Achieving them moves the objective forward.
+6. **Key results are within team influence.** Not entirely dependent on external factors.
+7. **3-5 key results per objective.** Single key results are fragile; many dilute focus.
+8. **Cascading explicit but not over-constrained.** Team OKRs ladder up but with autonomy on how.
+9. **Scoring honest, not rounded.** 0.0-1.0 reflects actual outcomes.
+10. **Recalibration rare.** OKRs hold absent strategic shift or major disruption.
+11. **Review cadence weekly + mid-quarter + end-of-quarter.** Tactical, then strategic, then scoring.
+12. **OKRs separate from roadmap items and metrics.** Each serves a different purpose.
+
+The output of the framework is OKRs that produce quarterly accountability infrastructure: ambitious goal-setting, mid-quarter learning, end-of-quarter scoring honest enough to inform the next quarter.
+
+---
+
+## Reference files
+
+- [`references/objective-design-patterns.md`](references/objective-design-patterns.md) - Outcome-vs-output distinction. Strong vs weak objective characteristics. Worked examples across domains. The few-objectives discipline.
+- [`references/key-result-design-patterns.md`](references/key-result-design-patterns.md) - Measurable, outcome-aligned, within-influence, time-bounded characteristics. Strong vs weak key results. The 3-5 KR rule. Worked examples.
+- [`references/cascading-okrs-decisions.md`](references/cascading-okrs-decisions.md) - When to cascade strictly vs loosely. The middle path. Cascading anti-patterns. The honest disclosure about cascading difficulty.
+- [`references/scoring-discipline.md`](references/scoring-discipline.md) - The 0.0-1.0 scale. The 60-70% target. Scoring honesty. What 100% and 30% mean. The compensation question.
+- [`references/mid-quarter-recalibration.md`](references/mid-quarter-recalibration.md) - When to recalibrate vs adapt tactics. Strategic shift vs uncomfortable OKRs. The recalibration discipline.
+- [`references/review-cadence-templates.md`](references/review-cadence-templates.md) - Weekly check-ins, mid-quarter review, end-of-quarter scoring, quarterly retrospective. Format and time investment per cadence.
+- [`references/okrs-vs-roadmap-vs-metrics.md`](references/okrs-vs-roadmap-vs-metrics.md) - The three concepts and their relationships. Common conflations. The complete picture across all three.
+- [`references/okr-anti-patterns.md`](references/okr-anti-patterns.md) - 8+ anti-patterns including OKR-as-roadmap, sandbagging, fantasy, vanity metrics, OKR theater, compensation coupling.
+- [`references/common-okr-failures.md`](references/common-okr-failures.md) - 11+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: OKRs are accountability infrastructure
+
+OKRs at their best produce quarterly accountability that informs the org's strategic learning. The team commits to outcomes; works toward them; scores honestly; learns from the gap between target and outcome; designs the next quarter's OKRs better.
+
+OKRs at their worst produce ritual that consumes time without producing signal. Sandbagged OKRs that always hit. Fantasy OKRs that nobody can. Vague OKRs that score generously regardless of outcome. The vocabulary persists; the practice has decayed.
+
+The teams that benefit from OKRs are the ones that hold the discipline: outcomes over outputs, measurable key results, stretch ambition, scoring honesty, recalibration only when warranted, and the review cadence that drives learning rather than performance theater.
+
+When in doubt about whether an OKR practice is working, ask: do the OKRs drive decisions about what to prioritize, do the scores produce learning that informs the next quarter, are key results actually measuring outcomes the team can influence, is the average score in the 60-70% range that stretch OKRs target? If yes to all of those, the practice is real. If no to any, the gap is where the OKR work is failing to produce the accountability infrastructure it is meant to provide.

--- a/skills/okr-design/references/cascading-okrs-decisions.md
+++ b/skills/okr-design/references/cascading-okrs-decisions.md
@@ -1,0 +1,187 @@
+# Cascading OKRs decisions
+
+When to cascade strictly vs loosely. The middle path. Cascading anti-patterns. The honest disclosure about cascading difficulty.
+
+Cascading is one of the most contested OKR practices. Conference talks describe clean ladders from company to team to individual; in practice, strict cascading produces over-constrained team OKRs, while loose cascading produces team work disconnected from company priorities. The middle path is harder than the talks suggest.
+
+---
+
+## The trade-off
+
+Cascading exists on a spectrum.
+
+**Strict cascading.**
+
+- Company sets OKRs.
+- Each function (product, engineering, sales) cascades to function-level OKRs.
+- Each team cascades to team OKRs.
+- Each individual cascades to personal OKRs.
+- All ladders trace cleanly upward.
+
+**Loose cascading.**
+
+- Company sets OKRs.
+- Teams set their own OKRs informed by company priorities but with autonomy on scope and contribution.
+- Teams may set OKRs not directly tied to company OKRs (technical debt, team-specific work).
+- Individual OKRs often skipped.
+
+**The trade-off.**
+
+- Strict produces alignment but over-constrains. Teams set OKRs they think leadership wants rather than OKRs they can credibly commit to.
+- Loose produces autonomy but risks misalignment. Team work optimizes locally without contributing to org goals.
+
+---
+
+## When to cascade strictly
+
+**Early-stage companies aligning around small priorities.** When the company has 2-3 critical priorities and everyone needs to focus on them, strict cascading enforces the focus.
+
+**Times of strategic shift.** When the company is changing direction (new market, new segment, new product line), strict cascading helps the org turn together.
+
+**Crisis or focus periods.** When the company faces a specific challenge requiring all hands, strict cascading ensures everyone is rowing the same direction.
+
+**Common to these cases:** strategic clarity is high, alignment is more valuable than autonomy, and the org has fewer concurrent priorities to balance.
+
+---
+
+## When to cascade loosely
+
+**Mature organizations with established mandates.** Teams have clear scope; their OKRs naturally fit company priorities through team mandate; strict cascading adds overhead without value.
+
+**Cross-functional teams where strict cascading would over-constrain.** Teams that span functions cannot cleanly ladder to a single function-level OKR; loose cascading lets them pursue cross-functional outcomes.
+
+**High-trust environments.** Teams trusted to set their own OKRs and credibly commit to them; the org accepts the autonomy in exchange for the engagement and creativity it produces.
+
+**Common to these cases:** team mandates are clear, autonomy is more valuable than tight alignment, and the org tolerates some local optimization in exchange for team engagement.
+
+---
+
+## The middle path
+
+Most healthy OKR cultures sit between strict and loose.
+
+**The pattern.**
+
+- Company sets 3-5 OKRs at the start of the quarter.
+- Teams set OKRs that explicitly identify which company OKRs they ladder up to (when applicable).
+- Teams have autonomy on how to contribute (which key results, which initiatives, what scope).
+- Some team OKRs are team-specific (technical debt, infrastructure, experimentation foundations) without direct company ladders. Surface these explicitly.
+- Individual OKRs are usually skipped; commitment is at the team level.
+
+**The "explicit ladder when applicable" rule.** Each team OKR either:
+
+- Explicitly identifies the company OKR it ladders to.
+- Explicitly identifies that it is team-specific without a company ladder.
+
+Both are honest; the failure mode is implicit ambiguity where the team is not sure whether their OKR connects to anything.
+
+---
+
+## Worked example: middle path
+
+Company OKRs for Q3:
+
+1. Improve net new ARR through enterprise segment growth.
+2. Improve activation for self-serve sign-ups.
+3. Reduce infrastructure costs through architecture optimization.
+
+Product team OKRs:
+
+- "Improve activation for new sign-ups" (ladders to company OKR 2).
+- "Establish enterprise-readiness foundations" (ladders to company OKR 1).
+- "Reduce technical debt in the activation funnel" (team-specific; does not ladder directly).
+
+Engineering team OKRs:
+
+- "Ship onboarding redesign by week 6" (ladders to company OKR 2 via product team OKR).
+- "Migrate to new search architecture" (ladders to company OKR 3).
+- "Strengthen test coverage in critical paths" (team-specific).
+
+Sales team OKRs:
+
+- "Close 8 enterprise deals in Q3" (ladders to company OKR 1).
+- "Improve discovery-call to demo conversion from 24% to 35%" (ladders to company OKR 1).
+- "Build the design partner program" (team-specific).
+
+The pattern. Most team OKRs ladder up; some are team-specific. Each ladder is explicit. Teams have autonomy on how they contribute (which KRs, which initiatives).
+
+---
+
+## Cascading anti-patterns
+
+**Strict cascading enforced top-down without team input.** Team OKRs become wishlist receivers from leadership; commitment is shallow because the team did not author what they are committing to.
+
+**Loose cascading without explicit ladders.** Team OKRs are set without any visible connection to company priorities. Some team work happens to align; some does not. Leadership cannot tell what is contributing to company OKRs.
+
+**Cascade theater.** OKR documents include ladders that look connected but do not actually drive anything. The team's work shows up the same regardless of which company OKR they "ladder to."
+
+**Over-cascading.** Every team OKR is required to ladder to a company OKR. Teams contort their work to fit. Team-specific work (technical debt, infrastructure) gets dressed up as ladder work or gets de-prioritized despite being important.
+
+**Personal OKRs as default.** Individual OKRs cascaded down. Most OKR cultures find this produces overhead without proportional value; commitment at team level is usually sufficient.
+
+---
+
+## Cascading and team mandate
+
+Teams whose OKRs do not naturally ladder to company priorities often have a team-mandate problem.
+
+**The signal.** A team consistently sets OKRs that are team-specific. None of their work ladders to company priorities.
+
+**The interpretation.**
+
+- Possibly the team's mandate does not match the company's current priorities. Either the mandate should change (broader scope, different focus) or the team's work is not strategically critical (consider deprioritizing or restructuring).
+- Possibly the team's work is foundational and supports many company priorities indirectly (platform teams, infrastructure teams). Their OKRs may legitimately be team-specific.
+
+**The audit.** Annually, review whether team mandates match company strategy. Teams whose mandates have drifted from strategy benefit from explicit redirection.
+
+---
+
+## Cascading frequency
+
+The cascading work happens at OKR-setting time (start of quarter) and is generally locked for the quarter.
+
+**Quarterly cascading.** Most common. Company OKRs set; teams cascade; quarter executes.
+
+**Mid-quarter cascade revision.** Rare. Strategic shift mid-quarter may warrant rewriting team OKRs. See `mid-quarter-recalibration.md`.
+
+**The honest frequency.** Most orgs over-cascade in the first few quarters of OKR adoption (treating cascading as a thing to perfect) and learn to relax it. Some orgs never relax and produce increasingly performative cascading. Recognize the pattern; loosen when it stops adding value.
+
+---
+
+## Cascading and individual goals
+
+Individual goals are usually a separate practice from OKRs.
+
+**Common patterns.**
+
+- Team OKRs commit at team level; individual contributors work toward team OKRs without separate personal OKRs.
+- Individual goals (career development, skill-building, role expectations) live in performance management, separate from OKRs.
+- Some orgs do cascade to individual OKRs; most find this produces overhead without value and stop after a few cycles.
+
+**The discipline.** Be intentional about whether to cascade to individuals. The default should be "no, commit at team level"; individual cascading should be justified rather than assumed.
+
+---
+
+## Common cascading failures
+
+**Top-down enforced cascading.** Teams receive OKRs from leadership; commitment is shallow.
+
+**Implicit cascading.** Team OKRs do not explicitly identify their ladders; alignment is ambiguous.
+
+**Over-cascading.** Every team OKR forced to ladder to company; team-specific work dressed up artificially.
+
+**Cascade theater.** Ladders documented but not driving anything.
+
+**Personal-OKR overhead.** Individual cascading without proportional value.
+
+**Mandate-strategy drift.** Teams with mandates disconnected from current strategy producing OKRs that ladder to nothing.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The cascading trade-off. When to cascade strictly and loosely. The middle path with explicit ladders. Worked example. Cascading anti-patterns. Team mandate considerations. Cascading frequency. Individual goals separation. Common failures.
+
+## Implementation choices that stay internal
+
+Specific OKR-tracking tools that visualize ladders. Specific cascade-review meeting formats. Specific role-based templates. The team's own conventions for surfacing team-specific OKRs. These vary by org and tooling.

--- a/skills/okr-design/references/common-okr-failures.md
+++ b/skills/okr-design/references/common-okr-failures.md
@@ -1,0 +1,205 @@
+# Common OKR failures
+
+Eleven-plus failure patterns with diagnoses and cures. Cross-references the OKR anti-patterns reference; this file covers operational failures that arise during the OKR cycle.
+
+The cross-cutting pattern: most OKR failures share a single root, which is treating OKRs as ceremony rather than as accountability infrastructure.
+
+---
+
+## Failure 1: Our OKRs are always 100% and produce no signal
+
+**Symptom.** End-of-quarter scoring shows the team hitting 95%+ on every KR. The OKR practice feels positive but does not produce learning.
+
+**Diagnosis.** Sandbagging. Targets set at or below the team's natural trajectory. The OKR practice has decayed into "what we know we can hit."
+
+**Cure.** Set targets above the historical trajectory. Use the historical-trajectory test: where would the metric land without focused effort? The target should be meaningfully above that.
+
+**Prevention.** Track the average score over multiple quarters. Drift toward 0.85+ is a sandbagging signal; intervene before the practice fully decays.
+
+---
+
+## Failure 2: Our OKRs are always 30% and demoralizing
+
+**Symptom.** End-of-quarter scoring shows the team consistently missing OKRs. Team disengages from OKRs by mid-quarter.
+
+**Diagnosis.** Aspirational fantasy. Targets have no realistic effort path. The OKR practice has decayed into "inspirational numbers nobody believes."
+
+**Cure.** Recalibrate to genuine stretch. Validate against the effort-path test: can the team identify specific initiatives that would produce the target?
+
+**Prevention.** During OKR setting, require effort-path reasoning. If the team cannot articulate what work would produce the target, the target is fantasy.
+
+---
+
+## Failure 3: Our key results measure work, not outcomes
+
+**Symptom.** KRs read as roadmap items. "Ship X by Y." "Run Z interviews."
+
+**Diagnosis.** Output-disguised-as-outcome. The team is committing to work, not to results.
+
+**Cure.** Rewrite each output KR to measure the outcome the output is meant to produce. The output itself lives in the roadmap.
+
+**Prevention.** During KR drafting, apply the outcome test: is this measuring a result, or counting work?
+
+---
+
+## Failure 4: We have 12 OKRs and the team is working on 47 things
+
+**Symptom.** Quarterly OKRs span many objectives and KRs; the team's work is scattered across many priorities.
+
+**Diagnosis.** OKR proliferation. Too many objectives produces no focus.
+
+**Cure.** Cap at 2-4 objectives, 3-5 KRs each. Surface deferred work explicitly so the team can see what they are choosing not to commit to.
+
+**Prevention.** Cap OKRs at the start of the cycle. Adding "just one more" OKR is a recurring pressure that should be resisted.
+
+---
+
+## Failure 5: Our OKRs are vague
+
+**Symptom.** Objectives like "improve user experience" or KRs like "make activation better." Cannot be scored honestly.
+
+**Diagnosis.** Lack of measurable specificity.
+
+**Cure.** Rewrite KRs with specific numbers, baselines, and targets. "Increase first-week activation rate from 32% to 45%" instead of "improve activation."
+
+**Prevention.** During KR review, apply the specificity test: could two reasonable people disagree on whether this KR was hit at end of quarter? If yes, it is too vague.
+
+---
+
+## Failure 6: Our cascading produces team OKRs that do not match team work
+
+**Symptom.** Team OKRs cascade to company OKRs but the team's actual capacity and mandate produce different work.
+
+**Diagnosis.** Strict cascading mismatched to team mandate.
+
+**Cure.** Loosen cascading; allow team-specific OKRs that do not directly ladder. Or change team mandate if it does not match strategy.
+
+**Prevention.** Use the middle path on cascading. Surface team-specific OKRs explicitly.
+
+---
+
+## Failure 7: We never recalibrate even when the strategy shifts
+
+**Symptom.** The org's strategy changed mid-quarter. Team OKRs no longer reflect strategy. The team holds them anyway.
+
+**Diagnosis.** Recalibration too tightly avoided.
+
+**Cure.** Surface the strategic shift; recalibrate the affected OKRs explicitly. Document the trigger.
+
+**Prevention.** Make strategic-shift criteria for recalibration explicit. The team should know when recalibration is appropriate.
+
+---
+
+## Failure 8: We recalibrate every quarter
+
+**Symptom.** OKRs get revised mid-quarter routinely. The team uses recalibration to soften uncomfortable OKRs.
+
+**Diagnosis.** Recalibration too easy. OKR design is failing or stretch ambition is being avoided.
+
+**Cure.** Hold OKRs absent the recalibration triggers (strategic shift, major disruption, invalidating information). Investigate why frequent recalibration is happening.
+
+**Prevention.** Track recalibration frequency. Drift toward "every quarter recalibrates" is a signal to intervene.
+
+---
+
+## Failure 9: Our weekly check-ins became status reports
+
+**Symptom.** Weekly OKR check-ins lost their tactical decision focus; they became "here's what I did this week" updates.
+
+**Diagnosis.** Check-in format drift. The session is no longer producing tactical adjustments.
+
+**Cure.** Reform the format. Per KR: trajectory, blockers, planned work for the upcoming week. End with explicit commitments.
+
+**Prevention.** The team lead facilitates the check-in's tactical scope. Status reports happen elsewhere.
+
+---
+
+## Failure 10: Our scoring rounds up
+
+**Symptom.** End-of-quarter scoring shows 0.85 average. Closer inspection shows scores were rounded up across most KRs.
+
+**Diagnosis.** Generous scoring. Honesty has decayed.
+
+**Cure.** Commit to honest scoring. A 0.55 KR scores 0.55, not 0.6. Document context; the context surfaces what produced the actual outcome regardless of the number.
+
+**Prevention.** Surface the rounding pattern explicitly. The team should know that rounding up is the failure mode.
+
+---
+
+## Failure 11: OKRs and bonuses are tied; people sandbag
+
+**Symptom.** OKR scores directly determine bonuses. Targets set conservatively; scoring round up; stretch ambition gone.
+
+**Diagnosis.** Compensation coupling.
+
+**Cure.** Decouple OKRs from compensation. Compensation flows through performance reviews informed by many inputs.
+
+**Prevention.** Establish from the start that OKRs are accountability infrastructure, not performance management. Compensation tied loosely or not at all.
+
+---
+
+## Failure 12: OKRs were set but never referenced
+
+**Symptom.** OKRs documented at start of quarter. Mid-quarter prioritization debates ignore them. End-of-quarter scoring is generous because nobody tracked rigorously.
+
+**Diagnosis.** OKR theater. The practice produces overhead without value.
+
+**Cure.** Reform the cadence. Weekly check-ins reference OKRs explicitly. Mid-quarter review uses OKRs as the assessment lens. Scoring informs next quarter.
+
+**Prevention.** Tie OKRs to specific decisions. If OKRs are not load-bearing for prioritization, surface the disconnect and reform or abandon.
+
+---
+
+## Failure 13: KRs depend on factors outside team influence
+
+**Symptom.** KRs miss because of external factors the team could not affect (market conditions, sales execution, infrastructure issues). The team cannot credibly own the KR.
+
+**Diagnosis.** KR design failure. Targets set on outcomes the team cannot meaningfully drive.
+
+**Cure.** Rewrite to focus on what the team can move. The team's contribution to a larger outcome may be the right KR, not the larger outcome itself.
+
+**Prevention.** During KR design, validate that the team can identify how their work moves the KR.
+
+---
+
+## Failure 14: Cross-team OKRs produce coordination failures
+
+**Symptom.** Multiple teams have KRs aimed at the same outcome. Teams pursue independently; the outcome lags because nobody owns the integration.
+
+**Diagnosis.** Cross-team coordination missing. Either single ownership should have been assigned, or split KRs need stronger coordination.
+
+**Cure.** Establish single ownership for outcome OKRs that span multiple teams. Or use split-KR pattern where each team's KR is their specific contribution.
+
+**Prevention.** During OKR design, surface cross-team dependencies. Decide single-owner or split-KR explicitly.
+
+---
+
+## Failure 15: OKRs are roadmap commitments to stakeholders
+
+**Symptom.** Stakeholders treat OKRs as commitments to specific work. Mid-quarter tactical adjustments feel like broken promises.
+
+**Diagnosis.** OKR-as-roadmap conflation. Stakeholders interpret outcomes as outputs.
+
+**Cure.** Distinguish between OKRs (outcomes the team commits to pursue) and roadmap (work the team plans to do). Both are visible; the OKR is the accountability; the roadmap is the team's current best guess at what work will produce the outcome.
+
+**Prevention.** When communicating OKRs to stakeholders, explicitly surface the distinction. Use different vocabulary.
+
+---
+
+## The cross-cutting pattern
+
+Most OKR failures share a single root: treating OKRs as ceremony rather than as accountability infrastructure.
+
+Ceremony focuses on the appearance of OKR practice: documents produced, meetings held, scores generated. Accountability focuses on the work the practice is meant to support: stretch goal-setting, mid-quarter learning, end-of-quarter scoring honesty, next-quarter improvement.
+
+The fix for almost any OKR failure starts with the same question: what decision is this OKR practice supposed to inform? When the answer is clear, the practice becomes load-bearing. When the answer is "we should follow the OKR process," the practice becomes ceremony.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The fifteen failure patterns with diagnoses and cures. The cross-cutting ceremony-vs-accountability pattern.
+
+## Implementation choices that stay internal
+
+Specific failure-pattern detection. Specific reviewer training. Specific intervention patterns. The team's own conventions for catching failures early. These vary by team.

--- a/skills/okr-design/references/key-result-design-patterns.md
+++ b/skills/okr-design/references/key-result-design-patterns.md
@@ -1,0 +1,242 @@
+# Key result design patterns
+
+Measurable, outcome-aligned, within-influence, time-bounded characteristics. Strong vs weak key results. The 3-5 KR rule. Worked examples.
+
+Key results are where the OKR practice succeeds or fails operationally. Objectives can be inspiring without measurable; key results have to be measurable. Most OKR failure at the operational level shows up in the key result design.
+
+---
+
+## The four characteristics of strong key results
+
+**Measurable.** A specific number, percentage, or testable threshold.
+
+- "Increase first-week activation rate from 32% to 45%."
+- "Reduce median time-to-first-value from 4.2 days to under 2 days."
+- "Reach 80% completion rate on onboarding flow (up from 64%)."
+
+**Outcome-aligned.** Achieving the key result actually moves the objective forward.
+
+- For the activation objective, the key results above are aligned: they all measure aspects of activation.
+- A key result like "ship the onboarding redesign" is not outcome-aligned; it measures the work, not the activation outcome.
+
+**Within team influence.** The team can affect the key result through their work.
+
+- "First-week activation rate" is influenced by onboarding design, welcome email content, in-product guidance. The team can affect it.
+- "Total signups" depends primarily on marketing acquisition; the activation team's onboarding work affects it weakly. Not a strong key result for the activation team.
+
+**Time-bounded.** The measurement window is the quarter (or appropriate sub-window).
+
+- "Increase first-week activation rate from 32% to 45% by end of Q3."
+- "Reach 80% completion rate by week 10 of the quarter."
+
+The four characteristics together produce key results the team can commit to credibly and measure honestly.
+
+---
+
+## Strong key result examples by objective
+
+**Objective: "Improve activation for new sign-ups so more reach value-realization in week one."**
+
+Strong KRs:
+
+- "Increase first-week activation rate from 32% to 45%."
+- "Reduce median time-to-first-value from 4.2 days to under 2 days."
+- "Reach 80% completion rate on onboarding flow (up from 64%)."
+- "Reduce signup-to-first-key-action time from 8 minutes to under 4 minutes."
+
+Each measures an aspect of activation. The team can influence each through their work. Each has a baseline and target.
+
+**Objective: "Make support experience deflect predictable issues."**
+
+Strong KRs:
+
+- "Reduce ticket volume on the top 3 deflection-eligible categories by 40%."
+- "Increase self-service resolution rate from 22% to 38%."
+- "Maintain CSAT at or above 4.4/5 (no degradation while deflecting)."
+
+The third KR matters: deflecting tickets without protecting CSAT could damage the experience; the KR keeps both in scope.
+
+**Objective: "Establish enterprise-readiness foundations."**
+
+Strong KRs:
+
+- "Pass SOC 2 Type II audit with zero high-severity findings."
+- "Complete admin role and permissions overhaul; reach 95% of enterprise-prospect compliance checklist items."
+- "Onboard 3 design partners from the enterprise segment to the alpha enterprise build."
+
+Each measures a foundation outcome the enterprise readiness depends on.
+
+---
+
+## Weak key result examples
+
+**Vague.**
+
+- "Improve activation significantly."
+- "Reduce ticket volume."
+
+No specific number; cannot be scored honestly.
+
+**Output disguised as outcome.**
+
+- "Ship 5 onboarding redesign initiatives."
+- "Run 12 customer interviews."
+
+Counts work done, not outcomes produced. The team can hit these by doing work without producing the outcome the objective targets.
+
+**Outside influence.**
+
+- "Increase total signups by 50%."
+- "Maintain market share."
+
+Total signups are upstream of activation work; market share depends on competitive dynamics largely outside the team's control.
+
+**Vanity.**
+
+- "Reach 1M users."
+- "Reach 10K NPS responses."
+
+Impressive numbers; not directly tied to the outcome the objective targets.
+
+**Single-data-point dependent.**
+
+- "Have one customer reference our product publicly."
+
+Fragile; a single data point may not represent progress.
+
+---
+
+## The 3-5 key results rule
+
+Most objectives benefit from 3-5 key results.
+
+**Why not 1.** Single key results are fragile. If the metric does not move for reasons outside the team's tactical choices, the team has no way to show progress on the objective. Multiple KRs triangulate.
+
+**Why not 6+.** Too many KRs dilute focus. The team scatters attention across many metrics; trade-offs across KRs become impossible because all are claimed as priority.
+
+**The 3-5 sweet spot.**
+
+- Enough KRs to triangulate the outcome.
+- Few enough that the team can pay attention to each.
+- Allows for KRs that protect against unintended degradation (e.g., deflect tickets while protecting CSAT).
+
+**The KR composition.**
+
+- 1-2 KRs measure the primary outcome.
+- 1-2 KRs measure secondary aspects of the outcome.
+- 0-1 KRs protect against unintended consequences.
+
+---
+
+## Baseline and target setting
+
+Each KR needs a baseline and target.
+
+**Baseline.** The current value of the metric. Pulled from analytics or recent measurement; should be honest, not aspirational.
+
+**Target.** The value the team commits to reaching by end of quarter.
+
+**Setting the target.**
+
+- Stretch: target a value that requires real work to reach. Should hit 60-70% of the time on average across KRs.
+- Not sandbagged: target should not be where the team would land without focused effort.
+- Not fantasy: target should be reachable through realistic effort paths the team can identify.
+
+**The historical-trajectory test.** Look at the metric over the past 4 quarters. Where would the metric be at end of next quarter on its current trajectory? The target should be meaningfully above that trajectory; otherwise, the OKR is sandbagged.
+
+**The effort-path test.** Can the team identify specific initiatives that would produce the target? If yes, the target is reachable. If the team cannot identify any path, the target is fantasy.
+
+---
+
+## Leading vs lagging key results
+
+Key results can measure leading indicators (early signals) or lagging indicators (final outcomes).
+
+**Lagging.** The outcome the team ultimately wants. "First-week activation rate" measures the activation outcome.
+
+**Leading.** Early signals that the lagging outcome will move. "Onboarding flow completion rate" leads first-week activation rate.
+
+**The blend.**
+
+- Some KRs measure leading indicators (so the team has signal early in the quarter).
+- Some KRs measure lagging indicators (so the team is accountable to the actual outcome).
+- A blend produces both early signal and end-of-quarter accountability.
+
+**The lagging-only failure.** OKRs that only measure lagging indicators produce no mid-quarter signal. The team cannot tell if they are on track until end of quarter.
+
+**The leading-only failure.** OKRs that only measure leading indicators produce no end-of-quarter accountability. Leading indicators can move without lagging indicators following.
+
+---
+
+## When binary KRs are appropriate
+
+Most KRs are quantitative (a number to reach). Some are binary (a milestone to achieve).
+
+**When binary works.**
+
+- Audit-pass milestones: "Pass SOC 2 Type II with zero high-severity findings."
+- Foundational milestones: "Complete admin role overhaul."
+- Launch milestones: "Ship the activation redesign to all users."
+
+**When binary fails.**
+
+- Used for KRs that should be quantitative. "Successfully implement activation improvements" is binary disguised as outcome; should be quantitative.
+- Used to dodge measurement. Binary KRs that are not actually milestones become "we did it" claims without underlying outcome verification.
+
+**The discipline.** Use binary KRs sparingly and only when the milestone genuinely is the outcome. Most outcome KRs benefit from quantitative measurement.
+
+---
+
+## KRs across teams
+
+When multiple teams contribute to the same outcome, KRs need careful design.
+
+**The split-KR pattern.** Each team has KRs that contribute to the cross-team outcome.
+
+- Product team KR: "Increase first-week activation rate from 32% to 45%."
+- Engineering team KR: "Ship onboarding redesign by week 6 of the quarter."
+- Customer success team KR: "Reduce activation-related support ticket volume by 30%."
+
+Each team is accountable for its contribution; the cross-team outcome benefits from all.
+
+**The single-owner pattern.** One team owns the outcome KR; other teams support without explicit KRs on the same metric.
+
+- Product team owns the activation KR.
+- Engineering and CS support without separate KRs.
+- Cross-team coordination happens outside the OKR structure.
+
+**The discipline.** Pick a pattern. Hybrid approaches (sometimes shared KRs, sometimes single-owner) produce confusion about accountability.
+
+---
+
+## Common KR design failures
+
+**Output KRs.** Counts of work shipped instead of outcomes produced. Cure: rewrite.
+
+**Vague KRs.** Lack measurable targets. Cure: specify number and threshold.
+
+**Out-of-influence KRs.** Depend on factors the team cannot affect. Cure: rewrite to what the team can move.
+
+**Vanity KRs.** Impressive numbers not tied to outcome. Cure: tie to the actual outcome.
+
+**Too few KRs.** Single KR fragility. Cure: 3-5 KRs per objective.
+
+**Too many KRs.** 6+ KRs dilute focus. Cure: cap at 5.
+
+**No baseline.** "Reach X" without naming current value. Cure: include baseline.
+
+**Sandbagged targets.** Targets at or below current trajectory. Cure: stretch beyond what the team would do without focus.
+
+**Fantasy targets.** Targets with no realistic effort path. Cure: validate against effort-path test.
+
+**Lagging-only.** No leading indicators. Cure: add leading-indicator KRs.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The four characteristics. Strong and weak KR examples. The 3-5 KR rule. Baseline and target setting. Leading vs lagging KRs. Binary KRs when appropriate. Cross-team KR patterns. Common failures.
+
+## Implementation choices that stay internal
+
+Specific KR templates. Specific metrics tooling and dashboards. Specific historical-trajectory analysis. Specific KR scorecards. The team's own conventions for KR wording. These vary by team and tooling.

--- a/skills/okr-design/references/mid-quarter-recalibration.md
+++ b/skills/okr-design/references/mid-quarter-recalibration.md
@@ -1,0 +1,214 @@
+# Mid-quarter recalibration
+
+When OKRs should change vs when teams should adapt. Strategic shift vs uncomfortable OKRs. The recalibration discipline.
+
+The default is that OKRs hold for the quarter. Teams adapt their tactics; OKRs do not change to match what the team is doing. Recalibration is the exception, not the rule. Recalibrating frequently signals OKR design failure.
+
+---
+
+## The default: OKRs hold
+
+OKRs are quarterly commitments. The team commits at the start of the quarter and works toward them through the quarter regardless of whether progress feels comfortable.
+
+**Why holding matters.**
+
+- OKRs are accountability infrastructure. Changing them mid-quarter weakens the accountability.
+- Stretch OKRs are uncomfortable by design. The discomfort is the work.
+- Teams that recalibrate when uncomfortable train themselves to recalibrate as a coping mechanism.
+
+**Adapting tactics, not OKRs.**
+
+- The OKR target stays.
+- The team's tactics for reaching the target adapt as they learn what works.
+- New initiatives may be launched; existing ones may be scrapped; the OKR remains the destination.
+
+---
+
+## When to recalibrate
+
+Three conditions warrant recalibration.
+
+### Strategic shift
+
+The company's strategy changed materially mid-quarter. OKRs that no longer reflect the strategy are no longer the right targets.
+
+**Examples.**
+
+- The company pivoted to a new market segment; OKRs aimed at the prior segment are no longer strategic.
+- A major acquisition or restructure changed the team's mandate.
+- Leadership announced a new strategic priority that supersedes the quarter's OKRs.
+
+**The handling.** Recalibrate explicitly. Document what changed strategically and how OKRs are revised. Communicate to stakeholders so the recalibration is visible and intentional.
+
+### Major external disruption
+
+A market change, regulatory event, or significant outage warrants resetting the quarter's targets.
+
+**Examples.**
+
+- A major outage consumed weeks of engineering capacity that was meant for OKR work.
+- Regulatory changes required compliance work that displaced planned OKRs.
+- Market conditions shifted dramatically (recession, supply chain disruption) and the OKRs no longer reflect realistic ambition for the new conditions.
+
+**The handling.** Recalibrate explicitly. Surface the disruption and its impact. Set new targets that reflect the post-disruption reality.
+
+### Information that invalidates the OKR
+
+The team learned mid-quarter that the metric they were targeting does not actually represent the outcome.
+
+**Examples.**
+
+- Analytics work revealed that the activation metric the team was targeting is not the right measure of activation success; a better metric exists.
+- Customer research revealed that the user segment the team was prioritizing is smaller or less important than expected.
+- Technical investigation revealed that the planned approach to an OKR has fatal limitations that were not visible at planning time.
+
+**The handling.** Recalibrate explicitly. Document what was learned. Set new OKRs reflecting the new understanding.
+
+---
+
+## When NOT to recalibrate
+
+Three patterns that look like recalibration triggers but are not.
+
+### The team is not on track
+
+OKRs that the team is missing should remain as set; the miss is the signal.
+
+**Why.** Stretch OKRs are designed to miss sometimes. Hitting 60-70% on average means roughly 30-40% of KRs miss the target. The miss is informative; lowering the target to match the trajectory eliminates the signal.
+
+**The cure.** Hold the OKR. Score honestly at end of quarter. Use the miss to inform next quarter's design.
+
+### The OKR is uncomfortable
+
+Teams uncomfortable with stretch OKRs sometimes want to recalibrate to feel better.
+
+**Why.** Stretch is uncomfortable by design. Teams that learn to lower OKRs when uncomfortable lose the stretch discipline; OKRs drift toward sandbagging quarter over quarter.
+
+**The cure.** Hold the OKR. Acknowledge the discomfort. Surface what the team would need to push toward the target. Use the discomfort productively rather than recalibrating it away.
+
+### Easier OKRs would feel achievable
+
+The temptation to swap hard OKRs for easy ones is sandbagging in slow motion.
+
+**Why.** Hard OKRs are the point. Swapping for easier ones removes the accountability infrastructure stretch OKRs provide.
+
+**The cure.** Hold the OKR. If the original was genuinely fantasy (no realistic effort path), recalibrate per the strategic-shift pattern. If the original was genuine stretch but uncomfortable, hold.
+
+---
+
+## The recalibration discipline
+
+When recalibration is warranted, the discipline matters.
+
+**Surface the trigger.** What changed? Strategic shift, external disruption, or invalidating information. Be specific.
+
+**Document the original target and the revised target.** The history of recalibration is part of the OKR record. Future audits should be able to see what changed.
+
+**Explain the new target.** Why this revised target? What effort path produces it? How does it reflect the new reality?
+
+**Communicate to stakeholders.** Recalibration is visible. Stakeholders who expected the original target should know it changed and why.
+
+**Score against the revised target at end of quarter.** The recalibrated OKR is the OKR for scoring purposes. Do not score against the original.
+
+---
+
+## Frequency of recalibration
+
+Recalibration should be rare.
+
+**Healthy frequency.** 1-2 quarters out of 8 may include recalibration on at least one OKR. Most quarters should have no recalibrations.
+
+**Concerning frequency.** Every quarter includes recalibration on some OKR. This signals either:
+
+- The OKR design is consistently aggressive (fantasy targets).
+- The strategy is shifting too frequently (lack of strategic stability).
+- The team has learned to recalibrate as a coping mechanism for stretch.
+
+**The diagnosis.** Frequent recalibration is a signal to investigate, not a feature to lean into. The investigation surfaces whether the issue is OKR design, strategic stability, or team behavior.
+
+---
+
+## Recalibration as honest tool vs avoidance
+
+The line between honest recalibration and avoidance.
+
+**Honest recalibration.**
+
+- The trigger is specific and external (strategic shift, disruption, invalidating information).
+- The revised target reflects the new reality, not the team's preference.
+- The recalibration is documented and visible.
+
+**Avoidance dressed as recalibration.**
+
+- The trigger is vague ("things changed").
+- The revised target is conveniently achievable.
+- The recalibration happens when the OKR is uncomfortable, not when external conditions warrant it.
+
+**The honest test.** If a stakeholder asked the team to defend the recalibration, could the team point to a specific external trigger? If the answer is "we just thought the target was too ambitious," the recalibration is avoidance.
+
+---
+
+## Recalibration in the OKR system
+
+How recalibration affects the broader OKR practice.
+
+**Trust effects.**
+
+- Recalibration that is rare and well-justified preserves trust in OKRs.
+- Recalibration that is frequent or poorly justified erodes trust; stakeholders learn to expect targets to slide.
+
+**Org-wide signaling.**
+
+- One team's recalibration affects how other teams perceive recalibration norms.
+- Leaders that recalibrate strict targets signal to teams that recalibration is acceptable; teams take the cue.
+- Leaders that hold targets even when uncomfortable signal that stretch is real; teams take that cue.
+
+**The practice's calibration over time.** Recalibration norms accumulate. Healthy practices stay disciplined; decaying practices loosen. The annual review of OKR practice should look at recalibration frequency as one signal of practice health.
+
+---
+
+## Communicating recalibration
+
+When recalibration happens, communication matters.
+
+**To the team.**
+
+- Surface the trigger before the recalibration is decided. The team should understand what changed.
+- Discuss the revised target before committing. The team should be able to commit credibly to the new target.
+- Document the change in the OKR system.
+
+**To stakeholders.**
+
+- Notify stakeholders explicitly. Do not let recalibration appear as a quiet edit.
+- Explain the trigger and the revised target.
+- Invite questions; stakeholder concerns may surface issues with the recalibration that warrant further discussion.
+
+**To the org.**
+
+- Recalibration patterns inform org-wide OKR discussion. If multiple teams recalibrate in the same quarter, surface the pattern; the strategic clarity may be lacking.
+
+---
+
+## Common recalibration failures
+
+**Recalibration as the default.** Teams routinely revise OKRs mid-quarter. The OKR system collapses into rolling targets that always reflect current state.
+
+**Recalibration to avoid stretch discomfort.** Teams revise when OKRs feel uncomfortable; targets drift toward sandbagging.
+
+**Recalibration without trigger documentation.** OKRs change without surfaced reason; the change becomes invisible to stakeholders.
+
+**Refusal to recalibrate when warranted.** Teams hold OKRs even when strategy genuinely shifted; quarter ends with OKRs disconnected from strategy.
+
+**Recalibration to avoid scoring low.** Teams revise targets in the last weeks of the quarter to make the score look better. Scoring loses honesty.
+
+**Org-wide recalibration cascade.** One team's recalibration triggers others; the whole quarter resets; the OKR system loses meaning.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The default-to-hold principle. When to recalibrate (strategic shift, major disruption, invalidating information). When not to recalibrate (uncomfortable, off-track, easier-feels-better). The recalibration discipline. Frequency norms. Honest vs avoidance recalibration. Communication. Common failures.
+
+## Implementation choices that stay internal
+
+Specific OKR-tracking tools that capture recalibration history. Specific approval workflows for recalibration. The team's own conventions for recalibration communication. These vary by org.

--- a/skills/okr-design/references/objective-design-patterns.md
+++ b/skills/okr-design/references/objective-design-patterns.md
@@ -1,0 +1,191 @@
+# Objective design patterns
+
+Outcome-vs-output distinction. Strong vs weak objective characteristics. Worked examples across domains. The few-objectives discipline.
+
+Objectives are the outcome statements that name what the team is trying to achieve in the quarter. Most OKR failure begins at the objective level: outputs disguised as outcomes, vague aspirations, or too many objectives diluting focus. Getting the objective right is upstream of everything else.
+
+---
+
+## Outcome vs output
+
+The most consequential distinction.
+
+**Output objectives.** Describe work the team plans to do.
+
+- "Ship the activation redesign."
+- "Migrate to the new auth service."
+- "Run 12 customer interviews."
+
+**Outcome objectives.** Describe results the team is trying to achieve.
+
+- "Improve activation for new sign-ups so more reach value-realization in week one."
+- "Establish auth foundations that support enterprise compliance review."
+- "Build a research-grounded picture of how mid-market customers actually use the product."
+
+**Why the distinction matters.** Outputs can be shipped without producing outcomes. The activation redesign ships; activation rate stays the same. The auth migration completes; compliance review still fails. The interviews happen; the team cannot point to decisions that changed.
+
+**The output-as-outcome failure.** Output objectives shift the team's incentives toward shipping rather than achieving. The team optimizes for the work; the work gets done; the underlying goal goes unachieved.
+
+**The cure.** Each output objective gets rewritten to name the outcome the output is meant to produce. If the team cannot name the outcome, the output's value is unclear and may not warrant quarterly priority.
+
+---
+
+## Strong objective characteristics
+
+**Outcome-focused.** Names the result, not the work.
+
+**Specific to the quarter.** Vague aspirations ("be more user-focused") do not focus quarterly work. The objective should be specific enough that the team knows when they have moved it forward.
+
+**Inspiring without being fantasy.** The team should feel pulled toward the objective. Fantasy demoralizes; sandbag bores. Stretch motivates.
+
+**Few in number.** 2-4 objectives per team per quarter. More dilutes focus; the team works on too many things and excels at none.
+
+**Connected to strategy.** Objectives ladder up to company-level priorities or to the team's strategic mandate. Disconnected objectives produce work that does not contribute to the org's direction.
+
+**Within team influence.** The team can affect the outcome through their work. Objectives entirely dependent on external factors are not the team's to commit to.
+
+---
+
+## Weak objective characteristics
+
+**Output-disguised-as-outcome.** "Ship the redesign" is the work; the outcome should be the result the redesign produces.
+
+**Too vague.** "Improve user experience" is too broad to focus a quarter's work. What aspect of UX, in what part of the product, for which users?
+
+**Too tactical.** "Refactor the auth service" is a tactical decision the team makes within larger initiatives, not a quarterly objective.
+
+**Too many.** 8 objectives produces no focus. Each objective gets less attention; trade-offs become impossible because everything is priority.
+
+**Disconnected from strategy.** Objectives that do not ladder to company priorities or team mandate produce work that does not contribute.
+
+**Outside team influence.** "Total revenue grows 30%" may not be the product team's to commit to if revenue depends on sales execution, market conditions, and product work combined.
+
+---
+
+## Worked objective examples by domain
+
+### B2B SaaS product team
+
+- "Improve activation for new sign-ups so that more reach the value-realization moment within their first week."
+- "Make the support experience deflect predictable issues so the team can focus on harder cases."
+- "Establish enterprise-readiness foundations so we can serve the segment we are targeting next year."
+
+### Consumer mobile app team
+
+- "Increase retention through the first month so users build habit before the typical churn window."
+- "Improve performance and reliability so the experience matches the brand's reputation."
+
+### Internal platform team
+
+- "Reduce the time it takes engineering teams to ship a new service from days to under a day."
+- "Eliminate the top three reasons engineering teams escalate to platform support."
+
+### Marketing-product team
+
+- "Convert more product trial users to paid by removing friction in the upgrade path."
+- "Position the product clearly enough that prospects evaluating against alternatives understand the differentiation."
+
+Each objective is outcome-focused, specific to the quarter, and within the team's ability to influence. The work that produces these outcomes is multiple roadmap items; the OKR is the result, not the work.
+
+---
+
+## The few-objectives discipline
+
+Most teams should have 2-4 objectives per quarter. The discipline produces focus.
+
+**Why fewer is better.**
+
+- Each objective gets serious attention. The team thinks about it weekly, makes trade-offs against it, surfaces blockers.
+- Trade-offs are possible. With 3 objectives, the team can decide that work on objective A takes priority over work on objective C this week. With 12 objectives, all work claims priority.
+- The team can credibly commit. 3 objectives are credible; 12 are not.
+
+**Why more feels tempting.**
+
+- Multiple stakeholders want their priorities reflected. Adding objectives feels like accommodating; capping objectives feels like saying no.
+- The team sees many things they could pursue. Picking 3 means deferring others.
+- Past quarters' OKRs sometimes accumulate; teams forget to retire objectives that no longer fit.
+
+**The discipline.**
+
+- Cap objectives. 4 is the upper bound for most teams.
+- Surface what is being deferred. The objectives that did not make the cut get named explicitly; the team's choice to defer is transparent.
+- Retire objectives quarter-over-quarter. Objectives are quarterly; they do not carry over by default.
+
+---
+
+## Objectives across an org
+
+When the org has multiple teams, objectives should compose without overlap or contradiction.
+
+**Cross-team coordination.**
+
+- Objectives that depend on multiple teams should name the dependencies explicitly. The product team's objective may depend on engineering hiring; the engineering team's objective may depend on product prioritization.
+- Objectives that conflict across teams need resolution before the quarter starts. Teams pulling in opposite directions waste capacity.
+
+**Team mandate alignment.**
+
+- Each team's objectives should fit the team's mandate. Product team objectives are product outcomes; engineering team objectives are engineering outcomes; design team objectives are design outcomes.
+- Cross-functional outcomes (e.g., "improve activation") require multiple teams to commit. The lead team owns the OKR; the supporting teams commit dependencies in their own OKRs.
+
+---
+
+## Objective writing process
+
+How objectives get drafted.
+
+**Draft sources.**
+
+- Strategy work that named the priorities for the quarter or year.
+- Discovery synthesis that identified user-job priorities.
+- Roadmap-planning work that surfaced major initiatives.
+- Performance review that identified gaps from the prior quarter.
+
+**Draft method.**
+
+- Start from the outcome the team is trying to produce.
+- Surface multiple draft phrasings.
+- Test each: is this an outcome or an output? Is it specific enough? Is it within team influence?
+- Iterate to a 2-4 objective set that the team can commit to and that ladders to strategy.
+
+**Stakeholder review.**
+
+- Draft objectives circulate to stakeholders before commit. Surfaces dependencies and conflicts.
+- Stakeholder feedback informs revisions; the team owns the final commit.
+
+**The commitment.** Objectives published and visible to the org. The team is on the hook for them.
+
+---
+
+## Objective revision through the quarter
+
+Objectives generally hold for the quarter. See `mid-quarter-recalibration.md` for when revision is appropriate.
+
+**The default.** Objectives stay; tactics adapt to keep moving toward them.
+
+**The exception.** Strategic shift, major external disruption, or invalidating information warrants revision. Rare.
+
+---
+
+## Common objective design failures
+
+**Output objectives.** "Ship X" instead of "Achieve outcome Y through X." Cure: name the outcome.
+
+**Vague objectives.** "Improve experience" without specifying what or where. Cure: specificity.
+
+**Too many objectives.** 8+ per team per quarter. Cure: cap at 4.
+
+**Tactical objectives.** Specific implementation decisions framed as objectives. Cure: tactical decisions belong in roadmap items, not OKRs.
+
+**Strategic-disconnect.** Objectives that do not ladder to company or team priorities. Cure: explicit ladder before commit.
+
+**Out-of-influence.** Objectives entirely dependent on factors the team does not control. Cure: rewrite to focus on what the team can affect.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The outcome-vs-output distinction. Strong and weak objective characteristics. Worked examples across domains. The few-objectives discipline. Cross-team coordination. The drafting and review process. Common failures.
+
+## Implementation choices that stay internal
+
+Specific OKR-tracking tools the team uses. Specific document templates for objectives. Specific stakeholder-review formats. The team's own conventions for objective wording within the principles. These vary by team and tooling.

--- a/skills/okr-design/references/okr-anti-patterns.md
+++ b/skills/okr-design/references/okr-anti-patterns.md
@@ -1,0 +1,249 @@
+# OKR anti-patterns
+
+Eight-plus anti-patterns including OKR-as-roadmap, sandbagging, fantasy, vanity metrics, OKR theater, compensation coupling, and others. Each anti-pattern names a recurring failure mode that decays OKR practice over time.
+
+---
+
+## Anti-pattern 1: OKR-as-roadmap
+
+**The pattern.** OKRs are written as a list of features the team plans to ship.
+
+**Examples.**
+
+- "Objective: Ship the activation redesign. KR: Activation redesign launched by week 8. KR: Welcome email v2 launched by week 4."
+
+**Why it fails.**
+
+- Outputs disguised as outcomes. The team is committing to work, not to results.
+- The outcome the work is meant to produce goes unspecified; the team can ship the redesign without producing the activation outcome.
+- OKRs become roadmap commitments to stakeholders; mid-quarter tactical changes feel like broken promises.
+
+**The cure.** Each OKR names the outcome the work is meant to produce. The work itself lives in the roadmap.
+
+---
+
+## Anti-pattern 2: Sandbagging
+
+**The pattern.** OKRs designed to hit 100%. Targets at or below the team's current trajectory.
+
+**How it manifests.**
+
+- KR targets within 5% of current values.
+- KR targets achievable on standard execution without focused effort.
+- Average end-of-quarter scores at 95%+.
+- Team consistently celebrates "hitting all our OKRs."
+
+**Why it fails.**
+
+- No stretch; no learning. The team did not commit to ambition; the OKR practice produced no signal beyond what the team would have done anyway.
+- Sandbagging compounds. Teams that sandbag once learn that sandbagging is safe; subsequent quarters get worse.
+- Stakeholder trust degrades. Stakeholders learn that "hitting OKRs" does not mean ambitious work was done.
+
+**The cure.** Set targets above the team's current trajectory. Use the historical-trajectory test: where would the metric land without focused effort? The OKR target should be meaningfully above that.
+
+---
+
+## Anti-pattern 3: Aspirational fantasy
+
+**The pattern.** OKRs that nobody can hit. Targets with no realistic effort path.
+
+**How it manifests.**
+
+- KR targets at 5x or 10x current values without underlying capacity changes.
+- Targets set for inspiration rather than commitment.
+- Average end-of-quarter scores at 30% or below.
+- Team disengages from OKRs by week 3-4 of the quarter.
+
+**Why it fails.**
+
+- Demoralizing. Teams cannot hit fantasy targets; the targets become decoration.
+- Loss of meaning. When OKRs cannot be hit, scoring loses meaning; teams stop tracking.
+- Compensation distortion. If OKRs are tied to compensation, fantasy targets create unfairness; teams cannot earn rewards regardless of effort.
+
+**The cure.** Validate against the effort-path test. Can the team identify specific initiatives that would produce the target? If yes, the target is reachable. If the team cannot identify any path, recalibrate.
+
+---
+
+## Anti-pattern 4: Vanity metrics
+
+**The pattern.** KRs that measure impressive numbers not tied to the outcome.
+
+**Examples.**
+
+- "Reach 1M users."
+- "Generate 10K leads."
+- "Reach 500K social followers."
+
+**Why it fails.**
+
+- Numbers can be moved without producing the outcome the OKR was meant to address.
+- Vanity targets often correlate with marketing or acquisition spend rather than with product outcomes.
+- The team can hit vanity KRs while the underlying outcome (engagement, retention, revenue) does not improve.
+
+**The cure.** Each KR should connect to the outcome the OKR targets. If the connection is unclear, the KR is probably vanity. Replace with a KR that more directly measures the outcome.
+
+---
+
+## Anti-pattern 5: OKR theater
+
+**The pattern.** OKRs are documented and presented but do not drive decisions.
+
+**How it manifests.**
+
+- OKRs are set at the start of the quarter and not referenced again until end of quarter.
+- Mid-quarter prioritization decisions ignore OKRs.
+- The team makes the same prioritization choices that they would have made without OKRs.
+- OKR scores are produced at end of quarter but do not inform the next quarter's planning.
+
+**Why it fails.**
+
+- The OKR practice produces overhead without value. The team spends time on OKR ceremony without changing what they would have done.
+- Stakeholder skepticism builds. Stakeholders learn that OKRs are not load-bearing.
+- The practice decays further over time as the team rationalizes that the ceremony does not matter.
+
+**The cure.** Tie OKRs to specific decisions. Mid-quarter prioritization debates should reference OKRs. Roadmap items should map to OKRs. Scoring should inform the next quarter. If none of these happen, the OKR practice is theater; reform or abandon.
+
+---
+
+## Anti-pattern 6: Compensation coupling
+
+**The pattern.** OKR scores directly determine bonuses or performance ratings.
+
+**Why it fails.**
+
+- Sandbagging incentives become severe. Teams set OKRs they know they can hit to protect their compensation.
+- Honest scoring suffers. Teams round scores up to avoid compensation impact.
+- Stretch ambition disappears. The OKR practice collapses to "what we are confident we can hit."
+- Team trust in OKRs degrades; the practice becomes performance management theater.
+
+**The cure.** Decouple OKRs from compensation. Compensation flows through performance reviews informed by many inputs (manager assessment, peer feedback, role expectations); OKR scores may be one input but should not be dominant.
+
+**The transition.** Orgs that have coupled OKRs and compensation need explicit decoupling communication. Teams need to trust that scoring honestly will not affect bonuses; the trust takes 2-3 cycles to establish.
+
+---
+
+## Anti-pattern 7: OKR proliferation
+
+**The pattern.** Teams set 8-12 OKRs per quarter. Every team member's work is reflected in some OKR.
+
+**Why it fails.**
+
+- Focus dilutes. The team works on too many things; trade-offs become impossible because everything is priority.
+- Tracking burden grows. Weekly check-ins become status reports across too many KRs.
+- Scoring becomes performative. Teams cannot honestly score 40+ KRs at end of quarter.
+
+**The cure.** Cap OKRs. 2-4 objectives per team; 3-5 KRs per objective. Surface what is not in OKRs as deferred work that the team is choosing not to commit to this quarter.
+
+---
+
+## Anti-pattern 8: Cascade theater
+
+**The pattern.** OKR documents include cascading ladders that look connected but do not actually drive work.
+
+**How it manifests.**
+
+- Team OKRs claim ladders to company OKRs but the team's actual work would have happened regardless.
+- Cascading documents look impressive but do not coordinate cross-team work.
+- The cascade is performed for stakeholders rather than for execution.
+
+**Why it fails.**
+
+- Cascading work is overhead without value.
+- Cross-team coordination does not actually happen through the cascade.
+- Stakeholders learn that the cascade is theater.
+
+**The cure.** Make ladders explicit only when they genuinely connect. Loosen cascading where strict ladders produce theater. See `cascading-okrs-decisions.md` for the discipline.
+
+---
+
+## Anti-pattern 9: Mid-quarter recalibration as default
+
+**The pattern.** OKRs get revised mid-quarter routinely. The team uses recalibration to soften OKRs that feel uncomfortable.
+
+**Why it fails.**
+
+- OKRs lose accountability. Teams learn that revising mid-quarter is acceptable; commitment loosens.
+- Stretch ambition disappears. Discomfort triggers recalibration rather than effort.
+- Targets drift toward sandbagging quarter over quarter.
+
+**The cure.** Hold OKRs absent strategic shift, major disruption, or invalidating information. See `mid-quarter-recalibration.md` for the discipline.
+
+---
+
+## Anti-pattern 10: Output-only KRs
+
+**The pattern.** Key results count work shipped rather than measure outcomes produced.
+
+**Examples.**
+
+- "Ship 5 onboarding initiatives."
+- "Run 12 customer interviews."
+- "Publish 8 marketing pieces."
+
+**Why it fails.**
+
+- Counts work, not outcomes. The team can hit these by doing work without producing the outcome.
+- Optimizes for shipping volume rather than impact.
+- Loses the connection between work and result.
+
+**The cure.** For each output KR, identify the outcome the output is meant to produce. Replace the count with a measurement of the outcome.
+
+---
+
+## Anti-pattern 11: KRs entirely outside team influence
+
+**The pattern.** KRs depend on factors the team cannot control.
+
+**Examples.**
+
+- "Total revenue grows 30%" (depends on sales execution and market conditions, not just product work).
+- "Maintain market share" (depends on competitive dynamics).
+- "Reach Series B" (depends on investor decisions outside the team).
+
+**Why it fails.**
+
+- The team cannot credibly commit. Effort does not produce predictable outcomes.
+- Failure is not informative. Misses do not reveal what the team should have done differently.
+- Demoralizing. Teams hit fail OKRs they had little ability to affect.
+
+**The cure.** Rewrite KRs to focus on what the team can move. Total revenue may not be the team's KR; the team's contribution to revenue (e.g., product-led acquisition rate) might be.
+
+---
+
+## Anti-pattern 12: Generous scoring
+
+**The pattern.** End-of-quarter scoring rounds up systematically.
+
+**How it manifests.**
+
+- KRs at 0.55 score 0.6 or 0.7.
+- KRs at 0.85 score 1.0.
+- The team's average score is 0.85+ even when objective outcomes were mid-range.
+
+**Why it fails.**
+
+- Honest signal lost. Scoring no longer reflects outcomes.
+- Sandbagging compounds. Teams learn that scoring high is rewarded; subsequent quarters drift further.
+- Lessons get lost. Misses scored as hits do not inform improvement.
+
+**The cure.** Hold the discipline of honest scoring. Document context per score; the context surfaces what produced the actual outcome regardless of the number.
+
+---
+
+## The cross-cutting pattern
+
+Most OKR anti-patterns share a single root: optimizing for the appearance of OKR success rather than for the underlying outcomes.
+
+Sandbagging optimizes for hitting 100%. Fantasy optimizes for inspirational targets. OKR theater optimizes for documentation. Compensation coupling optimizes for bonus protection. Generous scoring optimizes for end-of-quarter celebration.
+
+Each anti-pattern produces apparent OKR success while undermining the OKR practice's actual purpose. The fix in every case is the same: focus on the underlying outcomes the practice is meant to produce, not on the OKR ceremony itself.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The twelve anti-patterns with diagnoses and cures. The cross-cutting appearance-vs-outcome pattern.
+
+## Implementation choices that stay internal
+
+Specific anti-pattern detection in the team's tracking tools. Specific reviewer training. Specific intervention patterns when anti-patterns are detected. The team's own conventions for catching drift early. These vary by team.

--- a/skills/okr-design/references/okrs-vs-roadmap-vs-metrics.md
+++ b/skills/okr-design/references/okrs-vs-roadmap-vs-metrics.md
@@ -1,0 +1,235 @@
+# OKRs vs roadmap vs metrics
+
+The three concepts and their relationships. Common conflations. The complete picture across all three.
+
+OKRs, roadmaps, and metrics are often conflated. Each serves a different purpose; conflating them produces confusion that decays each practice. Distinguishing them clarifies what each is for and how they compose.
+
+---
+
+## OKRs
+
+Outcome targets for the quarter.
+
+**Characteristics.**
+
+- Quarterly time horizon.
+- Outcome-focused.
+- Stretch-ambition.
+- Designed for accountability and learning, not for execution sequencing.
+
+**Examples.**
+
+- Objective: "Improve activation for new sign-ups."
+- Key result: "Increase first-week activation rate from 32% to 45%."
+
+**What OKRs are not.**
+
+- A roadmap. OKRs do not specify which initiatives to ship.
+- A metric. OKRs are quarterly targets on metrics; the metrics themselves are tracked continuously regardless of OKRs.
+- A commitment to specific work. The team commits to pursuing the outcome; the tactics adapt.
+
+---
+
+## Roadmap items
+
+Initiatives the team is building or doing.
+
+**Characteristics.**
+
+- Variable time horizon (weeks to months per initiative).
+- Output-focused (the work being done).
+- Sequenced by priority and dependency.
+- Designed for execution coordination.
+
+**Examples.**
+
+- "Onboarding redesign."
+- "Migrate to new auth service."
+- "Build admin role overhaul."
+
+**What roadmap items are not.**
+
+- OKRs. Roadmap items are work; OKRs are outcomes.
+- Metrics. Roadmap items contribute to moving metrics but are not metrics themselves.
+- Permanent commitments. Items can be added, dropped, or re-prioritized as circumstances change.
+
+---
+
+## Metrics
+
+Ongoing measurements the team tracks.
+
+**Characteristics.**
+
+- Continuous time horizon (always tracked).
+- Quantitative, time-stamped, queryable.
+- Designed for monitoring, learning, and OKR target-setting.
+
+**Examples.**
+
+- "First-week activation rate."
+- "Median time-to-first-value."
+- "Onboarding flow completion rate."
+
+**What metrics are not.**
+
+- OKRs. Metrics are continuous; OKRs are quarterly targets on metrics.
+- Roadmap items. Metrics are measurements; roadmap items are work.
+- Targets. Metrics are values; targets on metrics are KRs (or more generally, performance targets).
+
+---
+
+## The relationship
+
+How the three compose.
+
+**OKR: "Improve activation for new sign-ups."**
+
+- Key result: "First-week activation rate from 32% to 45% by end of quarter."
+  - Underlying metric: "First-week activation rate" (tracked continuously).
+  - Roadmap items contributing: "Onboarding redesign," "Welcome email sequence revision," "Activation triage automation."
+
+**The composition.**
+
+- OKR names the outcome.
+- Key result quantifies the outcome with a metric and target.
+- Metric is the underlying measurement.
+- Roadmap items are the work the team does to move the metric.
+
+**The flow.**
+
+- Strategy informs OKRs.
+- OKRs inform roadmap prioritization (which work moves which OKR).
+- Roadmap items get executed.
+- Metrics track the impact.
+- Scoring at end of quarter assesses the OKR's actual outcome.
+
+---
+
+## Common conflations
+
+### OKRs treated as roadmap commitments
+
+**The pattern.** "Ship the onboarding redesign" written as an OKR.
+
+**The diagnosis.** This is a roadmap item, not an OKR. The OKR is the outcome the redesign is meant to produce.
+
+**The cure.** Rewrite as outcome: "Improve activation through onboarding redesign that reaches first-week activation 45%." The redesign is the contributing work; the outcome is what the work is meant to produce.
+
+### Roadmap items treated as OKRs
+
+**The pattern.** Quarterly OKRs are a list of features the team plans to ship.
+
+**The diagnosis.** Output disguised as outcome. The team is committing to work, not to results.
+
+**The cure.** For each output OKR, identify the outcome the output is meant to produce. The OKR is the outcome; the output is roadmap work that contributes.
+
+### Every metric needing an OKR
+
+**The pattern.** The team feels every metric they track must have an OKR target.
+
+**The diagnosis.** Metrics serve monitoring purposes regardless of whether the team is currently driving them. Some metrics are leading indicators the team watches without driving; some are protective metrics the team watches to ensure they do not degrade.
+
+**The cure.** OKRs select which metrics the team is actively driving this quarter. Other metrics get tracked without OKR targets.
+
+### OKRs as roadmap commitments to stakeholders
+
+**The pattern.** Stakeholders ask "what are you committing to ship next quarter?" The team answers with OKRs.
+
+**The diagnosis.** The team is using OKRs as roadmap; stakeholders interpret them as roadmap commitments; mid-quarter tactical adjustments feel like broken promises.
+
+**The cure.** Distinguish between OKRs (outcomes the team commits to pursue) and roadmap (work the team plans to do). Stakeholders can see both; the OKR is what the team is accountable for; the roadmap is the team's current best guess at what work will produce the outcome.
+
+### Treating metrics as OKRs
+
+**The pattern.** "Maintain CSAT at 4.5" written as an OKR for a quarter when the team has no specific work aimed at CSAT.
+
+**The diagnosis.** This is metric monitoring, not an OKR. OKRs are stretch outcomes the team is actively pursuing; metric monitoring continues regardless.
+
+**The cure.** Track CSAT as a metric. Set an OKR if the team is actively driving CSAT improvement; otherwise, the metric is monitored without an OKR.
+
+---
+
+## When the three diverge
+
+Sometimes OKRs, roadmap, and metrics tell different stories.
+
+**The pattern.**
+
+- OKR is on track (KR moving toward target).
+- Roadmap items are shipping on schedule.
+- A different metric the team tracks is degrading.
+
+**The interpretation.** The OKR work is succeeding at its target; an unintended consequence may be hurting another metric. The team must decide whether to address the unintended consequence within the quarter or to defer.
+
+**The discipline.** OKRs are the formal commitment; roadmap items contribute to OKRs; metrics monitor everything (including OKR targets and protective metrics). When the three diverge, the team has decisions to make.
+
+---
+
+## Roadmap-OKR alignment
+
+How the roadmap maps to OKRs.
+
+**The mapping.**
+
+- Each roadmap item gets associated with the OKR(s) it contributes to.
+- Items not associated with any OKR are either team-specific work (technical debt, tooling) or candidates for deferral.
+
+**Worked example.**
+
+- OKR: "Improve activation for new sign-ups."
+- Contributing roadmap items: "Onboarding redesign," "Welcome email sequence revision," "Activation triage automation."
+
+- OKR: "Establish enterprise-readiness foundations."
+- Contributing roadmap items: "Admin role overhaul," "SOC 2 audit preparation."
+
+- Team-specific roadmap items (no OKR ladder): "Migrate to new auth service" (foundational; supports many OKRs), "Strengthen test coverage in critical paths" (engineering health).
+
+**The discipline.** All roadmap items have either an OKR ladder or an explicit team-specific designation. Items with neither are candidates for deprioritization.
+
+---
+
+## Metric coverage and OKR targets
+
+How metrics are selected and how OKR targets relate.
+
+**Metric coverage.** The team tracks metrics that:
+
+- Reflect strategic outcomes (input metrics for OKRs).
+- Monitor protective concerns (metrics that should not degrade).
+- Surface leading indicators of larger outcomes.
+- Provide diagnostic signal for issues.
+
+**OKR target selection.** Each quarter, the team selects which metrics to set OKR targets on:
+
+- Metrics tied to the quarter's strategic priorities.
+- Metrics where stretch progress is plausible and meaningful.
+- Often a subset of the broader metric set.
+
+**The remaining metrics.** Tracked without OKR targets. Monitored for movement; surfaced if they shift unexpectedly.
+
+---
+
+## Common failures across the three
+
+**OKR-as-roadmap.** Quarterly commitments written as features rather than outcomes.
+
+**Roadmap-as-OKR.** Roadmap items called OKRs; output disguised as outcome.
+
+**Every-metric-as-OKR.** OKRs proliferate to cover every tracked metric; focus diluted.
+
+**OKR-without-roadmap-mapping.** OKRs set without identifying which work will move them; teams miss the OKRs because no work is aimed at them.
+
+**Roadmap-without-OKR-mapping.** Work happens without explicit OKR connection; teams cannot tell what their work is contributing to.
+
+**Metrics-without-OKR-distinction.** All metrics treated as targets; team cannot prioritize.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The three concepts and their characteristics. The relationship and composition. Common conflations and cures. When the three diverge. Roadmap-OKR alignment. Metric coverage and OKR target selection. Common failures.
+
+## Implementation choices that stay internal
+
+Specific OKR-tracking tools. Specific roadmap tools. Specific metrics dashboards. Specific integration between OKR system and roadmap system. The team's own conventions for OKR-roadmap-metric documentation. These vary by team and tooling.

--- a/skills/okr-design/references/review-cadence-templates.md
+++ b/skills/okr-design/references/review-cadence-templates.md
@@ -1,0 +1,230 @@
+# Review cadence templates
+
+Weekly check-ins, mid-quarter review, end-of-quarter scoring, quarterly retrospective. Format and time investment per cadence.
+
+OKRs benefit from a structured review rhythm. The cadence produces accountability infrastructure: weekly tactical adjustment, mid-quarter strategic assessment, end-of-quarter scoring, and quarterly practice review. Teams that skip the cadence often watch OKRs decay into year-end reckoning that produces no learning.
+
+---
+
+## Weekly check-ins
+
+The shortest, most frequent review.
+
+**Format.**
+
+- 15-30 minutes per team.
+- Team reviews progress on each key result.
+- Surfaces blockers, dependencies, signal that the trajectory is off.
+- Decides tactical adjustments for the upcoming week.
+
+**Structure.**
+
+- Per KR: current value, trajectory, blockers, planned work for the upcoming week.
+- Cross-OKR: any priority shifts, dependencies needing attention.
+- Closing: commitments for the week.
+
+**Purpose.**
+
+- Tactical adjustment, not OKR adjustment.
+- Surface blockers early so they can be addressed.
+- Maintain focus on OKRs across the quarter (without weekly check-ins, OKRs get forgotten in the press of immediate work).
+
+**What this is not for.**
+
+- Adjusting the OKR or its targets. That is mid-quarter or end-of-quarter work.
+- Status reports for stakeholders. Status reports may flow from the check-in but are a separate output.
+- Detailed work review. The check-in is OKR-focused; other work happens elsewhere.
+
+**Common failures.**
+
+- Becoming status reports. The check-in turns into "here's what I did this week"; OKR-driven decisions get crowded out. Reform the format.
+- Becoming OKR adjustment sessions. Teams uncomfortable with OKRs sometimes use weekly check-ins to soften them. Hold to tactical scope.
+- Skipping when busy. Weeks where the check-in feels less urgent are exactly when discipline is needed. Skip rarely.
+
+---
+
+## Mid-quarter review
+
+A longer, more strategic review.
+
+**Format.**
+
+- 60-90 minutes per team.
+- Roughly week 6 of the quarter (mid-point).
+- Honest assessment of trajectory: which KRs are on track, which are off.
+- Decision point for any recalibration (rare; should not be the default outcome).
+- Surface external dependencies that affect end-of-quarter outcomes.
+
+**Structure.**
+
+- Per OKR: current state vs target, trajectory analysis, on-track or off-track assessment.
+- Cross-OKR: priority adjustments, capacity reallocations, blockers requiring escalation.
+- Recalibration check: is any OKR a candidate for revision per the strategic-shift / disruption / invalidating-information criteria? (See `mid-quarter-recalibration.md`.)
+- Closing: tactical decisions for the second half of the quarter.
+
+**Purpose.**
+
+- Strategic assessment of OKR progress.
+- Course correction before end-of-quarter when there is still time.
+- Surface OKRs that may need recalibration (with the discipline that recalibration should be rare).
+
+**What this is not for.**
+
+- Routine recalibration. Most mid-quarter reviews end with no recalibration; tactical adjustments are the typical output.
+- Scoring. Scoring is end-of-quarter; mid-quarter assesses trajectory toward the score.
+- Postmortem. Postmortems are for completed work; mid-quarter is for live work in progress.
+
+**Common failures.**
+
+- Becoming a recalibration session. Teams uncomfortable with stretch use mid-quarter review to lower OKRs. Hold to the rare-recalibration discipline.
+- Becoming a status meeting. The session becomes a presentation rather than a decision-making review. Reform format to surface decisions.
+- Skipping. Teams that skip mid-quarter review often discover at end of quarter that they could have course-corrected; the missed opportunity is the cost.
+
+---
+
+## End-of-quarter scoring
+
+The OKR-cycle closing review.
+
+**Format.**
+
+- 60-90 minutes per team.
+- Last week of the quarter.
+- Score each key result honestly.
+- Identify what produced the scores: tactical choices, external factors, OKR design decisions.
+- Inform next-quarter OKR design with the lessons.
+
+**Structure.**
+
+- Per KR: actual outcome, score (0.0-1.0), context (what produced this score).
+- Per objective: average KR score, context.
+- Cross-OKR: average score across all OKRs (informs whether the quarter was stretch, sandbag, or fantasy).
+- Lessons: what this quarter's scoring reveals about OKR design, team capacity, or strategic clarity.
+- Closing: insights to carry into next quarter's OKR setting.
+
+**Purpose.**
+
+- Honest scoring of outcomes.
+- Learning from the gap between target and outcome.
+- Input to the next quarter's OKR design.
+
+**What this is not for.**
+
+- Compensation discussions. OKRs work best decoupled from compensation; scoring should not feel like a performance evaluation.
+- Blame allocation. Misses are informative; the discussion is about what produced the gap, not who failed.
+- Setting next quarter's OKRs. That is a separate session.
+
+**Common failures.**
+
+- Generous scoring. Scores rounded up; the team protects feelings; honest signal lost. Hold the discipline.
+- Skipping context. Scores published without explanation of what produced them. Lessons get lost.
+- Treating scores as performance. Compensation coupling produces sandbagging in subsequent quarters.
+- Not informing next quarter. Scores reviewed but lessons do not influence the next OKR setting. The cycle does not learn.
+
+---
+
+## Quarterly retrospective
+
+A separate review focused on the OKR practice itself.
+
+**Format.**
+
+- 60-90 minutes per team or org.
+- After end-of-quarter scoring.
+- Reviews the OKR practice, not the OKR outcomes.
+- Often combined with the next-quarter OKR setting session.
+
+**Structure.**
+
+- What worked in this quarter's OKR practice (cadence, format, design)?
+- What did not work?
+- What should change in the next cycle?
+- What patterns are emerging across multiple quarters?
+
+**Purpose.**
+
+- Improve the OKR practice itself.
+- Surface decay or drift in OKR discipline.
+- Inform process changes for the next cycle.
+
+**What this is not for.**
+
+- Scoring or recalibrating current OKRs. That is end-of-quarter work.
+- Setting next quarter's OKRs. That is a separate session that uses the retrospective's inputs.
+
+**Common patterns surfaced.**
+
+- Sandbagging or fantasy drift. Average score patterns over multiple quarters reveal practice decay.
+- Cadence breakdown. Weekly check-ins becoming status reports; mid-quarter reviews becoming recalibration sessions.
+- Cascading misalignment. Teams setting OKRs that do not ladder; cross-team coordination failing.
+- Compensation coupling. OKRs becoming performance theater because they are tied to bonuses.
+
+**Common retrospective failures.**
+
+- Skipping the retrospective. The OKR practice does not improve; decay accumulates.
+- Conflating with next-quarter OKR setting. Both can happen in one session, but the retrospective lens (process review) should be distinct from the OKR design lens (setting).
+- Producing recommendations without follow-through. Retrospectives surface improvements; the team must implement them in the next cycle for the retrospective to matter.
+
+---
+
+## The cadence as a system
+
+The four cadences compose.
+
+**The system.**
+
+- Weekly check-ins maintain tactical focus and surface blockers.
+- Mid-quarter review provides strategic assessment and rare recalibration opportunity.
+- End-of-quarter scoring produces honest signal on outcomes.
+- Quarterly retrospective improves the practice over time.
+
+**The reinforcement.**
+
+- Weekly check-ins make mid-quarter assessment honest (the team has been tracking trajectory all along).
+- Mid-quarter review surfaces issues end-of-quarter scoring will face.
+- End-of-quarter scoring informs the retrospective.
+- The retrospective informs the next cycle's design.
+
+**The skip risk.** Teams that skip cadences often skip several. Weekly check-ins falter; mid-quarter review becomes ad-hoc; end-of-quarter scoring becomes generous because the team has not been tracking honestly all along; the retrospective never happens.
+
+---
+
+## Cadence ownership
+
+Each cadence has a clear owner.
+
+**Weekly check-ins.** Owned by the team lead (manager, PM, engineering lead). Facilitates the meeting; ensures it stays tactical.
+
+**Mid-quarter review.** Owned by the team lead, often with cross-functional partners attending. Surfaces strategic decisions.
+
+**End-of-quarter scoring.** Owned by the team lead. Ensures honest scoring; documents context.
+
+**Quarterly retrospective.** Owned by the team lead or by a process-focused role (chief of staff, ops lead). Often facilitated by someone slightly outside the team to bring fresh perspective.
+
+**Cross-team coordination.** When multiple teams have OKRs that compose, coordination across teams happens at the cadence boundaries (typically mid-quarter review).
+
+---
+
+## Common cadence failures
+
+**Skipping cadences.** Weekly check-ins falter; mid-quarter review becomes ad-hoc; the system breaks.
+
+**Cadence merging.** Mid-quarter review and end-of-quarter scoring combined into one session. Loses the distinct purposes.
+
+**Status-report drift.** Weekly check-ins become status reports; tactical decisions get displaced.
+
+**Recalibration drift.** Mid-quarter review becomes a recalibration session; OKRs lose accountability.
+
+**Generous-scoring drift.** End-of-quarter scoring rounds up; honest signal lost.
+
+**Retrospective skipping.** OKR practice does not improve; decay accumulates.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The four cadence formats. Time investment per cadence. Structure and purpose per cadence. The cadence-as-system reinforcement. Ownership. Common failures.
+
+## Implementation choices that stay internal
+
+Specific meeting templates. Specific OKR-tracking tools that support each cadence. Specific facilitation conventions. Specific cross-team coordination formats. The team's own conventions for cadence cadence (no pun intended). These vary by team and tooling.

--- a/skills/okr-design/references/scoring-discipline.md
+++ b/skills/okr-design/references/scoring-discipline.md
@@ -1,0 +1,191 @@
+# Scoring discipline
+
+The 0.0-1.0 scale. The 60-70% target. Scoring honesty. What 100% and 30% mean. The compensation question.
+
+End-of-quarter scoring is where OKR practice succeeds or decays. Honest scoring produces signal: which OKRs the team hit, which they missed, what the gap reveals about the work. Dishonest scoring produces theater: 100% scores claimed regardless of outcome, generous rounding, partial credit for effort rather than outcome.
+
+---
+
+## The 0.0-1.0 scale
+
+Each key result scores from 0.0 (no progress) to 1.0 (fully achieved). The objective scores as the average of its key results.
+
+**Key result scoring examples.**
+
+- KR: "Increase first-week activation rate from 32% to 45%."
+- Outcome: rate reached 41%.
+- Score: (41 - 32) / (45 - 32) = 9/13 = 0.69.
+
+- KR: "Reduce median time-to-first-value from 4.2 days to under 2 days."
+- Outcome: reduced to 2.6 days.
+- Score: (4.2 - 2.6) / (4.2 - 2.0) = 1.6/2.2 = 0.73.
+
+- KR: "Pass SOC 2 Type II audit with zero high-severity findings."
+- Outcome: passed with zero high-severity findings.
+- Score: 1.0 (binary KR; achieved).
+
+**Objective scoring.** Average of the key result scores.
+
+- Objective with 3 KRs scoring 0.69, 0.73, 1.0: objective scores (0.69 + 0.73 + 1.0) / 3 = 0.81.
+
+---
+
+## The 60-70% target
+
+Stretch OKRs are designed so that the average score across the team's OKRs is 0.6-0.7.
+
+**Why this target.**
+
+- Average above 0.85 suggests sandbagging. The team set OKRs they were already on track to deliver.
+- Average below 0.4 suggests fantasy. The team set OKRs that no realistic effort path would have produced.
+- Average between 0.6-0.7 suggests stretch. The team committed to ambition and delivered most of it.
+
+**The trajectory check.** Track the team's average score over multiple quarters. Drift toward 0.85+ signals sandbagging is creeping in; drift toward 0.4 signals fantasy. The target zone is 0.55-0.75 over a multi-quarter window.
+
+**Variance is normal.** Some quarters will hit 0.8 average; some will hit 0.5. The variance reflects the genuine uncertainty in stretch OKRs. Programs that hit 0.65 every single quarter are usually managing scores rather than honestly scoring outcomes.
+
+---
+
+## Scoring honesty
+
+**Score the actual outcome, not the effort.** A team that worked hard but did not move the metric scores low. A team that got lucky and moved the metric without much effort scores high. The score reflects outcome.
+
+**Do not round up.** A KR at 0.55 scores 0.55, not 0.6. Honest scoring produces honest signal. Rounding up across multiple KRs accumulates into systemic over-scoring.
+
+**Acknowledge what changed.** Some misses reflect mid-quarter priority shifts. Surface these without using them as excuses. "We deprioritized this in week 5 to address the security incident" is honest context; "we hit our priorities even though we missed this OKR" is hand-waving.
+
+**Scoring sessions are honest, not adversarial.** The scoring conversation is for capturing reality, not for blame. Honest low scores are fine; effort recognition happens elsewhere.
+
+---
+
+## What 100% scores mean
+
+100% scores warrant scrutiny.
+
+**Possibilities.**
+
+- The OKR was sandbagged. The team set targets they were already on track to hit.
+- The team had a great quarter. Sometimes hitting 100% reflects unusual progress; informative.
+- The team is rounding up. The actual outcome was 0.85 but got rounded.
+- Binary KRs that hit 1.0. A milestone-based KR that achieves the milestone is 1.0; this is not sandbagging.
+
+**The investigation.**
+
+- Compare the target to the historical trajectory. Was the target above what the metric would have done without focused effort?
+- Compare the target to other teams setting similar OKRs. Was this target genuinely stretch?
+- Look at the work the team did. Did the team push beyond their normal capacity, or did they hit the target on standard execution?
+
+**The interpretation.** Single-quarter 100% scores are not necessarily problematic. Repeated 100% scores across many KRs across multiple quarters are a sandbagging signal. The next OKR cycle should set targets above the prior quarter's actuals to prevent sandbagging compounding.
+
+---
+
+## What 30% scores mean
+
+30% scores warrant scrutiny.
+
+**Possibilities.**
+
+- The OKR was fantasy. Targets had no realistic effort path; the team could not have hit them.
+- Unexpected disruption. A market event, security incident, or priority shift consumed capacity that would have gone to the OKR.
+- Mid-quarter deprioritization. The team chose to deprioritize this OKR for other work.
+- Underperformance. The team did not execute well; the score reflects the execution gap.
+
+**The investigation.**
+
+- Was the target reachable? At setting time, could the team identify effort paths that would produce the target?
+- What changed during the quarter that affected the trajectory?
+- What did the team actually work on? Did effort match the OKR, or did effort go elsewhere?
+
+**The interpretation.** 30% scores are informative regardless of cause. Fantasy targets need recalibration in the next quarter. Disruption-driven misses inform what to plan around. Deprioritization-driven misses surface tension between OKRs and other work. Execution gaps surface team-capability or process issues.
+
+**The non-recovery.** Repeated 30% scores quarter after quarter signal that OKR design is failing. Either the org is consistently setting fantasy targets, or the team is consistently mismatched to its commitments. Investigate.
+
+---
+
+## The compensation question
+
+OKRs work best when not directly tied to compensation.
+
+**The problem with compensation-coupling.** When OKRs determine bonuses or reviews, sandbagging incentives become severe. Teams set OKRs they know they can hit. The 60-70% target collapses to 95% target because nobody wants to risk their bonus on stretch.
+
+**Why decoupling works.** OKRs become genuine accountability infrastructure. The team can stretch without risking compensation. Honest scoring is safe. Misses produce learning rather than punishment.
+
+**Compensation alternatives.**
+
+- Compensation tied to overall performance (manager assessment, peer feedback, role expectations) rather than to OKR scores specifically.
+- OKR scores inform performance review as one input among many, not as the dominant signal.
+- Bonus structures based on company performance rather than team-OKR scores.
+
+**The transition for orgs already coupled.** Decoupling requires explicit communication. Teams need to trust that scoring honestly will not affect their bonuses. The transition can take 2-3 cycles before teams believe the decoupling is real.
+
+---
+
+## Scoring formats
+
+How scoring sessions get run.
+
+**The format.**
+
+- Team meets at end of quarter (60-90 minutes).
+- Each KR scored honestly.
+- Each objective scored as the KR average.
+- Discussion: what produced the scores, what worked, what did not.
+- Output: published scores with brief context per OKR.
+
+**The discussion content.**
+
+- For high-scoring OKRs: was this stretch? What worked? What can be replicated?
+- For low-scoring OKRs: what got in the way? What does the team need next quarter?
+- For mid-scoring OKRs: where did the work land? What was the gap between target and actual?
+
+**The output.** Scores published to the team and stakeholders. Brief context per OKR. The published record informs the next quarter's setting and the org's broader OKR practice.
+
+---
+
+## Scoring across multiple teams
+
+When multiple teams cascade to a company OKR, scoring composes.
+
+**The composition.**
+
+- Each team scores its KRs independently.
+- The company OKR's score reflects the cumulative outcome (not the average of team scores).
+- A company OKR can score high even if some contributing team OKRs scored low, depending on which contributions mattered most.
+
+**Worked example.** Company OKR: "Improve net new ARR through enterprise segment growth."
+
+- Sales team KR (close 8 enterprise deals): scored 0.85 (closed 7).
+- Product team KR (enterprise-readiness foundations): scored 0.7 (achieved most foundations; SOC 2 in progress).
+- Marketing team KR (enterprise-segment marketing campaigns): scored 0.5 (delayed launch).
+
+Company OKR score: depends on the actual ARR outcome, not the average of team scores. If ARR met the target despite the marketing delay (because sales over-delivered), the company OKR scores high.
+
+**The discipline.** Score outcomes, not averages of inputs.
+
+---
+
+## Common scoring failures
+
+**Rounding up.** Systemic over-scoring through small individual rounds.
+
+**Effort-based scoring.** Scoring based on how hard the team worked rather than what was achieved.
+
+**Compensation-coupled scoring.** Sandbagging incentives produce 95%+ scores.
+
+**Avoidance of low scores.** Teams reluctant to score low; OKRs renamed or rewritten retroactively to avoid the miss.
+
+**Aggregate-of-input scoring.** Company OKR scored as average of team scores rather than as the actual outcome.
+
+**Scoring without context.** Scores published without the conditions that produced them. Lessons get lost.
+
+**One-quarter-at-a-time view.** Scoring evaluated only against the current quarter; trajectory over multiple quarters not surfaced.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The 0.0-1.0 scale and worked examples. The 60-70% target. Scoring honesty. What 100% and 30% scores mean. The compensation question. Scoring formats. Scoring across teams. Common scoring failures.
+
+## Implementation choices that stay internal
+
+Specific scoring tools and dashboards. Specific scoring-session facilitation formats. Specific compensation structures. The team's own conventions for context publishing. These vary by org.

--- a/skills/user-feedback-aggregation/SKILL.md
+++ b/skills/user-feedback-aggregation/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: user-feedback-aggregation
 description: "Collecting and synthesizing user feedback across channels (support tickets, NPS, in-app feedback, sales calls, social mentions, customer councils) into a continuous signal that informs product decisions. The triage discipline that distinguishes loudest-voice (whoever complains most wins) from averaged-noise (every signal weighted equally) from triaged-synthesis (signal weighted by source quality, frequency, and decision relevance). Triggers on user feedback, customer feedback aggregation, NPS, support ticket analysis, customer councils, feedback synthesis, voice of customer, feedback triage, in-app feedback. Also triggers when feedback channels overflow with volume that does not produce decisions, when the loudest-voice problem is steering roadmap, or when continuous feedback streams need synthesis discipline."
-category: project-management
+category: research
 catalog_summary: "Collecting and synthesizing user feedback across channels into continuous decision signal. Triage discipline that distinguishes loudest-voice (whoever complains most) from averaged-noise (every signal weighted equally) from triaged-synthesis (weighted by source quality and decision relevance)"
-display_order: 15
+display_order: 5
 ---
 
 # User Feedback Aggregation

--- a/skills/user-feedback-aggregation/SKILL.md
+++ b/skills/user-feedback-aggregation/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: user-feedback-aggregation
+description: "Collecting and synthesizing user feedback across channels (support tickets, NPS, in-app feedback, sales calls, social mentions, customer councils) into a continuous signal that informs product decisions. The triage discipline that distinguishes loudest-voice (whoever complains most wins) from averaged-noise (every signal weighted equally) from triaged-synthesis (signal weighted by source quality, frequency, and decision relevance). Triggers on user feedback, customer feedback aggregation, NPS, support ticket analysis, customer councils, feedback synthesis, voice of customer, feedback triage, in-app feedback. Also triggers when feedback channels overflow with volume that does not produce decisions, when the loudest-voice problem is steering roadmap, or when continuous feedback streams need synthesis discipline."
+category: project-management
+catalog_summary: "Collecting and synthesizing user feedback across channels into continuous decision signal. Triage discipline that distinguishes loudest-voice (whoever complains most) from averaged-noise (every signal weighted equally) from triaged-synthesis (weighted by source quality and decision relevance)"
+display_order: 15
+---
+
+# User Feedback Aggregation
+
+A senior product leader's playbook for collecting and synthesizing user feedback across channels into continuous decision signal. Support tickets, NPS surveys, in-app feedback, sales calls, social mentions, customer councils, all aggregated into a triaged synthesis the team can actually act on.
+
+Most product programs accumulate feedback they do not use. Channels overflow with submissions; CSAT and NPS scores get reported in monthly updates; customer council meetings produce notes that nobody references. The loudest voices steer roadmap because they are easiest to hear; quieter signal that matters more goes unaddressed.
+
+This skill is the triage discipline that turns continuous feedback streams into continuous decision signal. Each channel surfaces different signal at different reliability. Each signal type warrants different weight in different decisions. The team that aggregates feedback well makes better decisions; the team that drowns in feedback makes the same decisions they would have made without the feedback.
+
+Different from `discovery-research-synthesis`, which covers one-off research projects (a defined batch of artifacts, a defined synthesis output). This skill covers the always-on streams: feedback that arrives every day, every week, every month, and that the team must continuously triage and synthesize.
+
+The voice is the senior product leader who has watched feedback aggregation work and watched it fail. Concrete, opinionated about which channels matter for which decisions, willing to call out where loudest-voice or averaged-noise patterns produce bad outcomes.
+
+When to use this skill: building a feedback aggregation system, auditing a feedback program that is producing volume without decisions, deciding which feedback channels matter for the program, or designing the synthesis cadence for ongoing feedback streams.
+
+---
+
+## What this skill is for
+
+This skill spans continuous user-feedback aggregation. The PM-skill distinction:
+
+- `discovery-research-synthesis` is one-off discovery research. Defined batch, defined output.
+- **`user-feedback-aggregation` (this skill)** is ongoing feedback streams. Always-on channels needing continuous synthesis.
+- `beta-program-management` covers feedback specific to beta participants. This skill spans all users continuously.
+- `ux-research` is structured research projects. This skill is unsolicited feedback.
+- `pm-spec-writing` is downstream: specs use feedback aggregation as input.
+- `roadmap-planning` is downstream: roadmap uses feedback patterns as input.
+
+The audience: senior PMs, product directors, customer success and support managers running feedback programs, in-house teams aggregating feedback across many channels.
+
+What is not in scope: structured discovery research (covered by `discovery-research-synthesis`); beta-specific feedback (covered by `beta-program-management`); commissioned research projects (covered by `ux-research`).
+
+---
+
+## Loudest-voice vs averaged-noise vs triaged-synthesis
+
+The keystone framing.
+
+**Loudest-voice.** Whoever complains the most gets their feature. Vocal minorities steer roadmap. Silent majority's needs go unaddressed. The squeaky-wheel anti-pattern. Cost: the program optimizes for the loudest customer, not for the broader customer base; quieter customers leave for products that addressed their needs.
+
+**Averaged-noise.** Every signal weighted equally. 1 enterprise customer's feedback = 1 trial user's feedback = 1 angry social mention. Volume aggregates without weighting; noise drowns signal. Cost: the team cannot tell which feedback matters; decisions get made on aggregate sentiment that does not reflect the customers who matter most for the strategy.
+
+**Triaged-synthesis.** Signal weighted by source quality, frequency, and decision relevance. Different feedback types have different weights for different decisions. The team that does this well makes decisions grounded in the signal that matters; the team that does it badly defaults to loudest-voice or averaged-noise.
+
+The litmus test. Pick a recent product decision. Can the team explain why specific feedback signals weighted into the decision the way they did? If yes, the aggregation is triaged. If the answer is "we heard a lot about this from customers," without specificity about which customers in which contexts, the aggregation is loudest-voice or averaged-noise.
+
+---
+
+## Feedback channels and what each surfaces
+
+Six common channels. Each surfaces different signal at different reliability.
+
+**Support tickets.** What users hit when things break or confuse them. High volume, high signal-on-friction, biased toward users willing to contact support.
+
+**NPS surveys.** Aggregate sentiment toward the product or specific features. Periodic, quantitative-with-comments, bias toward respondents who feel strongly (positive or negative).
+
+**In-app feedback.** Friction at the moment users encounter it. Contextualized to specific product moments; volume varies; quality varies.
+
+**Sales calls.** Pre-purchase prospect perspective. Objections, competitive mentions, gaps between marketing and what sales leads with. Bias toward prospects, not existing customers.
+
+**Social mentions.** Public commentary about the product. Real-time but biased toward customers willing to post publicly; often skews negative or hyper-positive.
+
+**Customer councils.** Curated panels of customers in structured forums. High-quality feedback from selected customers; bias depends on selection.
+
+Each channel has strengths and weaknesses. Strong feedback aggregation triangulates across channels rather than relying on one.
+
+Detail in `references/channel-types-and-what-each-surfaces.md`.
+
+---
+
+## Channel-source weighting
+
+The discipline that distinguishes triaged-synthesis from averaged-noise.
+
+**The principle.** Different sources warrant different weights in different decisions.
+
+**Worked example.** A decision about whether to prioritize an enterprise admin feature.
+
+- Sales call data showing enterprise prospects asking for the feature: high weight (the decision is about enterprise; the source matches).
+- Support ticket data from enterprise customers: high weight (existing enterprise customers' friction is directly relevant).
+- NPS data from small-team customers: low weight (the feature is not for them; their satisfaction is not load-bearing for the decision).
+- Social mentions: variable weight (signal depends on who is mentioning; enterprise practitioners on LinkedIn carry more weight than anonymous trial users on social).
+
+**The discipline.** For each decision, identify which sources matter most. Weight accordingly. Volume from low-weight sources should not override signal from high-weight sources.
+
+**The averaged-noise failure.** Decisions made on aggregate volume regardless of source. The enterprise admin feature gets deprioritized because more total feedback came from small-team customers who do not need it; enterprise customers churn because their needs went unaddressed.
+
+Detail in `references/channel-source-weighting.md`.
+
+---
+
+## Categorization and tagging discipline at scale
+
+How feedback gets organized when it arrives at high volume.
+
+**The taxonomy.**
+
+- Feature area or product surface (where in the product the feedback applies).
+- Issue type (bug, friction, feature request, positive signal, edge case).
+- User segment (who is providing the feedback).
+- Severity or urgency (how blocking is it for the user).
+- Source channel (where the feedback came from).
+
+**The discipline.**
+
+- Tags emerge from feedback patterns, not from a pre-built taxonomy.
+- Tags get refined over time as patterns clarify.
+- Multiple tags per feedback item; do not force single-category.
+- Periodic taxonomy review surfaces categories that need to merge or split.
+
+**The volume challenge.** A program receiving 500-2000 feedback items per week needs aggregation tooling that supports tagging at scale. Manual tagging at scale burns out the team; AI-assisted tagging with human review on patterns is often the practical middle path.
+
+Detail in `references/categorization-and-tagging-at-scale.md`.
+
+---
+
+## Frequency vs intensity
+
+Two dimensions of feedback signal.
+
+**Frequency.** How often the same feedback recurs.
+
+- High-frequency feedback: many users describe the same issue. Suggests broad applicability.
+- Low-frequency feedback: rare or unique observations. Suggests narrow applicability or edge cases.
+
+**Intensity.** How strongly the user feels.
+
+- High-intensity feedback: users describe the issue as severely disruptive, or describe satisfaction as transformative.
+- Low-intensity feedback: minor friction or mild satisfaction.
+
+**The matrix.**
+
+- High-frequency, high-intensity: top priority. Many users hit this; it matters to them.
+- High-frequency, low-intensity: papercuts. Address in batches; individual items are minor but cumulatively erode experience.
+- Low-frequency, high-intensity: the affected users are deeply impacted but few. Often segment-specific.
+- Low-frequency, low-intensity: noise. Capture; do not action individually.
+
+**The discipline.** Triage assigns each piece of feedback a frequency-intensity assessment. The combination informs prioritization weight.
+
+Detail in `references/frequency-vs-intensity.md`.
+
+---
+
+## From feedback to product decision
+
+The synthesis loop that turns aggregated feedback into roadmap input.
+
+**The loop.**
+
+- Feedback arrives across channels.
+- Triage categorizes and weights.
+- Periodic synthesis (weekly, monthly, quarterly) surfaces patterns.
+- Patterns inform roadmap discussions, spec drafts, prioritization debates.
+- Decisions reference specific feedback patterns as input.
+
+**The cadences.**
+
+- Daily: critical feedback (security, data loss, broken core flows) handled immediately.
+- Weekly: team review of recent patterns. Adjusts current-quarter execution.
+- Monthly: synthesis review. Surfaces trending patterns; informs next-quarter roadmap.
+- Quarterly: strategic synthesis. Patterns over the quarter inform strategic planning.
+
+**The discipline.** Feedback aggregation has cadence. Without cadence, feedback accumulates without producing decisions.
+
+Detail in `references/from-feedback-to-product-decision.md`.
+
+---
+
+## Closing the loop with users
+
+When feedback shapes product, telling users matters.
+
+**The practice.**
+
+- When feedback drives a change, communicate to the users who provided that feedback.
+- "We heard from many of you that X was painful; we shipped Y this week to address it. Thanks for the feedback that informed this work."
+- Communication can be public (release notes, blog posts) or targeted (email to users who opened tickets on the issue).
+
+**Why it matters.**
+
+- Users who see their feedback acted on engage more in the future.
+- The closed loop signals that the team is listening, which strengthens the relationship.
+- Users without feedback follow-through stop providing feedback over time.
+
+**The risk of over-promising.** Promising changes that do not ship erodes trust faster than not promising. Communicate what shipped, not what might ship.
+
+Detail in `references/closing-the-loop-with-users.md`.
+
+---
+
+## Detecting drift in feedback patterns over time
+
+What changes in feedback signal over time can reveal.
+
+**Drift patterns.**
+
+- Increasing feedback volume in a category: either the issue is worsening, the user base is growing, or awareness of the channel is increasing. Investigate the cause.
+- New patterns emerging: previously-rare feedback becomes more common. Often signals product or market change.
+- Patterns disappearing: feedback that used to be common stops. The issue may be resolved, or users may have given up reporting it.
+- Sentiment shifts: NPS or CSAT trending differently than before. Often signals broader experience changes.
+
+**The investigation discipline.** Drift signals warrant investigation. Why did the volume increase? Why did this pattern emerge? The root cause often informs product decisions more than the surface signal.
+
+Detail in `references/detecting-drift-in-feedback.md`.
+
+---
+
+## Feedback aggregation tooling considerations
+
+Tooling choices without endorsing specific products.
+
+**Tooling categories.**
+
+- Customer feedback platforms (aggregate across multiple sources, support tagging, surface patterns).
+- Support ticket systems with analytics layers.
+- NPS or survey platforms with response aggregation.
+- Customer relationship management systems with feedback fields.
+- Custom dashboards combining feedback signal with usage analytics.
+
+**The criteria for tooling selection.**
+
+- Does it support multi-channel aggregation, or is it single-channel?
+- Does it support tagging at scale?
+- Does it surface patterns, or is it just storage?
+- Does it integrate with the team's other systems (roadmap, ticketing, communication)?
+- Does it scale with program volume?
+
+**The build-vs-buy tension.** Many programs end up with a mix: dedicated tooling for some channels, custom dashboards for cross-channel synthesis. Pure single-tool solutions often miss the multi-channel pattern detection.
+
+Detail in `references/tooling-considerations.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-feedback-aggregation-failures.md`.
+
+- "Loudest customers steer the roadmap." Loudest-voice pattern; vocal minorities dominate; silent majority underaddressed.
+- "We have lots of feedback but no decisions." Aggregation without synthesis; no triage cadence.
+- "Our channels overflow; we cannot keep up." Aggregation without weighting or tooling that scales.
+- "Different teams cite different feedback for the same decision." Channel-source weighting absent; teams reach for whatever feedback supports their position.
+- "Customer council meetings produce notes nobody references." Council without synthesis loop; the meeting is the deliverable.
+- "NPS is reported monthly but does not inform decisions." NPS as compliance metric, not as decision input.
+- "Feedback we shipped against did not move sentiment." Wrong feedback prioritized; the loud feedback was not the most consequential.
+- "Users gave feedback once and never returned." Closed-loop missing; users feel ignored.
+- "We tagged everything but cannot find patterns." Taxonomy too granular or too noisy; periodic taxonomy review missing.
+- "Drift in feedback caught us by surprise." Drift detection missing; the team did not investigate trending patterns until they became problems.
+- "Sales call data and support ticket data tell different stories." Cross-channel synthesis missing; each channel's signal stays in its own silo.
+
+---
+
+## The framework: 12 considerations for feedback aggregation
+
+When designing or auditing a feedback aggregation system, walk these 12 considerations.
+
+1. **Triaged-synthesis, not loudest-voice or averaged-noise.** Signal weighted by source, frequency, decision relevance.
+2. **Channel taxonomy known.** Support, NPS, in-app, sales, social, councils. What each surfaces.
+3. **Channel-source weighting per decision.** Different decisions weight channels differently.
+4. **Categorization and tagging at scale.** Taxonomy that emerges from data; tooling that supports volume.
+5. **Frequency-intensity matrix.** Each feedback item assessed on both dimensions.
+6. **Synthesis cadence.** Daily critical, weekly patterns, monthly review, quarterly strategic.
+7. **Cross-channel triangulation.** Patterns that appear across channels are stronger.
+8. **Closing the loop with users.** When feedback drives change, communicate.
+9. **Drift detection.** Patterns over time reveal changes.
+10. **Tooling that scales.** Multi-channel aggregation, pattern surfacing, integration.
+11. **Specific feedback informs specific decisions.** Decisions traceable to specific signals.
+12. **Honest assessment of source bias.** Each channel's bias acknowledged in synthesis.
+
+The output of the framework is feedback aggregation that produces decision-grade signal continuously, scales with program volume, and treats users well enough that they keep providing feedback over time.
+
+---
+
+## Reference files
+
+- [`references/channel-types-and-what-each-surfaces.md`](references/channel-types-and-what-each-surfaces.md) - Six common channels with strengths, weaknesses, biases, and synthesis implications.
+- [`references/channel-source-weighting.md`](references/channel-source-weighting.md) - Decision-relative weighting. Worked examples of how channels weight differently for different decisions.
+- [`references/categorization-and-tagging-at-scale.md`](references/categorization-and-tagging-at-scale.md) - Taxonomy that emerges from data. Tooling at volume. Periodic taxonomy review.
+- [`references/frequency-vs-intensity.md`](references/frequency-vs-intensity.md) - The two dimensions of feedback signal. The four-quadrant matrix and prioritization implications.
+- [`references/from-feedback-to-product-decision.md`](references/from-feedback-to-product-decision.md) - The synthesis loop. Cadences. The discipline of decisions traceable to feedback.
+- [`references/closing-the-loop-with-users.md`](references/closing-the-loop-with-users.md) - When and how to communicate feedback-driven changes. The over-promising risk.
+- [`references/detecting-drift-in-feedback.md`](references/detecting-drift-in-feedback.md) - Drift patterns. Investigation discipline. Drift as early signal of change.
+- [`references/tooling-considerations.md`](references/tooling-considerations.md) - Tooling categories without specific endorsements. Criteria for selection. Build-vs-buy tension.
+- [`references/common-feedback-aggregation-failures.md`](references/common-feedback-aggregation-failures.md) - 11+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: feedback as continuous signal, not periodic survey
+
+The teams that make good product decisions over time are the ones that aggregate feedback continuously and synthesize it into decision input. Not as compliance with a feedback-collection mandate; not as monthly NPS reporting; not as ad-hoc reactions to whoever complains loudest. As a continuous discipline that surfaces what users are actually experiencing, weighted appropriately, synthesized for the decisions the team is actually making.
+
+Feedback aggregation done well is invisible: the team makes better decisions, but the feedback work itself does not feel heroic. Feedback aggregation done badly is loud: channels overflow, NPS gets reported, customer councils produce decks, and decisions still get made on gut feel because the feedback work did not produce decision input.
+
+The discipline is in the triage. Each channel weighted by what it reveals. Each piece of feedback assessed on frequency and intensity. Patterns surfaced through synthesis. Decisions traceable to specific feedback. The closed loop with users that keeps feedback flowing.
+
+When in doubt about whether a feedback program is working, ask: can the team trace recent decisions to specific feedback patterns, are channels weighted differently for different decisions, is the synthesis cadence producing input the team uses, are users seeing their feedback acted on? If yes to all of those, the program is real. If no to any, the gap is where the feedback work is failing to convert into decisions.

--- a/skills/user-feedback-aggregation/references/categorization-and-tagging-at-scale.md
+++ b/skills/user-feedback-aggregation/references/categorization-and-tagging-at-scale.md
@@ -1,0 +1,213 @@
+# Categorization and tagging at scale
+
+Taxonomy that emerges from data. Tooling at volume. Periodic taxonomy review.
+
+How feedback gets organized when it arrives at high volume. The discipline that prevents the "we tagged everything but cannot find patterns" failure.
+
+---
+
+## The taxonomy dimensions
+
+Each feedback item gets tagged across multiple dimensions.
+
+**Feature area or product surface.** Where in the product the feedback applies. Examples: onboarding, dashboard, billing, integrations, mobile app.
+
+**Issue type.** Bug, friction, feature request, positive signal, edge case.
+
+**User segment.** Who is providing the feedback. Examples: free tier, pro tier, enterprise, trial, churned.
+
+**Severity or urgency.** How blocking is the issue. Examples: critical (blocks core flow), high (significant friction), medium (workaround exists), low (minor).
+
+**Source channel.** Where the feedback came from. Examples: support ticket, NPS comment, in-app widget, sales call, social mention, customer council.
+
+**Date or time period.** When the feedback was submitted. Useful for drift detection.
+
+Most programs use 3-6 of these dimensions. More dimensions produce richer queries; more dimensions also increase tagging burden.
+
+---
+
+## Tags emerge from data, not from a pre-built taxonomy
+
+The same principle as discovery research synthesis (see `discovery-research-synthesis`).
+
+**The pattern.** Tags emerge from feedback patterns. Initial tagging captures what users actually said; the taxonomy builds up from the data.
+
+**The anti-pattern.** Pre-built taxonomies that force feedback into categories. Patterns the taxonomy did not anticipate get missed; categories that do not match the data get used anyway.
+
+**Why emergent tagging matters.**
+
+- Users describe issues in their own language; pre-built categories often miss the actual issues.
+- New product features generate new categories; emergent tagging adapts.
+- Issues evolve over time; emergent tagging captures the evolution.
+
+**The transition.** Programs starting feedback aggregation often need a starting taxonomy to begin with. The starting taxonomy is provisional; it gets refined as feedback accumulates and patterns clarify.
+
+---
+
+## Multiple tags per feedback item
+
+Most feedback items deserve multiple tags.
+
+**The pattern.** A single feedback item often touches multiple feature areas, issue types, or context dimensions.
+
+**Worked example.** Support ticket: "I'm an enterprise admin trying to set up SSO for the team and the configuration step keeps timing out."
+
+Tags:
+
+- Feature area: SSO configuration, admin settings.
+- Issue type: bug (timeout) + friction (configuration is hard).
+- User segment: enterprise.
+- Severity: high (blocks core enterprise setup).
+- Source channel: support ticket.
+
+Multiple tags capture the feedback's full context. Single-tag forcing loses information.
+
+---
+
+## Tagging at volume
+
+Programs receiving 500-2000+ feedback items per week need tooling support.
+
+**Tooling approaches.**
+
+- **Manual tagging.** Each item tagged by a human. Highest quality; lowest scale. Works for low-volume programs (under 100 items per week).
+- **AI-assisted tagging.** AI suggests tags; humans review and adjust. Scales better; quality depends on the AI's training and the team's review discipline.
+- **Automated tagging.** AI tags without human review. Scales highest; quality is lowest because no one validates.
+- **Hybrid.** Manual tagging for high-priority items (enterprise feedback, critical issues), AI-assisted for the bulk.
+
+**The recommended pattern for most programs.** AI-assisted tagging with human review on patterns. The AI handles bulk classification; humans review aggregate patterns and validate that the categorization is producing useful signal.
+
+**The volume calibration.**
+
+- Under 100 items/week: manual tagging is feasible and preferred.
+- 100-500 items/week: AI-assisted with sample review.
+- 500+ items/week: AI-assisted with pattern review; manual handling reserved for high-priority items.
+
+---
+
+## Tag quality vs tag granularity
+
+Two competing pressures.
+
+**Granularity helps.** More specific tags surface more specific patterns. "Onboarding configuration step 3 friction" is more useful than "onboarding friction."
+
+**Granularity also harms.** More specific tags fragment data. If 10 different tags split what should be one pattern, the pattern is invisible.
+
+**The middle path.**
+
+- Start with moderate granularity.
+- Refine over time. Tags that consistently co-occur may need to merge; tags that combine distinct patterns may need to split.
+- Periodic taxonomy review (see below) catches granularity issues.
+
+---
+
+## Periodic taxonomy review
+
+Quarterly or bi-annual review of the taxonomy.
+
+**The questions.**
+
+- Are there tags that consistently co-occur and could merge?
+- Are there tags that contain multiple distinct patterns and should split?
+- Are there new patterns that need new tags?
+- Are there tags that no longer apply (deprecated features, resolved issues)?
+- Is the taxonomy too granular (fragmenting patterns) or too coarse (hiding patterns)?
+
+**The output.** A revised taxonomy. Old tags may get retired; new tags may get added; some tags may get renamed.
+
+**The discipline.** Without periodic review, taxonomies decay. Old tags accumulate; new patterns get tagged into wrong categories; the taxonomy stops surfacing useful patterns.
+
+**The frequency.** Quarterly works for most programs. Annual works for stable programs with low product change rate. Bi-annual works as a middle path.
+
+---
+
+## Tag conflicts and resolution
+
+Sometimes feedback could be tagged in multiple ways.
+
+**Resolution approaches.**
+
+- **Multi-tagging.** When in doubt, apply multiple tags. Captures the ambiguity rather than forcing a choice.
+- **Convention.** Document conventions for ambiguous cases. "Friction with the dashboard's filter functionality" gets tagged "dashboard" + "filtering" + "friction" rather than choosing.
+- **Reviewer judgment.** Train reviewers (human or AI) on conventions. Ambiguous cases get reviewed for consistency.
+
+**The cost of inconsistent tagging.** Patterns become invisible because the same kind of feedback gets tagged differently. The "we tagged everything but cannot find patterns" failure often traces to inconsistent tagging.
+
+---
+
+## Tag distribution as signal
+
+The distribution of tags across feedback can be informative beyond individual tags.
+
+**Examples.**
+
+- Spike in volume on a specific tag: trending issue or feature area in flux.
+- Decline in volume on a tag: issue resolved or users gave up reporting.
+- Co-occurrence patterns: tags that consistently appear together suggest related issues.
+- Segment-specific tag distributions: enterprise vs free-tier feedback patterns differ.
+
+**The dashboard view.** Most feedback aggregation tooling supports tag-distribution dashboards. The dashboards surface patterns the team would not see in individual feedback items.
+
+---
+
+## Tagging discipline at the channel level
+
+Different channels need different tagging conventions.
+
+**Support tickets.** Often pre-tagged by the support system (issue type, product area). Augment with feedback-specific tags.
+
+**NPS comments.** Lighter tagging. Often just sentiment + topic area. Open-ended comments are mined for patterns; not every comment needs comprehensive tagging.
+
+**In-app feedback.** Auto-tagged by context (which page, which feature). Augment with issue-type and severity.
+
+**Sales calls.** Often summarized rather than tagged at the moment level. Summaries get tagged.
+
+**Social mentions.** Auto-classified by sentiment and topic; manual review for high-impact mentions.
+
+**Customer council notes.** Manually tagged after each council session. Higher tagging investment because volume is low and signal is high.
+
+---
+
+## Cross-channel tag consistency
+
+Tags should mean the same thing across channels.
+
+**The risk.** "Onboarding friction" in support tickets means something slightly different than "onboarding friction" in NPS comments because the channels surface different aspects.
+
+**The mitigation.**
+
+- Document tag definitions explicitly. "Onboarding friction" includes X, Y, Z signals.
+- Periodic cross-channel calibration. Review tagged samples from each channel to ensure consistency.
+- Channel-specific sub-tags where appropriate. "Onboarding-friction-support" vs "Onboarding-friction-nps" if the distinction matters.
+
+**The honest framing.** Cross-channel tag consistency is hard. Strong programs work toward it; perfect consistency is rare.
+
+---
+
+## Common tagging failures
+
+**Pre-built taxonomy forced.** Patterns the taxonomy did not anticipate get missed.
+
+**Single-tag forcing.** Multi-dimensional feedback gets reduced to one tag; information lost.
+
+**Inconsistent tagging.** The same kind of feedback gets tagged differently across reviewers or time periods.
+
+**Tag bloat.** Too granular; patterns fragment across many tags.
+
+**Tag coarseness.** Too broad; distinct patterns hide within the same tag.
+
+**No taxonomy review.** Tags decay over time without periodic review.
+
+**Volume overwhelms tagging.** High-volume programs without tooling support; tagging falls behind; old feedback never gets tagged.
+
+**Tag-without-purpose.** Tagging happens because it is supposed to; nobody uses the tags for synthesis.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The taxonomy dimensions. Emergent tagging. Multi-tag discipline. Tagging at volume (manual, AI-assisted, automated, hybrid). Tag quality vs granularity tradeoffs. Periodic taxonomy review. Tag conflict resolution. Tag distribution as signal. Channel-specific tagging. Cross-channel consistency. Common failures.
+
+## Implementation choices that stay internal
+
+Specific tagging tools and AI models. Specific tag definition documents. Specific reviewer training. Specific dashboard configurations. The team's own conventions for tagging within the principles. These vary by team.

--- a/skills/user-feedback-aggregation/references/channel-source-weighting.md
+++ b/skills/user-feedback-aggregation/references/channel-source-weighting.md
@@ -1,0 +1,216 @@
+# Channel-source weighting
+
+Decision-relative weighting. Worked examples of how channels weight differently for different decisions.
+
+The discipline that distinguishes triaged-synthesis from averaged-noise. Different sources warrant different weights for different decisions; treating all sources as equal produces decisions made on aggregate volume rather than on signal that matters.
+
+---
+
+## The weighting principle
+
+Each piece of feedback has a source. The source's weight in a decision depends on how relevant the source is to that decision.
+
+**Worked principle.** A piece of feedback from an enterprise customer has different weight than a piece of feedback from a trial user when the decision is about enterprise pricing. The enterprise customer's feedback is high-weight; the trial user's feedback is low-weight (they are not the audience for the decision).
+
+The same piece of feedback from a trial user has different weight when the decision is about trial conversion. Now the trial user is the audience; their feedback is high-weight.
+
+The weighting is decision-relative, not source-absolute.
+
+---
+
+## Worked examples of channel weighting
+
+### Decision: Should we prioritize the enterprise admin role overhaul this quarter?
+
+**Audience for the decision.** Existing enterprise customers and enterprise prospects.
+
+**Channel weights for this decision.**
+
+- Sales call data with enterprise prospects: high weight. They directly inform the decision.
+- Support ticket data from enterprise customers: high weight. Existing enterprise friction is directly relevant.
+- Customer council data from enterprise members: high weight. Curated enterprise perspective.
+- NPS data from enterprise customers: moderate weight. Aggregate signal but not specific to admin features.
+- NPS data from small-team customers: low weight. Different segment; admin features not relevant.
+- Social mentions: variable weight. Enterprise practitioners' posts higher than anonymous trial accounts.
+- In-app feedback from small-team users: low weight. Different segment.
+
+The decision weighs enterprise sources heavily. Volume from non-enterprise sources should not displace enterprise signal.
+
+### Decision: Should we redesign the onboarding flow for new free-tier signups?
+
+**Audience for the decision.** Free-tier new signups.
+
+**Channel weights for this decision.**
+
+- Support tickets from free-tier users in their first week: high weight. Direct friction signal.
+- In-app feedback from free-tier users during onboarding: high weight. Moment-of friction.
+- NPS data from free-tier users: moderate weight. Aggregate sentiment.
+- Sales call data: low weight. Sales calls are usually with prospects, not free signups; pre-decision conversation differs from post-signup experience.
+- Customer council data: low weight. Councils usually have established customers, not new signups.
+- Support tickets from long-tenured customers: low weight. Their onboarding friction was a year ago; current onboarding may differ.
+
+The decision weighs new-signup sources heavily. Long-tenured customer feedback is informative for other decisions but not this one.
+
+### Decision: Should we launch a new pricing tier?
+
+**Audience for the decision.** Both prospects and existing customers (existing customers may move tiers; prospects' tier choice affects acquisition).
+
+**Channel weights for this decision.**
+
+- Sales call data on pricing conversations: high weight. Prospects' pricing perception is critical.
+- Support tickets about pricing or upgrade requests: high weight. Existing customer pricing pain points.
+- Customer council discussion on pricing: high weight. Strategic discussion with curated customers.
+- NPS data with pricing comments: moderate weight. Some signal but not decision-specific.
+- Social mentions about pricing: moderate weight. Public perception affects acquisition.
+- In-app feedback unrelated to pricing: low weight. Off-topic for this decision.
+
+Multiple high-weight channels because the decision spans audiences.
+
+### Decision: Should we invest in social mention monitoring as a primary channel?
+
+**Audience for the decision.** Strategic question about feedback aggregation infrastructure.
+
+**Channel weights for this decision.**
+
+- Past examples of social signal driving decisions: high weight. Direct evidence.
+- Past examples where social signal misled (vocal minority, anonymous accounts): high weight as counter-evidence.
+- Other companies' published patterns on social signal: moderate weight. Indicative but not specific.
+- Internal team intuition about social signal: low weight unless backed by data.
+
+The decision weighs evidence of past signal-driven decisions heavily.
+
+---
+
+## The averaged-noise failure
+
+When sources are weighted equally regardless of decision relevance.
+
+**The pattern.**
+
+- The team aggregates all feedback equally.
+- Volume from any source counts the same.
+- The most-feedback issue gets prioritized regardless of source.
+
+**Why it fails.**
+
+- Decisions get made on aggregate volume rather than on signal that matters for that decision.
+- Decisions that should be enterprise-driven get displaced by volume from segments that do not matter for that decision.
+- The team optimizes for the squeaky-wheel signal because it is loudest in the aggregate.
+
+**Worked failure.** The team is deciding whether to prioritize enterprise admin features. NPS and in-app feedback show low priority for this area (because most respondents are small-team users who do not need enterprise admin). Sales calls and enterprise support tickets clearly indicate the priority. The team aggregates volume, sees more total feedback against enterprise admin priority, and deprioritizes. Enterprise customers churn.
+
+**The cure.** Weight by decision relevance. Enterprise channels weight high for enterprise decisions; small-team feedback should not displace enterprise signal on enterprise decisions.
+
+---
+
+## The loudest-voice failure
+
+When the most vocal source dominates regardless of representativeness.
+
+**The pattern.**
+
+- A small number of customers complain frequently and loudly.
+- Their feedback dominates synthesis because they generate the most volume.
+- Their preferences shape the roadmap.
+
+**Why it fails.**
+
+- Vocal minorities do not represent the broader user base.
+- Silent majority's needs go unaddressed.
+- The roadmap optimizes for the customers most likely to complain rather than the customers most strategic for the business.
+
+**The cure.** Weight by source quality and representativeness, not by volume. A complaint repeated 50 times by one user is not 50x the signal of one complaint by 50 distinct users.
+
+---
+
+## How to set weights
+
+In practice, weighting is qualitative. Quantitative scoring schemes often produce false precision.
+
+**The discipline.**
+
+- For each decision, identify the audience (who the decision serves).
+- Identify which channels surface signal from that audience.
+- Identify which channels do not (and why their feedback is less relevant for this decision).
+- In synthesis, give high-weight channel signal more attention than low-weight channel signal.
+
+**Quantitative weighting risks.**
+
+- Scoring systems (this channel = 3x weight; that channel = 1x) often produce false precision.
+- Decisions made on weighted scores rather than on judgment can miss qualitative nuances.
+- The discipline is qualitative judgment informed by source-relevance, not arithmetic.
+
+**The honest framing.** Weighting is a judgment call. The synthesis names the weighting choices explicitly: "We weighted enterprise channel signal heavily here because the decision is about enterprise priorities." Readers can disagree with the weighting; disagreement is productive.
+
+---
+
+## Source bias acknowledgment
+
+Each source has biases that affect its signal.
+
+**Sources skew toward.**
+
+- Support: users willing to contact support; tend toward problem-reporting.
+- NPS: users with strong opinions; middle-ground underrepresented.
+- In-app feedback: users who interact with widgets; specific segments may dominate.
+- Sales calls: prospects, not existing customers; pre-purchase context.
+- Social: users who post publicly; enthusiasts and angry voices.
+- Councils: curated members; specific selection criteria.
+
+**The synthesis discipline.** When weighting, acknowledge the bias. "Support tickets show high friction in this area" should be paired with "noting the support-channel bias toward users who contact support." The acknowledgment makes synthesis more honest and readers more informed.
+
+---
+
+## Multi-channel triangulation as weighting
+
+When patterns appear across multiple channels, weighting becomes easier.
+
+**Strong cross-channel signal.** Same pattern in support, NPS, in-app, and sales. The cross-channel pattern survives any single channel's bias.
+
+**Single-channel signal.** Pattern in only one channel. Weighting depends on channel reliability for the decision; treat with more caution.
+
+**Conflicting cross-channel signal.** Different channels disagree. Investigate the source of the conflict; the disagreement often reveals segment differences or context-specific patterns.
+
+The discipline. Cross-channel triangulation is a form of weighting: patterns that survive multiple channels' biases are more reliable signal.
+
+---
+
+## Weighting in tooling
+
+Some feedback aggregation tools support explicit weighting (priority scores, segment-specific dashboards).
+
+**Tooling support.**
+
+- Tagging by source channel and segment.
+- Filtering and grouping by tag combinations.
+- Dashboards that show signal per segment or channel.
+
+**The tooling principle.** Tooling supports weighting; the weighting judgment still belongs to humans. Tools that automate weighting away from human judgment risk false precision.
+
+**The build-vs-buy tension.** Many programs end up with custom dashboards or filtering that supports their specific weighting. Generic tooling rarely supports the program's specific decision-relative weighting needs out of the box.
+
+---
+
+## Common weighting failures
+
+**No weighting.** All sources treated equally. Averaged-noise pattern.
+
+**Static weighting.** Same weights regardless of decision. Misses that different decisions need different weights.
+
+**Quantitative false precision.** Scoring systems that produce decisions without judgment.
+
+**Volume as proxy for weight.** Loudest-voice pattern; whoever generates most feedback wins.
+
+**Bias acknowledgment skipped.** Synthesis claims stronger signal than the channel's bias warrants.
+
+**Single-channel reliance.** Decisions made on one channel's signal without triangulation.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The decision-relative weighting principle. Worked weighting examples for different decisions. The averaged-noise and loudest-voice failures. How to set weights. Source bias acknowledgment. Multi-channel triangulation. Weighting in tooling. Common failures.
+
+## Implementation choices that stay internal
+
+Specific weighting conventions for specific decision types. Specific tooling that supports weighting. Specific dashboard configurations. The team's own conventions for naming weighting choices in synthesis. These vary by team.

--- a/skills/user-feedback-aggregation/references/channel-types-and-what-each-surfaces.md
+++ b/skills/user-feedback-aggregation/references/channel-types-and-what-each-surfaces.md
@@ -1,0 +1,263 @@
+# Channel types and what each surfaces
+
+Six common feedback channels with strengths, weaknesses, biases, and synthesis implications. Each channel surfaces different signal at different reliability; strong aggregation triangulates across channels.
+
+---
+
+## Channel 1: Support tickets
+
+What users hit when things break or confuse them.
+
+**What support surfaces.**
+
+- Functional friction (where the product breaks down for users).
+- Documentation gaps (questions users ask repeatedly).
+- Feature requests that arrive in the form of complaints.
+- Edge case failures.
+- Confusion about intended behavior vs actual behavior.
+
+**Strengths.**
+
+- High volume; signal accumulates from many users.
+- Grounded in specific user contexts (the user was trying to do something specific).
+- Captures friction users actually encountered, not friction they speculated about.
+
+**Weaknesses.**
+
+- Bias toward users willing to contact support. Users who silently leave the product do not appear here.
+- Bias toward fixable issues. Users who struggle but figure it out (or give up) without contacting support are invisible.
+- Sentiment skew: users contact support when frustrated; positive experience is underrepresented.
+
+**Synthesis implications.**
+
+- Support volume on a feature area is a strong signal of friction; absence of volume is weak signal of satisfaction.
+- Pattern-detection across tickets reveals systemic issues better than individual tickets.
+- Combine with usage analytics: a feature with high support volume and low usage suggests broken value; high support volume and high usage suggests meaningful friction in something users still want.
+
+---
+
+## Channel 2: NPS surveys
+
+Aggregate sentiment toward the product or specific features.
+
+**What NPS surfaces.**
+
+- Aggregate sentiment trend lines.
+- Distribution between promoters, passives, and detractors.
+- Open-ended comments (often the most useful part).
+- Sentiment differences across segments.
+
+**Strengths.**
+
+- Quantitative signal that aggregates across many users.
+- Trends over time reveal whether sentiment is improving or degrading.
+- Open-ended comments provide qualitative depth.
+- Industry-standard metric makes benchmarking possible.
+
+**Weaknesses.**
+
+- Response bias. Users with strong opinions (positive or negative) respond at higher rates than users in the middle.
+- Cultural and segment biases in scoring (some segments score lower on average than others for cultural reasons).
+- The 0-10 scale loses granularity; many decisions need more than promoter/passive/detractor categorization.
+- Surveys on specific features can have small sample sizes that produce noisy signal.
+
+**Synthesis implications.**
+
+- NPS as a single number is less useful than NPS distribution and trend.
+- Open-ended comments are often the highest-value section; mine them for patterns.
+- Segment-specific NPS is more actionable than aggregate NPS.
+- Single-quarter NPS shifts can be noise; multi-quarter trends are more reliable signal.
+
+---
+
+## Channel 3: In-app feedback
+
+Friction at the moment users encounter it.
+
+**What in-app feedback surfaces.**
+
+- Contextual friction (the user was at a specific moment in the product when they submitted).
+- Ratings or sentiment scoped to specific features or flows.
+- Quick observations users would not bother to file as a ticket.
+
+**Strengths.**
+
+- Captures the moment. Friction is fresh; context is automatic (the system knows where the user was).
+- Lower friction submission than support tickets; surfaces issues users would not formally report.
+- Volume varies; some products see high in-app feedback, others minimal.
+
+**Weaknesses.**
+
+- Bias toward users who interact with the feedback widget. Some segments use it heavily; others rarely.
+- Quality varies. Quick submissions are often shallow.
+- Volume can overwhelm if the widget triggers too aggressively.
+
+**Synthesis implications.**
+
+- In-app feedback is best for detecting moment-specific friction.
+- Pair with usage analytics: where users submit feedback in the product is informative.
+- Filter by submission length and pattern; one-word submissions ("frustrating!") are weak signal compared to specific submissions ("I expected the export to include the filters I had applied; it did not").
+
+---
+
+## Channel 4: Sales calls
+
+Pre-purchase prospect perspective.
+
+**What sales calls surface.**
+
+- Objections prospects raise (what makes the sale hard).
+- Pricing-conversation patterns and price sensitivity by segment.
+- Competitive mentions (which competitors are top-of-mind, what differentiation prospects ask about).
+- The gap between marketing positioning and what sales actually leads with.
+- Prospect vocabulary for describing their situation (often different from internal product language).
+
+**Strengths.**
+
+- Prospect view of the product before they have invested in it. Reveals what attracts and what blocks adoption.
+- Competitive intelligence in the form of comparisons prospects make.
+- Hire criteria signal (why prospects would choose the product).
+
+**Weaknesses.**
+
+- Bias toward prospects, not existing customers. Existing-customer experience differs.
+- Sales-team interpretation can color how calls are tagged.
+- Stage selection matters: early-stage discovery calls reveal different things than late-stage closing calls.
+
+**Synthesis implications.**
+
+- Sales call data informs positioning, pricing, and adoption-hire-criteria decisions.
+- Combine with existing-customer feedback to understand the full lifecycle.
+- Lost-deal analysis (specifically, calls with prospects who did not buy) is a separate research mode that surfaces what the product would need to win.
+
+---
+
+## Channel 5: Social mentions
+
+Public commentary about the product.
+
+**What social mentions surface.**
+
+- Public sentiment in real time.
+- Comparison to competitors (often more honest than survey responses).
+- Use cases and use contexts the team did not anticipate.
+- Reputation signals (how the product is perceived in the broader market).
+
+**Strengths.**
+
+- Real-time signal.
+- Public visibility means the team can respond to issues that affect brand reputation.
+- Captures users who post publicly but would not file feedback through formal channels.
+
+**Weaknesses.**
+
+- Bias toward users willing to post publicly. Often skews toward enthusiasts (positive) or angry (negative); middle-ground users are quiet.
+- Volume can overwhelm; signal-to-noise ratio is low.
+- Anonymous accounts complicate weighting (who is this person? are they a real customer?).
+- Platform algorithms shape what is visible; the visible signal is not the full signal.
+
+**Synthesis implications.**
+
+- Social signal is one input, rarely a primary driver. Triangulate with other channels.
+- Track reputational themes (what the product is known for in the broader market).
+- Respond to specific issues that affect brand reputation; do not use social as the primary feedback prioritization channel.
+
+---
+
+## Channel 6: Customer councils
+
+Curated panels of customers in structured forums.
+
+**What customer councils surface.**
+
+- Curated customer perspective on strategic questions.
+- Deep discussion that reveals motivations and priorities.
+- Cross-customer patterns (council members compare notes; the team sees what they share).
+- Long-term relationship signal (council members commit time and engagement).
+
+**Strengths.**
+
+- High-quality feedback from selected customers.
+- Structured forum makes discussion deeper than ad-hoc feedback.
+- Council members often become advocates and references.
+
+**Weaknesses.**
+
+- Bias depends on selection. A council selected for size, role, or vocal customers will skew accordingly.
+- Council members are often outliers (engaged, willing to commit time); their perspective may not represent broader users.
+- Small sample size (usually 5-30 members); patterns from one council are weak signal.
+- Cost: councils require curation, scheduling, and ongoing relationship management.
+
+**Synthesis implications.**
+
+- Council feedback is valuable but limited; do not treat as representative of the full user base.
+- Use councils for strategic discussions, not for tactical prioritization.
+- Council patterns can be a leading indicator of broader user patterns; validate with other channels.
+
+---
+
+## Channels not covered here
+
+Some feedback channels are out of scope for this skill but worth naming.
+
+**Beta participants.** Covered by `beta-program-management`. Beta feedback is bounded to the beta period; this skill covers ongoing streams.
+
+**Discovery research interviews.** Covered by `discovery-research-synthesis`. One-off research projects, not always-on streams.
+
+**App store reviews.** A specific channel for consumer products. Similar dynamics to social mentions: public, biased toward strong opinions, real-time but volume-heavy.
+
+**Customer success quarterly business reviews.** Often produce structured customer feedback; can be treated as a council-like channel for top customers.
+
+**Internal employee feedback.** Sometimes valuable (employees are users of internal tools, or use the product alongside customers); always biased toward internal context.
+
+---
+
+## Cross-channel triangulation
+
+Patterns that appear across channels are stronger than patterns from a single channel.
+
+**Worked example.** A feature area showing:
+
+- Support tickets: increasing volume in this area.
+- NPS comments: this area mentioned negatively in detractor comments.
+- In-app feedback: friction submissions in this area.
+- Sales calls: prospects asking about this area as a comparison point against competitors.
+
+The cross-channel pattern is stronger than any single-channel signal. The feature area is a load-bearing issue across multiple lenses.
+
+**Worked counter-example.** A loud single-channel signal:
+
+- Social mentions: vocal complaints about a feature.
+- Support tickets: minimal volume on the same feature.
+- NPS: feature not flagged in detractor comments.
+- Sales calls: feature not raised by prospects.
+
+The cross-channel pattern shows the social signal is loud but not load-bearing. Loud-on-one-channel-only is often vocal-minority signal.
+
+---
+
+## Channel reliability calibration
+
+Different channels have different reliability for different kinds of decisions.
+
+**Functional friction decisions.** Support tickets and in-app feedback are most reliable. NPS is moderate. Social and sales are less reliable.
+
+**Adoption hire-criteria decisions.** Sales calls are most reliable. Support tickets and in-app feedback are less reliable (existing-customer bias).
+
+**Positioning decisions.** Sales calls and social mentions are most reliable (prospect/public perception). NPS and councils are moderate.
+
+**Strategic prioritization.** Customer councils and NPS trends are useful inputs. Support tickets indicate friction but not strategic priority.
+
+**Reputation decisions.** Social mentions are direct signal. Support and NPS are indirect.
+
+The discipline. For each decision, identify which channels are most reliable. Weight accordingly.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The six channel types with strengths, weaknesses, biases, and synthesis implications. Channels not covered. Cross-channel triangulation. Channel reliability calibration for different decision types.
+
+## Implementation choices that stay internal
+
+Specific tooling per channel. Specific tagging schemas. Specific integration patterns across channels. The team's own conventions for channel coverage. These vary by team and tooling.

--- a/skills/user-feedback-aggregation/references/closing-the-loop-with-users.md
+++ b/skills/user-feedback-aggregation/references/closing-the-loop-with-users.md
@@ -1,0 +1,246 @@
+# Closing the loop with users
+
+When and how to communicate feedback-driven changes. The over-promising risk.
+
+Closing the loop is the practice of telling users when their feedback drove a product change. Done well, it strengthens the feedback relationship; users see their input matter. Done badly, it over-promises or appears performative; trust erodes.
+
+---
+
+## Why closing the loop matters
+
+Users who provide feedback are doing the team a favor. The cost is their time and attention. The return on their investment is, in part, seeing their input acted on.
+
+**What happens when the loop is open.**
+
+- Users provide feedback.
+- The team uses it (or does not).
+- Users do not know what happened.
+- Engagement decays. Why provide feedback if it does not seem to matter?
+
+**What happens when the loop is closed.**
+
+- Users provide feedback.
+- The team uses it (or explains why not).
+- Users see their input matter.
+- Engagement strengthens. Future feedback flows.
+
+---
+
+## What gets communicated
+
+Three categories of communication.
+
+**Changes shipped.** "We shipped X this week. Many of you reported Y was painful; X addresses that."
+
+- Specific, actionable, ties to specific feedback.
+- Best when the team can quantify the change ("Step 3 deferral; activation rate increased from 32% to 41% in the first month").
+
+**Changes coming.** "We are working on X for Q3. Several of you have asked about this; here is the timeline."
+
+- Specific timeline.
+- Honest about uncertainty if applicable.
+- Risk: over-promising. Communicating coming changes that do not ship erodes trust.
+
+**Decisions to defer or decline.** "We have heard feedback about X; we are choosing not to prioritize it because Y. Here is the reasoning."
+
+- Honest about the deferral.
+- Explains the reasoning.
+- Treats users as capable of understanding tradeoffs.
+
+The third category is rarely done; it is the most credibility-building. Teams that explain why something was not prioritized earn more trust than teams that promise everything.
+
+---
+
+## Communication channels
+
+How to close the loop.
+
+**Public channels.**
+
+- **Release notes.** Standard post-launch communication. Includes feedback context where relevant.
+- **Blog posts or changelog.** Longer-form for major changes. Names the feedback patterns that drove the work.
+- **Public roadmap.** Shows what is coming; signals that user feedback informs prioritization.
+
+**Targeted channels.**
+
+- **Email to users who reported the issue.** "You reported X; we shipped Y to address it." Personalized; high impact for specific users.
+- **In-app notification at the moment of relevance.** When the user encounters the changed flow, an in-product banner: "We changed this based on feedback like yours; here is what is different."
+- **Customer success outreach.** For high-value or high-engagement users, direct outreach is appropriate.
+
+**Community channels.**
+
+- **Beta or community forums.** Where applicable, communicate to the engaged community.
+- **Social media.** For high-visibility changes; risk of public attention if poorly communicated.
+
+The channel should match the audience and the change. High-impact public changes warrant public communication; targeted changes warrant targeted communication.
+
+---
+
+## Frequency and timing
+
+When to close the loop.
+
+**Immediately after shipping.** Most effective. The change is fresh; users remember providing feedback.
+
+**Periodic recap (monthly or quarterly).** "Here are the changes we shipped this quarter, and the feedback patterns that motivated them."
+
+- Useful for changes that did not warrant individual announcement.
+- Builds an aggregate sense that feedback is shaping the product.
+
+**Before shipping (preview).** "We are about to ship X; here is what to expect."
+
+- Heads-up for users who will encounter the change.
+- Risk: pre-launch announcements that get delayed; users wonder when the change is coming.
+
+The frequency calibration. Avoid silence (users feel ignored). Avoid over-communication (users tune out). Calibrate to the change cadence and audience attention.
+
+---
+
+## The over-promising risk
+
+Communicating future changes that do not ship erodes trust.
+
+**The pattern.**
+
+- The team announces "we are working on X" with a timeline.
+- The work gets deprioritized, delayed, or canceled.
+- Users who counted on the change feel deceived or ignored.
+
+**Why it happens.**
+
+- Marketing or stakeholder pressure to share roadmap information.
+- The team's own optimism about timelines.
+- Failure to communicate when plans change.
+
+**The cure.**
+
+- Communicate shipped changes with confidence.
+- Communicate coming changes with appropriate hedging ("we are exploring this," "we are planning this for next quarter").
+- Communicate plan changes when they happen, not silently.
+
+**The honest framing.** Promising "X will ship in Q3" is high-risk; promising "X is on our radar; we are evaluating priority" is honest. The first looks more confident; the second is more credible over time.
+
+---
+
+## Communication for declined or deferred feedback
+
+When the team decides not to prioritize requested changes.
+
+**The pattern.**
+
+- User provides feedback requesting a change.
+- The team evaluates and decides not to prioritize.
+- The team communicates the decision.
+
+**Strong communication.**
+
+- "Several of you have asked about [feature]. We have evaluated and are choosing not to prioritize it this year because [reason]. Here are alternatives or workarounds that may help in the meantime."
+- "We hear the feedback about [issue]. We are choosing not to address this for now because [tradeoff]. We are open to reconsidering if the pattern strengthens."
+
+**Why it builds trust.**
+
+- Acknowledges the feedback was heard.
+- Explains the reasoning.
+- Treats the user as capable of understanding tradeoffs.
+
+**The risk of avoiding.**
+
+- Silence. The user wonders if the feedback was heard.
+- "Maybe in the future." Vague commitments that do not commit.
+- "We will consider it." Performative.
+
+The decline communication is rare in practice but disproportionately valuable.
+
+---
+
+## Communication for high-volume feedback
+
+When many users have provided similar feedback.
+
+**The pattern.**
+
+- A specific change addresses widely-reported feedback.
+- The team has many users to potentially notify.
+
+**Approaches.**
+
+- **Public announcement** referencing the feedback pattern. "Many of you reported X; we shipped Y."
+- **Targeted email to users who reported the issue** (using support ticket history, NPS comments, etc.).
+- **In-product notification** at the moment of relevance.
+
+**The capacity calibration.** Targeted communication is high-effort; public communication scales. Most programs combine: public announcement for visibility, targeted communication for highest-impact users.
+
+---
+
+## Personal vs aggregate
+
+Sometimes the closing-the-loop communication is to a specific user; sometimes it is aggregate.
+
+**Personal.**
+
+- "John, you reported X two months ago. We shipped Y this week to address it. Thanks for the feedback that informed this work."
+- Direct email or in-app message.
+- High impact for the specific user; low cost; very high relationship value.
+
+**Aggregate.**
+
+- "Many of you have asked about X; we shipped Y this week."
+- Public announcement; reaches many users.
+- Lower per-user impact but scales.
+
+The discipline. Personal communication for high-impact users (long-tenured customers, design partners, council members). Aggregate for broader changes.
+
+---
+
+## When closing the loop fails
+
+Common failures.
+
+**Silence.** The most common failure. Users provide feedback; the team uses it (or does not); users never know what happened. Engagement decays.
+
+**Generic acknowledgment.** "Thanks for the feedback! We will look into it." Standard auto-reply that everyone gets. Feels performative; closes the loop technically but not meaningfully.
+
+**Over-promising.** "We will ship this in Q3." The team misses the date or cancels; users feel deceived.
+
+**Late communication.** Changes shipped months ago; communication never happens; users stopped using the product.
+
+**Vague communication.** "We have heard your feedback and are working on improvements." No specifics; users cannot tell what was actually changed.
+
+**No deferral communication.** Changes the team decided not to prioritize go uncommunicated. Users keep wondering or assume the feedback was ignored.
+
+**Communication only on shipping.** Successes communicated; failures and deferrals never. Trust erodes when users notice the asymmetry.
+
+---
+
+## Closing the loop and feedback volume
+
+Programs that close the loop well often see feedback volume increase over time. Users who saw their input matter contribute more.
+
+**The virtuous cycle.**
+
+- Feedback closes the loop.
+- Users see their input matter.
+- Engagement strengthens.
+- Feedback volume and quality increase.
+- The team has more signal to act on.
+
+**The vicious cycle.**
+
+- Feedback aggregation happens in silos.
+- Closing the loop does not happen.
+- Users feel ignored.
+- Engagement decays.
+- Feedback volume and quality decrease.
+- The team has less signal.
+
+The discipline. Closing the loop is an investment in the future of the feedback program.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+Why closing the loop matters. What gets communicated. Communication channels. Frequency and timing. The over-promising risk. Communication for declined or deferred feedback. Communication for high-volume feedback. Personal vs aggregate. Common failures. The virtuous and vicious cycle.
+
+## Implementation choices that stay internal
+
+Specific email templates for closing-the-loop communication. Specific automation that triggers communication. Specific in-product notification systems. The team's own conventions for personal vs aggregate. These vary by team.

--- a/skills/user-feedback-aggregation/references/common-feedback-aggregation-failures.md
+++ b/skills/user-feedback-aggregation/references/common-feedback-aggregation-failures.md
@@ -1,0 +1,193 @@
+# Common feedback aggregation failures
+
+Eleven-plus failure patterns with diagnoses and cures. The cross-cutting pattern: most feedback aggregation failures share a single root, which is treating feedback aggregation as collection rather than as decision input.
+
+---
+
+## Failure 1: Loudest customers steer the roadmap
+
+**Symptom.** A small number of vocal customers dominate roadmap discussions. Quieter customers' needs go unaddressed. The product evolves to serve the loudest, not the broadest.
+
+**Diagnosis.** Loudest-voice pattern. Volume from vocal users mistaken for broad signal.
+
+**Cure.** Apply channel-source weighting. Distinguish between distinct-user signal and per-user volume. Triangulate across channels to validate that loud signal represents broad pattern.
+
+**Prevention.** Synthesis names the source distribution explicitly. "This pattern came from 50 distinct users across 3 channels" is different from "this pattern came from 5 users with 200 tickets."
+
+---
+
+## Failure 2: We have lots of feedback but no decisions
+
+**Symptom.** Feedback channels overflow. Tagging happens. Dashboards exist. Decisions get made on intuition rather than on the feedback signal.
+
+**Diagnosis.** Aggregation without synthesis. The triage cadence is missing or broken; feedback is collected without being turned into decision input.
+
+**Cure.** Establish the synthesis cadence (weekly, monthly, quarterly). Each cadence produces output the team uses for decisions.
+
+**Prevention.** Synthesis ownership explicit. Whoever owns synthesis is accountable for the loop's continuity.
+
+---
+
+## Failure 3: Our channels overflow; we cannot keep up
+
+**Symptom.** Feedback volume exceeds the team's capacity to triage, tag, and synthesize. Old feedback never gets reviewed; new feedback piles up.
+
+**Diagnosis.** Capacity mismatch. Either tooling does not scale, or the team is under-staffed for the volume, or both.
+
+**Cure.** Scale tooling: AI-assisted tagging, aggregated channels, automated pattern surfacing. Or reduce capture: not every channel needs to be aggregated.
+
+**Prevention.** Match tooling and capacity to expected volume. Plan for growth; the volume that is comfortable today often is not in 6 months.
+
+---
+
+## Failure 4: Different teams cite different feedback for the same decision
+
+**Symptom.** Engineering team cites one feedback pattern; product team cites another; sales team cites a third. The teams reach for whatever feedback supports their position.
+
+**Diagnosis.** Channel-source weighting absent. Each team uses the channel that is most accessible to them, regardless of decision relevance.
+
+**Cure.** Establish weighting per decision. The synthesis surfaces what the relevant channels say, weighted appropriately. Teams use the synthesis rather than going to channels independently.
+
+**Prevention.** Centralize synthesis ownership. The synthesis owner produces the canonical view; teams reference it rather than producing parallel interpretations.
+
+---
+
+## Failure 5: Customer council meetings produce notes nobody references
+
+**Symptom.** Customer council convenes regularly. Notes are taken. Decks summarize. The notes get filed; no roadmap discussions reference them.
+
+**Diagnosis.** Council without synthesis loop. The meeting is the deliverable; the analytical follow-through is missing.
+
+**Cure.** Apply the synthesis loop to council inputs. Each council meeting produces specific actionable input that feeds product decisions.
+
+**Prevention.** Treat council inputs as part of the broader feedback aggregation, not as a separate stream that produces ceremonial outputs.
+
+---
+
+## Failure 6: NPS is reported monthly but does not inform decisions
+
+**Symptom.** NPS scores get reported in monthly business reviews. The number is part of compliance reporting. It does not inform product decisions.
+
+**Diagnosis.** NPS as compliance metric. The number gets tracked; the underlying signal does not.
+
+**Cure.** Mine NPS comments for patterns. Segment NPS by user segment. Use NPS trends as drift signal. The number itself is less informative than the underlying signal.
+
+**Prevention.** NPS reporting includes the qualitative signal alongside the quantitative score. Decisions reference what NPS comments revealed, not just the score.
+
+---
+
+## Failure 7: Feedback we shipped against did not move sentiment
+
+**Symptom.** Major feature shipped to address feedback. Post-launch sentiment did not improve. The team is confused.
+
+**Diagnosis.** Wrong feedback prioritized. The loud feedback was not the most consequential; the patterns the team addressed were not the patterns that drove sentiment.
+
+**Cure.** Re-examine the synthesis that motivated the work. Was the pattern strong across channels, or was it loud in one channel? Was the segment broad or narrow? Was the change the right response to the pattern?
+
+**Prevention.** Strong synthesis grounds prioritization in cross-channel patterns and frequency-intensity assessment. Single-channel signals get treated cautiously.
+
+---
+
+## Failure 8: Users gave feedback once and never returned
+
+**Symptom.** Users submit feedback through channels. They never engage again. Repeat feedback rates are low.
+
+**Diagnosis.** Closed-loop missing. Users feel ignored after providing feedback.
+
+**Cure.** Establish closing-the-loop communication. Tell users when their feedback drove change. Personal communication for high-impact users; aggregate for broader changes.
+
+**Prevention.** Closing the loop is part of the feedback workflow, not an afterthought. Decisions to ship include closing-the-loop communication as a step.
+
+---
+
+## Failure 9: We tagged everything but cannot find patterns
+
+**Symptom.** Tagging happens systematically. The team applies tags to most feedback items. But synthesis cannot identify clear patterns.
+
+**Diagnosis.** Taxonomy too granular, too coarse, or noisy. Periodic taxonomy review missing.
+
+**Cure.** Run a taxonomy review. Merge tags that fragment patterns; split tags that hide distinct issues; deprecate tags that no longer apply.
+
+**Prevention.** Quarterly or bi-annual taxonomy review. The taxonomy evolves with the program.
+
+---
+
+## Failure 10: Drift in feedback caught us by surprise
+
+**Symptom.** A feedback category grew significantly over weeks or months. The team discovered the change only when it became a problem.
+
+**Diagnosis.** Drift detection missing. The team did not investigate trending patterns until they became urgent.
+
+**Cure.** Establish drift detection: trend dashboards, threshold alerts, periodic trend review.
+
+**Prevention.** Weekly quick scans for sharp drift. Monthly systematic review of category trends. Tooling that surfaces changes automatically.
+
+---
+
+## Failure 11: Sales call data and support ticket data tell different stories
+
+**Symptom.** Sales suggests one priority; support suggests another. Both teams have data; the data conflicts.
+
+**Diagnosis.** Cross-channel synthesis missing. Each channel's signal stays in its own silo.
+
+**Cure.** Run cross-channel synthesis. Compare what sales calls reveal (prospect view) to what support tickets reveal (existing customer view). Often the conflict surfaces meaningful differences (different segments, different lifecycle stages); sometimes it surfaces inconsistency that warrants investigation.
+
+**Prevention.** Synthesis includes cross-channel triangulation. Conflicts get surfaced and resolved or acknowledged.
+
+---
+
+## Failure 12: Feedback aggregation as compliance
+
+**Symptom.** Feedback collection happens because customers expect it or because leadership mandates it. The collection is performative; the synthesis is minimal.
+
+**Diagnosis.** Feedback aggregation treated as ceremony rather than as decision input.
+
+**Cure.** Tie feedback aggregation to specific decisions. The synthesis informs roadmap; decisions reference patterns. If the team cannot trace decisions to feedback, the program is compliance, not aggregation.
+
+**Prevention.** Feedback program goals are explicit and tied to decisions. The program's success is measured by whether decisions reference its synthesis, not by whether feedback was collected.
+
+---
+
+## Failure 13: Synthesis that does not surface patterns
+
+**Symptom.** Monthly or quarterly synthesis happens. The output is descriptive but does not surface patterns or inform decisions.
+
+**Diagnosis.** Synthesis writing is documentation rather than analytical work. The patterns are not extracted; the implications are not drawn.
+
+**Cure.** Apply discovery-research-synthesis discipline to feedback synthesis. Patterns named with conviction; implications drawn; decisions informed.
+
+**Prevention.** Synthesis ownership includes analytical responsibility, not just documentation responsibility.
+
+---
+
+## Failure 14: Tooling-led process
+
+**Symptom.** The team's process follows what the tooling supports. Capabilities the tooling does not support do not happen.
+
+**Diagnosis.** Tooling drives the process rather than the process driving tooling selection.
+
+**Cure.** Step back. Define what the team needs the feedback aggregation to produce. Evaluate tooling against those needs.
+
+**Prevention.** Tooling decisions are downstream of process design. The team designs the process, then selects or builds tooling that supports it.
+
+---
+
+## The cross-cutting pattern
+
+Most feedback aggregation failures share a single root: treating feedback aggregation as collection rather than as decision input.
+
+Collection focuses on capturing feedback: channels integrated, items tagged, dashboards built, scores reported. Output: a record that feedback was collected.
+
+Decision input focuses on what the feedback informs: which decisions, what signal will inform them, what synthesis surfaces patterns the team needs. Output: decisions traceable to feedback patterns.
+
+The fix for almost any feedback aggregation failure starts with the same question: what specifically is this feedback program supposed to inform, and is the synthesis loop producing that input? When the answer is clear, the program becomes load-bearing. When the answer is "we should be aggregating feedback," the program becomes ceremony.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The fourteen failure patterns with diagnoses and cures. The cross-cutting collection-vs-decision-input pattern.
+
+## Implementation choices that stay internal
+
+Specific failure-pattern detection. Specific reviewer training. Specific intervention patterns. The team's own conventions for catching failures early. These vary by team.

--- a/skills/user-feedback-aggregation/references/detecting-drift-in-feedback.md
+++ b/skills/user-feedback-aggregation/references/detecting-drift-in-feedback.md
@@ -1,0 +1,236 @@
+# Detecting drift in feedback
+
+Drift patterns. Investigation discipline. Drift as early signal of change.
+
+Feedback signal changes over time. Volume in a category increases or decreases; new patterns emerge; old patterns disappear; sentiment shifts. The team that detects drift early often catches issues before they compound; the team that does not detect drift often discovers problems after they are large.
+
+---
+
+## The drift patterns
+
+Common ways feedback signal changes over time.
+
+### Increasing volume in a category
+
+**Signal.** Feedback volume in a specific area is rising over weeks or months.
+
+**Possible causes.**
+
+- The issue is worsening.
+- The user base is growing (more total volume across all categories).
+- Awareness of the channel is increasing (more users finding the feedback channel).
+- Recent product changes introduced or amplified an issue.
+
+**The investigation.** Look at the cause:
+
+- Is the percentage of total feedback in this category increasing? (If yes, this category is growing relative to others; the issue is real, not just user-base growth.)
+- Did recent product changes affect this area? (Often the cause when volume increases sharply.)
+- Are users describing similar issues in different ways? (Could be one underlying issue surfacing through multiple feedback styles.)
+
+### Decreasing volume in a category
+
+**Signal.** Feedback volume in a specific area is declining over weeks or months.
+
+**Possible causes.**
+
+- The issue was resolved.
+- Users gave up reporting (resignation rather than satisfaction).
+- The user base shifted (fewer users in the affected segment).
+- Channel access changed (users stopped using the feedback channel for this category).
+
+**The investigation.** Decreasing volume can be good or bad:
+
+- If a fix shipped and volume dropped: fix worked.
+- If no fix shipped but volume dropped: investigate. Are users churning? Are they working around the issue silently?
+
+### New patterns emerging
+
+**Signal.** Feedback that was rare or non-existent starts appearing more frequently.
+
+**Possible causes.**
+
+- Recent product changes introduced new patterns.
+- Market conditions changed (new competitors, new user expectations).
+- User base expansion brought new use cases.
+- Existing users developed new workflows.
+
+**The investigation.** Investigate the cause; new patterns often inform roadmap decisions.
+
+### Patterns disappearing
+
+**Signal.** Feedback patterns that used to be common stop appearing.
+
+**Possible causes.**
+
+- Product changes addressed the issue.
+- Users migrated away from the affected workflows.
+- The user base shifted.
+
+**The investigation.** Validate that the disappearance reflects resolution, not silent abandonment.
+
+### Sentiment shifts
+
+**Signal.** Aggregate sentiment (NPS, CSAT, in-app rating) trends differently than before.
+
+**Possible causes.**
+
+- Specific changes affected sentiment.
+- External factors (market conditions, competitor actions, news cycles).
+- User base composition changed.
+- Cumulative experience changes that the team did not flag individually.
+
+**The investigation.** Sentiment shifts warrant root-cause analysis; both improvements and degradations are informative.
+
+---
+
+## The drift detection cadence
+
+When the team checks for drift.
+
+**Weekly:** quick scans for sharp drift in critical categories. Sharp increases in support volume on specific issues, sudden NPS drops, viral social mentions.
+
+**Monthly:** systematic review of category-level trends. Compare the past month to prior months. Identify categories with significant increases or decreases.
+
+**Quarterly:** strategic drift review. Long-term trends, sentiment shifts, emerging patterns. Pairs with quarterly strategic synthesis.
+
+**Annually:** taxonomy and aggregate drift. Are tag categories still appropriate? Has the user base composition changed? Long-term sentiment trends.
+
+---
+
+## Tooling for drift detection
+
+What infrastructure helps catch drift.
+
+**Trend dashboards.** Time-series views of feedback volume per category. Visual surfacing of changes.
+
+**Threshold alerts.** Automated alerts when a category's volume changes significantly (e.g., 50%+ increase week-over-week).
+
+**Sentiment tracking.** NPS or CSAT trends over time, segmented by user segment and product area.
+
+**Cross-channel views.** Aggregate trends across channels surface patterns that single-channel views miss.
+
+**Period comparisons.** Compare current period to prior periods (this month vs last month, this quarter vs same quarter last year).
+
+The tooling supports detection; humans interpret.
+
+---
+
+## Investigation discipline
+
+When drift is detected, what to investigate.
+
+**The questions.**
+
+- What changed in the product or in the user base that could explain the drift?
+- Is the drift persistent or a temporary spike?
+- Is the drift segment-specific or universal?
+- Is the drift correlated with other signals (churn, engagement, support volume)?
+- What is the underlying cause vs the surface signal?
+
+**The investigation methodology.**
+
+- Pull a sample of feedback from the drifting category.
+- Compare it to feedback in the same category from before the drift started.
+- Identify what changed: language, contexts, severity, user segments.
+- Map to product changes or external events that could explain.
+- Form a hypothesis; test it through additional investigation.
+
+---
+
+## Drift as early signal
+
+Drift often signals issues before they become large.
+
+**The leading-indicator pattern.**
+
+- A category's volume starts increasing.
+- The team investigates and identifies the cause.
+- The cause is addressed before it affects more users.
+
+Without drift detection, the same issue might compound for months before the team notices.
+
+**Worked example.**
+
+- Support tickets in the "configuration step 3" category increase 30% in two weeks.
+- Investigation reveals: a recent change to the configuration form introduced a confusing default.
+- The change is reverted or fixed within a week.
+- Without drift detection, the issue might have continued for months, affecting many more users.
+
+---
+
+## Drift in segments
+
+Drift can be segment-specific.
+
+**The pattern.** Aggregate metrics look stable; segment-specific metrics show drift.
+
+**Worked example.** Aggregate NPS is stable. Enterprise NPS is dropping; small-team NPS is improving. The aggregate hides the segment-specific drift.
+
+**The investigation.** Segment-level views surface patterns the aggregate hides. Enterprise drift may indicate a specific issue with enterprise features or experience that aggregate metrics miss.
+
+The discipline. Drift detection should include segment views, not just aggregate views.
+
+---
+
+## Drift in cross-channel patterns
+
+Sometimes drift appears across channels even when individual channels look stable.
+
+**The pattern.** Each channel shows mild changes; the cross-channel aggregate shows a stronger pattern.
+
+**Worked example.** Support tickets in onboarding category up 15%. NPS comments mentioning onboarding up 10%. In-app feedback in onboarding up 20%. No single channel signals an emergency; the cross-channel aggregate suggests a real issue.
+
+**The investigation.** Cross-channel drift detection requires unified views or manual cross-channel review.
+
+---
+
+## False-positive drift
+
+Not every change is real drift.
+
+**Common false positives.**
+
+- Seasonal patterns: support volume drops over holidays; NPS dips during certain campaigns.
+- One-off events: a viral social mention spikes social signal but does not represent persistent change.
+- Product launches: short-term volume spikes around new features, then normalize.
+- Channel changes: a new feedback channel launches; volume in that channel grows from zero, not because the underlying issue grew.
+
+**The investigation discipline.** Before declaring drift, validate that the change is persistent and not explained by known factors.
+
+---
+
+## Drift acknowledgment in synthesis
+
+Drift signals get surfaced in monthly and quarterly synthesis.
+
+**The pattern.** Synthesis documents include a drift section: what is changing, what may explain it, what action (if any) is recommended.
+
+**The honest framing.** Some drift gets acknowledged but not actioned (low-priority categories, edge cases). Some drift drives investigation. Some drift drives roadmap decisions. The synthesis names the disposition for each drift signal.
+
+---
+
+## Common drift detection failures
+
+**No detection.** Aggregate volume is the only metric tracked; trends invisible.
+
+**Aggregate only.** Segment-specific drift hidden by aggregate stability.
+
+**Single-channel only.** Cross-channel patterns missed.
+
+**Late detection.** Drift caught after it has compounded for months.
+
+**False positives treated as real drift.** Seasonal patterns or one-off events trigger investigation that wastes time.
+
+**Real drift treated as false positive.** The team dismisses signals as noise; underlying issues compound.
+
+**Investigation without follow-through.** Drift detected; team investigates; finds cause; does not act. The detection was performative.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The drift patterns (increasing/decreasing volume, new/disappearing patterns, sentiment shifts). The drift detection cadence. Tooling for drift detection. Investigation discipline. Drift as early signal. Drift in segments. Drift in cross-channel patterns. False-positive drift. Drift acknowledgment in synthesis. Common failures.
+
+## Implementation choices that stay internal
+
+Specific dashboards for drift detection. Specific threshold settings for alerts. Specific seasonality models. Specific segment-view configurations. The team's own conventions for drift acknowledgment in synthesis. These vary by team.

--- a/skills/user-feedback-aggregation/references/frequency-vs-intensity.md
+++ b/skills/user-feedback-aggregation/references/frequency-vs-intensity.md
@@ -1,0 +1,231 @@
+# Frequency vs intensity
+
+The two dimensions of feedback signal. The four-quadrant matrix and prioritization implications.
+
+Feedback signal varies along two dimensions: how often the same feedback recurs (frequency) and how strongly users feel about it (intensity). The combination produces a matrix that informs prioritization.
+
+---
+
+## The two dimensions
+
+**Frequency.** How often the same feedback recurs across users.
+
+- High-frequency feedback: many users describe the same issue. Suggests broad applicability.
+- Low-frequency feedback: rare or unique observations. Suggests narrow applicability or edge cases.
+
+**Intensity.** How strongly the user feels.
+
+- High-intensity feedback: users describe the issue as severely disruptive ("I cannot use the product because of this"), or describe satisfaction as transformative ("This feature changed how my team works").
+- Low-intensity feedback: minor friction ("Slightly annoying") or mild satisfaction ("It's fine").
+
+The two dimensions are independent. High frequency does not imply high intensity; high intensity does not imply high frequency.
+
+---
+
+## The four-quadrant matrix
+
+### Quadrant 1: High frequency, high intensity
+
+**Top priority.** Many users hit this; it matters to them.
+
+**Examples.**
+
+- A bug that affects core flow for many users.
+- A friction point users describe as "I almost canceled because of this."
+- A feature gap that users repeatedly cite as a competitive disadvantage.
+
+**The disposition.** Address quickly. The combination of broad impact and high stakes warrants priority investment.
+
+### Quadrant 2: High frequency, low intensity
+
+**Papercuts.** Many users hit this but it is minor.
+
+**Examples.**
+
+- A confusing button label that users figure out within seconds.
+- A slight delay in a flow that users tolerate.
+- A small visual inconsistency.
+
+**The disposition.** Address in batches. Individual papercuts are minor; cumulatively they erode experience. Periodic "papercut sprints" address many at once.
+
+**The risk of ignoring papercuts.** Papercuts compound. Users who tolerate one papercut leave when they accumulate. The cumulative experience is worse than the sum of individual papercuts.
+
+### Quadrant 3: Low frequency, high intensity
+
+**Affected users deeply impacted but few.** Often segment-specific.
+
+**Examples.**
+
+- A bug that affects users in a specific configuration that 5% of customers use, but for those users it is blocking.
+- A feature gap that prevents enterprise customers from passing compliance review.
+- An accessibility issue that excludes a specific user group entirely.
+
+**The disposition.** Depends on segment importance and reversibility.
+
+- If the affected segment is strategically important: high priority.
+- If the affected segment is marginal: lower priority but documented.
+- If the issue is a complete blocker for the affected users (cannot use the product at all): often warrants urgency regardless of segment size.
+
+### Quadrant 4: Low frequency, low intensity
+
+**Noise.** Capture; do not action individually.
+
+**Examples.**
+
+- One-off observations from users with unusual contexts.
+- Minor preferences that one user mentions.
+- Edge cases nobody else encounters.
+
+**The disposition.** Note in the system. Do not invest action on individual items. Aggregate sometimes reveals patterns; the noise can become signal if patterns emerge.
+
+---
+
+## Frequency assessment
+
+How to assess frequency.
+
+**Quantitative signals.**
+
+- Number of distinct users reporting the same issue across channels.
+- Volume of feedback items in the relevant tag or category.
+- Trend over time: is the frequency increasing or stable?
+
+**Cautions.**
+
+- Volume can reflect channel bias rather than actual frequency. A loud single user generating 50 tickets is not high-frequency feedback (50x).
+- Channel coverage matters. If a feedback channel only reaches a subset of users, frequency in that channel does not reflect frequency across all users.
+
+**The cross-channel triangulation.** Issues that show up across multiple channels are higher-frequency than issues that appear in one channel only.
+
+---
+
+## Intensity assessment
+
+How to assess intensity.
+
+**Verbal signals.**
+
+- Strong language: "I cannot use this," "This is unacceptable," "I love this," "This changed my workflow."
+- Specific impact descriptions: "I lost 3 hours," "This made my quarterly review possible," "I missed a deadline."
+- Workaround intensity: heavy workarounds suggest high-intensity friction; light workarounds suggest low-intensity.
+
+**Behavioral signals.**
+
+- Churn correlation: users with feedback in a category churn at higher rates.
+- Engagement correlation: users with positive feedback in a category engage more.
+- Escalation patterns: users escalating to higher support tiers or to executive contacts signal high intensity.
+
+**Cautions.**
+
+- Some users naturally use stronger language than others.
+- Cultural differences affect verbal intensity.
+- Triangulate verbal and behavioral signals.
+
+---
+
+## The matrix in practice
+
+Worked example: a feedback aggregation review for a product team's quarterly planning.
+
+**Top-of-list items (high frequency, high intensity).**
+
+- Onboarding configuration step 3 abandonment (broad signal across support, NPS comments, in-app feedback; users describe it as "I almost gave up").
+- Mobile app stability issues (frequent mobile crashes; users describe them as blocking).
+- Enterprise admin role limitations (consistent across enterprise sales calls and support tickets; described as compliance blockers).
+
+**Papercut batch (high frequency, low intensity).**
+
+- Inconsistent button labeling across the product.
+- Slow page transitions in the dashboard.
+- Filter resets when navigating between views.
+- Date format inconsistencies.
+
+**Strategic-decision items (low frequency, high intensity).**
+
+- Specific accessibility issues affecting screen reader users.
+- Compliance gaps for healthcare-segment customers (small segment but blocking for them).
+- Bug affecting users in specific timezone configurations (5% of users, but blocking).
+
+**Noise-watch (low frequency, low intensity).**
+
+- Various individual feature requests with no aggregate pattern.
+- Cosmetic preferences mentioned by single users.
+
+The team's quarterly planning weights the four quadrants differently:
+
+- Top-of-list: included in the next quarter's roadmap.
+- Papercut batch: scheduled for a dedicated sprint.
+- Strategic decisions: discussed at strategy review for prioritization.
+- Noise-watch: captured but not actioned.
+
+---
+
+## When the matrix is misapplied
+
+Common matrix misuses.
+
+**Volume as proxy for frequency.** Loudest-voice users generate volume that does not reflect distinct-user frequency.
+
+**Intensity assessed only verbally.** Some users complain loudly about minor issues; some users underreport severe ones. Triangulate verbal and behavioral signals.
+
+**Quadrant 4 dismissed too quickly.** Some apparent noise is early-signal of patterns that will grow. Periodic review of low-frequency items catches emerging patterns.
+
+**Quadrant 3 generalized to quadrant 1.** Strategic-segment issues weighted as if they affected all users. Or marginal-segment issues weighted as if they were strategic.
+
+**Frequency-only or intensity-only prioritization.** Looking at one dimension misses the matrix.
+
+---
+
+## Frequency over time
+
+Frequency dimensions can shift over time.
+
+**Increasing frequency.** Issue is worsening, user base is growing, or reporting awareness is increasing. Investigate the cause.
+
+**Decreasing frequency.** Issue is resolving, users are giving up reporting, or the user base shifted. The decreasing frequency may not mean problem solved.
+
+**Stable frequency.** Issue is recurring at consistent rate. May indicate steady-state or chronic issue.
+
+The drift detection (see `detecting-drift-in-feedback.md`) covers temporal changes in feedback signal.
+
+---
+
+## Intensity at scale
+
+Intensity assessments at high feedback volume.
+
+**The challenge.** Reading every piece of feedback to assess intensity is impractical at high volume.
+
+**The approach.**
+
+- Sample-based intensity assessment. Read a sample; characterize the intensity distribution.
+- Behavioral signal as proxy. Churn rates, escalation patterns, support-tier escalations.
+- AI-assisted intensity classification. AI flags high-intensity feedback for human review.
+
+**The discipline.** Even at high volume, the team should be able to identify high-intensity feedback and weight it appropriately.
+
+---
+
+## Common frequency-intensity failures
+
+**Loudest-voice as high-frequency.** A few loud users generate volume; the team mistakes volume for frequency.
+
+**Intensity ignored.** Volume drives prioritization; intensity is not assessed; quadrant 1 and quadrant 2 get treated similarly.
+
+**Frequency ignored.** A single emotional submission gets prioritized as if it were broad-pattern signal.
+
+**Papercuts ignored as "low priority."** Cumulative papercut impact erodes experience; treating each papercut as too minor to address misses the cumulative effect.
+
+**Strategic-segment issues underweighted.** Quadrant 3 treated as quadrant 4 because the affected segment is small.
+
+**Noise treated as signal.** Quadrant 4 items that are genuinely one-off get actioned as if they were broad patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The two dimensions (frequency and intensity). The four-quadrant matrix with worked dispositions. Frequency assessment. Intensity assessment. The matrix in practice. When the matrix is misapplied. Frequency over time. Intensity at scale. Common failures.
+
+## Implementation choices that stay internal
+
+Specific tooling for frequency tracking. Specific intensity classification (manual or AI-assisted). Specific dashboard views by quadrant. The team's own conventions for matrix application in prioritization. These vary by team.

--- a/skills/user-feedback-aggregation/references/from-feedback-to-product-decision.md
+++ b/skills/user-feedback-aggregation/references/from-feedback-to-product-decision.md
@@ -1,0 +1,225 @@
+# From feedback to product decision
+
+The synthesis loop. Cadences. The discipline of decisions traceable to feedback.
+
+Feedback aggregation produces value when it informs decisions. Without the synthesis loop that turns aggregated feedback into decision input, the program produces volume without action.
+
+---
+
+## The synthesis loop
+
+The cycle that turns continuous feedback into continuous decisions.
+
+**The stages.**
+
+1. Feedback arrives across channels.
+2. Triage categorizes and weights.
+3. Periodic synthesis surfaces patterns.
+4. Patterns inform roadmap discussions, spec drafts, prioritization debates.
+5. Decisions reference specific feedback patterns as input.
+6. Decisions ship; the loop continues with new feedback informed by the changes.
+
+**The discipline.** The loop is continuous. Feedback aggregation is not a one-time research project; it is a steady-state discipline.
+
+---
+
+## The cadences
+
+Feedback synthesis benefits from multiple cadences operating in parallel.
+
+**Daily: critical issues.**
+
+- Critical feedback (security incidents, data loss, broken core flows) handled immediately.
+- The triage system surfaces critical items for immediate attention.
+- Response within hours to a day.
+
+**Weekly: pattern review.**
+
+- Team review of recent feedback patterns.
+- Categorization, tagging, and pattern identification.
+- Adjusts current-quarter execution where patterns suggest changes.
+- 1-2 hours per week typical.
+
+**Monthly: synthesis review.**
+
+- Surfaces trending patterns over the past month.
+- Identifies what to escalate to roadmap discussions.
+- Compares current month patterns to prior months (drift detection).
+- 2-4 hours per month.
+
+**Quarterly: strategic synthesis.**
+
+- Patterns over the quarter inform strategic planning and next-quarter roadmap.
+- Customer council inputs and other longer-cadence channels integrated.
+- Pairs with the team's broader strategic planning.
+- A multi-day effort within the quarter's planning cycle.
+
+The cadences compose. Critical issues do not wait for weekly review; weekly review captures patterns that monthly review aggregates; monthly synthesis informs quarterly strategic decisions.
+
+---
+
+## The synthesis output
+
+What each cadence produces.
+
+**Daily/critical:** specific incidents handled, no formal output beyond the response.
+
+**Weekly:** internal team notes on emerging patterns. May include a short summary email or dashboard update.
+
+**Monthly:** a synthesis document covering the month's patterns. Surfaces what is emerging, what is stable, what has resolved. Roadmap discussions reference this document.
+
+**Quarterly:** a strategic synthesis document. Trends over the quarter, recommendations for next quarter, strategic implications. Senior product leadership reviews this.
+
+The output gets richer at longer cadences. Daily and weekly are tactical; monthly and quarterly are strategic.
+
+---
+
+## Decisions traceable to feedback
+
+The discipline that distinguishes triaged-synthesis from feedback ceremony.
+
+**The pattern.** Each major product decision can be traced to specific feedback patterns. The team can articulate: "We decided to prioritize X because feedback showed Y pattern across Z channels."
+
+**The anti-pattern.** Decisions get made on intuition or politics. Feedback aggregation happens in parallel but does not inform the decisions. The team uses general impressions ("we hear a lot about this from customers") rather than specific patterns.
+
+**The discipline.**
+
+- Roadmap items reference the feedback patterns that motivated them.
+- Prioritization debates reference specific signal weight.
+- Spec drafts include feedback context for the design decisions.
+- Stakeholder communication explains decisions in terms of feedback patterns.
+
+**The audit.** For recent decisions, can the team trace each to specific feedback signals? If yes, the program is informing decisions. If the answer is "we generally know what customers want," the program is feedback theater.
+
+---
+
+## Roadmap input from feedback
+
+How feedback aggregation informs roadmap planning.
+
+**The roadmap inputs.**
+
+- High-frequency-high-intensity patterns (quadrant 1 from the frequency-intensity matrix).
+- Strategic-segment patterns (quadrant 3 from segments that matter for strategy).
+- Cross-channel patterns that have validated across multiple sources.
+- Drift signals that suggest emerging issues.
+
+**The roadmap-output mapping.** Roadmap candidates get characterized by which feedback patterns they address.
+
+- Candidate: "Onboarding redesign." Feedback motivation: configuration step 3 abandonment pattern across support, NPS, in-app feedback.
+- Candidate: "Enterprise admin overhaul." Feedback motivation: enterprise sales-call objections + enterprise customer support patterns.
+
+The mapping makes the roadmap defensible: each item has a feedback-grounded reason.
+
+**The "no feedback signal, no priority" discipline.** Candidates that lack feedback grounding may still be valuable but should be defensible on other grounds (technical foundation, strategic bet). Candidates without any defensible grounding should be deprioritized.
+
+Pair with `roadmap-planning` for the broader prioritization discipline.
+
+---
+
+## Spec input from feedback
+
+How feedback aggregation informs spec writing.
+
+**The pattern.** Specs reference feedback context for design decisions.
+
+**Worked example.** A spec for an onboarding redesign:
+
+- Background: feedback shows 40% of new signups abandon at configuration step 3. Cross-channel pattern (support tickets, in-app feedback, NPS comments).
+- User stories: grounded in the specific feedback patterns. "As a new signup, I want to defer credit-card configuration until after I have seen the value, so I do not need my card on hand at signup."
+- Design decisions: tied to the feedback. "Step 3 deferral chosen because feedback specifically cites credit-card-not-on-hand as the abandonment cause; alternative approaches that do not address this would not move the metric."
+
+The spec is grounded in feedback rather than in intuition.
+
+Pair with `pm-spec-writing` for the broader spec discipline.
+
+---
+
+## Stakeholder communication from feedback
+
+How feedback aggregation informs stakeholder discussions.
+
+**The pattern.** Decisions presented to stakeholders are explained in terms of feedback patterns.
+
+**Strong stakeholder communication.**
+
+- "We are prioritizing the onboarding redesign because feedback across support, NPS, and in-app surveys consistently shows 40%+ abandonment at configuration step 3, with users citing credit-card friction as the cause."
+- "We are deferring the dashboard expansion because feedback signal is mixed: enterprise customers want it; small-team customers do not need it; the strategic priority for this quarter is small-team activation."
+
+**Weak stakeholder communication.**
+
+- "We have heard a lot of feedback about onboarding."
+- "Customers want this feature."
+
+The strong version is defensible; readers can engage substantively. The weak version is hand-waving.
+
+---
+
+## Closing the synthesis loop
+
+After decisions ship, feedback responds.
+
+**The post-decision feedback.**
+
+- Did the change reduce the feedback patterns that motivated it?
+- Did new patterns emerge as a result?
+- Did the change introduce new friction in adjacent areas?
+
+**The discipline.** Track post-decision feedback to validate that the decision worked. Decisions that ship without post-decision feedback tracking lose the loop's learning value.
+
+---
+
+## Cadence drift
+
+When the synthesis cadence breaks down.
+
+**Common drift patterns.**
+
+- Critical issues handled but no weekly pattern review. Tactical signal lost.
+- Weekly review happens but does not aggregate to monthly synthesis. Patterns over time invisible.
+- Monthly synthesis happens but does not inform quarterly planning. Strategic input missing.
+- Quarterly strategic synthesis happens but the team does not act on it. Synthesis ceremony.
+
+**The signal.** When decisions stop being traceable to feedback, the cadence has drifted. The fix is restoring the cadence rather than blaming the team.
+
+---
+
+## Synthesis ownership
+
+Who owns the synthesis loop.
+
+**Common ownership patterns.**
+
+- A dedicated feedback program owner (often a senior PM, product ops, or customer-success-product liaison).
+- The product team's PM rotates through synthesis duties.
+- A customer feedback team that synthesizes and feeds product teams.
+
+**The discipline.** Whoever owns synthesis is accountable for the loop's continuity. Without explicit ownership, synthesis falls to whoever has time, which often means it does not happen.
+
+---
+
+## Common decision-loop failures
+
+**Synthesis without decisions.** Patterns surfaced; team does not use them. Documentation theater.
+
+**Decisions without synthesis grounding.** Team makes decisions on intuition; feedback aggregation happens in parallel but does not inform.
+
+**Cadence breakdown.** Daily critical handled; weekly and monthly synthesis fall behind. Loop loses continuity.
+
+**No post-decision tracking.** Decisions ship; feedback response not tracked; learning lost.
+
+**Synthesis ownership missing.** No clear owner; synthesis falls between roles.
+
+**Synthesis output not actionable.** Documents produced but framed in ways that do not inform decisions. Dense, generic, or unfocused.
+
+**Stakeholder communication still hand-waving.** Synthesis happens internally but stakeholder communication does not reference the patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The synthesis loop. The cadences (daily, weekly, monthly, quarterly). The synthesis output per cadence. Decisions traceable to feedback. Roadmap input. Spec input. Stakeholder communication. Closing the loop after decisions ship. Cadence drift. Synthesis ownership. Common failures.
+
+## Implementation choices that stay internal
+
+Specific tooling for synthesis production. Specific document templates per cadence. Specific reviewer workflows. Specific dashboard configurations. The team's own conventions for owning synthesis. These vary by team.

--- a/skills/user-feedback-aggregation/references/tooling-considerations.md
+++ b/skills/user-feedback-aggregation/references/tooling-considerations.md
@@ -1,0 +1,247 @@
+# Tooling considerations
+
+Tooling categories without specific endorsements. Criteria for selection. Build-vs-buy tension.
+
+Feedback aggregation tooling shapes what the program can do. The right tooling supports multi-channel aggregation, tagging at scale, pattern surfacing, and integration with adjacent systems. The wrong tooling produces silos, manual labor, and synthesis bottlenecks.
+
+This skill is platform-agnostic; specific products are not endorsed. The categories below describe what kinds of tooling exist; the team's actual product choices depend on stack, budget, and program shape.
+
+---
+
+## Tooling categories
+
+Several categories of tooling support feedback aggregation.
+
+### Customer feedback platforms
+
+**What they do.** Aggregate feedback from multiple sources. Support tagging and categorization. Surface patterns through dashboards and analytics.
+
+**Strengths.**
+
+- Multi-channel support (often integrate with support, NPS, in-app, and other sources).
+- Built-in tagging and pattern detection.
+- Often include AI-assisted categorization.
+
+**Weaknesses.**
+
+- Pre-built taxonomies may not fit team-specific needs.
+- Vendor-locked: switching costs grow over time.
+- Coverage varies by vendor; some channels may not integrate.
+
+### Support ticket systems with analytics
+
+**What they do.** Track support tickets with tagging, routing, and reporting. Often the primary support channel.
+
+**Strengths.**
+
+- Native to support workflows.
+- Strong tagging and routing for support-specific work.
+- Analytics on support-team metrics.
+
+**Weaknesses.**
+
+- Often single-channel (support only).
+- Cross-channel synthesis requires additional tooling or custom integration.
+
+### NPS or survey platforms
+
+**What they do.** Distribute surveys, collect responses, track sentiment trends.
+
+**Strengths.**
+
+- Specialized for survey distribution and response collection.
+- Built-in NPS or CSAT methodology.
+- Trend tracking over time.
+
+**Weaknesses.**
+
+- Single-modality (surveys only).
+- Limited integration with other feedback sources.
+
+### Customer relationship management (CRM) systems
+
+**What they do.** Manage customer relationships, contact history, deal pipelines, customer feedback fields.
+
+**Strengths.**
+
+- Rich customer context (segment, deal stage, account history).
+- Integration with sales workflows.
+
+**Weaknesses.**
+
+- Feedback aggregation is often a side feature, not a core function.
+- Cross-channel feedback synthesis requires additional configuration.
+
+### Custom dashboards combining feedback signal with usage analytics
+
+**What they do.** Custom-built views combining feedback data with product analytics.
+
+**Strengths.**
+
+- Tailored to the team's specific needs.
+- Cross-channel synthesis built-in to the design.
+- Combines feedback patterns with behavioral signals.
+
+**Weaknesses.**
+
+- Build cost and ongoing maintenance.
+- Skill requirements: data engineering or analytics expertise.
+
+---
+
+## The criteria for tooling selection
+
+What to evaluate when choosing tooling.
+
+**Multi-channel aggregation.** Does it integrate with the channels the team uses? Or does it cover one channel only?
+
+**Tagging at scale.** Does it support the tagging volume the program needs? Manual tagging at low volume; AI-assisted at high volume.
+
+**Pattern surfacing.** Does it surface patterns, or is it just storage? Some tools store feedback without making it analyzable.
+
+**Integration with other systems.** Does it connect to roadmap tools, ticketing systems, communication channels? Isolated tools produce silos.
+
+**Scaling.** Does it scale with program volume? Tools that work at 100 items/week may break at 1000 items/week.
+
+**Cost.** License or build cost vs the value produced. Expensive tooling that fits is sometimes worth it; cheaper tooling that does not fit is often more expensive in practice.
+
+**Team skill match.** Does the team have skills to use the tool effectively? Sophisticated tools that the team cannot operate produce value that does not get realized.
+
+---
+
+## The build-vs-buy tension
+
+Most programs end up with a mix.
+
+**The reasons to buy.**
+
+- Faster setup. Off-the-shelf tools work immediately.
+- Specialized expertise. Vendors have built tooling for many programs.
+- Standard features that the team would not build themselves.
+
+**The reasons to build.**
+
+- Cross-channel synthesis often requires custom work that off-the-shelf tools do not support.
+- Team-specific tagging schemas and dashboards.
+- Integration with the team's specific stack.
+
+**The hybrid pattern.**
+
+- Off-the-shelf tools for primary channels (support ticketing, NPS surveys).
+- Custom dashboards for cross-channel synthesis.
+- Custom integration to bring data together.
+
+The hybrid is more common than pure build-or-pure-buy in practice.
+
+---
+
+## Volume considerations
+
+Different volume tiers warrant different tooling approaches.
+
+**Low volume (under 100 items/week).**
+
+- Manual tagging is feasible.
+- Off-the-shelf tools usually sufficient.
+- Custom build often overkill.
+
+**Mid volume (100-1000 items/week).**
+
+- AI-assisted tagging often worth the investment.
+- Multi-channel aggregation tools earn their keep.
+- Custom dashboards often add value.
+
+**High volume (1000+ items/week).**
+
+- Heavy AI-assisted or automated tagging.
+- Custom infrastructure for cross-channel synthesis.
+- Team capacity becomes the bottleneck; tooling must reduce manual work substantially.
+
+**Very high volume (10,000+ items/week).**
+
+- Often requires custom data engineering.
+- Sampling and aggregation strategies replace per-item review.
+- Tooling investment is substantial.
+
+---
+
+## Integration considerations
+
+Feedback aggregation rarely lives alone.
+
+**Common integrations.**
+
+- **Roadmap tools.** Feedback patterns feed roadmap candidates. Tools that integrate (or are linked through workflows) reduce manual transfer.
+- **Spec writing.** Feedback context for spec drafts.
+- **Communication channels.** Slack or email for surfacing patterns to the team.
+- **Customer success systems.** Closing the loop with users; account-level feedback views.
+- **Product analytics.** Cross-reference feedback with usage patterns.
+
+**The integration discipline.** Tooling that integrates produces value compound across the systems. Isolated tooling produces silos that the team must manually bridge.
+
+---
+
+## AI-assisted feedback work
+
+AI plays an increasing role in feedback aggregation.
+
+**Common AI uses.**
+
+- Automatic categorization and tagging.
+- Sentiment classification.
+- Pattern surfacing across feedback items.
+- Summary generation for synthesis documents.
+- Anomaly detection for drift identification.
+
+**The discipline.**
+
+- AI suggestions get human review at pattern-level.
+- Critical decisions remain human-driven; AI accelerates the work.
+- AI's biases (overfitting to training data, surface-level patterns) get checked through human pattern review.
+
+**The honest framing.** AI does not replace human synthesis; it supports it. Programs that automate synthesis entirely produce volume without judgment; programs that integrate AI with human review produce signal at scale.
+
+See `ai-content-collaboration` for the broader workflow discipline that applies to AI-assisted feedback work.
+
+---
+
+## Privacy and data considerations
+
+Feedback often contains user information.
+
+**Considerations.**
+
+- User consent for feedback use beyond the immediate channel.
+- Anonymization where appropriate (especially for sensitive feedback).
+- Data retention policies.
+- Compliance with regulations (GDPR, CCPA, industry-specific).
+
+**The discipline.** Tooling choices include data handling considerations. Vendors with poor data practices can create compliance issues regardless of tool capability.
+
+---
+
+## Common tooling failures
+
+**Single-channel reliance.** Tooling supports only one channel; cross-channel synthesis impossible without additional work.
+
+**Overly generic tools.** Pre-built taxonomies and dashboards do not match team needs.
+
+**Custom build that consumes capacity.** Building feedback infrastructure absorbs PM and engineering capacity that should produce product.
+
+**Volume mismatch.** Tools that fit current volume break when the program scales.
+
+**Integration neglected.** Feedback tooling isolated from roadmap, spec, customer success systems.
+
+**AI without review.** Automated categorization without human pattern review produces patterns the team cannot trust.
+
+**Tooling-led process.** The tool drives the process rather than the process driving tool selection. The team adopts a tool's workflow rather than designing for their needs.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The tooling categories. The criteria for selection. The build-vs-buy tension. Volume considerations. Integration considerations. AI-assisted feedback work. Privacy and data considerations. Common failures.
+
+## Implementation choices that stay internal
+
+Specific tooling vendor selections. Specific integration configurations. Specific dashboard designs. Specific data pipelines. The team's own conventions for tool evaluation. These vary by team, stack, and program shape.


### PR DESCRIPTION
Direction 7 Dispatch B. 5 PM skills shipped as a grouped dispatch: discovery-research-synthesis, jtbd-framing, okr-design, beta-program-management, user-feedback-aggregation. Single branch with separate commits per skill. Each skill includes 13-14 section SKILL.md (~2800-3000 words) plus 8-9 reference files.

## Skills (in commit order)

1. discovery-research-synthesis (research category) — synthesizing customer interviews, support tickets, sales calls into actionable PM decisions. Keystone: data-dump / insight-theater / actionable-synthesis.
2. jtbd-framing (product category) — Jobs-to-be-Done as applied product methodology. Keystone: feature-request-list / persona-theater / job-framing.
3. okr-design (product category) — OKRs as actually shipped. Keystone: sandbagged / aspirational-fantasy / stretch.
4. beta-program-management (product category) — running betas that produce real signal. Keystone: soft-launch / kitchen-sink / structured-beta.
5. user-feedback-aggregation (research category) — continuous feedback synthesis. Keystone: loudest-voice / averaged-noise / triaged-synthesis.

## Catalog growth

- 81 → 86 skills
- 271 → 315 reference files (+44: 9+8+9+9+9)
- Lint: 86 skills validated, 1 warning (documentation-strategy outlier preserved)

## Closes Direction 7

Dispatch A (Tier 2 content) + Dispatch B (remaining PM) = 9 skills total. Catalog now at 86 flagships before Walkthroughs Direction begins.

Companion landing pages in rampstackco-app PR.