### PR TITLE
feat(skills): add Growth Tooling Tier 1 (6 skills, new audience track)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-86-blue.svg)](#the-86-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-92-blue.svg)](#the-92-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 86 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 92 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -35,7 +35,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 86-skill catalog](#the-86-skill-catalog)
+- [The 92-skill catalog](#the-92-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -63,8 +63,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **86 skills** across 15 categories, every one with a complete `SKILL.md` and at least one reference file
-- **315 reference files** (templates, checklists, decision matrices, worked examples)
+- **92 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
+- **369 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -253,11 +253,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 86-skill catalog
+## The 92-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 86 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 92 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -389,45 +389,58 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 67 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
 | 68 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
+### Growth tooling (6)
+
+Interactive web tools that turn visitors into leads. Lead magnets, calculators, quizzes, multi-step forms, chatbots, and the cross-tool funnel architecture that orchestrates them.
+
+| # | Skill | What it does |
+|---|---|---|
+| 69 | [`lead-magnet-design`](skills/lead-magnet-design/SKILL.md) | Designing gated content that earns the email. Distinguishes thin-bait (overpromises, underdelivers) from kitchen-sink-resource (everything, helps with nothing) from earned-value-magnet (delivers standalone value while qualifying the lead) |
+| 70 | [`calculator-design`](skills/calculator-design/SKILL.md) | Designing interactive calculators that deliver decision-support value while qualifying leads. Distinguishes vanity-calculator (no real value) from lead-trap (hides answer behind email) from transparent-decision-tool (gives genuine value, captures leads honestly) |
+| 71 | [`quiz-and-assessment-design`](skills/quiz-and-assessment-design/SKILL.md) | Designing quizzes and assessments that produce actionable segmentation. Distinguishes clickbait-quiz (engagement only) from vanity-result (entertaining, not useful) from actionable-segmentation (genuine categorization that drives next-step recommendations) |
+| 72 | [`multi-step-form-design`](skills/multi-step-form-design/SKILL.md) | Designing multi-step forms that respect cognitive load while maintaining completion intent. Distinguishes kitchen-sink-single-page (overwhelms) from progress-theater (steps without genuine staging) from genuinely-staged (each step earns its own page) |
+| 73 | [`chatbot-flow-design`](skills/chatbot-flow-design/SKILL.md) | Designing conversational flows for chatbots and AI agents on websites. Distinguishes scripted-bot (rigid trees, fail edge cases) from hallucinating-bot (LLM without structure, makes things up) from structured-guided-conversation (LLM-powered with intent architecture and fallback discipline) |
+| 74 | [`funnel-flow-architecture`](skills/funnel-flow-architecture/SKILL.md) | Architecting cross-tool conversion flows that match audience and stage. Distinguishes silo-funnels (every tool standalone) from kitchen-sink-funnels (every audience squeezed through one path) from matched-funnels (architecture matched to audience-and-stage) |
+
 ### Marketing (3)
 
 Paid media discipline: strategy, creative, and performance analytics. Pairs with the paid media platforms in the /integrations catalog at rampstack.co.
 
 | # | Skill | What it does |
 |---|---|---|
-| 69 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
-| 70 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
-| 71 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
+| 75 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
+| 76 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
+| 77 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
 
 ### Research (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 72 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 73 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 74 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
-| 75 | [`discovery-research-synthesis`](skills/discovery-research-synthesis/SKILL.md) | Synthesizing customer interviews, research notes, and support tickets into actionable PM decisions. Distinguishes data-dump (no synthesis) from insight-theater (overpolished narrative) from actionable synthesis (decision-grade clarity) |
-| 76 | [`user-feedback-aggregation`](skills/user-feedback-aggregation/SKILL.md) | Collecting and synthesizing user feedback across channels into continuous decision signal. Triage discipline that distinguishes loudest-voice (whoever complains most) from averaged-noise (every signal weighted equally) from triaged-synthesis (weighted by source quality and decision relevance) |
+| 78 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 79 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 80 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 81 | [`discovery-research-synthesis`](skills/discovery-research-synthesis/SKILL.md) | Synthesizing customer interviews, research notes, and support tickets into actionable PM decisions. Distinguishes data-dump (no synthesis) from insight-theater (overpolished narrative) from actionable synthesis (decision-grade clarity) |
+| 82 | [`user-feedback-aggregation`](skills/user-feedback-aggregation/SKILL.md) | Collecting and synthesizing user feedback across channels into continuous decision signal. Triage discipline that distinguishes loudest-voice (whoever complains most) from averaged-noise (every signal weighted equally) from triaged-synthesis (weighted by source quality and decision relevance) |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 77 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 78 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 79 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 80 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 81 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 83 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 84 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 85 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 86 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 87 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 82 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 83 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 84 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 85 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 86 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 88 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 89 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 90 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 91 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 92 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/scripts/generate_readme_catalog.py
+++ b/scripts/generate_readme_catalog.py
@@ -75,6 +75,13 @@ CATEGORIES: list[tuple[str, str, str | None]] = [
     ("operations", "Operations", None),
     ("growth", "Growth", None),
     (
+        "growth-tooling",
+        "Growth tooling",
+        "Interactive web tools that turn visitors into leads. Lead "
+        "magnets, calculators, quizzes, multi-step forms, chatbots, "
+        "and the cross-tool funnel architecture that orchestrates them.",
+    ),
+    (
         "marketing",
         "Marketing",
         "Paid media discipline: strategy, creative, and performance "

--- a/skills/calculator-design/SKILL.md
+++ b/skills/calculator-design/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: calculator-design
+description: "Designing interactive calculators (ROI calculators, pricing estimators, savings projections, mortgage calculators, custom assessments) that deliver real decision-support value while serving as lead magnets and qualified-traffic generators. Honest about vanity-calculator (no real value), lead-trap (hides the answer behind email), and transparent-decision-tool (gives the result and earns the email through tiered value) patterns. Triggers on calculator, ROI calculator, pricing estimator, savings calculator, custom calculator, interactive tool, decision tool, financial calculator. Also triggers when an audience needs a calculation-driven lead magnet, when a vanity calculator is producing leads but no qualified ones, or when a calculator is being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing interactive calculators that deliver decision-support value while qualifying leads. Distinguishes vanity-calculator (no real value) from lead-trap (hides answer behind email) from transparent-decision-tool (gives genuine value, captures leads honestly)"
+display_order: 2
+---
+
+# Calculator Design
+
+A senior growth practitioner's playbook for designing interactive calculators that deliver real decision-support value while serving as lead magnets and qualified-traffic generators. ROI calculators, pricing estimators, savings projections, mortgage calculators, custom assessments. The discipline of building a tool the audience actually trusts.
+
+Most calculators on the web are bait. Random multipliers behind official-looking math; an "Industry Average" number that does not cite a source; the result hidden behind a contact-sales form. The calculator captures emails because the format implies calculation; the leads are unqualified because the calculator did not actually help anyone decide anything.
+
+The calculators that work as compounding assets do something different. They give the audience a result they can defend to a stakeholder. They show the methodology so the result is interrogatable. They capture leads through value (a PDF report, a save-and-compare account, a custom analysis) rather than through manipulation.
+
+This skill is one of the specific lead-magnet types covered as its own skill. The parent-frame methodology lives in `lead-magnet-design`; the calculator-specific methodology (calculation transparency, tiered value, methodology disclosure) lives here.
+
+The voice is the senior growth practitioner who has watched calculators earn long-term credibility and watched them burn it within weeks of launch. Practical, opinionated about transparency, willing to say when a calculator is the wrong investment for the goal.
+
+When to use this skill: scoping a calculator for the first time, auditing a calculator that converts but does not qualify, designing the methodology disclosure that earns audience trust, or deciding which features warrant the email gate.
+
+---
+
+## What this skill covers
+
+This skill spans calculator design as one specific lead-magnet type. The growth-tooling distinctions:
+
+- `lead-magnet-design` is the parent-frame methodology (when to invest in any magnet, format selection, audience-fit, follow-up sequence). Calculators are one specific lead-magnet type.
+- **`calculator-design` (this skill)** is calculator-specific methodology (calculation transparency, tiered value, methodology disclosure, input design).
+- `quiz-and-assessment-design` is a sister tool type. Calculators give numbers; quizzes give categories. The methodology differs.
+- `landing-page-copy` is the calculator landing page (downstream of calculator design).
+- `pm-spec-writing` is writing the spec for engineers building the calculator. This skill is about WHAT to build; pm-spec-writing is about communicating it.
+
+The audience: growth marketers, product marketers, marketing teams building lead-magnet calculators, agencies running growth-tooling work for clients.
+
+Out of scope: lead-magnet design at the parent-frame level (covered by `lead-magnet-design`); landing-page copy (covered by `landing-page-copy`); the engineering implementation of the calculator (handed off via `pm-spec-writing`).
+
+---
+
+## The calculator decision: when calculators earn investment
+
+Before designing the calculator, decide whether a calculator is the right tool for the audience and the goal.
+
+**Calculators earn investment when:**
+
+- The audience faces a specific calculation as part of a decision. ROI on a software purchase, savings from a refinance, monthly cost of an expense, sizing for a service tier. Without a real calculation in the audience's actual workflow, the calculator becomes a vanity tool.
+- The calculation is non-trivial. Multiplying two numbers does not need a calculator; calibrating across 5-10 inputs with branching logic does.
+- The brand has methodology authority. The calculator's output has to be defensible. Brands without methodology authority (or unwilling to disclose methodology) often produce calculators audiences do not trust.
+- The follow-up sequence has a real purpose for the lead. Calculators capture a specific signal (the inputs reveal the lead's situation); the sequence has to use that signal.
+
+**Calculators do NOT earn investment when:**
+
+- The audience does not actually run this calculation. A calculator solving a problem the audience does not have produces low usage.
+- The calculation is trivial. A "savings calculator" that computes "monthly cost x 12" does not earn its build.
+- The brand cannot disclose methodology honestly. If the math depends on assumptions the brand cannot defend, the calculator becomes a vanity tool by necessity.
+- A simpler magnet would serve the same audience and goal. Templates and checklists are cheaper to build and maintain than calculators; choose the calculator only when the calculation is the value.
+
+The decision is not "should we have a calculator"; it is "is the calculator the right next investment for this specific audience and goal."
+
+Detail in `references/calculator-investment-criteria.md`.
+
+---
+
+## Vanity-calculator vs lead-trap vs transparent-decision-tool
+
+The keystone framing.
+
+**Vanity-calculator.** Inputs and outputs that do not actually help anyone decide anything. "Calculate your marketing ROI" with random multipliers; "estimate your savings" with no defensible methodology. Looks impressive in a screenshot; helps nothing in a real decision. Cost: leads downloaded the result, found it useless, and remember the brand as the source of the useless tool.
+
+**Lead-trap.** Genuine calculation logic but the result is hidden behind an email gate. The user inputs 8 fields, hits "Calculate," and sees "enter your email to see your result." Manipulative; reader resents the friction; conversion drops below baseline because the audience can tell when the gate is bait rather than value-add.
+
+**Transparent-decision-tool.** Genuine calculation that gives the result immediately. Email gate for advanced features (PDF report, custom analysis, save-and-compare across scenarios) where the additional value justifies the ask. The reader gets the answer they came for; the brand gets the email through demonstrated generosity.
+
+The litmus test. After running the calculator, can a stranger in the target audience defend the result to a stakeholder? Can they cite the methodology behind the number? If yes, the calculator is a transparent-decision-tool. If they got a number with no defensible source, the calculator is vanity. If they could not see the result without giving an email, the calculator is a lead-trap.
+
+---
+
+## Input design
+
+The calculator's inputs are the audience's first interaction. Bad input design loses the user before the calculation runs.
+
+**The principle.** Each input should be necessary for the calculation, easy for the user to provide, and respectful of the user's time.
+
+**Necessary.** If an input does not affect the output meaningfully, do not ask for it. Calculators that ask 18 inputs but only use 5 in the actual math signal that the form is collecting data for sales rather than for the calculation. The audience can tell.
+
+**Easy to provide.** Use defaults from honest assumptions. "Average company size" preset to a reasonable industry baseline. "Typical conversion rate" preset to a defensible number. Defaults reduce the cognitive load and let the user adjust where their context differs.
+
+**Respectful of time.** Group related inputs visually. Show only the fields the user is currently working through (progressive disclosure where it helps). Indicate progress so the user knows how many steps remain.
+
+**Input types.**
+
+- Numeric (revenue, customer count, monthly cost). The most common. Often warrants tooltip explaining what the number represents.
+- Slider (percentage estimates, conversion rates). Good for ranges where exact values are not knowable.
+- Dropdown (industry, company size, region). Good for predefined categories.
+- Toggle (feature on/off, scenario A vs B). Good for binary choices.
+- Free text (only when the value is genuinely user-specific and cannot be calculated). Use sparingly; free text is friction.
+
+Detail in `references/input-design-patterns.md`.
+
+---
+
+## Calculation logic transparency
+
+The defensibility of the result is the calculator's credibility currency.
+
+**The principle.** The audience should be able to inspect the methodology. Either the calculation is shown openly, or a methodology link explains it, or the team is willing to share the spec on request.
+
+**Methodology disclosure options.**
+
+- **Inline formulas.** "Your savings = (current cost x 12) - (our cost x 12) + implementation savings of $X." Explicit and verifiable.
+- **Methodology page.** A link from the calculator to a page explaining the assumptions, sources, and formulas. The audience can read if they care; defaults are good for those who do not.
+- **Source citations.** When inputs come from external benchmarks ("Industry Average: 14 percent"), cite the source. Uncited benchmarks erode trust.
+- **Assumption list.** A list of the calculator's assumptions, plain-language. "We assume you are comparing month-over-month after a 3-month implementation period."
+
+**The vanity-calculator failure.** Assumptions hidden, sources missing, formulas opaque. The audience uses the tool, gets a number, and cannot defend it. The brand is invisible in their next conversation about the decision because the calculator did not earn the credibility.
+
+**The transparent-tool win.** Assumptions visible, sources cited, formulas inspectable. The audience uses the tool, gets a number, and can defend it. The brand is in the conversation because the audience cites the calculator as their source.
+
+Detail in `references/calculation-logic-transparency.md`.
+
+---
+
+## Result presentation
+
+The result is the calculator's product. Bad result presentation wastes the calculation work.
+
+**The principle.** The result should be specific, contextualized, and actionable.
+
+**Specific.** A number with units. "Estimated annual savings: $14,200." Not "Significant savings." Not "Up to 60 percent off."
+
+**Contextualized.** Compare to a baseline the user can understand. "Based on your inputs, you would save $14,200 annually compared to your current configuration." The context makes the number interpretable.
+
+**Actionable.** What does the user do with this number? "Use this estimate to make the case to your CFO" or "Save this scenario to compare against alternative configurations" or "Get a PDF report you can share." The next step is the calculator's bridge from result to action.
+
+**Result-presentation patterns.**
+
+- **Headline number.** The single most important output, large and prominent.
+- **Breakdown.** Sub-results that explain how the headline number was calculated.
+- **Visualization.** Bar chart, comparison table, or simple graphic that helps the user see the relationship.
+- **Scenario comparison.** "Your current state vs the optimized state." Useful when the calculator is illustrating a delta.
+
+**Avoid.**
+
+- Burying the result. The result should be visible immediately, not after a scroll.
+- Result followed by 5 paragraphs of marketing. The result is what the user came for; marketing belongs after, not before.
+- Result that requires re-entering all inputs to view. Persist inputs and results within the session.
+
+Detail in `references/result-presentation-patterns.md`.
+
+---
+
+## Email-capture decision
+
+What to gate, what to give freely.
+
+**The principle.** Give the audience the result they came for. Gate the additional value (PDF report, custom analysis, save-and-compare, saved scenarios across visits).
+
+**What to give freely.**
+
+- The headline result.
+- The breakdown of how the result was calculated.
+- A visualization of the result.
+- The methodology disclosure.
+
+**What to gate (with email or account creation).**
+
+- A formatted PDF report the user can share or save.
+- A saved scenario the user can revisit and compare against alternatives.
+- A custom analysis (a deeper version of the calculation, often delivered later).
+- Email-based notifications when assumptions change or new benchmarks emerge.
+
+**The lead-trap failure.** The headline result is gated. The user inputs 8 fields, hits Calculate, sees "enter your email to see your result." Conversion drops because the audience perceives the manipulation. The lead-trap pattern is short-term thinking.
+
+**The transparent-tool win.** The result is free; the additional value is gated. Conversion is honest; lead quality is high because the lead opted in for the additional value, which signals real interest.
+
+Detail in `references/email-capture-decision-tree.md`.
+
+---
+
+## Tiered-value structures
+
+The architecture that lets calculators capture leads honestly.
+
+**The principle.** The calculator delivers tiered value: free immediate result + gated advanced features.
+
+**Tier 1 (free, no gate):** the headline result, the breakdown, the methodology, basic visualization.
+
+**Tier 2 (email-gated):** a formatted PDF, a saved scenario, an emailed copy of the result.
+
+**Tier 3 (account or sign-up gated):** save-and-compare across multiple scenarios over time, advanced analysis, integration with the brand's product or service.
+
+**The tier-design discipline.**
+
+- Each tier should add real value over the previous. If Tier 2 is just "the same result in a PDF," the tier does not justify the email ask.
+- The gate at each tier should be matched to the value. Email for Tier 2; account creation only for Tier 3.
+- The tier transitions should feel natural. The user gets the free result, sees the additional value visibly, and chooses whether to opt in for it.
+
+**Worked example.**
+
+A B2B SaaS pricing calculator.
+
+- Tier 1 (free): the user enters team size and use case, sees the recommended plan and the estimated monthly cost. Methodology link explains tier breakpoints.
+- Tier 2 (email-gated): a PDF showing the recommended plan, the calculation, and a comparison to alternative plans the user might consider.
+- Tier 3 (account-gated): a saved scenario the user can revisit; ability to compare against historical pricing if the calculator is used periodically; option to receive notifications if pricing or recommended plans change.
+
+Each tier earns its gate.
+
+Detail in `references/tiered-value-structures.md`.
+
+---
+
+## Calculator anti-patterns
+
+Patterns that look like calculators but degrade trust.
+
+**The lead-trap.** Result hidden behind email. Detail in keystone framing.
+
+**The vanity output.** A number that looks impressive but does not help any real decision. "Your marketing efficiency score is 87." 87 of what?
+
+**The hidden-methodology calculator.** No way to see the math; no methodology page; no assumption list. The audience uses the tool, gets a number, and cannot defend it.
+
+**The interrogation form disguised as calculator.** 18 input fields, of which 5 affect the math. The form is collecting sales-qualification data under cover of calculation.
+
+**The misleading-baseline calculator.** "Industry Average" or "Typical Customer" baselines that are flattering to the brand and unsourced. The audience that knows the industry sees the gap.
+
+**The misaligned-units calculator.** "Estimated savings: 14X" without a base value. Or "60 percent improvement" without saying improvement in what.
+
+**The static-assumption calculator.** Assumptions hardcoded in 2022 that have not been updated. The calculator's outputs are stale.
+
+**The mobile-broken calculator.** Calculator works fine on desktop, breaks on mobile. The mobile audience either bounces or gets a worse experience that misrepresents the brand.
+
+Detail in `references/calculator-anti-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-calculator-failures.md`.
+
+- "Conversion rate is high; downstream conversion is near zero." Lead-trap or vanity-output pattern; the audience captured did not get value, did not engage with the follow-up, did not convert.
+- "Audience visits the calculator, runs it once, never returns." Calculator does not produce a save-worthy or share-worthy result; no reason to come back.
+- "Sales team says the calculator-sourced leads are unqualified." Calculator's audience-fit weak; the calculation does not match the buyer's actual decision.
+- "We get questions about how the calculator works; we have no answer." Methodology not documented; the team cannot defend the calculator's outputs.
+- "We updated the product; the calculator outputs are now wrong." No update cadence; the calculator drifted out of sync with the actual offering.
+- "The calculator works; nobody uses it." Calculator hidden in the site; no distribution; the audience does not know it exists.
+- "Our calculator looks like our competitor's." Generic calculator-template patterns produce generic calculators; the brand differentiation absent.
+- "The form has 12 fields and 4 percent conversion." Interrogation-form pattern; the calculator is collecting data, not delivering value.
+- "Audience trusts our brand; the calculator outputs feel arbitrary." Methodology disclosure missing; the brand's credibility does not transfer to the tool because the tool does not show its work.
+
+---
+
+## The framework: 12 considerations for calculator design
+
+When designing or auditing a calculator, walk these 12 considerations.
+
+1. **The calculator decision.** Is a calculator the right investment, or would a simpler magnet serve?
+2. **Transparent-decision-tool, not vanity or lead-trap.** Result is free; methodology is visible; gate is on additional value, not on the result.
+3. **Inputs are necessary, easy, respectful of time.** Each input affects the math; defaults reduce friction; progressive disclosure where it helps.
+4. **Calculation methodology disclosed.** Inline formulas, methodology page, source citations, or assumption list.
+5. **Result is specific, contextualized, actionable.** Number with units; baseline for interpretation; clear next step.
+6. **Tiered value structure.** Free immediate result; gated advanced features; each tier earns its gate.
+7. **Email-capture decision honest.** Gate on real value-add (PDF, save-and-compare, custom analysis), not on the result the user came for.
+8. **Source attribution clear.** Industry averages, benchmarks, and assumptions all cited or explained.
+9. **Mobile experience tested.** Calculator works on the device the audience uses.
+10. **Update cadence defined.** When inputs, benchmarks, or product details change, the calculator gets updated.
+11. **Distribution planned.** The calculator's audience knows it exists. Landing page, navigation, content references all include the calculator.
+12. **Lead quality measured.** Downstream conversion from calculator-sourced leads is the real metric, not surface conversion.
+
+The output of the framework is a calculator that delivers real decision-support value, earns the email through demonstrated generosity, and produces leads the team can convert downstream.
+
+---
+
+## Reference files
+
+- [`references/calculator-investment-criteria.md`](references/calculator-investment-criteria.md) - When a calculator is the right tool for the audience and goal, and when a simpler magnet would serve.
+- [`references/input-design-patterns.md`](references/input-design-patterns.md) - Input necessity, default discipline, input types, progressive disclosure. The friction the audience does not need.
+- [`references/calculation-logic-transparency.md`](references/calculation-logic-transparency.md) - Methodology disclosure options. Inline formulas, methodology pages, source citations, assumption lists.
+- [`references/result-presentation-patterns.md`](references/result-presentation-patterns.md) - Specific, contextualized, actionable. Headline number, breakdown, visualization, scenario comparison.
+- [`references/email-capture-decision-tree.md`](references/email-capture-decision-tree.md) - What to give freely, what to gate. The lead-trap failure and the transparent-tool win.
+- [`references/tiered-value-structures.md`](references/tiered-value-structures.md) - Tier 1 free, Tier 2 email-gated, Tier 3 account-gated. Worked examples.
+- [`references/methodology-disclosure-templates.md`](references/methodology-disclosure-templates.md) - Templates for assumption lists, methodology pages, source citations, formula explanations.
+- [`references/calculator-anti-patterns.md`](references/calculator-anti-patterns.md) - The patterns that look like calculators but degrade trust.
+- [`references/common-calculator-failures.md`](references/common-calculator-failures.md) - 9+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: calculators earn the email when they would have been worth paying for
+
+The calculators that work as compounding assets are the ones the audience trusts. Not impressive screenshots. Not high conversion rates. Trust. The audience runs the calculator, gets a result they can defend, and remembers the brand as the source of the result they used in their actual decision.
+
+That is the bar. Below the bar are vanity-calculators (no real result) and lead-traps (result hidden until you pay with an email). Above the bar are transparent-decision-tools that give the audience the answer freely and capture leads through additional value the audience opts in for.
+
+The discipline is in the design choices. The methodology disclosure that earns credibility. The input design that respects the audience's time. The tiered value structure that makes the email-capture honest. The result presentation that makes the calculator's output usable in the audience's real conversation. The update cadence that keeps the calculator in sync with the offering it represents.
+
+When in doubt, ask: would the audience pay for this calculator if it were not free, and can they defend the result to a stakeholder after they use it? If yes to both, the calculator earns the email. If no to either, redesign or do not ship.

--- a/skills/calculator-design/references/calculation-logic-transparency.md
+++ b/skills/calculator-design/references/calculation-logic-transparency.md
@@ -1,0 +1,200 @@
+# Calculation logic transparency
+
+Methodology disclosure options. Inline formulas, methodology pages, source citations, assumption lists. The defensibility of the result is the calculator's credibility currency.
+
+A calculator's output is only as trustworthy as the audience's ability to inspect how it was computed. Calculators that hide methodology produce numbers; calculators that disclose methodology produce defensible numbers. The difference shows up in whether the audience cites the calculator in stakeholder conversations.
+
+---
+
+## The transparency principle
+
+The audience should be able to inspect the methodology if they care.
+
+Three levels of transparency, in increasing depth.
+
+**Level 1: Inline.** The methodology appears in the calculator itself, near the result. "Your annual savings: $14,200 = (current cost x 12) - (estimated new cost x 12) + first-year implementation savings of $X."
+
+**Level 2: Methodology page.** A linked page explaining the formulas, assumptions, and sources in detail. The result page links to it; users who want depth find it.
+
+**Level 3: Spec on request.** The team is willing to share the underlying spec, customer-data sources, or formula derivations on request. Useful for analytical or enterprise audiences who want full inspection.
+
+A calculator should at minimum support Level 1 or Level 2. Level 3 is optional and signals analytical credibility.
+
+---
+
+## Inline formulas
+
+Show the math near the result.
+
+**The pattern.** Below or alongside the headline result, show the formula that produced it.
+
+**Example: ROI calculator inline formula.**
+
+```
+Annual savings: $14,200
+
+Calculation:
+  Current annual cost: $36,000 ($3,000 / month x 12)
+  Estimated new annual cost: $24,000 ($2,000 / month x 12)
+  Annual savings: $36,000 - $24,000 = $12,000
+  + First-year implementation savings: $2,200
+  Total: $14,200
+```
+
+**The win.** The audience can verify the math. They can adjust their inputs and predict how the result will change. They can defend the result to a stakeholder by citing the formula.
+
+**When to use inline formulas.** When the calculation is straightforward enough to display in a few lines. Most ROI, savings, and pricing calculators fit this pattern.
+
+**When inline formulas hurt.** When the calculation is so complex (multi-stage, with branching) that the formula display overwhelms the result. In those cases, link to a methodology page instead.
+
+---
+
+## Methodology page
+
+A linked page explaining the calculation in depth.
+
+**The pattern.** The result page includes a "How this is calculated" or "Methodology" link. The link opens a page with formulas, assumptions, and sources.
+
+**What a methodology page should include.**
+
+- The central formulas in plain text (not just images).
+- Each variable defined.
+- Each assumption listed plainly. "We assume a 3-month implementation period." "We assume the user is comparing month-over-month."
+- Sources for any external benchmarks. "Industry Average: 14 percent. Source: [Industry Benchmark Report 2025]."
+- Worked example. A specific scenario with input values and the resulting calculation.
+- Caveats. "This calculator does not account for [X]; for that, see [other resource]."
+
+**The methodology page test.** A skeptical reader of the methodology page should come away thinking "this is reasonable" or "I disagree with assumption Y, here is why." Either response is a sign the methodology is real and the audience can engage with it.
+
+**Methodology pages and SEO.** Methodology pages can themselves rank for search terms ("how is X calculated"), bringing additional traffic to the calculator. The page is not just transparency; it is also a content asset.
+
+---
+
+## Source citations
+
+When the calculator uses external benchmarks or data, cite the source.
+
+**The pattern.** "Industry Average: 14 percent. Source: [Industry Benchmark Report 2025, page 23]."
+
+**Why source citations matter.** They signal that the benchmark is real, not invented. They let the skeptical user verify. They protect the brand if the benchmark is later disputed.
+
+**Citation discipline.**
+
+- Cite the most authoritative source available (industry report, academic paper, published study).
+- Date the source. Benchmarks decay; an undated source could be from any year.
+- Link to the source where possible. Inaccessible sources (paywalled reports cited from memory) are weaker than linked sources.
+- If the source is internal customer data, say so. "Source: [Brand]'s customer cohort, n=200, 2024-2025." Internal sources are valid; honesty about their origin matters.
+
+**The uncited-benchmark failure.** "Industry Average: 14 percent" with no source. The audience that knows the industry sees the gap; the audience that does not know rolls the dice on whether to trust. Either way, credibility leaks.
+
+---
+
+## Assumption lists
+
+A plain-language list of what the calculator assumes.
+
+**The pattern.** Either inline (near the result) or on the methodology page, list the assumptions in plain English.
+
+**Example assumption list for a SaaS pricing calculator.**
+
+- "We assume your team will use the platform daily."
+- "We assume implementation takes 4-6 weeks."
+- "We assume the productivity gains compound through year 1 and stabilize in year 2."
+- "We assume your current solution costs include licenses, hosting, and 1 FTE for maintenance."
+- "We do not account for [specific factors] in this estimate."
+
+**Why assumption lists matter.** They make the calculator's worldview visible. The audience can see whether the assumptions match their situation. If the assumptions diverge, the audience knows to discount the result accordingly.
+
+**Honest assumptions vs flattering assumptions.** Honest assumptions reflect the typical case; flattering assumptions reflect the case that produces the most attractive output. Audiences that catch flattering assumptions stop trusting the calculator.
+
+**The assumption-decay problem.** Assumptions need updating as the world changes. A calculator with assumptions from 2022 may have outdated benchmarks; review quarterly.
+
+---
+
+## The methodology-authority spectrum
+
+Calculators sit on a spectrum from "fully transparent" to "fully opaque." Each position has tradeoffs.
+
+**Fully transparent.** All formulas, all assumptions, all sources visible. The audience can fully reconstruct the calculation. Trust is maximum; competitive risk (others copying the methodology) is highest.
+
+**Largely transparent.** Major formulas visible; minor weighting or proprietary elements glossed. The audience trusts the result; the brand keeps some IP. Common middle ground.
+
+**Methodology-page transparent.** The result is shown without inline formulas; the methodology page has the depth. The audience that cares finds the depth; the audience that does not, does not have to.
+
+**Opaque.** No methodology shown. The audience either trusts the brand or not; there is no inspection path. High competitive protection; low audience trust.
+
+The right position depends on the audience and the goal. Analytical audiences (engineers, finance teams, technical buyers) need transparency to trust. Less-analytical audiences may accept opacity if the brand has earned trust through other means. Most calculators benefit from at least Level 2 (methodology page) transparency.
+
+---
+
+## When the calculation cannot be fully disclosed
+
+Some calculations include proprietary IP. Honest framing matters.
+
+**The honest framing.** "The output combines public benchmark data with proprietary insights from our customer cohort. Public elements are detailed in the methodology page; the proprietary weighting reflects our own data and is not detailed here."
+
+**The dishonest framing.** Hiding the proprietary nature; presenting opaque outputs as if they came from public methodology.
+
+**The audience's reaction.** Honest framing about proprietary IP is usually accepted. The audience understands that some IP is protected; they appreciate the honesty about what is shown and what is not. Dishonest framing breaks trust when the audience tries to interrogate and finds nothing.
+
+**The discipline.** Disclose what can be disclosed. Honestly label what cannot. The combination earns more trust than full opacity or false transparency.
+
+---
+
+## Methodology display patterns
+
+How to integrate methodology into the calculator's UI.
+
+**Pattern A: Always-visible inline formulas.** The result and the formula appear together. Best for short calculations where the formula is digestible.
+
+**Pattern B: Expandable methodology details.** The result appears prominently; "How this was calculated" is an expandable section below. The user opens it if they want depth.
+
+**Pattern C: Methodology link to a separate page.** The result is shown; the methodology page is linked. Good for complex calculations that need full discussion.
+
+**Pattern D: Hover-revealed assumption tooltips.** Each variable in the result has a tooltip explaining how it was derived. Useful when the calculation has many components.
+
+**Pattern E: Methodology in PDF report.** The free result shows the headline; the gated PDF contains the full methodology. This pattern works when the PDF is genuinely the value-add and the headline result is enough for free users.
+
+The choice depends on calculator complexity, audience analytical depth, and the brand's transparency posture.
+
+---
+
+## Common transparency failures
+
+**No methodology shown.** Result is a number; user has no way to verify or defend it.
+
+**Hidden assumptions.** Inputs and outputs visible; assumptions baked into the math without disclosure.
+
+**Uncited benchmarks.** "Industry Average: 14 percent" with no source.
+
+**Stale assumptions.** Methodology written in 2022, never reviewed.
+
+**Flattering defaults.** Defaults set to produce favorable outputs; the audience that catches the bias stops trusting.
+
+**Methodology page that hides more than it reveals.** Marketing copy disguised as methodology; no actual formulas or sources.
+
+**Inconsistent precision.** Result shown as "$14,237" when the inputs justify only "$14,000 (estimated)." False precision erodes trust.
+
+**No version history on methodology.** Methodology page changed over time without record; users who relied on previous outputs cannot tell what changed.
+
+---
+
+## The credibility compounding effect
+
+Transparent calculators compound credibility.
+
+**The mechanism.** The audience uses the calculator, gets a defensible result, cites it in their decision-making conversation. The brand is in the conversation. The audience returns to the calculator for related decisions. The brand's authority on the topic deepens.
+
+**The opposite.** Opaque calculators do not compound. The audience uses the calculator, gets a number they cannot defend, leaves it out of their stakeholder conversation. The brand is invisible. The audience does not return.
+
+**The metric.** Track whether the calculator is being cited. Mentions in customer conversations, references in industry discussions, backlinks from other content all signal compounding credibility.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The transparency principle and the three levels. Inline formulas, methodology pages, source citations, assumption lists. The methodology-authority spectrum. Honest framing for proprietary calculations. Methodology display patterns. Common transparency failures. The credibility compounding effect.
+
+## Implementation choices that stay internal
+
+Specific methodology pages for specific calculators. Specific source citations and benchmark relationships. Specific tooling for methodology display. Specific brand-voice methodology copy. The team's update calendars and version control for methodology. These vary by team.

--- a/skills/calculator-design/references/calculator-anti-patterns.md
+++ b/skills/calculator-design/references/calculator-anti-patterns.md
@@ -1,0 +1,211 @@
+# Calculator anti-patterns
+
+The patterns that look like calculators but degrade trust. Anti-patterns are easy to ship; the cost shows up in lead quality, downstream conversion, and brand reputation over time.
+
+---
+
+## The lead-trap
+
+The pattern. The user enters inputs, hits Calculate, sees "enter your email to see your result."
+
+The signal. Conversion-rate metric on the email form looks fine; downstream conversion is near zero; the audience that recognizes the pattern bounces immediately.
+
+The cost. The leads captured are unqualified or actively annoyed. The brand earns "lead-trap" reputation; trust erodes across all future interactions.
+
+The cure. Restructure so the result is free and the additional value (PDF, save-and-compare, custom analysis) is gated. Detail in `references/email-capture-decision-tree.md`.
+
+---
+
+## The vanity output
+
+The pattern. A number that looks impressive but does not help any real decision. "Your marketing efficiency score is 87." 87 of what? Compared to what?
+
+The signal. Audiences run the calculator out of curiosity; do not return; do not cite the result anywhere; do not engage with the follow-up sequence.
+
+The cost. The calculator's build cost was wasted. The audience does not associate the brand with useful analysis.
+
+The cure. Anchor the result to a decision the audience actually makes. The output should be a number with units, contextualized against a baseline, with a clear next step.
+
+---
+
+## The hidden-methodology calculator
+
+The pattern. No way to see the math. No methodology page. No assumption list. The audience uses the tool, gets a number, and cannot defend it.
+
+The signal. Sales-team friction; prospects who used the calculator cannot bring its outputs into stakeholder conversations.
+
+The cost. The calculator does not compound credibility. Each user runs it once and does not return; the brand stays invisible in the audience's actual decision conversations.
+
+The cure. Disclose methodology. Detail in `references/calculation-logic-transparency.md`.
+
+---
+
+## The interrogation form disguised as calculator
+
+The pattern. 18 input fields, of which 5 affect the math. The form is collecting sales-qualification data under cover of calculation.
+
+The signal. Conversion rate on the form is poor. The audience self-selects out at the form length.
+
+The cost. The calculator's reach drops dramatically. The leads that do convert are over-disclosed and may resent the friction; the audience the calculator could have served does not get to use it.
+
+The cure. Audit the input set. Remove fields that do not affect the calculation. Capture additional data later in the relationship, not at the form.
+
+---
+
+## The misleading-baseline calculator
+
+The pattern. "Industry Average" or "Typical Customer" baselines that are flattering to the brand and unsourced.
+
+The signal. Audiences with industry knowledge notice the gap. Those audiences do not return; they may post about the bias publicly.
+
+The cost. Trust damage that can be hard to recover. Brand earns "spin" reputation.
+
+The cure. Source the baselines honestly. Use defensible benchmarks; if the brand's data is favorable, disclose that the data comes from the brand's own customer cohort and acknowledge the bias.
+
+---
+
+## The misaligned-units calculator
+
+The pattern. "Estimated savings: 14X" without a base value. Or "60 percent improvement" without saying improvement in what.
+
+The signal. Audiences cannot interpret the result; cannot use it in their decision; do not return.
+
+The cost. The calculator's outputs are uninterpretable; the calculator does not produce decision-grade signal.
+
+The cure. Numbers with units. Percentages with bases. Multipliers with reference values. Contextualization that makes the result interpretable.
+
+---
+
+## The static-assumption calculator
+
+The pattern. Assumptions hardcoded in 2022 that have not been updated. Industry benchmarks from 2 years ago. Tooling references to products that have been deprecated.
+
+The signal. Audiences with current knowledge see the staleness; trust drops; some users may report the inaccuracy.
+
+The cost. The calculator's outputs are unreliable. The brand looks careless or out of touch.
+
+The cure. Quarterly maintenance review. Update assumptions, refresh benchmarks, prune stale references.
+
+---
+
+## The mobile-broken calculator
+
+The pattern. Calculator works fine on desktop; breaks on mobile. Sliders impossible to grab; dropdowns overflow; result hidden below the fold.
+
+The signal. High mobile bounce rate; mobile conversion drops below desktop.
+
+The cost. The mobile audience either bounces or has a worse experience that misrepresents the brand. Mobile is often the majority of traffic; this failure is significant.
+
+The cure. Mobile-first design and testing. Test on actual devices, not just dev tools. Detail in `references/input-design-patterns.md` (mobile section).
+
+---
+
+## The over-precise calculator
+
+The pattern. Result shown as "$14,237.42" when the inputs justify only "$14,000 (estimated)." False precision suggests the calculator knows more than it does.
+
+The signal. Analytical audiences see the false precision and discount the result. The calculator earns "fake math" reputation among the audience that matters most.
+
+The cost. Trust erosion specifically among the audience the calculator was designed to serve.
+
+The cure. Round to honest precision. Use "estimated" or "approximately" framing. Disclose the precision the inputs support.
+
+---
+
+## The marketing-disguised-as-methodology calculator
+
+The pattern. The methodology page exists but contains marketing copy ("our proprietary algorithm draws on industry-leading data") rather than actual formulas, sources, or assumptions.
+
+The signal. Audiences who click through to verify find no real verification; trust drops.
+
+The cost. The calculator's credibility is performative rather than real; the audience that interrogates discovers the gap.
+
+The cure. Real methodology. Formulas, assumptions, sources. Brand voice can frame the methodology page; brand voice cannot replace the methodology itself.
+
+---
+
+## The orphan-result calculator
+
+The pattern. The result loads; no next step is offered. The user gets the number and leaves.
+
+The signal. Conversion to next step (PDF, save, contact, demo) is near zero because no next step is offered.
+
+The cost. The calculator captures attention without converting it. The brand has the audience's moment of intent and does nothing with it.
+
+The cure. Offer a clear next step at the result. PDF, save scenario, talk to team, related resource. Detail in `references/result-presentation-patterns.md` (result-to-action transitions).
+
+---
+
+## The popup-interrupted calculator
+
+The pattern. The result loads; the user starts reading; a popup appears asking for email or offering a different magnet. The user's flow breaks.
+
+The signal. Bounce rate spikes at the popup moment; users complain about the interruption.
+
+The cost. The calculator's user experience is hostile. The brand earns "annoying" reputation.
+
+The cure. Offers in context with the result, not as popups that interrupt. Detail in `references/result-presentation-patterns.md`.
+
+---
+
+## The cookie-cutter calculator
+
+The pattern. The calculator looks and behaves like every other calculator from a template platform. Generic UI, generic assumption set, generic output styling.
+
+The signal. The calculator does not differentiate; the audience does not associate it specifically with the brand.
+
+The cost. The calculator becomes commodity; the brand's investment does not compound credibility because the tool does not stand out.
+
+The cure. Custom design that reflects the brand. Methodology that reflects the brand's specific authority. The calculator should look like it could only have come from this brand.
+
+---
+
+## The pessimistic-default calculator
+
+The pattern. Defaults set to make the brand's outputs look favorable through pessimistic baselines. "Current cost" defaults to the high end; "savings" defaults to the optimistic end.
+
+The signal. Audiences who notice (often analytical audiences) discount the result. The audience the calculator was built for stops trusting it.
+
+The cost. Same as misleading-baseline. Trust damage; brand earns "spin" reputation.
+
+The cure. Honest defaults sourced from data; let the user adjust to their actual context.
+
+---
+
+## The form-without-calculator
+
+The pattern. A "calculator" that is actually a form. No real calculation; the result is generic ("based on your inputs, our team will reach out") or static ("your estimated savings: 30 percent").
+
+The signal. Audiences expecting a real calculation get a sales form; bounce rate spikes; the audience perceives bait-and-switch.
+
+The cost. The calculator's framing was a lie; trust collapses.
+
+The cure. Either build a real calculator with real math, or do not call the form a calculator.
+
+---
+
+## How to detect anti-patterns in a portfolio
+
+Audit cadence. Quarterly review of every active calculator, looking specifically for these anti-patterns.
+
+**Audit questions per calculator.**
+
+- Is the result accessible without email gate (anti-pattern check: lead-trap)?
+- Is the methodology disclosed in a way the audience can verify (anti-pattern check: hidden-methodology)?
+- Are the inputs all necessary for the calculation (anti-pattern check: interrogation-form)?
+- Are the baselines and benchmarks sourced and current (anti-pattern check: misleading-baseline, static-assumption)?
+- Does the calculator work on mobile (anti-pattern check: mobile-broken)?
+- Is the result actionable, with a clear next step (anti-pattern check: orphan-result)?
+- Does the calculator differentiate from other calculators on similar topics (anti-pattern check: cookie-cutter)?
+
+**The retire decision.** Anti-pattern calculators often warrant retirement. Maintaining them costs more than the diminishing returns they produce.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing for each. Cures matched to anti-patterns. The audit cadence and audit questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and the lessons learned. Specific portfolio audit results. Specific retirement decisions and successor-tool plans. The team's audit calendar and reviewer list. These vary by team.

--- a/skills/calculator-design/references/calculator-investment-criteria.md
+++ b/skills/calculator-design/references/calculator-investment-criteria.md
@@ -1,0 +1,144 @@
+# Calculator investment criteria
+
+When a calculator is the right tool for the audience and the goal, and when a simpler magnet would serve. The conditions that warrant the calculator's build cost.
+
+A calculator is one of the highest-build-cost magnet formats. Engineering, design, methodology research, and ongoing maintenance all add up. The calculator earns this investment only when specific conditions are present.
+
+---
+
+## When a calculator earns the build
+
+Five conditions that, when present, make a calculator a strong investment.
+
+**The audience faces a specific calculation as part of a real decision.** ROI on a software purchase, savings from a refinance, monthly cost projection, sizing for a service tier, time-to-payback estimate. The calculation has to be one the audience actually runs in their workflow. Without a real calculation, the calculator becomes vanity.
+
+**The calculation is non-trivial.** Multiplying two numbers does not need a calculator; the audience can do that in their head. Calibrating across 5-10 inputs with branching logic, applying industry benchmarks, or running a multi-scenario comparison earns the format.
+
+**The brand has methodology authority.** The output has to be defensible. Brands with research, customer data, or industry expertise that informs the calculation can disclose methodology credibly. Brands without that authority often produce calculators audiences cannot trust.
+
+**The follow-up sequence has a real purpose for the lead.** Calculators capture a specific signal (the inputs reveal the lead's situation: company size, current configuration, projected savings). The sequence has to use that signal. A generic sequence wastes the input data.
+
+**The success metric is defined.** What does "the calculator works" look like? Lead volume, lead quality, downstream conversion, the audience citing the calculator in stakeholder conversations. Without the success metric defined, evaluation is impossible.
+
+When all five are present, the calculator is a strong investment. When two or fewer are present, a simpler magnet (template, checklist, or worked example) often serves better.
+
+---
+
+## When a calculator does NOT earn the build
+
+Funnels where the calculator is the wrong tool.
+
+**The audience does not actually run this calculation.** The team imagines the audience would benefit from the calculation; the audience does not actually face this decision. Usage is low; the build cost was wasted.
+
+**The calculation is trivial.** A "savings calculator" that computes "monthly cost x 12" is not a calculator; it is a multiplication. The audience can do this without a tool.
+
+**The brand cannot disclose methodology honestly.** If the math depends on assumptions the brand cannot defend ("we estimate 60 percent improvement based on internal data we cannot share"), the calculator becomes a vanity tool by necessity. The audience that would benefit from a defensible calculator gets a brand-flattering one instead.
+
+**A simpler magnet would serve the same audience and goal.** A pricing PDF that shows worked examples and methodology might serve the same audience as a pricing calculator at one-tenth the build cost. Choose the simpler magnet when it would serve.
+
+**The audience is too small to justify the build.** A calculator for a niche of 200 prospects is hard to justify against the build cost. Direct outreach or a simpler resource may be more efficient.
+
+**The team cannot maintain the calculator.** Calculators decay as benchmarks change, product details evolve, and tooling updates. Without maintenance commitment, the calculator becomes a stale liability.
+
+The honest assessment matters more than the default. "Should we have a calculator" is not the question. "Is the calculator the right investment for this audience and decision" is.
+
+---
+
+## The opportunity-cost frame
+
+A calculator's cost is significant. Account for it honestly.
+
+**The build cost.** Methodology research, formula design, input UX, result UX, calculation engine, methodology disclosure, mobile responsiveness, edge-case handling. A meaningful calculator often takes 60-200 engineering hours plus design and copy.
+
+**The maintenance cost.** Benchmarks change; product details change; assumptions shift. Quarterly review and updates run 4-12 hours per active calculator.
+
+**The sequence cost.** The follow-up sequence using the input data is itself a build. 10-30 hours upfront.
+
+**The opportunity cost.** What else could the team have built? A funnel improvement, a content piece, a paid-traffic optimization, a product improvement. The calculator's success has to clear the bar of those alternatives.
+
+The decision frame. The calculator earns investment when it produces more lift than the alternatives, accounting for the full cost of build plus maintenance plus sequence.
+
+---
+
+## The methodology-authority precondition
+
+Without methodology authority, the calculator cannot be defensible.
+
+The audience's question. After running the calculator: "Where does this number come from?"
+
+If the team can answer with sources (industry benchmarks, customer data, public research, defensible assumptions), the calculator has methodology authority. The audience can trust the result and use it in their decision.
+
+If the team cannot answer ("our model just produces this number"), the calculator does not have methodology authority. The audience either does not trust the result or trusts it without understanding it (which is worse for the audience and ultimately for the brand).
+
+**How to assess methodology authority.**
+
+- Does the team have direct customer data on the calculation's central variables?
+- Does the team have access to defensible industry benchmarks?
+- Is the team willing to publish the methodology, or does the methodology have to stay proprietary?
+- Can the team defend the methodology to a sophisticated stakeholder?
+
+If the answer to most of these is yes, the calculator has methodology authority. If the answer is no, the calculator is being built on assumptions that will not survive interrogation.
+
+---
+
+## The decision worked example
+
+A SaaS analytics platform considering a "ROI of moving from spreadsheets" calculator.
+
+**Conditions check.**
+
+- Specific calculation: yes. Prospects evaluating the platform run an internal estimate of switching value.
+- Non-trivial: yes. The calculation involves time-saved-per-week, hourly cost of analyst time, error-rate reduction, decision-speed lift, and implementation cost.
+- Methodology authority: yes. The team has customer data on time saved, error reduction, and decision speed across 200+ deployed customers.
+- Sequence has purpose: yes. Calculator inputs reveal company size, analytics maturity, and current tooling. Sequence can match the lead's profile.
+- Success metric defined: yes. Lead volume from the calculator, lead quality (audience-fit at SaaS companies above 50 employees), downstream conversion to demo within 90 days.
+
+**Decision.** Build the calculator. The conditions warrant it.
+
+**Tier design.** Tier 1 (free): the headline annual savings number, the breakdown across time-saved, error-reduction, and decision-speed components, methodology disclosure linked. Tier 2 (email-gated): a PDF the prospect can share with their stakeholders showing the calculation in defensible form. Tier 3 (account-gated, optional): saved scenarios across multiple analyst counts and use-case configurations.
+
+**Maintenance commitment.** Quarterly review of the customer-data benchmarks. Update assumptions when the customer base shifts.
+
+The decision was not "should we have a calculator" but "given these conditions, this is the calculator to build."
+
+---
+
+## When to choose a simpler magnet instead
+
+The calculator is the wrong tool. What works.
+
+**Pricing one-pager template.** When the calculation is "what would my pricing look like," a worked-example one-pager often serves better than a calculator. The prospect adapts the example; the team avoids building.
+
+**ROI worked-example PDF.** When the calculation is "what would I save," a PDF showing 3-5 worked-example customer scenarios often serves better. The prospect identifies which scenario matches them; the team gets a downloadable resource without engineering overhead.
+
+**Sizing checklist.** When the calculation is "what tier do I need," a checklist of features and team-size signals can guide the prospect to the right tier without a calculator.
+
+**Comparison table.** When the calculation is "is this better than the alternative," a static comparison table often serves better than a dynamic calculator.
+
+The pattern. Many "we need a calculator" intuitions are actually "we need a clear way to communicate this calculation to prospects." Often the simpler format works as well or better, at one-tenth the build cost.
+
+---
+
+## When to retire a calculator
+
+Calculators decay. Retiring them is part of the discipline.
+
+**Retire when:**
+
+- Lead volume has dropped below baseline for two consecutive quarters.
+- The product or pricing has changed enough that the calculator's calculations no longer reflect the offering.
+- The benchmarks the calculator relies on are stale and the team cannot update them.
+- A newer tool or magnet on the same topic is outperforming.
+- The maintenance cost exceeds the lead value.
+
+The retiring discipline frees capacity. A portfolio of stale calculators costs maintenance attention without producing results.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The investment conditions for whether to build a calculator. The opportunity-cost frame. The methodology-authority precondition. The decision worked example. When to choose a simpler magnet. The retirement discipline.
+
+## Implementation choices that stay internal
+
+Specific calculator topics for specific audiences. The team's capacity benchmarks for build, maintenance, and sequence. Specific tooling for calculator engineering, hosting, and integration. Specific methodology sources and update calendars. These vary by team.

--- a/skills/calculator-design/references/common-calculator-failures.md
+++ b/skills/calculator-design/references/common-calculator-failures.md
@@ -1,0 +1,179 @@
+# Common calculator failures
+
+9+ failure patterns with diagnoses and cures. The patterns that surface as "the calculator did not work" or "the leads are unqualified" or "we cannot tell what the calculator is producing."
+
+---
+
+## "Conversion rate is high; downstream conversion is near zero."
+
+**The diagnosis.** Lead-trap or vanity-output pattern. The audience captured did not get value; did not engage with the follow-up; did not convert downstream.
+
+**The cure.** Audit for lead-trap (`references/email-capture-decision-tree.md`). Audit for vanity-output (`references/result-presentation-patterns.md`). The result has to be specific, contextualized, and actionable; the email gate has to be on additional value, not on the result itself.
+
+---
+
+## "Audience visits the calculator, runs it once, never returns."
+
+**The diagnosis.** The calculator does not produce a save-worthy or share-worthy result. No reason to come back.
+
+**The cure.** Add tier-2 value (PDF, saved scenario) that gives the user something to bring back to. Audit the result presentation (`references/result-presentation-patterns.md`); a result the user cannot share with stakeholders rarely produces return visits.
+
+---
+
+## "Sales team says the calculator-sourced leads are unqualified."
+
+**The diagnosis.** Calculator's audience-fit is weak. The calculation does not match the buyer's actual decision; the audience captured is curious-but-not-buying.
+
+**The cure.** Audit the calculator's audience-fit. Does the calculation map to a real decision the buyer faces? If not, the calculator may be capturing wrong-segment leads. Detail also in `lead-magnet-design`'s audience-fit qualification.
+
+---
+
+## "We get questions about how the calculator works; we have no answer."
+
+**The diagnosis.** Methodology not documented. The team cannot defend the calculator's outputs.
+
+**The cure.** Document the methodology (`references/calculation-logic-transparency.md`, `references/methodology-disclosure-templates.md`). The methodology page should answer the audience's interrogation questions before they ask.
+
+---
+
+## "We updated the product; the calculator outputs are now wrong."
+
+**The diagnosis.** No update cadence. The calculator drifted out of sync with the actual offering.
+
+**The cure.** Maintenance discipline. Quarterly review of every active calculator. Update inputs, recommendations, and pricing as the offering evolves.
+
+---
+
+## "The calculator works; nobody uses it."
+
+**The diagnosis.** Calculator hidden in the site; no distribution; the audience does not know it exists.
+
+**The cure.** Distribution. Link to the calculator from related landing pages, blog posts, and navigation. Promote it in newsletter and social channels. Cite it in sales conversations. The calculator's existence is not enough; the audience has to know about it.
+
+---
+
+## "Our calculator looks like our competitor's."
+
+**The diagnosis.** Generic calculator-template patterns produce generic calculators. Brand differentiation is absent.
+
+**The cure.** Custom design that reflects the brand. Methodology that reflects the brand's specific authority. The calculator should look like it could only have come from this brand.
+
+---
+
+## "The form has 12 fields and 4 percent conversion."
+
+**The diagnosis.** Interrogation-form pattern. The calculator is collecting data, not delivering value.
+
+**The cure.** Audit the input set (`references/input-design-patterns.md`). Each input should affect the calculation. Remove fields that do not.
+
+---
+
+## "Audience trusts our brand; the calculator outputs feel arbitrary."
+
+**The diagnosis.** Methodology disclosure missing. The brand's credibility does not transfer to the tool because the tool does not show its work.
+
+**The cure.** Disclose methodology (`references/calculation-logic-transparency.md`). The brand-trust is one part of credibility; the tool's transparency is a separate part. Both have to be present.
+
+---
+
+## "Our pricing changed; the calculator was not updated for 6 months."
+
+**The diagnosis.** Maintenance lapse. The calculator's outputs were misleading for half a year.
+
+**The cure.** Set a maintenance trigger: when pricing or product details change, the calculator update is part of the change. Otherwise, set a calendar review at minimum quarterly.
+
+---
+
+## "The calculator was great at launch; conversion has dropped 40 percent over a year."
+
+**The diagnosis.** Decay. Stale benchmarks; outdated references; methodology that no longer reflects the brand's offering.
+
+**The cure.** Audit and refresh. If the calculator is still relevant, update it. If it is not, retire it.
+
+---
+
+## "The free result is just 'estimated savings: significant.'"
+
+**The diagnosis.** Vanity output. The free tier is a teaser rather than a substantive result.
+
+**The cure.** The free tier has to be substantive. "Estimated annual savings: $14,200" with breakdown and methodology beats "significant savings" with email gate.
+
+---
+
+## "Audiences complete the inputs but do not opt for the PDF."
+
+**The diagnosis.** The PDF does not justify the email exchange. Either the PDF is the same content as the free result (no value-add) or the audience does not perceive the PDF as worth the email.
+
+**The cure.** Make the PDF genuinely better. Add comparison tables, case studies, or additional analysis. Frame the PDF as "what you can share with your CFO" so the audience sees the use case.
+
+---
+
+## "We get traffic; we get email signups; the sales team never hears about the leads."
+
+**The diagnosis.** Sequence missing or poorly designed. The leads sit on the list without being routed to sales.
+
+**The cure.** Design the post-conversion flow. Calculator-sourced leads should be tagged, routed, and sequenced. Sales should know which leads came from the calculator and what the leads' inputs revealed.
+
+---
+
+## "We added a calculator; our other lead magnets stopped converting."
+
+**The diagnosis.** Cannibalization. The calculator absorbed the audience that previously converted via other magnets.
+
+**The cure.** This may not be a failure. If the calculator-sourced leads are higher quality than the previous magnets, the cannibalization is a portfolio improvement. If the calculator absorbed leads but produced no incremental value, the calculator may have replaced a working magnet with a worse one.
+
+---
+
+## "The calculator works on Chrome desktop; it breaks on Safari mobile."
+
+**The diagnosis.** Browser/device-specific bugs. The calculator was tested on the team's primary platform; the audience's actual devices were not covered.
+
+**The cure.** Cross-browser, cross-device testing. The audience uses what they use; the calculator has to work there.
+
+---
+
+## "The calculator estimates 60 percent savings; our actual customers see 35 percent."
+
+**The diagnosis.** The calculator's assumptions are flattering rather than accurate. The customers who used the calculator's projections are now disappointed.
+
+**The cure.** Recalibrate. Use actual customer cohort data to set the assumptions. The honest result may be less impressive on the marketing screen but earns more trust over time.
+
+---
+
+## "We want to A/B test the calculator's email gate placement."
+
+**The diagnosis.** This is fine, but the test should be designed carefully. Moving the email gate is a gating-decision change that affects both conversion and lead quality.
+
+**The cure.** Test gate placement with both conversion-rate and downstream-conversion metrics. A change that lifts conversion but tanks downstream is a regression, not an improvement.
+
+---
+
+## "The calculator's methodology page got 200 visits and 50 unsubscribes."
+
+**The diagnosis.** Likely the audience interrogated the methodology and found it wanting. Either the methodology has a real flaw, or the methodology page is unclear.
+
+**The cure.** Audit the methodology page. Either fix the methodology (if there is a real flaw) or clarify the page (if the issue is presentation).
+
+---
+
+## The pattern across failures
+
+Most calculator failures fall into one of three patterns.
+
+**Pattern 1: The calculator does not deliver real value.** Vanity output, hidden methodology, lead-trap. The fix is to deliver real, defensible, accessible results.
+
+**Pattern 2: The calculator does not match the audience or decision.** Audience-fit weak, calculation-decision mismatch, interrogation-form. The fix is to align the calculator to the audience the brand serves and the decision the audience faces.
+
+**Pattern 3: The calculator decays.** Stale assumptions, outdated benchmarks, broken integration. The fix is maintenance discipline.
+
+The metric pattern: calculator failures often look fine on conversion rate. The signal is in lead quality, downstream conversion, and audience interrogation behavior. Programs that track only conversion rate keep shipping the same patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (delivery, audience-fit, decay). The principle that conversion rate alone is insufficient as a success metric.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered and the lessons learned. Specific multi-metric dashboards the team uses. Specific cures the team applies. The team's audit and retirement processes. These vary by team.

--- a/skills/calculator-design/references/email-capture-decision-tree.md
+++ b/skills/calculator-design/references/email-capture-decision-tree.md
@@ -1,0 +1,205 @@
+# Email-capture decision tree
+
+What to give freely, what to gate. The lead-trap failure and the transparent-tool win.
+
+The single most consequential decision in calculator design is what gets shown freely and what requires an email. Get this wrong and the calculator is either a lead-trap (gating the result the user came for) or a missed opportunity (giving away everything with no capture mechanism).
+
+---
+
+## The honest principle
+
+Give the audience the result they came for. Gate the additional value.
+
+The audience showed up to run a calculation. They want the answer. Gating the answer is bait-and-switch: the calculator promised a result, the user provided inputs, and the result is held hostage until they trade an email.
+
+The transparent alternative: give the result freely. The audience gets what they came for. The brand offers additional value (a PDF report, a saved scenario, a custom analysis) that the audience can opt in for. The email exchange is then for additional value, not for the result the calculator promised.
+
+---
+
+## What to give freely
+
+Tier 1, no gate.
+
+**The headline result.** The number the user came for. "Your annual savings: $14,200" or "Recommended plan: Growth."
+
+**The breakdown.** The components that explain how the headline number was calculated. Necessary for the audience to defend the result.
+
+**A basic visualization.** A chart or comparison that helps the user see the relationship.
+
+**The methodology disclosure.** Either inline formulas or a methodology link. Necessary for the audience to trust the result.
+
+**Source citations.** Where the calculator's benchmarks come from.
+
+**The assumption list.** What the calculator assumes about the user's situation.
+
+This set is what the audience needs to use the calculator's output in their decision. Holding any of it hostage is the lead-trap pattern.
+
+---
+
+## What to gate (with email)
+
+Tier 2, email-required.
+
+**A formatted PDF report.** The result, breakdown, methodology, and assumptions in a shareable format. The user can send this to their stakeholders. The PDF has to be genuinely better than a screenshot of the result; otherwise the gate is not justified.
+
+**A saved scenario the user can revisit.** Persistence across visits. The user adjusts inputs over time, returns to compare, sees how the result has changed. Email-required to identify the user.
+
+**A custom or deeper analysis.** A second-pass calculation that uses the user's inputs as a starting point and adds more depth (more variables, more scenarios, more methodology). Often delivered later (by email) rather than immediately.
+
+**Email-based notifications.** When the calculator's benchmarks change or new versions launch, the user can be notified.
+
+The discipline. Each gated tier has to add real value over the free tier. If the PDF is just "the same result in a PDF," the gate is not earning the email.
+
+---
+
+## What to gate (with account or sign-up)
+
+Tier 3, account-required.
+
+**Save-and-compare across multiple scenarios.** The user models 5 different configurations and compares them side-by-side. Account-level persistence supports this.
+
+**Integration with the brand's product or service.** The calculator's output flows into the user's account on the brand's platform; the calculation becomes part of an ongoing workflow.
+
+**Historical comparison.** When the calculator is used periodically (monthly cost projection, quarterly review), the user's historical inputs and results are tracked.
+
+**Collaboration features.** Multiple users on the same account can model scenarios together.
+
+These features warrant the higher friction of account creation. Email alone is insufficient; the user needs persistent identity for these to work.
+
+---
+
+## The lead-trap failure
+
+The pattern that destroys conversion.
+
+**The pattern.** The user enters inputs, hits Calculate, sees "enter your email to see your result."
+
+**Why it fails.**
+
+- The audience perceives the manipulation. The calculator promised a result; the result is hidden.
+- Conversion drops. Many users abandon at the gate; some enter throwaway emails.
+- The leads that do convert are unqualified or actively annoyed; downstream conversion is poor.
+- The brand earns "lead-trap" reputation; future users who recognize the pattern bounce immediately.
+
+**Why teams build lead-traps.** Short-term thinking. The team optimizes for capture rate without measuring downstream conversion. The lead-trap looks like it works because the form-fill rate is high; the lead-trap fails because the leads do not convert.
+
+**The cure.** Restructure the calculator so the result is free and the additional value is gated. Conversion to the email gate may drop in absolute terms, but the leads that do opt in are higher-quality.
+
+---
+
+## The transparent-tool win
+
+The pattern that compounds credibility.
+
+**The pattern.** The user enters inputs, sees the result immediately, and is offered a "Get this as a PDF" or "Save this scenario" option that requires email.
+
+**Why it works.**
+
+- The audience trusts the brand. The calculator delivered on its promise.
+- The email opt-in is for additional value, not for the result. Users who opt in are signaling real interest in the topic.
+- Lead quality is higher because the lead opted in for value-add, which signals genuine interest.
+- The brand earns "honest" reputation; word-of-mouth and referral grow.
+
+**The metrics that matter.**
+
+- Free-tier completion rate (how many users finish the calculation and see the result).
+- Email-tier conversion rate (of those who see the result, how many opt in for the additional value).
+- Downstream conversion (of those who opted in, how many engage with the follow-up sequence and convert to the next step).
+
+The transparent-tool optimizes for downstream conversion, which is the metric that matters for the program.
+
+---
+
+## The decision tree
+
+Walk through this for each gating decision.
+
+**Question 1: Is this the result the user came for?**
+
+- If yes: do not gate. Holding the user-promised result hostage is lead-trap.
+- If no: continue.
+
+**Question 2: Is this additional value the user might want?**
+
+- If yes: gating is potentially appropriate.
+- If no: do not gate; the user does not want it badly enough for the email exchange to be worthwhile.
+
+**Question 3: Is the additional value substantial enough to justify the email?**
+
+- If yes: gate it. The user gets real value; the brand gets the email; the exchange is honest.
+- If no: do not gate; the gate is not earning its friction.
+
+**Question 4: Could the additional value be delivered better as a follow-up after the email?**
+
+- If yes: gate it as a follow-up offer in the post-result flow, not as a barrier to the result.
+- If no: gate it as a clear "get this additional value" offer near the result.
+
+This decision tree separates honest gating from manipulative gating.
+
+---
+
+## Worked examples
+
+**Example 1: SaaS pricing calculator.**
+
+- Free: recommended plan, monthly cost estimate, breakdown by component, methodology link.
+- Email-gated: a PDF showing the recommendation, alternative plans considered, and a printable comparison table.
+- Account-gated: ability to save the scenario and adjust over time as the team's needs change.
+
+The free tier delivers what the prospect came for. The email gate delivers a shareable artifact for the prospect's internal stakeholders. The account gate enables ongoing use.
+
+**Example 2: ROI calculator for a B2B service.**
+
+- Free: estimated annual savings, breakdown across cost reduction and productivity gains, methodology disclosure.
+- Email-gated: PDF analysis with industry-comparison context and worked-example case study.
+- Account-gated: not offered. The calculator is single-use; account creation is unnecessary friction.
+
+The free tier serves the audience. The email gate serves the prospect's internal stakeholders by providing a shareable analysis.
+
+**Example 3: Mortgage calculator.**
+
+- Free: estimated monthly payment, breakdown across principal, interest, taxes, insurance, methodology link.
+- Email-gated: a personalized rate quote (which requires the bank to underwrite based on user inputs).
+- Not offered: account creation. The calculator is a one-shot tool; account creation does not match the use case.
+
+The email gate is justified by genuine value-add (personalized rate quote requires underwriting). The free tier delivers the calculator's promise.
+
+---
+
+## When the email gate is the wrong tool
+
+Sometimes no gating is the right answer.
+
+**Calculators built primarily for SEO or brand authority.** A widely-shared, well-ranked calculator can be a strong brand asset even without lead capture. The audience that uses it associates the brand with the topic; the SEO ranking compounds traffic.
+
+**Calculators where lead-capture friction destroys the value proposition.** A simple, quick-use calculator may be best as a no-gate tool. The audience uses it, gets value, returns; the brand becomes the source of the tool.
+
+**Calculators in regulated industries.** Some sectors have specific privacy or regulatory constraints on email capture. The calculator may need to operate without standard lead-capture flows.
+
+The decision depends on the program's goals. Not every calculator needs to be a lead magnet. Some calculators serve other purposes (SEO, brand, audience-building) better without gates.
+
+---
+
+## Common gating failures
+
+**Result hidden behind email.** The lead-trap. Conversion drops; downstream metrics drop further.
+
+**Gate without value.** Email required to access something that should have been free; no real additional value behind the gate.
+
+**Gate that lies about what is gated.** "Get the full analysis" suggests the free version was incomplete; the user expects more depth, gets the same content reformatted, feels deceived.
+
+**Multiple gates in sequence.** Email for one tier, account for another, phone number for a third. Each step adds friction; cumulative drop-off destroys the audience.
+
+**Gate copy that is manipulative.** "Don't lose your result, give us your email" is hostile. "Want this as a PDF? Enter your email" is honest.
+
+**Gate placement that interrupts the result viewing.** The result loads; the user starts reading; a popup appears asking for email. The user's flow breaks; trust drops.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The honest principle. What to give freely. What to gate at email and at account level. The lead-trap failure pattern. The transparent-tool win pattern. The decision tree. Worked examples. When the email gate is the wrong tool. Common gating failures.
+
+## Implementation choices that stay internal
+
+Specific gating decisions for the team's calculators. Specific PDF templates and follow-up flows. Specific account-creation flows and integration patterns. Specific gate copy in brand voice. The team's downstream-conversion benchmarks. These vary by team.

--- a/skills/calculator-design/references/input-design-patterns.md
+++ b/skills/calculator-design/references/input-design-patterns.md
@@ -1,0 +1,218 @@
+# Input design patterns
+
+Input necessity, default discipline, input types, progressive disclosure. The friction the audience does not need.
+
+The calculator's inputs are the audience's first interaction with the tool. Bad input design loses users before the calculation runs. Good input design respects the user's time and produces inputs that genuinely affect the math.
+
+---
+
+## The necessity principle
+
+Each input should be necessary for the calculation. Inputs that do not affect the output meaningfully should not be asked for.
+
+**The test.** For each input, ask: does removing this input change the result by a meaningful amount? If no, the input is not necessary; remove it.
+
+**The interrogation-form failure.** Calculators that ask 18 inputs but only use 5 in the math are signaling that the form is collecting sales-qualification data. The audience can tell. Conversion drops; trust drops.
+
+**The honest input set.** Most calculators need 4-10 inputs. Tools asking 15+ inputs almost always have non-essential fields that should move to a separate (later, optional) interaction.
+
+**The exception: meaningful customization.** When inputs do affect the result and the audience values the customization, more inputs are warranted. A pricing calculator that customizes to industry, team size, use case, and feature needs may need 8-12 inputs because each input affects the output.
+
+The discipline. Audit the input set against the actual math. Remove fields that do not affect the result.
+
+---
+
+## Default discipline
+
+Defaults reduce cognitive load. Bad defaults bias the result.
+
+**Honest defaults.** Set defaults to honest, sourced values. "Average company size: 50" if 50 is the median across the audience. "Typical conversion rate: 14 percent" if 14 percent is a defensible benchmark.
+
+**Sourced defaults.** When defaults come from external benchmarks, source them. A footnote or tooltip explaining the default's origin earns trust.
+
+**Adjustable defaults.** The user should be able to override the default with their actual value. Defaults that look hardcoded reduce trust; defaults the user can edit signal that the calculator respects the user's situation.
+
+**Bias-flattering defaults.** Defaults set to flatter the brand's outputs (high savings, low costs) destroy credibility when the user notices. The audience that catches the bias remembers it.
+
+**Default decay.** Defaults need updating as benchmarks shift. A default set in 2022 that has not been touched is stale; the audience that knows the current benchmark sees the gap.
+
+---
+
+## Input types
+
+Choose the right input control for each variable.
+
+**Numeric input.** Free-form number entry. Use for variables that are user-specific and where exact values matter (revenue, customer count, monthly cost). Often warrants a tooltip explaining what the number represents.
+
+**Slider.** Visual range control. Use for percentage estimates and ranges where exact values are not knowable (conversion rate, growth rate, retention). Sliders communicate the range and reduce cognitive load on choosing a precise number.
+
+**Dropdown.** Select from predefined categories. Use for variables that are categorical (industry, region, company size band). Dropdowns prevent invalid inputs and group similar audiences.
+
+**Toggle.** Binary on/off. Use for feature inclusion/exclusion or scenario switching (with implementation / without implementation).
+
+**Stepper.** Increment/decrement controls. Use for small whole-number variables (number of users, number of locations) where the range is bounded.
+
+**Free text.** Open-ended text input. Use sparingly. Free text adds friction and rarely affects calculation; if the calculator needs free text to function, the calculation may be the wrong format.
+
+The choice depends on the variable's nature. The wrong control type adds friction; the right control type makes the input feel natural.
+
+---
+
+## Progressive disclosure
+
+Show only the inputs the user is currently working through.
+
+**The pattern.** The calculator presents 2-4 inputs at a time. The user completes those, the next set appears. Each step builds on the previous.
+
+**When progressive disclosure helps.** When the calculator has 8+ inputs, when input groups are conceptually distinct (company info, then current state, then desired state), or when later inputs depend on earlier choices.
+
+**When progressive disclosure hurts.** When the calculator has 4-6 inputs that the user could complete in 30 seconds, hiding any of them adds friction. Single-page calculators are fine for short input sets.
+
+**Progress indicators.** When the calculator is multi-step, show progress ("Step 2 of 4") so the user knows the time commitment.
+
+**Back navigation.** The user should be able to go back and adjust earlier inputs without losing later ones.
+
+---
+
+## Input grouping and visual flow
+
+Group related inputs visually. The user processes related inputs as a unit.
+
+**Logical groups.**
+
+- Company info (name, size, industry).
+- Current state (current cost, current process, current tools).
+- Desired state (target outcome, target timeline).
+- Configuration choices (tier, options, add-ons).
+
+**Visual cues.**
+
+- Section headers for each group.
+- Spacing between groups.
+- Consistent input styles within a group.
+
+**Avoid.**
+
+- Mixing unrelated inputs in one section.
+- Inconsistent label patterns across the form.
+- Required-vs-optional ambiguity (mark required inputs explicitly).
+
+---
+
+## Tooltips and explanations
+
+Inputs that are not self-explanatory need explanation. Inputs that are self-explanatory do not need it.
+
+**When tooltips help.** When the input requires context the user may not have ("Customer Acquisition Cost: the marketing and sales spend per new customer"), when the input has a specific definition that varies by interpretation, or when the default needs sourcing ("Industry average from [source]").
+
+**When tooltips hurt.** When the input is obvious (no tooltip needed for "Number of users"), when the tooltip is marketing rather than explanation, or when the tooltip overwhelms the form visually.
+
+**Tooltip placement.** Inline (right next to the field label) or hover-triggered. Hover-triggered keeps the form clean for users who do not need explanation.
+
+**Tooltip discipline.** Each tooltip should answer one question. Multiple paragraphs in a tooltip signal that the input itself needs redesign.
+
+---
+
+## Validation and error handling
+
+Inputs need validation. Errors need helpful messages.
+
+**Inline validation.** Validate as the user types or after they leave the field. Catch errors at the point of input, not at submission.
+
+**Helpful error messages.** "Number must be greater than 0" beats "Invalid input." "Try a value between 1 and 1000" beats "Out of range."
+
+**Avoid friction.** Validation that rejects too aggressively (rejecting all special characters when only a few cause problems) frustrates users. Error messages that scold ("You must enter...") signal a hostile form.
+
+**Required vs optional.** Mark required inputs explicitly. Optional inputs should be obvious (and rare; if it is not used, why ask).
+
+---
+
+## Mobile input design
+
+Many calculator users are on mobile. The input experience has to work there.
+
+**Mobile-specific considerations.**
+
+- Touch-friendly input sizes (minimum 44x44 pixel touch targets).
+- Numeric keyboards for numeric inputs (use input type="number" or appropriate inputmode).
+- Sliders sized for thumb interaction.
+- Dropdowns that work with native mobile selection.
+- Sufficient spacing between inputs to prevent accidental taps.
+
+**Mobile testing.** Test the calculator on actual mobile devices, not just browser dev tools. Real-device behavior often differs.
+
+**Mobile-broken calculator failure.** Calculator works on desktop, breaks on mobile. The mobile audience either bounces or has a worse experience. This failure is common; mobile testing prevents it.
+
+---
+
+## Input examples and worked patterns
+
+**Pattern: company info input set.**
+
+- Company size (dropdown: 1-10, 11-50, 51-200, 201-500, 501-2000, 2000+)
+- Industry (dropdown of 8-12 categories)
+- Current annual revenue (numeric, optional, with tooltip explaining how it affects calculation)
+
+3 inputs, 30 seconds to complete, all affect the calculation.
+
+**Pattern: current state input set.**
+
+- Current monthly cost (numeric, with tooltip)
+- Current team size on the relevant function (numeric)
+- Current process (dropdown: manual, partially automated, fully automated)
+
+3 inputs, sets the baseline for the calculation.
+
+**Pattern: desired state input set.**
+
+- Target outcome (dropdown: cost reduction, time savings, revenue lift, all of the above)
+- Target timeline (slider: 3 months to 24 months)
+
+2 inputs, sets the goal for the calculation.
+
+Total: 8 inputs across 3 logical groups. Each input affects the math. Defaults reduce friction. Progressive disclosure presents groups one at a time.
+
+---
+
+## Input decay
+
+Inputs need maintenance.
+
+**What decays.**
+
+- Defaults based on benchmarks that have shifted.
+- Tooltips referencing tools or terms that have changed.
+- Dropdown options that are no longer accurate (industry categories, product tiers).
+- Sources cited in tooltips that no longer exist or have moved.
+
+**Maintenance cadence.** Quarterly review of every active calculator's inputs. Update defaults, refresh tooltips, prune stale options.
+
+**The decay-trust connection.** Stale defaults erode trust. The audience notices when "Industry Average: 14 percent (2022)" appears in a 2026 tool.
+
+---
+
+## Common input failures
+
+**Too many inputs.** 15+ inputs signal interrogation rather than calculation. Audit for non-essential fields.
+
+**Bias-flattering defaults.** Defaults that produce favorable outputs for the brand. Audiences notice; trust drops.
+
+**Hardcoded defaults that cannot be changed.** The audience cannot adjust to their actual situation. The calculator feels generic.
+
+**Wrong input type for the variable.** Free text where dropdown would be better; dropdown where slider would be better. Adds friction.
+
+**Missing tooltips on non-obvious inputs.** The audience does not know what the input means; they guess; the result is meaningless.
+
+**Mobile-broken inputs.** Sliders impossible to grab on mobile; dropdowns that overflow; numeric keyboards not triggered.
+
+**Stale defaults.** Benchmarks from years ago; tooltips referencing deprecated tools; dropdown options that no longer match reality.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The necessity principle. Default discipline. Input type guidance. Progressive disclosure. Input grouping and visual flow. Tooltip discipline. Validation and error handling. Mobile input design. Input decay and maintenance.
+
+## Implementation choices that stay internal
+
+Specific input sets for specific calculators. Specific default values from the team's data sources. Specific tooltip copy in brand voice. Specific input components and styling. The team's mobile testing benchmarks. These vary by team and calculator.

--- a/skills/calculator-design/references/methodology-disclosure-templates.md
+++ b/skills/calculator-design/references/methodology-disclosure-templates.md
@@ -1,0 +1,321 @@
+# Methodology disclosure templates
+
+Templates for assumption lists, methodology pages, source citations, formula explanations. Patterns for disclosing calculation logic in ways the audience can use to defend the result.
+
+A methodology disclosure is not a marketing document. It is a technical document that lets the audience interrogate the calculator. The templates here cover the patterns that hold up to interrogation.
+
+---
+
+## Methodology page template
+
+A standalone page that explains the calculator's calculations in detail.
+
+**Structure.**
+
+```
+# How the [calculator name] is calculated
+
+## What this calculator does
+[2-3 sentences describing the calculation in plain language]
+
+## The formulas
+[Plain-text formulas with each variable defined]
+
+## Assumptions
+[Plain-language list of what the calculator assumes]
+
+## Sources
+[Citations for any external benchmarks or data]
+
+## Worked example
+[A specific scenario with input values and resulting calculation]
+
+## Caveats
+[What the calculator does not account for; when to seek additional analysis]
+
+## Updates
+[Date of last methodology review; how often the calculator is updated]
+```
+
+---
+
+## Assumption list template
+
+A plain-language list of assumptions, formatted for scan-ability.
+
+**Structure.**
+
+```
+## What this calculator assumes
+
+- [Assumption 1: stated plainly]
+- [Assumption 2: stated plainly]
+- [Assumption 3: stated plainly]
+
+## What this calculator does NOT account for
+
+- [Excluded factor 1]
+- [Excluded factor 2]
+
+If your situation differs significantly from these assumptions, the result is an estimate; consider [additional resource] for more precise analysis.
+```
+
+**Example assumption list for a SaaS pricing calculator.**
+
+```
+## What this calculator assumes
+
+- Your team will use the platform daily across business hours.
+- Implementation takes 4-6 weeks for teams in the 50-200 employee range.
+- The recommended plan is based on typical usage patterns from our customer base.
+- Productivity gains compound through year 1 and stabilize in year 2.
+
+## What this calculator does NOT account for
+
+- Custom integrations or enterprise SSO requirements.
+- Volume discounts available for annual contracts above $50K.
+- Migration cost from your current platform.
+
+If your situation involves enterprise SSO, custom integrations, or migration costs, talk to our team for a tailored estimate.
+```
+
+---
+
+## Source citation template
+
+How to cite external benchmarks or data.
+
+**Inline citation pattern.**
+
+```
+Industry Average: 14 percent (Source: [Industry Benchmark Report 2025], page 23)
+```
+
+**Footnote pattern.**
+
+```
+Industry Average: 14 percent [^1]
+
+[^1]: Industry Benchmark Report 2025. Available at [URL]. Accessed [Date].
+```
+
+**Multi-source pattern.**
+
+```
+The conversion-rate benchmark we use combines:
+- Industry Benchmark Report 2025 (Source A)
+- Our customer cohort data (n=200, 2024-2025)
+- Public conversion-rate studies from [Source C]
+
+The composite benchmark is 14 percent.
+```
+
+**Internal-source pattern.**
+
+```
+Source: [Brand]'s customer cohort data, n=200, 2024-2025. The cohort represents customers in the 50-500 employee range across SaaS, e-commerce, and B2B services.
+```
+
+---
+
+## Formula explanation template
+
+How to display formulas in ways the audience can verify.
+
+**Plain-text formula pattern.**
+
+```
+Annual savings = (current annual cost) - (estimated new annual cost) + first-year implementation savings
+
+Where:
+  current annual cost = current monthly cost x 12
+  estimated new annual cost = recommended plan price x 12
+  first-year implementation savings = $500 if migrating from a manual process, otherwise $0
+```
+
+**Step-by-step calculation pattern.**
+
+```
+1. Calculate current annual cost: $3,000 / month x 12 = $36,000
+2. Calculate estimated new annual cost: $2,000 / month x 12 = $24,000
+3. Calculate cost reduction: $36,000 - $24,000 = $12,000
+4. Add first-year implementation savings: $12,000 + $2,200 = $14,200
+
+Annual savings: $14,200
+```
+
+**Conditional logic pattern.**
+
+```
+The recommended plan is determined by:
+
+If team size is 1-10: Starter plan ($X / month)
+If team size is 11-50: Growth plan ($Y / month)
+If team size is 51-200: Business plan ($Z / month)
+If team size is 201+: Enterprise (contact for pricing)
+
+Plan recommendations may shift based on use case (e.g., teams with heavy data needs may benefit from a higher tier even at a lower seat count).
+```
+
+---
+
+## Worked-example template
+
+A concrete scenario the audience can read end-to-end.
+
+**Structure.**
+
+```
+## Worked example: [scenario description]
+
+Inputs:
+- [Input 1]: [value]
+- [Input 2]: [value]
+- [Input 3]: [value]
+
+Calculation:
+[Step-by-step formula application]
+
+Result:
+[Final output with units]
+
+Interpretation:
+[1-2 sentences explaining what the result means and how the audience would use it]
+```
+
+**Example for a SaaS pricing calculator.**
+
+```
+## Worked example: 75-person B2B SaaS team
+
+Inputs:
+- Team size: 75
+- Use case: Customer support
+- Current solution: Manual spreadsheets
+
+Calculation:
+- Recommended plan: Business ($45 / user / month)
+- Monthly cost: 75 users x $45 = $3,375
+- Annual cost: $3,375 x 12 = $40,500
+- Estimated time savings: 8 hours / week / agent x 75 agents x $40 / hour x 50 weeks = $1.2M
+- Net annual value: $1.2M - $40,500 = $1.16M
+
+Result:
+- Recommended plan: Business
+- Monthly investment: $3,375
+- Estimated annual time-savings value: $1.2M
+- Net annual value: $1.16M
+
+Interpretation:
+A 75-person customer-support team migrating from manual spreadsheets to the Business plan would invest $40,500 annually and save approximately $1.16M in time-equivalent value. The largest contributor is hours saved per agent per week.
+```
+
+---
+
+## Caveats template
+
+What the calculator does not do, stated honestly.
+
+**Structure.**
+
+```
+## What this calculator does not account for
+
+- [Excluded factor 1]: why it is excluded and what to do if it matters
+- [Excluded factor 2]: why it is excluded and what to do if it matters
+
+For situations involving [specific complex case], the calculator's estimate may not apply; consider [additional resource or contact] for more precise analysis.
+```
+
+**Why caveats matter.** Caveats signal the calculator's honesty. The audience that knows the caveats can use the result with appropriate confidence; the audience that does not know the caveats may apply the result to a situation it does not fit.
+
+**Common caveats to include.**
+
+- The calculator does not account for taxes, regulations, or jurisdiction-specific factors.
+- The calculator does not account for one-time setup or migration costs.
+- The calculator's benchmarks reflect the typical case; outliers may differ significantly.
+- The calculator's projections are estimates, not guarantees.
+
+---
+
+## Update-history template
+
+How to track methodology changes over time.
+
+**Structure.**
+
+```
+## Updates
+
+This calculator's methodology was last reviewed on [date].
+
+Recent updates:
+- [Date]: Updated industry-benchmark source from [old] to [new].
+- [Date]: Adjusted productivity-gains assumption based on cohort data through [year].
+- [Date]: Added consideration for [new factor].
+
+Major version history:
+- v1.0 ([date]): Initial release.
+- v1.1 ([date]): Added [feature].
+- v2.0 ([date]): Refactored methodology to include [new dimension].
+```
+
+**Why update history matters.** Audiences who relied on previous outputs can see what changed. The transparency about updates signals that the calculator is maintained, not abandoned.
+
+---
+
+## Methodology integration patterns
+
+How to integrate the methodology disclosure into the calculator UI.
+
+**Pattern A: Inline disclosure.** The methodology appears alongside the result. Best for short calculations where the formula is digestible.
+
+**Pattern B: Expandable section.** "How this is calculated" expandable below the result. The user opens it if they want depth.
+
+**Pattern C: Linked methodology page.** A "How this is calculated" link to a separate page. Best for complex calculations.
+
+**Pattern D: Hover-revealed detail.** Each result component has a tooltip explaining how it was derived. Useful for multi-component results.
+
+**Pattern E: Methodology-in-PDF.** The free result shows the headline; the gated PDF contains full methodology. Works when the PDF is genuine value-add.
+
+---
+
+## Audience-specific methodology depth
+
+Calibrate methodology depth to the audience's analytical sophistication.
+
+**Highly analytical audiences (engineers, finance, data scientists).** Detailed formulas, source citations, version history. The audience expects depth and rewards transparency.
+
+**Moderately analytical audiences (PMs, marketers, operations).** Plain-language formulas, key assumptions, summary citations. The audience wants to verify but does not need every variable.
+
+**Less analytical audiences (executives, generalists).** Plain-language summary of the methodology, key assumptions, "talk to us if you want depth" option. The audience trusts based on the summary; depth is available if needed.
+
+The discipline. Match the methodology depth to the audience that uses the calculator. Too thin loses analytical audiences; too dense loses generalist audiences.
+
+---
+
+## Common methodology disclosure failures
+
+**No methodology shown.** Result without explanation; audience cannot verify or defend.
+
+**Methodology hidden behind email.** Lead-trap pattern applied to methodology; audience that wants to verify must opt in first.
+
+**Methodology in marketing language.** "Our proprietary algorithm draws on industry-leading data" is not methodology; it is brand copy.
+
+**Methodology that hides the assumptions.** Formulas shown; assumptions not stated; audience cannot tell what the calculator assumes about their situation.
+
+**Methodology that hides the sources.** Industry averages cited without attribution.
+
+**Methodology that does not match the calculation.** Stated methodology and actual implementation drift apart over time.
+
+**Methodology with no update history.** Calculator changes silently; audience that relied on previous outputs cannot see what changed.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The methodology page template. The assumption list template. The source citation patterns. Formula explanation patterns. Worked-example template. Caveats template. Update-history template. Methodology integration patterns. Audience-specific methodology depth. Common disclosure failures.
+
+## Implementation choices that stay internal
+
+Specific methodology pages for specific calculators. Specific source-citation conventions and benchmark relationships. Specific formula-display tooling and styling. Specific worked-example libraries. The team's methodology update calendars and version control. These vary by team.

--- a/skills/calculator-design/references/result-presentation-patterns.md
+++ b/skills/calculator-design/references/result-presentation-patterns.md
@@ -1,0 +1,247 @@
+# Result presentation patterns
+
+Specific, contextualized, actionable. Headline number, breakdown, visualization, scenario comparison. The result is the calculator's product; bad presentation wastes the calculation work.
+
+A calculator that runs the right math and presents the result poorly fails as completely as a calculator that runs the wrong math. Result presentation is half the user experience. Get it wrong and the audience does not know what to do with the number they computed.
+
+---
+
+## The presentation principle
+
+The result should be specific, contextualized, and actionable.
+
+**Specific.** A number with units. "Estimated annual savings: $14,200." Not "Significant savings." Not "Up to 60 percent off." Precision matters; the audience uses the result in their actual decision.
+
+**Contextualized.** Compare to a baseline the user can understand. "Based on your inputs, you would save $14,200 annually compared to your current configuration." Without the baseline, the number is just a number; with the baseline, it becomes meaningful.
+
+**Actionable.** What does the user do with this number? "Use this estimate to make the case to your CFO" or "Save this scenario to compare against alternative configurations" or "Get a PDF report you can share." The next step bridges from result to action.
+
+A result that hits all three is one the audience can use in their actual decision. A result that misses any of the three leaves the audience with an unanswered "so what."
+
+---
+
+## The headline number
+
+The single most important output, large and prominent.
+
+**The pattern.** One number, one label, large type, central placement. The audience sees the headline number first.
+
+**Example headline outputs.**
+
+- "Estimated annual savings: $14,200"
+- "Recommended plan: Growth (37 users, 3 admins)"
+- "Time to payback: 8 months"
+- "Estimated monthly cost: $2,400"
+
+**The discipline.**
+
+- One headline number, not five. Multiple competing headlines fragment the user's attention.
+- Number with units. "$14,200" beats "14200." "8 months" beats "8."
+- Honest framing. "Estimated" or "Projected" is honest; "Guaranteed" is overstatement.
+- Visual hierarchy. The headline is the largest text on the result screen.
+
+**Headline number antipatterns.**
+
+- "Up to $50,000" (range with no specific value).
+- "Significant savings" (no number).
+- "X% improvement" (no base).
+- Multiple competing numbers (user does not know which to focus on).
+
+---
+
+## The breakdown
+
+Sub-results that explain how the headline number was calculated.
+
+**The pattern.** Below the headline, show the components that make up the result.
+
+**Example breakdown for an ROI calculator.**
+
+```
+Annual savings: $14,200
+
+  Cost reduction: $9,200
+    Current cost: $36,000
+    New cost: $26,800
+
+  Productivity gains: $4,000
+    Hours saved per week: 8
+    Hourly cost: $50
+    Weeks per year: 50
+
+  Implementation savings: $1,000 (first year only)
+```
+
+**Why the breakdown matters.**
+
+- It makes the headline number defensible. The user can cite the components.
+- It helps the user understand how their inputs influenced the result. Adjusting inputs becomes meaningful.
+- It surfaces the assumptions implicitly. The user sees what the calculator weighted.
+
+**Breakdown display options.**
+
+- Stacked text (as above).
+- Expandable section (compact by default; user opens for detail).
+- Visual breakdown (stacked bar chart, pie chart for components).
+
+---
+
+## Visualization
+
+Charts and graphics that help the user see the relationship.
+
+**When visualization helps.**
+
+- Comparing the result against a baseline ("current vs new").
+- Showing components contributing to a total ("savings breakdown").
+- Showing change over time ("month-by-month savings projection").
+- Showing thresholds ("you fall in the 'mid-market' band based on your inputs").
+
+**When visualization hurts.**
+
+- When the data does not warrant a chart (a single number does not need a pie chart).
+- When the chart obscures rather than clarifies (3D pie charts, gratuitous animation).
+- When the chart cannot be interpreted on mobile.
+
+**Visualization patterns.**
+
+- **Bar comparison.** Current state vs new state. Easy to read; instant relative comparison.
+- **Stacked bar (component breakdown).** Total height = headline; segments = components.
+- **Line chart (time series).** Monthly cost projection over 12-24 months.
+- **Threshold indicator.** Position the user's result on a scale ("you are at the 73rd percentile").
+
+**Visualization quality discipline.**
+
+- Charts should be readable at the size displayed.
+- Labels should be present and legible.
+- Color should reinforce, not decorate (different colors for different components, not random palette).
+- Mobile rendering should preserve readability; charts that work on desktop and break on mobile fail half the audience.
+
+---
+
+## Scenario comparison
+
+Useful when the calculator is illustrating a delta between two states.
+
+**The pattern.** Show the user's current state and the projected state side-by-side, with the delta highlighted.
+
+**Example: SaaS migration calculator.**
+
+```
+                Current     New        Change
+Annual cost     $36,000    $24,000    -$12,000
+Hours/week     12 hrs/wk  4 hrs/wk    -8 hrs/wk
+Errors/month    14         3           -11
+```
+
+**Why scenario comparison works.**
+
+- The delta is the value proposition; showing both states makes the delta concrete.
+- The user can see what they are giving up (if anything) alongside what they are gaining.
+- The comparison format is familiar from spreadsheets and decision tools.
+
+**When scenario comparison applies.** Calculators that compare a current state to a proposed state (migrations, refinances, configurations). Less applicable to calculators that produce a single recommendation without an explicit baseline.
+
+---
+
+## Result-presentation antipatterns
+
+Patterns that waste the calculation.
+
+**Buried result.** The result requires scrolling past 5 paragraphs of marketing. The user came for the result; serve it first.
+
+**Vague output.** "Significant" or "Up to" framing without specific values. The audience cannot use vague results in real decisions.
+
+**Result followed by 5 paragraphs of marketing.** The result is what the user came for; the brand pitch belongs after, not before.
+
+**Result that requires re-entering inputs to view.** Persist inputs and results within the session. Forcing re-entry is a friction the user did not consent to.
+
+**False precision.** "$14,237.42" when the inputs justify only "$14,000 (estimated)." Precision the math does not support erodes trust.
+
+**Multiple competing headlines.** Five "important" numbers; the user does not know what to focus on.
+
+**Disconnected result and breakdown.** The headline number does not obviously add up from the breakdown components. The user does the mental math, finds the gap, loses trust.
+
+**Result without a next step.** The user gets the number, then what? Without a next step, the calculator does not bridge to action.
+
+---
+
+## Mobile result presentation
+
+The result should work on mobile.
+
+**Mobile-specific considerations.**
+
+- Headline number readable without zoom.
+- Breakdown components stack vertically rather than spread horizontally.
+- Visualizations sized for mobile screens; complex multi-axis charts often do not translate.
+- Scroll position lands on the result, not the inputs.
+
+**Common mobile failures.**
+
+- Headline number tiny on mobile because it was sized for desktop.
+- Breakdown table requires horizontal scroll.
+- Charts illegible at mobile size.
+- Result hidden below the fold; user does not know it loaded.
+
+---
+
+## Result-to-action transitions
+
+The result should lead naturally to a next step.
+
+**Patterns.**
+
+- **CTA below the result.** "Get a PDF of this analysis" or "Save this scenario" or "Talk to our team about implementing this."
+- **Multiple CTAs ranked.** Primary action prominent; secondary action visible but smaller; tertiary action available but not pushy.
+- **Email-capture in context.** When the gated tier (PDF, save) is offered, the form appears in context with the result, not in a popup that breaks flow.
+
+**The discipline.**
+
+- The next step should match the audience's likely intent. After a savings calculator, "talk to sales" may be premature; "get a PDF I can share" may match.
+- Multiple CTAs should not compete; rank them by likely user intent.
+- The next step should be honest. Promising "instant analysis from a specialist" and delivering "we will email you in 5 days" breaks trust.
+
+---
+
+## Result update behavior
+
+When the user adjusts inputs, the result updates.
+
+**Real-time updates.** As the user changes a slider, the result recalculates. Useful for exploration; the audience sees the relationship between inputs and result.
+
+**On-submit updates.** The user adjusts inputs, hits Calculate, sees the new result. Useful for calculators with many inputs where real-time updates would be distracting.
+
+**Hybrid.** Real-time for sliders and toggles; on-submit for full input changes. Common middle ground.
+
+**The choice.** Depends on calculator complexity and the value of input exploration. Calculators that benefit from "what if" exploration favor real-time; calculators that produce a definitive recommendation favor on-submit.
+
+---
+
+## Result-context for share-ability
+
+When users share the result with stakeholders, the result has to be self-contained.
+
+**The principle.** The shared result (PDF, email, screenshot, link) should be interpretable by someone who did not run the calculator.
+
+**What share-able results need.**
+
+- The headline number and what it represents.
+- The breakdown so the recipient can verify the math.
+- The methodology so the recipient can interrogate the assumptions.
+- The inputs so the recipient knows what scenario was modeled.
+- Brand attribution so the recipient knows the source.
+
+**The non-shareable result.** "Your savings: $14,200" with no inputs, no methodology, no breakdown. The recipient cannot use this; they ignore it or come back to ask follow-up questions that should not have been necessary.
+
+The shareable result extends the calculator's reach. The audience that shares is bringing the brand into a conversation; make the result strong enough to carry that weight.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The presentation principle (specific, contextualized, actionable). Headline number discipline. Breakdown patterns. Visualization patterns and discipline. Scenario comparison. Result-presentation antipatterns. Mobile result presentation. Result-to-action transitions. Result update behavior. Share-ability discipline.
+
+## Implementation choices that stay internal
+
+Specific result-page layouts for specific calculators. Specific visualization libraries and styling. Specific PDF templates for share-able results. Specific brand-voice copy for next-step CTAs. The team's mobile testing benchmarks. These vary by team and calculator.

--- a/skills/calculator-design/references/tiered-value-structures.md
+++ b/skills/calculator-design/references/tiered-value-structures.md
@@ -1,0 +1,236 @@
+# Tiered value structures
+
+Tier 1 free, Tier 2 email-gated, Tier 3 account-gated. Worked examples.
+
+The architecture that lets calculators capture leads honestly. The user gets immediate value (free tier) and is offered progressively richer value at each tier with proportional friction. Each tier earns its gate.
+
+---
+
+## The tier-design principle
+
+Each tier should add real value over the previous. Tiers that gate the same content at higher friction destroy trust.
+
+**Tier 1 (no gate).** Immediate, complete result. The audience gets what they came for. The free tier is not a teaser; it is the substantive output of the calculator.
+
+**Tier 2 (email-gated).** Additional value the user might want for sharing, persistence, or depth. Email is the appropriate friction level for this value.
+
+**Tier 3 (account-gated).** Persistent, multi-session, collaborative, or product-integrated value. Account creation is the appropriate friction level for this value.
+
+Each tier's friction matches its value-add. Tiers that ask for more friction than they justify destroy conversion.
+
+---
+
+## Tier 1: free immediate result
+
+What lives at Tier 1.
+
+**The calculator's primary output.** The headline result the user came for. Annual savings, recommended plan, monthly cost, time to payback.
+
+**The breakdown.** Components that show how the headline was calculated.
+
+**Basic visualization.** A chart or comparison that helps the user see the relationship.
+
+**Methodology disclosure.** Either inline formulas or a methodology link.
+
+**Assumption list.** What the calculator assumes about the user's situation.
+
+**Source citations.** Where the calculator's benchmarks come from.
+
+The Tier 1 set is complete. A user who never opts into Tier 2 still got the calculator's full value. The brand still earns trust; the audience still associates the brand with the topic.
+
+**What Tier 1 should NOT include.**
+
+- A teaser version of the result that withholds the actual answer.
+- A "preview" of the analysis that requires email to see in full.
+- Marketing copy that displaces the result itself.
+
+---
+
+## Tier 2: email-gated additional value
+
+What lives at Tier 2.
+
+**A formatted PDF report.** The Tier 1 content packaged in a shareable format. The PDF has to be genuinely better than a screenshot, or the gate is not justified.
+
+**A saved scenario.** The user's inputs and result persist; they can return to the calculator and see their previous calculation.
+
+**A custom analysis.** A deeper second-pass calculation, often delivered by email after submission.
+
+**Notification opt-in.** Updates when benchmarks change, when new calculator versions launch, or when the brand publishes related content.
+
+**Tier 2 design discipline.**
+
+- Each Tier 2 offering must clearly justify the email exchange. "Get a PDF that you can share with your CFO" is justifiable; "Get the same content in a PDF" is not.
+- The email-capture form should appear in context with the offer, not as an interruption to the Tier 1 viewing.
+- The follow-up email should deliver the promised value immediately, not delay it.
+
+---
+
+## Tier 3: account-gated persistent value
+
+What lives at Tier 3.
+
+**Save-and-compare across multiple scenarios.** The user models 5 different configurations and compares them side-by-side. Account-level persistence supports this.
+
+**Historical tracking.** When the calculator is used periodically (monthly projection, quarterly review), the user's historical inputs and results are tracked over time.
+
+**Collaboration features.** Multiple users on the same account can model scenarios together.
+
+**Product integration.** The calculator's output flows into the user's account on the brand's platform; the calculation becomes part of an ongoing workflow.
+
+**Tier 3 design discipline.**
+
+- Account creation is significant friction. Tier 3 features must justify it.
+- Tier 3 is often unnecessary. Many calculators serve their purpose with Tier 1 and Tier 2 alone; do not add Tier 3 unless the use case warrants it.
+- Account-creation friction can be reduced (social login, magic link) but not eliminated.
+
+---
+
+## Worked example: SaaS pricing calculator
+
+A B2B SaaS platform considering a tiered pricing calculator.
+
+**Tier 1 (free).**
+
+- The user enters team size, role distribution, and use case.
+- Sees the recommended plan and the estimated monthly cost.
+- Sees a breakdown showing per-seat cost, included features, and any add-ons.
+- Sees a comparison against the next-tier-up plan with a brief explanation of when it would be worth it.
+- Sees a methodology link explaining how recommendations are made.
+
+**Tier 2 (email-gated).**
+
+- A PDF showing the recommended plan, the breakdown, the next-tier comparison, and 2-3 customer case studies of similar teams using similar plans.
+- The PDF is shareable and contains enough context for an internal stakeholder to evaluate.
+
+**Tier 3 (account-gated).**
+
+- The user can save the scenario and adjust inputs over time as the team grows.
+- The user can model alternative scenarios (different team size, different use case) and compare side-by-side.
+- The user can receive an email when their team size threshold suggests a tier change.
+
+Each tier earns its gate. The user can stop at Tier 1 and still get value. Tier 2 is offered as a way to share with stakeholders. Tier 3 is offered for users who want ongoing tracking.
+
+---
+
+## Worked example: ROI calculator for a B2B service
+
+A B2B service company considering an ROI calculator.
+
+**Tier 1 (free).**
+
+- The user enters current cost, team size, and process maturity.
+- Sees estimated annual savings.
+- Sees a breakdown across cost reduction, productivity gains, and implementation savings.
+- Sees the methodology disclosed inline.
+
+**Tier 2 (email-gated).**
+
+- A PDF showing the calculation in defensible form, with industry-context comparison and a worked-example case study from a similar customer.
+
+**Tier 3.** Not offered. The calculator is single-use; account creation would be unnecessary friction.
+
+The two-tier structure fits the use case. Adding Tier 3 would add friction without value.
+
+---
+
+## Worked example: financial calculator (mortgage, refinance, savings)
+
+A financial services company considering a savings calculator.
+
+**Tier 1 (free).**
+
+- The user enters current loan details, target rate, and timeline.
+- Sees estimated monthly savings, total savings over the loan term, and break-even point on closing costs.
+- Sees the breakdown and methodology.
+
+**Tier 2 (email-gated).**
+
+- A PDF analysis with comparison across multiple lender scenarios.
+- A personalized rate quote (which requires underwriting based on user inputs).
+
+**Tier 3.** Optional. An account that tracks the user's loan over time and notifies them when refinance opportunities emerge as rates change.
+
+The Tier 2 includes genuine value-add (personalized quote requires underwriting). The Tier 3 is optional for users who want ongoing monitoring.
+
+---
+
+## Tier-design failures
+
+Patterns that look like tiered value but degrade trust.
+
+**Teaser-tier-as-Tier-1.** The free tier shows a partial result; the email tier shows the full result. This is lead-trap dressed as tiered value.
+
+**Same-content-different-format.** Tier 1 is the result on screen; Tier 2 is the same result in a PDF. The PDF is not value-add; the gate is not justified.
+
+**Inverted tiers.** Tier 1 is thin; Tier 2 is what should have been Tier 1; Tier 3 is what should have been Tier 2. The audience that gets Tier 1 sees nothing useful; conversion drops.
+
+**Tier-3 friction without Tier-3 value.** Account creation required for features that could have been email-only or free. Friction without value-add destroys the gate.
+
+**Surprise upsells.** The user opts into Tier 2; the email follow-up reveals additional gates the user did not anticipate. Trust drops.
+
+---
+
+## The flat-tier alternative
+
+Some calculators do not need tiers.
+
+**When flat is right.**
+
+- Simple calculators where the result is the only output worth offering.
+- Calculators built for SEO or brand authority where lead capture is secondary.
+- Calculators where account creation does not match the use case.
+
+**The flat structure.** Tier 1 (free, complete result). Optional email opt-in for newsletter or related content (no gate, no friction).
+
+This structure works when the calculator's primary value is the calculation itself and the lead-capture motion is secondary or absent.
+
+---
+
+## Tier transitions
+
+How the user moves from tier to tier.
+
+**Tier 1 to Tier 2.** The user sees the free result. Below or alongside, an offer: "Want this as a PDF you can share?" or "Save this scenario for later." Email-capture in context.
+
+**Tier 2 to Tier 3.** After the user has engaged with Tier 2 (downloaded the PDF, returned to the saved scenario), an offer: "Want to track this over time? Create an account." The friction increase is justified by the additional value.
+
+**The discipline.** Tier transitions should feel natural, not pushy. The user gets value at each tier; the next tier is offered, not demanded.
+
+---
+
+## Tier maintenance
+
+Tiers decay along with the calculator.
+
+**Tier 1 maintenance.** Update defaults, refresh sources, update methodology as benchmarks shift.
+
+**Tier 2 maintenance.** Update PDF templates as the brand evolves; refresh case studies; update comparison data.
+
+**Tier 3 maintenance.** Maintain the account-side functionality; ensure persistence works; update integrations.
+
+**The retire-tier decision.** Tier 3 features that are not used can be retired. Tier 2 PDFs that no one downloads can be simplified. Periodic audit of tier usage informs maintenance.
+
+---
+
+## Common tier failures
+
+**Tier 1 is a teaser.** Lead-trap pattern.
+
+**Tier 2 does not justify the email.** Same content, repackaged.
+
+**Tier 3 is offered but unused.** Friction without payoff; sometimes the right answer is to retire Tier 3.
+
+**Tier transitions are pushy.** Aggressive popups at each transition; the user feels pressured.
+
+**Tier maintenance lapses.** Stale PDFs, broken account features, outdated comparison data.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The tier-design principle. What lives at each tier. Tier-design discipline at each level. Worked examples across calculator types. The flat-tier alternative. Tier transitions. Tier maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific tier structures for specific calculators. Specific PDF templates and account-creation flows. Specific tooling for tier transitions. The team's tier-usage measurement and audit calendars. These vary by team.

--- a/skills/chatbot-flow-design/SKILL.md
+++ b/skills/chatbot-flow-design/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: chatbot-flow-design
+description: "Designing conversational flows for website chatbots and AI agents. Intent recognition architecture, branching logic, fallback handling, escalation to human, conversation analytics. Honest about scripted-bot (rigid trees, fail edge cases), hallucinating-bot (LLM without structure, makes things up), and structured-guided-conversation (LLM-powered with intent architecture and fallback discipline) patterns. Distinguishes chatbot DESIGN (this skill) from chatbot IMPLEMENTATION (engineering and platform work). Triggers on chatbot, conversational AI, AI agent, chat widget, intent design, conversational flow, bot escalation, LLM grounding. Also triggers when a chatbot is hallucinating, when a scripted bot is failing edge cases, or when a chatbot is being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing conversational flows for chatbots and AI agents on websites. Distinguishes scripted-bot (rigid trees, fail edge cases) from hallucinating-bot (LLM without structure, makes things up) from structured-guided-conversation (LLM-powered with intent architecture and fallback discipline)"
+display_order: 5
+---
+
+# Chatbot Flow Design
+
+A senior growth practitioner's playbook for designing conversational flows for website chatbots and AI agents. Intent recognition architecture, branching logic, fallback handling, escalation to human, conversation analytics. The discipline of building a bot that knows what it knows and routes appropriately when it does not.
+
+Most chatbots on the web fail in one of two ways. Scripted bots break the moment a user phrases something the script did not anticipate; the user gets pushed through a decision tree that does not fit their situation. LLM-powered bots without structure hallucinate; they confidently answer questions about pricing, policy, or capabilities and frequently make up answers, creating support burden and trust damage.
+
+The chatbots that work do something different. They have an intent architecture that defines what the bot can and cannot handle. They ground their responses in a knowledge base so they do not invent facts. They have explicit fallback paths for unclear or out-of-scope intents. They escalate to humans cleanly when the bot's job is done. The audience trusts the bot because the bot is honest about its scope.
+
+The voice is the senior growth practitioner who has watched chatbots become trusted brand surfaces and watched them become liability risks. Practical, opinionated about the architecture that distinguishes the two outcomes, willing to call out when a chatbot is the wrong investment or when an existing chatbot needs to be redesigned rather than tuned.
+
+When to use this skill: scoping a chatbot for the first time, auditing a chatbot that hallucinates or fails edge cases, designing the intent architecture and fallback patterns, or deciding when to escalate to humans.
+
+---
+
+## What this skill covers
+
+This skill spans chatbot design as conversational flow architecture, not chatbot implementation. The growth-tooling distinctions:
+
+- `ai-content-collaboration` covers AI in content workflows. This skill covers AI in customer-facing conversations.
+- `integration-orchestrator` covers cross-team coordination for chatbot deployment. This skill is the conversational design itself.
+- `pm-spec-writing` covers the spec for engineers building the bot. This skill is about WHAT the conversation should be; pm-spec-writing is about communicating it.
+- `discovery-research-synthesis` covers customer research that informs intent architecture. Input to this skill, not part of it.
+- **`chatbot-flow-design` (this skill)** is intent architecture, knowledge-base grounding, fallback patterns, and escalation discipline.
+
+The audience: growth marketers and product marketers shipping chatbot growth tooling, in-house teams designing conversational flows for marketing or support contexts, agencies running chatbot work for clients.
+
+Out of scope: AI in content workflows (covered by `ai-content-collaboration`); the engineering implementation of chatbots (handed off via `pm-spec-writing`); platform-specific bot configurations (those stay implementation-side); voice agents and IVR flows (different methodology though related principles apply).
+
+---
+
+## The chatbot decision: when chatbots earn deployment
+
+Before designing the chatbot, decide whether a chatbot is the right tool.
+
+**Chatbots earn deployment when:**
+
+- The audience asks the same questions repeatedly. FAQ-style support, product capability questions, qualification routing. The bot handles the volume; humans handle the exceptions.
+- The audience is on the site at hours when humans cannot respond. Coverage gap that the bot fills meaningfully.
+- The bot can ground its answers in real knowledge (documentation, product specs, pricing pages). Without grounding, the bot's answers are at best generic and at worst fabricated.
+- The team can maintain the bot. Chatbots decay; intents drift; knowledge bases need updating. Without maintenance commitment, the bot becomes stale liability.
+
+**Chatbots do NOT earn deployment when:**
+
+- The audience expects human conversation. Sales conversations, complex troubleshooting, sensitive topics often warrant human-first.
+- The team cannot ground the bot in real knowledge. A bot without grounding either hallucinates or stays so generic it adds no value.
+- The bot would replace working human channels. Replacing a high-quality sales chat with a low-quality bot degrades the experience.
+- The audience is small enough that direct human conversation is more efficient.
+- The team cannot maintain the bot. Stale bots produce wrong answers.
+
+The decision is not "should we have a chatbot"; it is "is the chatbot the right tool for this specific audience and conversation."
+
+Detail in `references/chatbot-decision-criteria.md`.
+
+---
+
+## Scripted-bot vs hallucinating-bot vs structured-guided-conversation
+
+The keystone framing.
+
+**Scripted-bot.** Rigid decision tree. "Press 1 for X, 2 for Y." Fails the moment a user phrases something the script did not anticipate. The chatbot equivalent of an automated phone tree. Cost: the user's actual question goes unanswered; the bot pushes the user through paths that do not fit; the audience leaves with a worse experience than no bot.
+
+**Hallucinating-bot.** LLM-powered with no structure. Will confidently answer questions about pricing, policy, capabilities, and frequently make up answers. Liability risk; trust-eroding; support burden when wrong answers reach customers. Cost: the bot's confident wrong answers damage the brand more than no bot would; the team learns about the hallucinations through customer complaints.
+
+**Structured-guided-conversation.** LLM-powered with intent architecture, knowledge-base grounding, defined fallback paths, and explicit escalation to humans. The bot knows what it knows, knows what it does not, and routes appropriately. Cost: the design effort upfront is significant; the maintenance is real; the audience trusts the bot because the bot is honest about its scope.
+
+The litmus test. Ask the bot a question outside its intended scope. Does it confidently make up an answer (hallucinating), refuse rigidly (scripted), or honestly route the user to a human or alternative resource (structured-guided)? The third response is the goal.
+
+---
+
+## Intent architecture
+
+Defining what the bot can and cannot handle.
+
+**The principle.** The bot has a defined set of intents it can handle. Each intent maps to a conversation pattern (questions to ask, knowledge to ground in, response to provide). Anything outside the intent set falls to fallback.
+
+**Intent design patterns.**
+
+- **Named intents.** "Pricing question," "feature comparison," "integration question," "support escalation," "demo request." Each intent is explicit.
+- **Intent hierarchy.** Top-level categories with sub-intents. "Pricing question" includes sub-intents for "tier comparison," "discount inquiry," "billing question."
+- **Intent boundaries.** Each intent has clear scope. Out-of-scope topics route to fallback.
+
+**Intent coverage.** The bot's intents should cover 70-90 percent of expected conversations. The remaining percentage falls to fallback. Trying to cover 100 percent often produces bloated intent sets that the bot cannot handle reliably.
+
+**Intent maintenance.** Intents drift as products evolve, audiences shift, and conversations change. Periodic review surfaces which intents are useful and which need refining.
+
+Detail in `references/intent-architecture-patterns.md`.
+
+---
+
+## Knowledge-base grounding
+
+The bot's responses must come from real knowledge, not made-up confidence.
+
+**The principle.** The bot's response generation should reference a structured knowledge base (documentation, product specs, pricing pages, support articles). The bot does not invent answers; it retrieves and presents.
+
+**Grounding patterns.**
+
+- **Retrieval-augmented generation (RAG).** The bot searches a knowledge base for relevant content before generating a response. The response is grounded in retrieved content.
+- **Source-of-truth design.** The knowledge base is the canonical source. When the bot answers, the underlying source is identified.
+- **Citation discipline.** The bot can cite the source ("based on our pricing page, ..."). Audiences benefit from knowing where the answer came from.
+- **Knowledge-base maintenance.** The knowledge base is maintained as the product evolves; the bot's answers stay current.
+
+**The hallucinating-bot failure.** No grounding. The LLM generates confident-sounding answers from nothing. The team discovers wrong answers through customer complaints.
+
+**The structured-guided win.** Grounded answers. The bot's responses match the source-of-truth. Customer-facing accuracy is maintained.
+
+Detail in `references/knowledge-base-grounding-patterns.md`.
+
+---
+
+## Branching and conditional logic
+
+How the bot adapts the conversation based on user input.
+
+**The principle.** The bot's conversation can branch based on user inputs (intent recognized, prior answers, user attributes). Branching makes the conversation feel adaptive.
+
+**Branching patterns.**
+
+- **Intent-driven branching.** Different intents lead to different conversation flows.
+- **Context-driven branching.** "Are you asking about plan A or plan B?" routes to plan-specific information.
+- **User-attribute branching.** Logged-in users may see different responses than anonymous users; enterprise visitors may see different responses than SMB.
+- **Multi-turn branching.** The conversation deepens over turns; later turns build on earlier context.
+
+**Branching discipline.** Each branch should add value. Decorative branching (asking for confirmation when none is needed) adds friction.
+
+**Branching limits.** Bots that branch too deeply lose users. 3-5 turns is often the practical limit before the user wants resolution.
+
+Detail in `references/branching-and-conditional-logic.md`.
+
+---
+
+## Fallback patterns
+
+What happens when intent is unclear or out-of-scope.
+
+**The principle.** Every conversation has fallback paths. The bot has rehearsed responses for "I do not know," "I am not sure I can help with that," "Let me connect you with a human."
+
+**Fallback patterns.**
+
+- **Clarifying question.** "Can you tell me more about what you are looking for?" Asks the user to refine; sometimes recovers.
+- **Suggested intents.** "I can help with X, Y, or Z. Were you asking about one of those?" Surfaces what the bot can do.
+- **Resource handoff.** "I cannot answer that, but here is our [documentation page] that covers it."
+- **Human escalation.** "Let me connect you with a human who can help."
+
+**Fallback discipline.** Multiple fallback layers. First, try clarification. If unclear after one round, suggest alternatives or escalate. Do not loop the user through 5 clarification attempts.
+
+**The fallback-as-honesty principle.** A bot that admits it does not know earns more trust than a bot that fakes confidence. Audiences forgive limitations they were told about; audiences punish wrong answers they were given confidently.
+
+Detail in `references/fallback-pattern-design.md`.
+
+---
+
+## Escalation to human
+
+When, how, with what context handoff.
+
+**The principle.** Some conversations need a human. The bot escalates when its scope is exceeded, when the user requests it, or when the conversation pattern indicates the user is frustrated.
+
+**Escalation triggers.**
+
+- **User-initiated.** "Talk to a human." The bot escalates immediately.
+- **Out-of-scope intent.** The bot recognizes the user's intent is outside its scope; escalates with the intent context.
+- **Repeated fallback.** After 2-3 unclear exchanges, the bot escalates rather than loop.
+- **Sentiment-driven.** The user's sentiment indicates frustration; the bot escalates rather than persist.
+- **High-stakes topic.** Sensitive topics (cancellations, complaints, security) escalate by default.
+
+**Escalation context handoff.** When escalating, the bot passes the conversation history and recognized intent to the human. The human does not start from scratch; they pick up where the bot left off.
+
+**The escalation-quality test.** Does the human pick up the context smoothly, or do they have to ask the user to repeat everything? The latter signals broken handoff.
+
+Detail in `references/escalation-to-human-patterns.md`.
+
+---
+
+## Conversation analytics
+
+Measuring what the bot is and is not doing well.
+
+**The principle.** Track the bot's performance per intent, per fallback, per escalation. The data informs maintenance and design improvements.
+
+**Conversation metrics.**
+
+- **Intent recognition rate.** What percentage of conversations are correctly classified into intents?
+- **Resolution rate per intent.** What percentage of conversations starting with intent X resolve successfully (user gets the answer they needed)?
+- **Fallback rate.** What percentage of conversations hit fallback? High fallback rates signal intent gaps.
+- **Escalation rate per intent.** What percentage of conversations within each intent escalate? High escalation may signal the intent should not be bot-handled.
+- **User satisfaction.** Post-conversation surveys when feasible. Useful but limited; many users do not respond.
+
+**Diagnostic uses.**
+
+- High fallback rate: intents missing or unclear; expand or refine intent set.
+- Low resolution rate per intent: knowledge base inadequate; improve grounding.
+- High escalation rate per intent: the intent may not be appropriate for bot handling.
+- High repeat-fallback within conversations: clarifying questions not landing; redesign clarification.
+
+Detail in `references/conversation-analytics-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-chatbot-failures.md`.
+
+- "Bot makes up answers about pricing." Hallucinating-bot pattern; no grounding to pricing source-of-truth.
+- "Users say the bot is rigid and unhelpful." Scripted-bot pattern; intents do not cover real questions.
+- "Sales is angry that the bot is qualifying leads wrong." Intent recognition or routing logic broken; audit qualification flow.
+- "Support tickets increase after chatbot launch." Bot is producing wrong answers that send users to support; audit grounding and resolution.
+- "Users abandon mid-conversation." Bot loops or fallback patterns are inadequate.
+- "We cannot tell what the bot is actually doing." Analytics missing; instrument before further changes.
+- "Bot was great at launch; quality has degraded." Maintenance lapse; knowledge base or intent set out of date.
+- "Bot escalates to humans for everything." Escalation logic too permissive; bot should handle more.
+- "Bot tries to handle everything itself." Escalation logic too restrictive; bot should escalate more.
+- "Users complain the bot does not know what they asked five minutes ago." Conversation context not preserved across turns.
+
+---
+
+## The framework: 12 considerations for chatbot flow design
+
+When designing or auditing a chatbot, walk these 12 considerations.
+
+1. **The chatbot decision.** Is a chatbot the right tool for this audience and conversation, or would a different channel serve?
+2. **Structured-guided-conversation, not scripted or hallucinating.** Intent architecture; knowledge-base grounding; fallback discipline.
+3. **Intent architecture sound.** Named intents with clear scope; coverage targets 70-90 percent of expected conversations.
+4. **Knowledge-base grounded.** Responses retrieved from source-of-truth; the bot does not invent answers.
+5. **Branching adds value.** Each branch serves a real need; depth limited to 3-5 turns.
+6. **Fallback patterns multi-layered.** Clarification, suggested intents, resource handoff, human escalation.
+7. **Escalation triggers defined.** User-initiated, out-of-scope, repeated fallback, sentiment-driven, high-stakes.
+8. **Escalation context handoff clean.** Humans pick up where the bot left off.
+9. **Analytics instrumented.** Per-intent recognition, resolution, fallback, escalation rates.
+10. **Maintenance cadence defined.** Knowledge base refreshed; intent set audited; bot quality verified.
+11. **Brand voice consistent.** The bot sounds like the brand it represents.
+12. **Audience-fit honest.** The bot serves the audience it can actually help; out-of-fit audiences get escalated quickly.
+
+The output of the framework is a chatbot that knows what it knows, grounds its answers in real knowledge, escalates appropriately, and earns trust by being honest about its scope.
+
+---
+
+## Reference files
+
+- [`references/chatbot-decision-criteria.md`](references/chatbot-decision-criteria.md) - When chatbots earn deployment and when they do not. The conditions that warrant the build.
+- [`references/intent-architecture-patterns.md`](references/intent-architecture-patterns.md) - Defining what the bot can and cannot handle. Named intents, hierarchies, boundaries, coverage.
+- [`references/knowledge-base-grounding-patterns.md`](references/knowledge-base-grounding-patterns.md) - Retrieval-augmented generation, source-of-truth design, citation discipline, knowledge-base maintenance.
+- [`references/branching-and-conditional-logic.md`](references/branching-and-conditional-logic.md) - How the bot adapts the conversation. Intent-driven, context-driven, user-attribute, multi-turn branching.
+- [`references/fallback-pattern-design.md`](references/fallback-pattern-design.md) - What happens when intent is unclear or out-of-scope. Multi-layered fallback patterns.
+- [`references/escalation-to-human-patterns.md`](references/escalation-to-human-patterns.md) - When, how, with what context. Escalation triggers and handoff quality.
+- [`references/conversation-analytics-patterns.md`](references/conversation-analytics-patterns.md) - Per-intent metrics. Diagnostic uses. The data that informs maintenance.
+- [`references/chatbot-anti-patterns.md`](references/chatbot-anti-patterns.md) - The patterns that look like chatbots but degrade trust.
+- [`references/common-chatbot-failures.md`](references/common-chatbot-failures.md) - 10+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: chatbots earn deployment when they know what they don't know
+
+The chatbots that work as compounding assets are the ones the audience trusts. Not because they answer every question. Not because they are infinitely capable. Because they are honest about their scope, ground their answers in real knowledge, and escalate to humans when the bot's job is done.
+
+That is the bar. Below the bar are scripted-bots (rigid trees that fail edge cases) and hallucinating-bots (LLMs without structure that make things up). Above the bar are structured-guided-conversations where the bot's intent architecture, knowledge-base grounding, fallback discipline, and escalation patterns combine into a tool the audience can rely on.
+
+The discipline is in the design choices. The intents that define what the bot can do. The knowledge-base grounding that prevents hallucination. The fallback patterns that handle the unknown gracefully. The escalation logic that knows when to step aside. The analytics that surface what is working and what is not. The maintenance discipline that keeps the bot in sync with the brand it represents.

--- a/skills/chatbot-flow-design/references/branching-and-conditional-logic.md
+++ b/skills/chatbot-flow-design/references/branching-and-conditional-logic.md
@@ -1,0 +1,269 @@
+# Branching and conditional logic
+
+How the bot adapts the conversation. Intent-driven, context-driven, user-attribute, multi-turn branching.
+
+The bot's conversation can branch based on user inputs. Branching makes the conversation feel adaptive; over-branching makes it feel labyrinthine.
+
+---
+
+## The adaptive principle
+
+The bot adapts the conversation to the user's situation. Branching is the mechanism.
+
+**The win.** A user asks about pricing; the bot recognizes the user is on the enterprise track (from earlier inputs or context); the response includes enterprise-specific information rather than starter-tier information.
+
+**The fail (no branching).** Every user gets the same response regardless of context. The pricing question gets a generic answer that helps no one specifically.
+
+**The fail (over-branching).** The conversation branches at every turn; the user feels stuck in a labyrinth; resolution recedes.
+
+The discipline. Branch when branching adds value. Avoid branching when it adds friction.
+
+---
+
+## Pattern A: Intent-driven branching
+
+Different intents lead to different conversation flows.
+
+**How it works.**
+
+- The bot recognizes the user's intent.
+- The conversation flow for that intent kicks in.
+- Each intent has its own scripted or templated response pattern.
+
+**Example.**
+
+User: "How much does the Pro plan cost?"
+Bot recognizes "pricing question" intent.
+Bot routes to pricing-conversation flow:
+- Retrieves pricing.
+- Presents Pro plan pricing.
+- Offers follow-up: "Would you like to compare with other tiers, or talk to sales for a custom quote?"
+
+**Strengths.**
+
+- Each intent gets a dedicated, optimized flow.
+- Easy to maintain (changes to one intent do not affect others).
+
+**Weaknesses.**
+
+- Requires intent recognition to work reliably.
+- Cross-intent topics may not fit any single flow.
+
+**When to use.** Default for most chatbots. Intent-driven branching is the foundation.
+
+---
+
+## Pattern B: Context-driven branching
+
+Branching within an intent based on context.
+
+**How it works.**
+
+- Within an intent's flow, the bot asks clarifying questions or branches based on context.
+- "Are you asking about plan A or plan B?" routes the rest of the conversation to plan-specific information.
+
+**Example.**
+
+User: "How does the API work?"
+Bot recognizes "integration question" intent.
+Within the integration flow, the bot asks: "Are you looking at REST or GraphQL?"
+User: "REST."
+Bot routes to REST-specific information.
+
+**Strengths.**
+
+- Within-intent precision.
+- The user feels heard; the response addresses their specific situation.
+
+**Weaknesses.**
+
+- Each clarifying question adds a turn; can frustrate users who want quick answers.
+
+**The discipline.** Use context-driven branching only when the context genuinely affects the response. Decorative clarifications add friction.
+
+---
+
+## Pattern C: User-attribute branching
+
+Branching based on user attributes (logged-in status, role, segment).
+
+**How it works.**
+
+- The bot accesses user attributes (often from a CRM or session data).
+- Responses adapt to those attributes.
+- "Logged-in users may see different responses than anonymous users; enterprise visitors may see different responses than SMB."
+
+**Example.**
+
+User: "Tell me about your pricing."
+Bot detects the user is from a domain associated with an enterprise account.
+Bot routes to enterprise-specific pricing conversation: "For teams of 200+, we offer a custom Enterprise plan. Here are the typical components..."
+
+**Strengths.**
+
+- Highly personalized.
+- The right information for the right audience.
+
+**Weaknesses.**
+
+- Requires attribute infrastructure (CRM integration, session data).
+- Privacy considerations (the bot is using data the user may not have explicitly shared).
+- Risk of getting attributes wrong (a freelancer with a corporate domain treated as enterprise).
+
+**When to use.** When the attribute infrastructure exists and the personalization genuinely improves the experience.
+
+---
+
+## Pattern D: Multi-turn branching
+
+The conversation deepens over turns. Later turns build on earlier context.
+
+**How it works.**
+
+- The bot maintains conversation state across turns.
+- Each turn's response considers what was said in previous turns.
+- The conversation can pivot, deepen, or refocus based on the cumulative context.
+
+**Example.**
+
+Turn 1.
+User: "I am evaluating CRMs."
+Bot: "What size is your team?"
+User: "We have 25 sales reps."
+
+Turn 2.
+Bot: "For a team of 25, our Growth plan often fits. Are you looking at any specific features?"
+User: "We need integration with HubSpot."
+
+Turn 3.
+Bot: "Our HubSpot integration supports two-way sync, lead routing, and custom fields. Would you like to see a demo focused on this integration?"
+
+The conversation deepens. Each turn builds on the previous.
+
+**Strengths.**
+
+- Conversation feels natural.
+- Bot can handle complex inquiries that require multiple inputs.
+
+**Weaknesses.**
+
+- Conversation state management is complex.
+- Long conversations risk losing context.
+- Users may want resolution faster than multi-turn allows.
+
+**The discipline.** Limit multi-turn conversations to 3-5 turns before either resolving, escalating, or offering a summary handoff. Beyond that, users abandon.
+
+---
+
+## Branching depth limits
+
+Bots that branch too deeply lose users.
+
+**The 3-5 turn principle.** Most users want resolution within 3-5 turns. Beyond that, the bot's value declines.
+
+**When 3-5 turns is enough.** Most marketing-site Q&A, simple support, qualification.
+
+**When more turns are needed.** Complex troubleshooting, detailed product configuration. In these cases, the bot should consider escalating to a human or offering a richer interface (form, video walkthrough).
+
+**Branching as turn-cost.** Each branch adds a turn. Branches that do not resolve within the turn budget should be reconsidered.
+
+---
+
+## Branching design patterns
+
+How to structure branches.
+
+**Linear branching.** A then B then C. Simple; fits intent-driven patterns.
+
+**Tree branching.** A leads to B or C; each leads to further options. Common; fits context-driven and user-attribute patterns.
+
+**Loop-back branching.** Conversation can return to earlier turns. Useful when users want to compare options.
+
+**Open-ended branching.** Conversation can take multiple paths from any point. Most flexible; hardest to maintain.
+
+The choice depends on conversation complexity. Most chatbots benefit from tree branching with limited depth.
+
+---
+
+## Branching and brand voice
+
+The bot's voice should stay consistent across branches.
+
+**The principle.** Branching changes the conversation's content; the brand voice stays consistent.
+
+**Voice failures across branches.**
+
+- One intent's flow is formal; another is casual. Inconsistent.
+- Bot voice shifts based on user attributes in ways that feel performative.
+- Branches that adopt different personas confuse the user.
+
+The discipline. Voice consistent; content adaptive.
+
+---
+
+## Conversation state management
+
+What the bot remembers across turns.
+
+**Within-conversation state.**
+
+- Recognized intent and sub-intent.
+- Captured user inputs (company size, role, specific interests).
+- Conversation history.
+- Pending follow-up actions.
+
+**Across-conversation state.** When the user returns later (in the same session or a new session), what does the bot remember?
+
+- Logged-in users: bot may remember previous conversations.
+- Anonymous users: bot typically starts fresh; some implementations use cookies for limited memory.
+- Privacy considerations: cross-session memory should be transparent and opt-in where appropriate.
+
+The discipline. State management should serve the user. State that improves the experience is good; state that surprises or feels invasive is bad.
+
+---
+
+## Branching testing
+
+Test the bot across branching paths.
+
+**The challenge.** A bot with multiple branching points has many paths through any given conversation. Testing all paths is infeasible; testing critical paths is the discipline.
+
+**Critical paths.**
+
+- The most common conversation patterns (most-frequent intents).
+- Each major branch point (one path that takes each branch).
+- Edge cases (unusual user inputs that could break branching).
+
+**Testing methods.**
+
+- Manual testing of critical paths.
+- Automated testing where feasible.
+- Sampling production conversations to verify branching behavior.
+
+---
+
+## Common branching failures
+
+**Decorative branching.** Clarifying questions that do not change the response; user feels stuck.
+
+**Branching without resolution.** Conversation branches but never resolves; user gives up.
+
+**Branching depth too deep.** 8+ turns without resolution; user abandons.
+
+**Inconsistent voice across branches.** Different intents speak differently.
+
+**State loss across turns.** Bot forgets earlier context; conversation feels disjointed.
+
+**Privacy-violating attribute branching.** Bot uses attributes the user did not consent to share.
+
+**Untested edge-case branches.** Specific paths break in production.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The adaptive principle. Patterns A through D with strengths, weaknesses, and when-to-use guidance. Branching depth limits. Branching design patterns. Branching and brand voice. Conversation state management. Branching testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific branching designs for specific bots. Specific state management implementations. Specific tooling for branching and testing. The team's testing protocols. These vary by team.

--- a/skills/chatbot-flow-design/references/chatbot-anti-patterns.md
+++ b/skills/chatbot-flow-design/references/chatbot-anti-patterns.md
@@ -1,0 +1,224 @@
+# Chatbot anti-patterns
+
+The patterns that look like chatbots but degrade trust. Anti-patterns are easy to ship; the cost shows up in lead quality, downstream conversion, and brand reputation over time.
+
+---
+
+## The scripted-bot
+
+The pattern. Rigid decision tree. "Press 1 for X, 2 for Y." Fails the moment a user phrases something the script did not anticipate.
+
+The signal. Users complain the bot is rigid; bot fails any conversation that does not match the predefined paths.
+
+The cost. The user's actual question goes unanswered. The bot pushes the user through paths that do not fit. Audience leaves with a worse experience than no bot.
+
+The cure. Move from rigid trees to LLM-powered intent recognition with grounded responses. Detail in `references/intent-architecture-patterns.md` and `references/knowledge-base-grounding-patterns.md`.
+
+---
+
+## The hallucinating-bot
+
+The pattern. LLM-powered with no structure. Confidently answers questions about pricing, policy, capabilities, and frequently makes up answers.
+
+The signal. Customer complaints about wrong information from the bot; sales or support hearing audiences cite incorrect bot answers.
+
+The cost. Liability risk. Trust damage. Support burden when wrong answers reach customers.
+
+The cure. Add intent architecture and knowledge-base grounding. The bot retrieves from sources-of-truth rather than generating from training data.
+
+---
+
+## The bot-that-tries-to-handle-everything
+
+The pattern. Bot scope is "anything the user asks." No defined intents; no fallback discipline.
+
+The signal. High hallucination rate; high resolution-rate variability across topics; users get inconsistent experiences.
+
+The cost. The bot is unreliable. Some conversations work; many do not. Users cannot predict what they will get.
+
+The cure. Define explicit intent scope. Honest fallback for everything outside scope. Detail in `references/intent-architecture-patterns.md`.
+
+---
+
+## The bot-that-handles-nothing
+
+The pattern. Bot's intent set is so narrow that most conversations fall to fallback or escalation.
+
+The signal. High fallback rate; high escalation rate; bot adds little value over a contact form.
+
+The cost. The build cost was significant; the value delivered is small.
+
+The cure. Expand the intent set to cover the conversations the audience actually has. Detail in `references/intent-architecture-patterns.md` (intent coverage section).
+
+---
+
+## The bot-that-loops
+
+The pattern. Bot does not understand; asks for clarification; user clarifies; bot still does not understand; asks again.
+
+The signal. Users abandon mid-conversation after 2-3 unsuccessful clarification attempts.
+
+The cost. The user feels stuck. The brand earns "frustrating bot" reputation.
+
+The cure. Limit clarification to one round. After that, escalate or offer alternatives. Detail in `references/fallback-pattern-design.md` (fallback loop section).
+
+---
+
+## The bot-that-refuses-rigidly
+
+The pattern. Bot says "I cannot help with that" without offering paths forward.
+
+The signal. Users complain that the bot is unhelpful; abandonment.
+
+The cost. The bot fails the user without offering recovery.
+
+The cure. Always offer alternatives. Resource handoff or human escalation. The bot's "I cannot help" should be followed by "but here is what might."
+
+---
+
+## The bot-with-no-escalation
+
+The pattern. Bot tries to handle everything itself; rarely escalates; users get stuck with bot for conversations needing humans.
+
+The signal. Specific intents have high abandonment; users complaining they could not reach a human; sensitive topics handled poorly by the bot.
+
+The cost. The user's frustration compounds. The brand earns "you cannot reach a human" reputation.
+
+The cure. Define escalation triggers. User-initiated, out-of-scope, repeated fallback, sentiment-driven, high-stakes. Detail in `references/escalation-to-human-patterns.md`.
+
+---
+
+## The bot-that-escalates-everything
+
+The pattern. Bot escalates almost every conversation; the bot is not really doing its job.
+
+The signal. Escalation rate near 100 percent; bot adds friction without value.
+
+The cost. The bot is decorative. The team built a chatbot when they needed staffing.
+
+The cure. Either expand the bot's intent handling capability or reconsider whether the chatbot is the right tool. Sometimes the answer is to invest in human chat instead.
+
+---
+
+## The bot-with-broken-handoff
+
+The pattern. Bot escalates; human picks up; the human starts from scratch because the context was not passed.
+
+The signal. Users complain about repeating themselves; humans report not knowing what the bot was discussing.
+
+The cost. The escalation experience is broken. Users feel the bot was wasted effort.
+
+The cure. Test the handoff. Ensure the human sees the conversation history and recognized intent. Detail in `references/escalation-to-human-patterns.md` (context handoff section).
+
+---
+
+## The bot-with-stale-knowledge
+
+The pattern. Knowledge base not updated; bot answers reflect outdated reality.
+
+The signal. Bot answers contradict current product; users notice; sales hears about wrong information.
+
+The cost. Trust damage. Each wrong answer is a moment the brand lost credibility.
+
+The cure. Knowledge-base maintenance discipline. Quarterly review at minimum. Detail in `references/knowledge-base-grounding-patterns.md`.
+
+---
+
+## The bot-with-no-citation
+
+The pattern. Bot generates answers without citing sources. Users cannot verify.
+
+The signal. Hallucination goes undetected because there is no verification path; users with deeper questions abandon because they cannot follow up.
+
+The cost. Trust does not compound. Each answer is taken on faith; some are wrong.
+
+The cure. Citation discipline. Bot cites sources; users can verify. Detail in `references/knowledge-base-grounding-patterns.md` (citation discipline section).
+
+---
+
+## The bot-with-inconsistent-voice
+
+The pattern. Different intents speak in different voices. Bot voice does not match brand voice elsewhere.
+
+The signal. Users report the bot feels disjointed; brand voice is fragmented.
+
+The cost. Brand consistency suffers. The bot is a brand surface that is undermining the brand.
+
+The cure. Brand voice document including bot examples. Test conversations across intents. Detail in `references/intent-architecture-patterns.md` (intent and brand voice section).
+
+---
+
+## The bot-with-no-analytics
+
+The pattern. Bot launched without per-intent tracking. Quality is invisible.
+
+The signal. Cannot diagnose issues; cannot track decay; remediation is guesswork.
+
+The cost. Quality decays unnoticed. Maintenance happens only when customers complain (too late).
+
+The cure. Instrument before launch. Per-intent recognition, resolution, fallback, escalation rates. Detail in `references/conversation-analytics-patterns.md`.
+
+---
+
+## The bot-that-pretends-to-be-human
+
+The pattern. Bot does not disclose it is a bot; users think they are talking to a human.
+
+The signal. Users feel deceived when they realize; complaints about hidden automation; trust collapse.
+
+The cost. Trust damage that can be hard to recover. Brand earns "deceptive" descriptors.
+
+The cure. Disclose that the user is talking to a bot. Modern AI chatbots can be disclosed openly without losing engagement; users often appreciate the honesty.
+
+---
+
+## The bot-with-mobile-broken-UI
+
+The pattern. Bot works on desktop; UI breaks on mobile. Conversation cramped; input field hidden; responses overflow.
+
+The signal. Mobile conversation completion is significantly lower than desktop.
+
+The cost. Mobile audience underserved. Mobile is often the majority of traffic.
+
+The cure. Mobile-first chatbot UI design. Test on actual devices.
+
+---
+
+## The bot-without-availability-disclosure
+
+The pattern. Bot escalates to humans without communicating that humans may not be available.
+
+The signal. Users wait indefinitely for a human; abandonment after escalation; frustration.
+
+The cost. Escalation creates expectation that is not met. Worse than no escalation.
+
+The cure. Communicate availability honestly. "Our team is available [hours]." Or offer async alternatives. Detail in `references/escalation-to-human-patterns.md`.
+
+---
+
+## How to detect anti-patterns in a portfolio
+
+Audit cadence. Quarterly review of every active bot, looking specifically for these anti-patterns.
+
+**Audit questions per bot.**
+
+- Does the bot have explicit intents (anti-pattern check: bot-that-tries-to-handle-everything, hallucinating-bot)?
+- Are responses grounded in source-of-truth (anti-pattern check: hallucinating-bot, bot-with-no-citation)?
+- Does fallback have multiple layers including escalation (anti-pattern check: bot-with-no-escalation, bot-that-loops)?
+- Does escalation pass context (anti-pattern check: bot-with-broken-handoff)?
+- Is the knowledge base maintained (anti-pattern check: bot-with-stale-knowledge)?
+- Is brand voice consistent across intents (anti-pattern check: bot-with-inconsistent-voice)?
+- Are analytics in place (anti-pattern check: bot-with-no-analytics)?
+- Does the bot disclose its nature and human availability (anti-pattern check: bot-that-pretends-to-be-human, bot-without-availability-disclosure)?
+
+**The retire decision.** Anti-pattern bots often warrant retirement or significant redesign. Patching anti-patterns rarely produces a good bot.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing for each. Cures matched to anti-patterns. The audit cadence and audit questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and the lessons learned. Specific portfolio audit results. Specific retirement and redesign decisions. The team's audit calendar and reviewer list. These vary by team.

--- a/skills/chatbot-flow-design/references/chatbot-decision-criteria.md
+++ b/skills/chatbot-flow-design/references/chatbot-decision-criteria.md
@@ -1,0 +1,163 @@
+# Chatbot decision criteria
+
+When chatbots earn deployment and when they do not. The conditions that warrant the build, and the funnels where a chatbot adds friction without lift.
+
+A chatbot is a meaningful build. Intent architecture, knowledge-base grounding, fallback patterns, escalation logic, ongoing maintenance. The chatbot earns this investment only when specific conditions are present.
+
+---
+
+## When chatbots earn deployment
+
+Five conditions that, when present, make a chatbot a strong investment.
+
+**The audience asks the same questions repeatedly.** FAQ-style support, product capability questions, qualification routing. The bot handles the volume; humans handle the exceptions. Without recurring question patterns, the bot has nothing to handle reliably.
+
+**The audience is on the site at hours when humans cannot respond.** Coverage gap that the bot fills meaningfully. Off-hours visitors get something instead of nothing.
+
+**The bot can ground its answers in real knowledge.** Documentation, product specs, pricing pages, support articles. Without grounding, the bot's answers are at best generic and at worst fabricated.
+
+**The team can maintain the bot.** Intents drift; knowledge bases need updating; conversation patterns shift. Without maintenance commitment, the bot becomes stale liability.
+
+**The success metric is defined.** Resolution rate, fallback rate, escalation rate, user satisfaction, downstream conversion. Without the success metric defined, evaluation is impossible.
+
+When all five are present, the chatbot is a strong investment. When two or fewer are present, a different channel (human chat, structured FAQ, contact form) often serves better.
+
+---
+
+## When chatbots do NOT earn deployment
+
+Funnels where the chatbot is the wrong tool.
+
+**The audience expects human conversation.** Sales conversations, complex troubleshooting, sensitive topics often warrant human-first. A chatbot in these contexts may be perceived as an obstacle to the human conversation the audience wants.
+
+**The team cannot ground the bot in real knowledge.** A bot without grounding either hallucinates (confident wrong answers) or stays so generic it adds no value (vague responses to specific questions).
+
+**The bot would replace working human channels.** Replacing a high-quality sales chat with a low-quality bot degrades the experience. The bot might be cheaper to operate but more expensive in lost conversions.
+
+**The audience is small enough that direct human conversation is more efficient.** Niche audiences with low conversation volume often work better with human-first channels; the chatbot's overhead is not justified.
+
+**The team cannot maintain the bot.** Stale bots produce wrong answers. Without quarterly maintenance commitment, the bot becomes a liability over time.
+
+**The conversation pattern is too varied to model.** Some audiences ask wildly different questions; the intent architecture cannot meaningfully cover the conversation space; the bot mostly fallbacks anyway.
+
+The honest assessment matters more than the default. "Should we have a chatbot" is not the question. "Is the chatbot the right tool for this audience and conversation pattern" is.
+
+---
+
+## The opportunity-cost frame
+
+A chatbot is significant work. Account for the cost honestly.
+
+**The build cost.** Intent architecture, knowledge-base preparation, RAG pipeline, fallback design, escalation logic, conversation UI, brand-voice tuning, mobile responsiveness, analytics instrumentation. A meaningful chatbot often takes 80-300 engineering hours plus design and content for the knowledge base.
+
+**The maintenance cost.** Knowledge base updates, intent refinement, hallucination detection, conversation analytics review. Quarterly maintenance often runs 8-20 hours per active bot.
+
+**The escalation infrastructure cost.** Human handoff requires staffing or routing infrastructure. The bot does not eliminate the need for humans; it changes when humans are involved.
+
+**The opportunity cost.** What else could the team have built? A better support documentation site, a self-serve help center, a different growth-tooling investment. The chatbot's success has to clear the bar of those alternatives.
+
+The decision frame. The chatbot earns investment when it produces more value than the alternatives, accounting for build plus maintenance plus escalation infrastructure.
+
+---
+
+## The grounding precondition
+
+Without knowledge-base grounding, the chatbot is the wrong tool.
+
+**The check.** Does the team have or can the team build a knowledge base that covers the conversation patterns the bot will handle?
+
+If yes, the chatbot can be grounded. The bot's responses retrieve from the knowledge base; hallucination risk is contained.
+
+If no (the team's knowledge is in people's heads, not documented), the chatbot will hallucinate or stay generic. The bot is the wrong tool until the knowledge base exists.
+
+**Building the knowledge base.** Sometimes the right move is to build the knowledge base first (which itself is valuable as documentation) before deploying the bot. The knowledge base serves users directly even before the bot accesses it.
+
+---
+
+## The decision worked example
+
+A B2B SaaS company considering a chatbot for the marketing site.
+
+**Conditions check.**
+
+- Recurring questions: yes. Visitors ask about pricing, integrations, security, and demo requests recurringly.
+- Off-hours coverage gap: yes. The team handles US business hours; international visitors get nothing in their evening hours.
+- Knowledge-base grounding possible: yes. Pricing, integrations, security details all documented; FAQ exists; product specs are detailed.
+- Maintenance commitment: yes. Marketing operations has capacity for quarterly bot review.
+- Success metric defined: yes. Resolution rate per intent, escalation rate, downstream conversion to demo within 14 days.
+
+**Decision.** Build the chatbot. The conditions warrant it.
+
+**Intent architecture.** 7 named intents: pricing, integrations, security, demo request, support escalation, integration troubleshooting, account access.
+
+**Knowledge-base grounding.** RAG pipeline pulling from docs, pricing page, security page, integration catalog.
+
+**Fallback strategy.** Clarification on first unclear; suggested intents on second unclear; escalation to human on third or sentiment-driven.
+
+**Escalation handoff.** Bot passes conversation history and recognized intent to the human; the human picks up where the bot left off.
+
+The decision was not "should we have a chatbot" but "given these conditions, this is the chatbot to build."
+
+---
+
+## The decision worked example: when to choose differently
+
+The same company considering a chatbot for sales conversations.
+
+**Conditions check.**
+
+- Recurring questions: partially. Sales conversations vary widely; while some patterns recur, the conversation often needs nuance.
+- Off-hours coverage: not relevant; sales conversations work async via demo bookings already.
+- Knowledge-base grounding possible: yes for product info; less so for personalized recommendations.
+- Maintenance commitment: yes.
+- Success metric: hard to define. Sales conversion is the goal; the bot's contribution is hard to attribute.
+
+**Decision.** Do not build a sales-focused chatbot. The audience expects human sales conversation; the bot would add friction. Use the bot for marketing-site Q&A and demo qualification; route demo requests to human sales.
+
+The decision was "is this chatbot right for this conversation" and the answer was "for some conversations yes, for others no." The bot's scope was constrained accordingly.
+
+---
+
+## The audience-fit precondition
+
+The chatbot's audience must be willing to interact with chatbots.
+
+**Audiences that engage with chatbots well.**
+
+- Self-service-oriented users who want quick answers without human contact.
+- Off-hours visitors who would otherwise get nothing.
+- Users with specific factual questions (pricing, hours, policies).
+
+**Audiences that resist chatbots.**
+
+- Users who explicitly want to talk to a human (often signaled in the conversation opening).
+- Sales-focused enterprise buyers expecting white-glove human attention.
+- Users in distress (frustration, urgency) who need empathy not automation.
+
+**The discipline.** The chatbot should serve the audiences who engage well and escalate the audiences who do not. Trying to serve everyone with the bot fails both groups.
+
+---
+
+## When to retire a chatbot
+
+Chatbots can be wrong even after being right initially.
+
+**Retire when:**
+
+- Resolution rate has dropped below an acceptable threshold consistently.
+- Escalation rate climbs as intents fail to keep pace with audience evolution.
+- The knowledge base maintenance burden exceeds the bot's value.
+- A redesigned support model (better docs, expanded human team, different tooling) makes the bot unnecessary.
+- The team can no longer commit to maintenance.
+
+The retiring discipline is part of the program. Stale bots produce wrong answers; honest retirement protects the brand.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The conditions that warrant chatbot deployment. The conditions that argue against. The opportunity-cost frame. The grounding precondition. The audience-fit precondition. Decision worked examples (yes and no). The retire decision.
+
+## Implementation choices that stay internal
+
+Specific chatbot scope decisions for specific audiences. The team's capacity benchmarks. Specific tooling for chatbot platforms, RAG pipelines, and analytics. Specific success-metric baselines. These vary by team.

--- a/skills/chatbot-flow-design/references/common-chatbot-failures.md
+++ b/skills/chatbot-flow-design/references/common-chatbot-failures.md
@@ -1,0 +1,187 @@
+# Common chatbot failures
+
+10+ failure patterns with diagnoses and cures. The patterns that surface as "the bot is hallucinating" or "users complain the bot is unhelpful" or "we cannot tell what the bot is doing."
+
+---
+
+## "Bot makes up answers about pricing."
+
+**The diagnosis.** Hallucinating-bot pattern. No grounding to pricing source-of-truth.
+
+**The cure.** Add knowledge-base grounding for pricing. The bot retrieves from the pricing page or pricing knowledge base; answers reflect the source. Detail in `references/knowledge-base-grounding-patterns.md`.
+
+---
+
+## "Users say the bot is rigid and unhelpful."
+
+**The diagnosis.** Scripted-bot pattern. Intents do not cover real questions; bot fails when users phrase things unexpectedly.
+
+**The cure.** Move from rigid trees to LLM-powered intent recognition. Define more flexible intents. Add fallback that handles unexpected phrasings. Detail in `references/intent-architecture-patterns.md`.
+
+---
+
+## "Sales is angry that the bot is qualifying leads wrong."
+
+**The diagnosis.** Intent recognition or routing logic broken. The bot is recognizing leads as one type when they should be another.
+
+**The cure.** Audit the qualification flow. Verify intent recognition with realistic test cases. Tighten routing logic. Add human review for edge cases.
+
+---
+
+## "Support tickets increase after chatbot launch."
+
+**The diagnosis.** Bot is producing wrong answers that send users to support after the fact. Worse than no bot.
+
+**The cure.** Audit grounding and resolution. Identify the intents producing bad answers. Either improve grounding or escalate those intents to humans. Detail in `references/knowledge-base-grounding-patterns.md` and `references/escalation-to-human-patterns.md`.
+
+---
+
+## "Users abandon mid-conversation."
+
+**The diagnosis.** Bot loops or fallback patterns are inadequate. Users get stuck without resolution path.
+
+**The cure.** Review fallback patterns. Limit clarification rounds. Add multi-layered fallback ending in human escalation. Detail in `references/fallback-pattern-design.md`.
+
+---
+
+## "We cannot tell what the bot is actually doing."
+
+**The diagnosis.** Analytics missing. Without instrumentation, quality is invisible.
+
+**The cure.** Instrument per-intent recognition, resolution, fallback, and escalation rates before any further changes. Detail in `references/conversation-analytics-patterns.md`.
+
+---
+
+## "Bot was great at launch; quality has degraded."
+
+**The diagnosis.** Maintenance lapse. Knowledge base or intent set out of date.
+
+**The cure.** Quarterly maintenance review. Update knowledge base; refine intents; verify grounding. Set the maintenance trigger so updates happen alongside product changes.
+
+---
+
+## "Bot escalates to humans for everything."
+
+**The diagnosis.** Escalation logic too permissive, or the bot's intent handling is so weak that everything ends up at humans.
+
+**The cure.** Audit which intents escalate most. If the bot can handle them with better grounding, fix that. If the bot truly cannot handle them, reconsider whether they should be in scope.
+
+---
+
+## "Bot tries to handle everything itself."
+
+**The diagnosis.** Escalation logic too restrictive. Bot stays with conversations it should not.
+
+**The cure.** Add escalation triggers. User-initiated, out-of-scope, repeated fallback, sentiment-driven, high-stakes. Detail in `references/escalation-to-human-patterns.md`.
+
+---
+
+## "Users complain the bot does not know what they asked five minutes ago."
+
+**The diagnosis.** Conversation context not preserved across turns. Bot treats each message as standalone.
+
+**The cure.** Implement conversation state management. Bot remembers earlier turns within the same conversation; later responses build on that context. Detail in `references/branching-and-conditional-logic.md` (conversation state management section).
+
+---
+
+## "Bot gives different answers to the same question."
+
+**The diagnosis.** Either grounding is inconsistent (different retrievals for similar queries), or the LLM generation has variability that produces different answers.
+
+**The cure.** Review grounding pipeline. Verify retrieval consistency. Tune generation parameters for consistency. Audit specific cases.
+
+---
+
+## "We tried the bot in our pricing page; conversion went down."
+
+**The diagnosis.** Bot may be adding friction to a flow that worked. Some pages benefit from chatbots; some do not.
+
+**The cure.** A/B test bot presence vs absence on the affected pages. The data informs whether the bot is the right tool there.
+
+---
+
+## "Bot ignores the user when sentiment is negative."
+
+**The diagnosis.** No sentiment-driven escalation. Bot continues handling conversations where the user is frustrated.
+
+**The cure.** Add sentiment-driven escalation. Recognize frustration signals; escalate to human. Detail in `references/escalation-to-human-patterns.md`.
+
+---
+
+## "Sales team finds qualification bot data unreliable."
+
+**The diagnosis.** Bot's qualification logic does not match sales-team criteria, or recognition is misclassifying leads.
+
+**The cure.** Align bot qualification with sales criteria. Audit recognition with sales feedback. Update intents and routing.
+
+---
+
+## "We added a chatbot; our overall site conversion dropped."
+
+**The diagnosis.** Bot may be displacing higher-converting paths (direct CTAs, contact forms). Bot is the wrong tool for this audience or page.
+
+**The cure.** A/B test bot presence vs absence at the funnel level. If the bot reduces conversion, reconsider its placement or scope.
+
+---
+
+## "Bot answers correctly but conversation never closes."
+
+**The diagnosis.** No clear conversation-end pattern. Bot keeps offering more help; user does not know when to stop.
+
+**The cure.** Add explicit conversation closing. "Anything else I can help with?" "If not, [next step option]." Detail in fallback patterns.
+
+---
+
+## "We migrated platforms; the bot quality dropped."
+
+**The diagnosis.** Platform migration may have broken intent recognition, knowledge base integration, or escalation routing.
+
+**The cure.** Test the migrated bot end-to-end before declaring it ready. Critical paths first. Roll back if quality dropped significantly.
+
+---
+
+## "Mobile conversations end with no resolution."
+
+**The diagnosis.** Mobile UI may be breaking; or the bot's responses may be too long for mobile screens.
+
+**The cure.** Mobile UI testing. Audit response lengths. Mobile-specific UI adjustments.
+
+---
+
+## "We cannot tell which intents need work."
+
+**The diagnosis.** Analytics aggregated rather than per-intent. The intent-level signal is hidden.
+
+**The cure.** Per-intent analytics. Recognition rate, resolution rate, escalation rate, hallucination rate per intent. Detail in `references/conversation-analytics-patterns.md`.
+
+---
+
+## "Bot's voice does not sound like our brand."
+
+**The diagnosis.** Bot is using generic LLM voice; brand voice was not specifically tuned.
+
+**The cure.** Brand voice document including bot examples. Tune bot prompts and response patterns to match. Detail in `references/intent-architecture-patterns.md` (intent and brand voice section).
+
+---
+
+## The pattern across failures
+
+Most chatbot failures fall into one of three patterns.
+
+**Pattern 1: The bot does not have proper architecture.** Hallucinating, scripted, no grounding, no fallback discipline. The fix is structural.
+
+**Pattern 2: The bot does not match the audience or context.** Bot in wrong context, wrong voice, wrong scope for audience. The fix is matching the bot to where it serves.
+
+**Pattern 3: The bot decays.** Knowledge base stale, intent set frozen, no maintenance. The fix is maintenance discipline.
+
+The metric pattern: chatbot failures often look fine on conversation count alone. The signal is in resolution rate per intent, hallucination rate, escalation quality, downstream conversion. Programs that track only conversation counts keep shipping the same patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (architecture, audience-context match, decay). The principle that conversation count alone is insufficient as a success metric.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered and the lessons learned. Specific multi-metric dashboards the team uses. Specific cures the team applies. The team's audit and retirement processes. These vary by team.

--- a/skills/chatbot-flow-design/references/conversation-analytics-patterns.md
+++ b/skills/chatbot-flow-design/references/conversation-analytics-patterns.md
@@ -1,0 +1,272 @@
+# Conversation analytics patterns
+
+Per-intent metrics. Diagnostic uses. The data that informs maintenance.
+
+Conversation analytics is the bot's diagnostic system. Without analytics, maintenance is guesswork; intent gaps go unnoticed; hallucination patterns persist; the bot's quality decays without anyone seeing the decay.
+
+---
+
+## The instrumentation principle
+
+Track the bot's performance per intent, per fallback, per escalation. The data informs every maintenance decision.
+
+**The minimum tracking.**
+
+- Conversation start (a user opens the bot).
+- Intent recognition (which intent the bot classified).
+- Conversation outcome (resolved, fallback, escalation, abandoned).
+- Per-turn data (each user message, each bot response).
+
+**The derived metrics.**
+
+- Intent recognition rate.
+- Resolution rate per intent.
+- Fallback rate.
+- Escalation rate per intent.
+- Abandonment rate.
+
+Without instrumentation, none of this data exists. Set up tracking before launch.
+
+---
+
+## Intent recognition rate
+
+What percentage of conversations are correctly classified.
+
+**The metric.** Of conversations where the user expressed intent, what percentage did the bot recognize correctly?
+
+**Measurement methods.**
+
+- **Sample auditing.** Periodically sample conversations and verify intent classification manually.
+- **User feedback signals.** Conversations where users complain or escalate often correlate with misrecognized intent.
+- **Conversation outcome correlation.** Conversations resolved successfully often had correct intent recognition.
+
+**Diagnostic uses.**
+
+- Low recognition rate: intent set may not cover real conversations; recognition logic may be brittle.
+- Specific intents misrecognized: those intents may be poorly defined or overlap with others.
+
+**Target ranges.** 80-90 percent recognition is achievable for well-designed chatbots. Below 70 percent suggests significant intent or recognition issues.
+
+---
+
+## Resolution rate per intent
+
+What percentage of conversations starting with intent X resolve successfully.
+
+**Resolution definition.** The user got the answer they needed and the conversation ended successfully (no escalation, no abandonment, no follow-up indicating frustration).
+
+**Measurement methods.**
+
+- **Conversation completion plus user signal.** User explicitly says "thanks" or rates the conversation positively.
+- **No follow-up issues.** User does not return with the same question or escalate later.
+- **Direct survey.** Post-conversation survey asking if the user got what they needed.
+
+**Diagnostic uses.**
+
+- Low resolution per intent: the bot's grounding or response pattern for that intent is weak.
+- Some intents have higher resolution than others: variation may signal intent design quality differences.
+
+**Target ranges.** 70-85 percent resolution per intent is reasonable. Lower for complex intents; higher for simple intents.
+
+---
+
+## Fallback rate
+
+What percentage of conversations hit fallback at any point.
+
+**The metric.** Conversations where the bot's intent recognition failed or the bot's response did not address the user's need, requiring fallback.
+
+**Diagnostic uses.**
+
+- High fallback rate (above 25-30 percent): intent set may be missing common conversations.
+- Specific fallback layers triggered disproportionately: that layer needs review.
+- Fallback rate trending up: audience evolving away from current intent set.
+
+**Per-layer breakdown.** Track which fallback layers (clarification, suggested intents, resource handoff, human escalation) trigger most. Each tells a different story.
+
+---
+
+## Escalation rate per intent
+
+What percentage of conversations within each intent escalate to humans.
+
+**The metric.** Of conversations classified as intent X, what percentage ended with human escalation?
+
+**Diagnostic uses.**
+
+- High escalation rate per intent: the intent may not be appropriate for bot handling; consider removing from bot scope.
+- Low escalation rate per intent: bot may be over-handling; some conversations may benefit from earlier escalation.
+- Specific intents with rising escalation: maintenance lapse or audience evolution.
+
+**The 100-percent-escalation intent.** An intent where the bot always escalates is not a bot intent; it should be a "tell me about [topic]; we will get back to you" intent or removed entirely.
+
+---
+
+## Abandonment rate
+
+What percentage of conversations end without resolution or escalation (the user just leaves).
+
+**The metric.** Conversations where the user stops responding without indicating resolution.
+
+**Diagnostic uses.**
+
+- High abandonment: bot is failing to satisfy users; review fallback patterns and conversation flows.
+- Abandonment concentrated at specific turn or intent: that point in the flow is breaking.
+- Mid-conversation abandonment vs first-turn abandonment: different diagnostic implications.
+
+---
+
+## User satisfaction
+
+When measurable, satisfaction is the highest-value metric.
+
+**Measurement methods.**
+
+- **Post-conversation rating.** "How was that conversation?" with 1-5 stars or thumbs up/down.
+- **Post-conversation survey.** Brief survey after the conversation ends.
+- **Sentiment analysis.** Programmatic analysis of conversation sentiment.
+
+**Diagnostic uses.**
+
+- Low satisfaction: bot is failing the user even when conversations technically complete.
+- Satisfaction-resolution mismatch: bot resolves but users are unhappy; quality of resolution is poor.
+
+**Limitations.**
+
+- Many users do not respond to satisfaction surveys.
+- Satisfaction can be biased (frustrated users more likely to respond than satisfied ones).
+- Sentiment analysis can miss nuance.
+
+The metric is valuable but not the only signal.
+
+---
+
+## Conversation length distribution
+
+How many turns the average conversation takes.
+
+**The metric.** Distribution of conversation turn count.
+
+**Diagnostic uses.**
+
+- Long average length: bot may be over-clarifying; conversations should resolve faster.
+- Bimodal distribution (very short or very long): some conversations resolve quickly; others get stuck.
+- Increasing trend: bot quality may be declining; users having to work harder.
+
+**Target ranges.** 2-5 turns for typical resolution. Longer for complex intents; shorter for simple ones.
+
+---
+
+## Response time
+
+How quickly the bot responds.
+
+**The metric.** Time between user message and bot response.
+
+**Diagnostic uses.**
+
+- Slow response: user perceives the bot as sluggish; abandonment may climb.
+- Variable response time: inconsistent experience; users unsure what to expect.
+
+**Target ranges.** Under 2 seconds for most responses. Longer responses (when retrieving or generating) should show typing indicators.
+
+---
+
+## Hallucination tracking
+
+Specifically tracking when the bot generates wrong answers.
+
+**Detection methods.**
+
+- Sample auditing of bot responses against source-of-truth.
+- User reports ("the bot said X; that is not right").
+- Citation verification (programmatic check that cited sources contain the cited content).
+
+**Diagnostic uses.**
+
+- Specific intents with hallucination rate: those intents need grounding review.
+- Specific topics within intents: knowledge base may have gaps.
+- Hallucination trend: if rate is rising, model or grounding may be drifting.
+
+**The honesty discipline.** Track hallucination explicitly. Teams that hide hallucination from themselves ship worse bots.
+
+---
+
+## Conversation funnel
+
+Track conversations as a funnel from start to resolution.
+
+**The funnel.**
+
+- Conversation started.
+- Intent recognized.
+- First response delivered.
+- User continued.
+- Resolution achieved (or escalation, or abandonment).
+
+**Diagnostic uses.** Drop-off at each stage points to specific issues.
+
+- Drop-off after intent recognition: bot's first response is not engaging or is wrong.
+- Drop-off mid-conversation: branching or follow-ups are not landing.
+- Drop-off near resolution: closing or call-to-action is weak.
+
+---
+
+## Per-segment analytics
+
+Different audience segments may experience the bot differently.
+
+**Segments.**
+
+- New visitors vs returning.
+- Logged-in vs anonymous.
+- Mobile vs desktop.
+- Source of arrival (paid, organic, referral).
+
+**Diagnostic uses.**
+
+- Segments with worse outcomes signal segment-specific issues.
+- Sometimes the right answer is segment-specific bot behavior.
+
+---
+
+## Analytics review cadence
+
+How often to look at the data.
+
+**Weekly review.** For high-volume bots or recently launched bots. Catches regressions and informs rapid iteration.
+
+**Monthly review.** For stable bots. Tracks trends and surfaces gradual decay.
+
+**Quarterly review.** For all active bots as part of the broader bot audit.
+
+**Triggered review.** When intent set changes, when knowledge base updates, when team escalation patterns shift. Ad-hoc reviews catch specific issues.
+
+---
+
+## Common analytics failures
+
+**No instrumentation.** Bot launched without per-intent tracking; quality is invisible.
+
+**Vanity metrics.** Tracking conversation count without tracking outcome quality.
+
+**Aggregate-only tracking.** Conversation rate tracked but not per-intent; remediation requires guesswork.
+
+**Instrumentation drift.** Tracking implemented at launch; intent renames or schema changes broke the tracking.
+
+**Confounded data.** Multiple changes deployed simultaneously; cannot attribute changes to any one update.
+
+**No segment-level data.** Aggregate hides segment-specific issues.
+
+**No hallucination tracking.** Bot wrongness goes unnoticed until customers complain.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The instrumentation principle. Intent recognition rate. Resolution rate per intent. Fallback rate. Escalation rate per intent. Abandonment rate. User satisfaction. Conversation length distribution. Response time. Hallucination tracking. Conversation funnel. Per-segment analytics. Analytics review cadence. Common failures.
+
+## Implementation choices that stay internal
+
+Specific dashboards for specific bots. Specific tooling for analytics implementation. Specific target ranges for the team's audience. The team's audit calendars. These vary by team.

--- a/skills/chatbot-flow-design/references/escalation-to-human-patterns.md
+++ b/skills/chatbot-flow-design/references/escalation-to-human-patterns.md
@@ -1,0 +1,209 @@
+# Escalation to human patterns
+
+When, how, with what context. Escalation triggers and handoff quality.
+
+Some conversations need a human. The bot escalates when its scope is exceeded, when the user requests it, or when the conversation pattern indicates the user is frustrated. Escalation done well preserves the conversation's momentum; escalation done poorly resets the user.
+
+---
+
+## The escalation principle
+
+Escalation is part of the bot's job. A bot that knows when to step aside earns more trust than a bot that tries to handle everything.
+
+**The win.** The bot recognizes its scope is exceeded; escalates with the conversation context; the human picks up where the bot left off.
+
+**The fail (no escalation).** The bot tries to handle everything; produces wrong answers; the user has to start over with a human eventually.
+
+**The fail (broken escalation).** The bot escalates but the human starts from scratch; the user has to repeat everything.
+
+The discipline. Escalation triggers defined; context handoff clean.
+
+---
+
+## Escalation triggers
+
+When the bot escalates.
+
+**User-initiated.** "Talk to a human." "I need to speak with someone." "Get me a person."
+
+The bot escalates immediately. Do not try to handle the request first; the user has been explicit.
+
+**Out-of-scope intent.** The bot recognizes the user's intent is outside its scope.
+
+The bot escalates with the intent context. "Looks like you have a [intent type] question; let me connect you with the team."
+
+**Repeated fallback.** After 2-3 unclear exchanges, the bot escalates rather than loop.
+
+The bot acknowledges: "I am having trouble understanding your question; let me get a human who can help."
+
+**Sentiment-driven.** The user's sentiment indicates frustration.
+
+The bot recognizes frustration signals (negative phrasing, repeated complaints, exclamation patterns) and escalates.
+
+**High-stakes topic.** Sensitive topics escalate by default.
+
+Account security, cancellations, complaints, signs of distress. The bot does not try to handle these; immediate escalation.
+
+**Complexity-driven.** The user's question requires deep customization or analysis the bot cannot provide.
+
+The bot acknowledges: "This needs a more detailed look; let me connect you with our team."
+
+---
+
+## The context handoff
+
+When escalating, the bot passes context to the human.
+
+**What to pass.**
+
+- The conversation history (full transcript).
+- The recognized intent (what the bot thought the user wanted).
+- The user's situation (any captured attributes: company, role, source).
+- The reason for escalation (user-initiated, out-of-scope, sentiment, etc.).
+- Any pending follow-up actions.
+
+**The handoff format.**
+
+- Visible to the human in their tool of choice (CRM, support ticket system, chat panel).
+- Structured so the human can scan it quickly.
+- Accurate (the recognized intent matches what the user actually said).
+
+**The handoff failure.** The human picks up the conversation but does not see the context; they ask the user to repeat everything; the user feels the escalation was for nothing.
+
+The discipline. Test the handoff. The human should pick up the context smoothly. The user should feel the escalation moved them forward, not backward.
+
+---
+
+## Escalation user experience
+
+What the user sees during escalation.
+
+**The pattern.**
+
+- Bot acknowledges the escalation: "Let me connect you with someone who can help."
+- Bot provides expectation: "Someone from our team will be with you in [timeframe]."
+- If the wait will be long, bot offers alternatives: "If you do not want to wait, you can [book a call / email us / submit a ticket]."
+- Conversation transitions to human cleanly when the human joins.
+
+**The escalation-as-transition principle.** The user should feel the conversation continued, not started over. The transition from bot to human is part of the experience.
+
+---
+
+## Escalation and human availability
+
+What happens when no human is available.
+
+**During business hours.** The bot escalates; a human picks up within the expected response time.
+
+**Off-hours.** The bot acknowledges: "Our team is available [hours]. I can take your information and have someone respond when they are back."
+
+**During high-volume.** The bot acknowledges the wait: "We are seeing high volume right now; expected wait is about [time]."
+
+**The honest framing.** The bot communicates availability honestly. Pretending humans are available when they are not creates frustrated users.
+
+**Asynchronous escalation.** When the user is willing, async escalation (email, ticket) is often better than waiting in chat. The bot can offer this option proactively.
+
+---
+
+## Escalation routing
+
+Which human gets the conversation.
+
+**Routing patterns.**
+
+- **Single team.** All escalations go to one team (often support). Simple but may not match all conversation types.
+- **Intent-based routing.** Different intents route to different teams (sales escalations to sales; support to support).
+- **Tier-based routing.** Different user tiers route to different teams (enterprise to enterprise account managers; SMB to general support).
+- **Context-based routing.** Routing combines intent, tier, and other attributes.
+
+**Routing failures.**
+
+- Wrong team gets the escalation; they have to re-route; user waits longer.
+- Routing logic stale; teams have changed but the bot has not.
+- Round-robin without consideration of expertise; users get inconsistent quality.
+
+**Routing maintenance.** Quarterly review of routing logic alongside team structure changes.
+
+---
+
+## Escalation measurement
+
+Track escalation rate and quality.
+
+**Metrics.**
+
+- **Escalation rate.** What percentage of conversations escalate?
+- **Escalation rate per intent.** Some intents may escalate more often than others.
+- **Time-to-human-pickup.** How quickly does the human respond after escalation?
+- **Resolution after escalation.** What percentage of escalated conversations resolve?
+- **User satisfaction post-escalation.** When measurable.
+
+**Diagnostic uses.**
+
+- High escalation rate per intent: that intent may not be appropriate for bot handling.
+- Long time-to-human: staffing or routing issues.
+- Low resolution after escalation: handoff quality may be poor or the team may not have the resources.
+
+The data informs both bot maintenance and human team capacity planning.
+
+---
+
+## Bot-to-human transition design
+
+The moment the human joins the conversation.
+
+**Pattern A: Visible transition.** The user sees a message: "Hi, I am [name] from the team. I see you were asking about [topic]; how can I help?"
+
+The transition is explicit; the user knows they are now with a human.
+
+**Pattern B: Continuous transition.** The conversation continues without explicit handoff; the bot's voice fades; the human's voice picks up.
+
+Less common; can confuse users about who they are talking to.
+
+**Pattern C: Bot stays available.** The bot remains in the conversation alongside the human; can be called on for specific information retrieval while the human leads.
+
+Useful for complex conversations; rare in simple chatbot deployments.
+
+**Pattern A is the default.** Explicit transitions reduce confusion.
+
+---
+
+## Escalation back to bot
+
+Sometimes the conversation can return to the bot after a human handoff.
+
+**When this works.** The human resolves the immediate issue; the user has a follow-up question that is bot-handlable; the bot can pick back up.
+
+**When this fails.** The user expected human attention; returning to the bot feels like demotion.
+
+**The discipline.** Bot-after-human transitions need user consent. "Is there anything else? I can connect you with our chatbot for quick questions, or keep you with me." Let the user choose.
+
+---
+
+## Common escalation failures
+
+**No escalation logic.** Bot tries to handle everything; produces wrong answers; users escalate to support after the fact (worse than escalating upfront).
+
+**Escalation without context handoff.** Human starts from scratch; user repeats everything.
+
+**Escalation to unavailable humans.** Bot creates expectation that is not met; user waits indefinitely or abandons.
+
+**Wrong-team routing.** Escalation goes to a team that cannot help; rerouting adds friction.
+
+**Sensitive topics not escalated.** Bot tries to handle account security, cancellations, complaints; makes things worse.
+
+**Escalation triggers too restrictive.** Bot rarely escalates; users get stuck.
+
+**Escalation triggers too permissive.** Bot escalates everything; the bot is not really doing its job.
+
+**No escalation user experience.** Transition to human is jarring; user is confused about whether they are still with the bot.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The escalation principle. Escalation triggers (6 patterns). Context handoff discipline. Escalation user experience. Escalation and human availability. Escalation routing. Escalation measurement. Bot-to-human transition design (3 patterns). Escalation back to bot. Common failures.
+
+## Implementation choices that stay internal
+
+Specific escalation routing for specific teams. Specific handoff formats and integration with CRM or support tools. Specific brand-voice transition copy. The team's staffing and SLA decisions. These vary by team.

--- a/skills/chatbot-flow-design/references/fallback-pattern-design.md
+++ b/skills/chatbot-flow-design/references/fallback-pattern-design.md
@@ -1,0 +1,257 @@
+# Fallback pattern design
+
+What happens when intent is unclear or out-of-scope. Multi-layered fallback patterns.
+
+Every conversation has fallback paths. The bot has rehearsed responses for "I do not know," "I am not sure I can help with that," "Let me connect you with a human." Done well, fallback earns trust through honesty; done poorly, fallback frustrates users into abandonment.
+
+---
+
+## The honesty principle
+
+A bot that admits it does not know earns more trust than a bot that fakes confidence. Audiences forgive limitations they were told about; audiences punish wrong answers given confidently.
+
+**The win.** A user asks about a topic outside the bot's scope. The bot says "I cannot help with that, but [here is the right resource or human contact]." The user gets routed to value; the brand earns trust.
+
+**The fail (faked confidence).** The bot generates an answer from training data because it has no scope discipline. The answer is wrong; the user finds out later; the brand earns "lying bot" reputation.
+
+**The fail (rigid refusal).** The bot says "I cannot help with that" and offers no alternative. The user has nowhere to go.
+
+The discipline. Honest about limits; helpful about alternatives.
+
+---
+
+## Multi-layered fallback
+
+Multiple fallback patterns, sequenced.
+
+**Layer 1: Clarifying question.** "Can you tell me more about what you are looking for?"
+
+When to use: when the user's intent is unclear and clarification might resolve.
+
+When it fails: when the user has already been clear; clarification feels patronizing.
+
+The discipline: ask clarification once, not repeatedly.
+
+**Layer 2: Suggested intents.** "I can help with X, Y, or Z. Were you asking about one of those?"
+
+When to use: when clarification did not work, or when the user asked something the bot can almost handle.
+
+When it fails: when the suggestions do not match what the user wanted.
+
+The discipline: suggest the bot's actual capabilities, not generic options.
+
+**Layer 3: Resource handoff.** "I cannot answer that, but here is our [documentation page] that covers it."
+
+When to use: when the bot cannot help but a self-serve resource exists.
+
+When it fails: when the resource is not actually relevant.
+
+The discipline: route to genuinely relevant resources; do not deflect to generic help.
+
+**Layer 4: Human escalation.** "Let me connect you with a human who can help."
+
+When to use: when self-serve will not work or the user has expressed frustration.
+
+When it fails: when no human is available; the escalation creates an expectation that does not get met.
+
+The discipline: escalate to humans only when humans are available; otherwise communicate the wait.
+
+---
+
+## Layer sequencing
+
+The order matters.
+
+**Standard sequence.**
+
+1. Recognize intent. If recognized, handle.
+2. If not recognized, try clarification (Layer 1).
+3. If clarification fails, suggest intents (Layer 2).
+4. If suggestions fail, offer resources (Layer 3).
+5. If resources do not match, escalate (Layer 4).
+
+**Sequence variations.**
+
+- High-stakes topics may skip to Layer 4 immediately.
+- User-initiated escalation ("talk to a human") goes to Layer 4 immediately.
+- Frustrated sentiment may trigger Layer 4 sooner.
+
+---
+
+## Anti-pattern: fallback loop
+
+Multiple clarification attempts that go nowhere.
+
+**The pattern.** Bot does not understand; asks for clarification; user clarifies; bot still does not understand; asks again; loop.
+
+**The signal.** Users abandon mid-conversation after 2-3 unsuccessful clarification attempts.
+
+**The cost.** The user feels stuck. The brand earns "frustrating bot" reputation.
+
+**The cure.** Limit clarification to one round. After that, escalate or offer alternatives. The bot's job is to resolve or hand off, not to keep asking the same question.
+
+---
+
+## Anti-pattern: rigid refusal
+
+Bot says "I cannot help" and offers no path forward.
+
+**The pattern.** User asks something out of scope; bot says "I cannot help with that"; conversation ends.
+
+**The signal.** Users complain that the bot is unhelpful; abandonment.
+
+**The cost.** The bot fails the user without offering recovery.
+
+**The cure.** Always offer an alternative. Resource handoff or human escalation. The bot's "I cannot help" should be followed immediately by "but here is what might."
+
+---
+
+## Fallback copy discipline
+
+What the fallback messages say.
+
+**Helpful fallback copy.**
+
+- "I am not sure I caught that. Are you asking about [option 1] or [option 2]?"
+- "I can answer questions about pricing, integrations, or features. Was your question about one of those?"
+- "I cannot answer that specifically. Our team can help; would you like me to connect you?"
+
+**Unhelpful fallback copy.**
+
+- "I do not understand."
+- "Please rephrase."
+- "Sorry, I cannot help with that."
+
+**The voice discipline.** Fallback copy should sound like the brand. Apologetic but not groveling; honest but not curt; helpful but not desperate.
+
+---
+
+## Fallback for sensitive topics
+
+Some topics warrant immediate escalation regardless of bot capability.
+
+**Sensitive triggers.**
+
+- Account security ("my account was hacked," "I think I was charged wrong").
+- Cancellation ("I want to cancel my subscription").
+- Complaints ("I want to speak to a manager").
+- Crises (any indication of user distress).
+
+**The pattern.** The bot recognizes the sensitive topic and escalates immediately rather than attempting to handle.
+
+**Why this matters.** Sensitive topics need human empathy. A bot trying to handle them often makes things worse. Immediate escalation protects the user and the brand.
+
+---
+
+## Fallback during human unavailability
+
+What happens when the user wants a human but no human is available.
+
+**The honest options.**
+
+- "Our team is available [hours]. Can I take a message they can respond to when they are back?"
+- "We are not available right now. You can [submit a ticket / book a call / email us]."
+- "I can help with [list of topics]; for [out-of-scope topic], please reach out to [channel] directly."
+
+**The dishonest option.**
+
+- Pretending a human is available when they are not. The user waits, gets frustrated, abandons.
+
+The discipline. Communicate availability honestly. Set the expectation upfront if humans cannot respond immediately.
+
+---
+
+## Fallback measurement
+
+Track fallback rate as a key metric.
+
+**The metric.** What percentage of conversations hit fallback at any point?
+
+**Diagnostic uses.**
+
+- High fallback rate (above 25-30 percent): intents are missing or recognition is poor.
+- Specific fallback layers triggered disproportionately: that layer needs design review.
+- Fallback escalation rate (what percentage of fallbacks lead to human escalation): high rates may signal the bot is doing less than it should; low rates may signal users abandoning rather than escalating.
+
+**The fallback-as-signal principle.** Fallback is not failure; it is the bot honestly recognizing limits. The signal is in the fallback patterns and what they reveal about intent gaps.
+
+---
+
+## Fallback maintenance
+
+Fallback decays.
+
+**What decays.**
+
+- Suggested intents that no longer reflect the bot's actual capabilities.
+- Resource links that have moved or broken.
+- Escalation routing that no longer matches the team structure.
+
+**Maintenance cadence.** Quarterly review of fallback messages, suggested intents, resource links, and escalation routing.
+
+**The drift indicator.** User feedback about unhelpful fallback responses; broken links in the fallback flow; escalations going to wrong teams.
+
+---
+
+## Fallback and brand voice
+
+Fallback responses are an opportunity for brand voice.
+
+**The principle.** Fallback is when the bot is most likely to lose the user. Brand voice in fallback can recover the moment.
+
+**Voice in fallback.**
+
+- Acknowledge the limitation honestly.
+- Maintain warmth (do not become cold or robotic when failing to help).
+- Offer the path forward with the same voice as the rest of the conversation.
+
+**The voice failure.** Fallback messages that sound generic; bot loses voice exactly when voice matters most.
+
+---
+
+## Fallback testing
+
+Test the fallback flow as carefully as the success flow.
+
+**Test cases.**
+
+- User asks something clearly out of scope.
+- User asks something on the edge of scope.
+- User asks something within scope but phrased unusually.
+- User explicitly asks for a human.
+- User shows frustration in their messages.
+- User asks during off-hours.
+
+**The testing discipline.** Each fallback layer should be tested with realistic triggers.
+
+---
+
+## Common fallback failures
+
+**No fallback patterns.** Bot has no rehearsed responses for unknown intents; generates whatever the LLM produces.
+
+**Single-layer fallback.** Only "I do not understand" without alternatives.
+
+**Fallback loops.** Bot keeps asking clarification; user gets stuck.
+
+**Rigid refusal.** Bot says "I cannot help" without offering paths.
+
+**Generic fallback copy.** Fallback messages do not match brand voice.
+
+**Stale resource links.** Resource handoff points to broken URLs.
+
+**Wrong escalation routing.** Bot escalates to teams that are not appropriate.
+
+**Hidden human availability.** Bot does not communicate when humans are or are not available.
+
+**Sensitive topics not escalated.** Bot tries to handle topics that need human empathy.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The honesty principle. Multi-layered fallback (4 layers with when to use). Layer sequencing. Anti-patterns (fallback loop, rigid refusal). Fallback copy discipline. Fallback for sensitive topics. Fallback during human unavailability. Fallback measurement. Fallback maintenance. Fallback and brand voice. Fallback testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific fallback messages for specific bots. Specific suggested intents and resource links. Specific escalation routing logic. The team's brand-voice fallback templates. These vary by team.

--- a/skills/chatbot-flow-design/references/intent-architecture-patterns.md
+++ b/skills/chatbot-flow-design/references/intent-architecture-patterns.md
@@ -1,0 +1,238 @@
+# Intent architecture patterns
+
+Defining what the bot can and cannot handle. Named intents, hierarchies, boundaries, coverage.
+
+The intent architecture is the bot's scope definition. Bad architecture produces bots that try to handle everything (and hallucinate) or bots that handle so little they fail audience expectations. Good architecture defines explicit scope and routes the rest to fallback.
+
+---
+
+## The named-intent principle
+
+The bot has a defined set of intents it can handle. Each intent has a name, a scope, and a conversation pattern.
+
+**The win.** A user asks "what does the Pro plan include?" The bot recognizes this as the "pricing question" intent. The conversation pattern for that intent retrieves from the pricing knowledge base, generates a response, and offers follow-up.
+
+**The fail (no named intents).** The bot tries to handle every question with the same generic flow. Some questions get good answers; some get hallucinated answers; the bot cannot reason about its own scope.
+
+The discipline. Define the intents explicitly. The bot's behavior at each intent is intentional; behavior outside the intents is fallback.
+
+---
+
+## Common intent patterns
+
+Patterns that recur across marketing-site and support chatbots.
+
+**Pricing question.** "How much does the Pro plan cost?" "What is included in the Enterprise tier?" "Do you offer discounts for nonprofits?"
+
+Conversation pattern: retrieve from pricing knowledge base, present the relevant tier or comparison, offer follow-up (talk to sales, see comparison, view full pricing page).
+
+**Feature comparison.** "What is the difference between A and B?" "Does feature X include Y?"
+
+Conversation pattern: retrieve from feature documentation, present comparison or specific feature details, offer follow-up.
+
+**Integration question.** "Do you integrate with Salesforce?" "How does the API work?"
+
+Conversation pattern: retrieve from integration catalog or API docs, present specific integration or API details, offer follow-up.
+
+**Support escalation.** "I need help with my account." "Something is broken."
+
+Conversation pattern: capture the issue context, escalate to human support with the captured context.
+
+**Demo request.** "Can I see a demo?" "I want to talk to sales."
+
+Conversation pattern: qualify the request (capture company size, use case, timeline), route to sales with the qualified context.
+
+**Account access.** "I forgot my password." "How do I access my account?"
+
+Conversation pattern: route to account-recovery flow or self-serve help.
+
+**General question.** "Tell me more about [topic]." "What can you help with?"
+
+Conversation pattern: present overview of bot capabilities; ask what specifically the user wants.
+
+---
+
+## Intent hierarchy
+
+Top-level categories with sub-intents.
+
+**The pattern.** "Pricing question" includes sub-intents for "tier comparison," "discount inquiry," "billing question," "annual vs monthly."
+
+**Strengths.**
+
+- Hierarchy mirrors how audiences think.
+- Each sub-intent can have specific knowledge-base grounding and conversation pattern.
+- Easier to maintain than flat intent set.
+
+**Weaknesses.**
+
+- More complex to build.
+- Risk of over-decomposition (sub-intents that nobody triggers).
+
+**When to use.** When the bot's scope is broad enough that a flat intent set becomes unwieldy. Most production chatbots benefit from hierarchy.
+
+---
+
+## Intent boundaries
+
+Each intent has clear scope. Out-of-scope topics route to fallback.
+
+**The principle.** The intent definition specifies what the intent covers and what it does not.
+
+**Example: "Pricing question" intent.**
+
+In scope: tier prices, plan inclusions, discount inquiries, billing-cycle questions.
+
+Out of scope: sales-specific negotiations (escalate to sales), custom pricing requests (escalate to sales), historical pricing (out-of-scope, fallback).
+
+**The boundary discipline.** Without clear boundaries, the bot tries to handle topics it should not. Boundaries are part of the intent definition.
+
+---
+
+## Intent coverage
+
+The bot's intents should cover 70-90 percent of expected conversations.
+
+**The principle.** Trying to cover 100 percent often produces bloated intent sets the bot cannot handle reliably. Aiming for 70-90 percent leaves room for honest fallback on the remaining edge cases.
+
+**Coverage measurement.**
+
+- After launch, sample conversations and classify them by intent.
+- The percentage classified into named intents is coverage.
+- The percentage falling to fallback is the gap.
+
+**Coverage targets by use case.**
+
+- Marketing-site Q&A: 80-90 percent coverage achievable.
+- Support: 60-80 percent coverage typical; support questions are more varied.
+- Sales qualification: 70-85 percent coverage; depending on audience.
+
+**The over-coverage trap.** Pursuing 100 percent coverage often means adding intents that fire rarely. The maintenance overhead is significant; the value is low. Honest fallback for rare cases is often better than rarely-triggered intents.
+
+---
+
+## Intent design discipline
+
+Designing each intent.
+
+**Step 1: Name the intent.** Specific name that reflects the conversation pattern.
+
+**Step 2: Scope the intent.** What topics in, what topics out.
+
+**Step 3: Identify the knowledge base.** What knowledge sources the intent grounds in.
+
+**Step 4: Design the conversation pattern.** Opening response, possible follow-ups, success state, escalation conditions.
+
+**Step 5: Define the success criterion.** What does success look like for this intent? User got the answer? User clicked through to a relevant page? User completed a follow-up action?
+
+**Step 6: Define escalation triggers.** When does this intent escalate to a human?
+
+The discipline. Each intent is designed deliberately. Generic conversation patterns produce generic results.
+
+---
+
+## Intent recognition
+
+How the bot determines which intent the user is in.
+
+**LLM-based intent recognition.** The LLM classifies the user's message into one of the named intents. Common in modern chatbots.
+
+**Rule-based intent recognition.** Keywords or patterns trigger intent assignment. Older approach; brittle but predictable.
+
+**Hybrid.** LLM as primary; rules for high-confidence overrides. Common middle ground.
+
+**The recognition challenge.** Users phrase the same intent in many ways. "How much?" "What does it cost?" "Is there a free tier?" all map to "pricing question." The intent recognition has to handle the variety.
+
+**Recognition failure modes.**
+
+- Misclassification (intent A treated as intent B).
+- Over-classification (too many intents recognized; conversation gets confusing).
+- Under-classification (intents go unrecognized; conversations fall to fallback).
+
+The discipline. Test intent recognition with realistic user messages. Tune until the classification matches user intent reliably.
+
+---
+
+## Intent maintenance
+
+Intents drift. Audiences shift; products evolve; conversation patterns change.
+
+**Maintenance signals.**
+
+- Specific intents see declining resolution rates.
+- New conversation patterns emerge that no intent covers.
+- Sub-intents become more or less common over time.
+
+**Maintenance cadence.** Quarterly review of intent performance. Add new intents when new patterns emerge consistently; retire intents that fire rarely.
+
+**The intent-maintenance audit.**
+
+- For each intent: trigger rate, resolution rate, escalation rate.
+- Identify intents that are over-triggering (capture too much) or under-triggering (rarely fire).
+- Identify gaps (conversations that should have an intent but do not).
+
+---
+
+## Intent and brand voice
+
+Each intent's conversation pattern should sound like the brand.
+
+**The principle.** The bot's voice in each intent matches the brand voice. Consistent across intents; consistent with the brand's other surfaces.
+
+**Brand-voice failures.**
+
+- Different intents speaking in different voices.
+- Bot voice that does not match the brand's other surfaces.
+- Generic LLM voice (no brand personality).
+
+**The cure.** Voice guidance specific to the bot. Brand voice document that includes bot-specific examples. Test conversations to verify voice consistency.
+
+---
+
+## Intent-architecture worked example
+
+A B2B SaaS chatbot for a project management tool.
+
+**Top-level intents.**
+
+1. Pricing question (sub-intents: tier comparison, discount inquiry, billing question, annual vs monthly)
+2. Feature inquiry (sub-intents: specific feature, comparison to competitor, roadmap question)
+3. Integration question (sub-intents: specific integration, API question, custom integration)
+4. Demo request (sub-intents: standard demo, enterprise demo, technical deep-dive)
+5. Support escalation (sub-intents: bug report, account issue, billing problem, general help)
+6. Account access (sub-intents: password reset, account login, organization-level access)
+7. General overview (sub-intent: introductory tour)
+
+**Coverage estimate.** 80-85 percent of expected conversations.
+
+**Fallback for the remaining 15-20 percent.** Multi-layered fallback (clarification, suggested intents, resource handoff, human escalation).
+
+The architecture is explicit. Each intent has scope, knowledge-base grounding, conversation pattern, and escalation triggers.
+
+---
+
+## Common intent failures
+
+**Too few intents.** Bot tries to handle everything with generic flow; hallucinates or stays generic.
+
+**Too many intents.** Intents that rarely fire; maintenance overhead with no value.
+
+**Overlapping intents.** Two intents claiming the same conversations; recognition becomes ambiguous.
+
+**Unclear intent boundaries.** Bot handles topics out of scope; quality drops.
+
+**Intent recognition unreliable.** Misclassification rate high; users get wrong responses.
+
+**No intent maintenance.** Intent set frozen at launch; audiences evolve away from it.
+
+**Brand voice inconsistent.** Each intent speaks differently; bot feels disjointed.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The named-intent principle. Common intent patterns. Intent hierarchy. Intent boundaries. Intent coverage. Intent design discipline. Intent recognition approaches. Intent maintenance. Intent and brand voice. Worked example. Common failures.
+
+## Implementation choices that stay internal
+
+Specific intent sets for specific bots. Specific conversation patterns and copy. Specific recognition implementations. Specific knowledge-base mappings per intent. The team's audit calendars. These vary by team.

--- a/skills/chatbot-flow-design/references/knowledge-base-grounding-patterns.md
+++ b/skills/chatbot-flow-design/references/knowledge-base-grounding-patterns.md
@@ -1,0 +1,263 @@
+# Knowledge-base grounding patterns
+
+Retrieval-augmented generation, source-of-truth design, citation discipline, knowledge-base maintenance. The bot's responses must come from real knowledge, not made-up confidence.
+
+Without grounding, the bot hallucinates. With grounding, the bot retrieves and presents. The difference is the gap between hallucinating-bot and structured-guided-conversation.
+
+---
+
+## The grounding principle
+
+The bot's response generation should reference a structured knowledge base. The bot does not invent answers; it retrieves and presents.
+
+**The win.** A user asks "what is included in the Pro plan?" The bot retrieves the current pricing page, extracts the Pro plan inclusions, and presents them. The answer matches the source-of-truth.
+
+**The fail (hallucinating).** A user asks the same question. The bot has no grounding; the LLM generates a response from training data or pattern-matching. The response sounds confident but may be wrong (outdated, fabricated, partially correct).
+
+The discipline. Every response that could be wrong if invented must be grounded.
+
+---
+
+## Pattern A: Retrieval-augmented generation (RAG)
+
+The bot searches a knowledge base for relevant content before generating a response.
+
+**How it works.**
+
+- The user's message is converted to a query.
+- The query searches the knowledge base (often via vector embedding similarity).
+- Relevant content chunks are retrieved.
+- The LLM generates a response grounded in the retrieved content.
+
+**Strengths.**
+
+- Responses reflect current knowledge base content.
+- Bot answers questions about specific topics it has been trained on.
+- Easier to update than retraining a model; updating the knowledge base updates the bot.
+
+**Weaknesses.**
+
+- Retrieval quality depends on knowledge-base structure and embedding quality.
+- Bot may still hallucinate if retrieval returns nothing or if generation strays from retrieved content.
+- Latency increases (retrieval + generation).
+
+**When to use.** Default pattern for grounded chatbots. Most production bots use some form of RAG.
+
+---
+
+## Pattern B: Source-of-truth design
+
+Defining the knowledge base as the canonical source.
+
+**The principle.** The knowledge base is the canonical source for the bot's responses. When the source-of-truth changes, the bot's answers change.
+
+**Source-of-truth examples.**
+
+- Pricing page = source for pricing answers.
+- Documentation = source for feature and integration answers.
+- Support knowledge base = source for support answers.
+- Security and compliance docs = source for security answers.
+
+**Source-of-truth discipline.**
+
+- Each topic has a single source-of-truth.
+- The bot retrieves from that source.
+- When the source updates, the bot's answers update automatically (depending on the RAG pipeline).
+
+**The fragmented-source failure.** Multiple sources for the same topic produce inconsistent answers. The bot might cite one source; the user might rely on another. Confusion.
+
+The cure. Single source-of-truth per topic. If multiple documents cover the same topic, designate one as canonical and reference the others.
+
+---
+
+## Pattern C: Citation discipline
+
+The bot can cite the source of its answer.
+
+**The principle.** Audiences benefit from knowing where the answer came from. Citation builds trust and lets the user verify.
+
+**Citation patterns.**
+
+- **Inline citation.** "Based on our pricing page, the Pro plan is $X per user per month."
+- **Source link.** "You can see the full plan comparison [here]."
+- **Source attribution at end.** "Source: [document name or link]"
+
+**Why citation matters.**
+
+- Trust-building. Users can verify the answer.
+- Hallucination protection. If the bot cannot cite, the answer may be fabricated.
+- User self-service. Users with deeper questions can follow the link.
+
+**Citation failures.**
+
+- Bot generates an answer without citation; the user cannot verify.
+- Bot cites a source that does not actually contain the answer (citation hallucination).
+- Bot cites a moved or deleted source; the link breaks.
+
+The discipline. Citations must point to real sources that contain the cited content.
+
+---
+
+## Pattern D: Boundary disclosure
+
+The bot tells the user when it is operating outside its grounding.
+
+**The principle.** When the bot's response is not grounded (the question is outside the knowledge base), the bot says so explicitly.
+
+**Disclosure patterns.**
+
+- "I do not have information on that specific topic; would you like me to connect you with our team?"
+- "Our pricing details are on the [pricing page]; the specific scenario you are asking about may need a custom quote from sales."
+- "I can answer questions about our integrations; for product roadmap, you may want to contact our team."
+
+**The disclosure-as-honesty principle.** A bot that admits limitations earns more trust than a bot that fakes confidence on out-of-scope questions.
+
+---
+
+## Knowledge-base structure
+
+How the knowledge base is organized affects retrieval quality.
+
+**Chunking.** Knowledge base content is broken into chunks for retrieval. Chunk size affects retrieval precision and context.
+
+- **Too small chunks.** Retrieval returns isolated facts without context. The bot may miss surrounding nuance.
+- **Too large chunks.** Retrieval returns too much; relevant content is buried; generation may stray.
+- **Right chunks.** Topically coherent units (a pricing tier description, a feature explanation, a support article section).
+
+**Metadata.** Each chunk has metadata (source document, section, last-updated date, topic tags). Metadata supports filtering and citation.
+
+**Embeddings.** Chunks are embedded for similarity search. Embedding quality affects retrieval relevance.
+
+**Index updates.** When the source-of-truth changes, the index must update. Stale index produces stale answers.
+
+---
+
+## Knowledge-base scope
+
+What goes into the knowledge base.
+
+**In scope.**
+
+- Pricing and plan details.
+- Feature and capability documentation.
+- Integration catalog and API documentation.
+- Support FAQs.
+- Security and compliance information.
+- Company overview, team, contact information.
+
+**Out of scope.**
+
+- Confidential information (internal-only docs, sensitive data).
+- Information that changes too rapidly to keep current (real-time inventory, live availability).
+- Information that requires personalization the bot cannot do (account-specific data).
+
+**Boundary discipline.** Sensitive or personalization-required topics should not be in the bot's knowledge base. The bot should escalate or route to authenticated channels for those.
+
+---
+
+## Knowledge-base maintenance
+
+The knowledge base decays. Maintenance is part of the bot's lifecycle.
+
+**What decays.**
+
+- Pricing changes that did not propagate to the knowledge base.
+- Features added or removed without docs being updated.
+- Integration partners changing names or capabilities.
+- Support articles that became outdated.
+
+**Maintenance cadence.**
+
+- Monthly review of high-traffic content (pricing, features).
+- Quarterly review of broader knowledge base.
+- Triggered review when the product or pricing changes (the change includes a knowledge-base update task).
+
+**Maintenance ownership.** Someone owns the knowledge base. Without owner, it decays.
+
+**Decay indicators.**
+
+- Bot answers that contradict current product reality.
+- User complaints about wrong information from the bot.
+- Sales or support hearing audiences cite outdated bot information.
+
+---
+
+## Hallucination detection
+
+Even with grounding, bots can hallucinate. Detection is part of the discipline.
+
+**Detection methods.**
+
+- **Sample auditing.** Periodically sample bot conversations and verify the responses against source-of-truth.
+- **User feedback signals.** "This response was not helpful" feedback often correlates with hallucination.
+- **Citation verification.** Programmatic checks that cited sources actually contain the cited content.
+- **Anomaly detection.** Conversations where the bot's response diverges significantly from retrieved content.
+
+**Remediation.**
+
+- Hallucinated content reported promptly.
+- Knowledge base or grounding logic updated to prevent recurrence.
+- Specific intent or topic may need re-design.
+
+**The honesty discipline.** Acknowledge hallucination when it happens. The team that hides hallucination from itself ships worse bots over time.
+
+---
+
+## Knowledge-base and brand voice
+
+The knowledge base content informs the bot's voice.
+
+**The principle.** Source documents written in brand voice produce bot responses in brand voice. Source documents written generically produce generic bot responses.
+
+**The discipline.** When preparing source documents for the knowledge base, write in the brand voice. The bot will reflect what it retrieves.
+
+**Brand-voice editing.** Some teams edit retrieved content for the bot's response. This adds brand voice but risks drifting from the source-of-truth. Trade-off worth considering.
+
+---
+
+## Multi-source grounding
+
+When the bot needs to combine information from multiple sources.
+
+**The pattern.** The bot retrieves from multiple sources and synthesizes a response.
+
+**Strengths.**
+
+- Bot can answer questions that span topics.
+- Richer responses possible.
+
+**Weaknesses.**
+
+- Synthesis can introduce hallucination.
+- Citation becomes more complex (multiple sources).
+- Quality control harder.
+
+**The discipline.** Use multi-source grounding sparingly. When used, ensure the synthesis is grounded in retrieved content, not generated from training data.
+
+---
+
+## Common grounding failures
+
+**No grounding.** Bot generates from training data; hallucinations are routine.
+
+**Stale grounding.** Knowledge base not updated; bot answers reflect outdated reality.
+
+**Fragmented grounding.** Multiple sources for same topic; bot answers are inconsistent.
+
+**Citation hallucination.** Bot cites sources that do not contain the cited content.
+
+**Generic content in knowledge base.** Source documents are not in brand voice; bot responses are generic.
+
+**Out-of-scope grounding.** Bot retrieves from sources that should not be in scope (confidential, personalized).
+
+**Boundary blur.** Bot answers questions outside its grounding without disclosure.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The grounding principle. Patterns A through D (RAG, source-of-truth, citation, boundary disclosure). Knowledge-base structure. Knowledge-base scope. Knowledge-base maintenance. Hallucination detection. Knowledge-base and brand voice. Multi-source grounding. Common grounding failures.
+
+## Implementation choices that stay internal
+
+Specific knowledge bases for specific bots. Specific RAG pipelines and embedding choices. Specific chunking and indexing approaches. Specific tooling for hallucination detection. The team's maintenance calendars. These vary by team.

--- a/skills/funnel-flow-architecture/SKILL.md
+++ b/skills/funnel-flow-architecture/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: funnel-flow-architecture
+description: "Architecting cross-tool conversion flows that match audience and stage. Landing page to lead magnet to nurture sequence to offer to advanced funnels. Honest about silo-funnels (every tool standalone), kitchen-sink-funnels (every audience squeezed through one path), and matched-funnels (architecture matched to audience-and-stage) patterns. Triggers on funnel design, conversion architecture, marketing funnel, growth funnel, lifecycle architecture, nurture sequence design, multi-tool funnel orchestration. Also triggers when the team's growth tools are working individually but not together, when audience segments share one nurture path, or when a funnel is being architected from scratch."
+category: growth-tooling
+catalog_summary: "Architecting cross-tool conversion flows that match audience and stage. Distinguishes silo-funnels (every tool standalone) from kitchen-sink-funnels (every audience squeezed through one path) from matched-funnels (architecture matched to audience-and-stage)"
+display_order: 6
+---
+
+# Funnel Flow Architecture
+
+A senior growth practitioner's playbook for architecting cross-tool conversion flows that match audience and stage. Landing page to lead magnet to nurture sequence to offer to advanced funnels. The discipline of building a funnel architecture, not just collecting tools.
+
+Most growth programs accumulate tools without architecture. A chatbot, a calculator, a quiz, a lead magnet, a newsletter signup, a demo CTA. Each tool works individually; none of them work together. Visitors hit one tool, leave, and never enter the broader nurture sequence. The funnel is a collection of orphans.
+
+The growth programs that compound do something different. They architect the funnel deliberately. Different entry points lead to different nurture sequences. Different stages get different CTAs. Different tools serve different segments. Each tool is part of a larger architecture, not a standalone artifact.
+
+This skill is the architecture skill that orchestrates the other 5 growth-tooling skills (lead-magnet-design, calculator-design, quiz-and-assessment-design, multi-step-form-design, chatbot-flow-design). Where those skills zoom into specific tool design, this skill zooms out to the cross-tool architecture that determines whether the tools compound.
+
+The voice is the senior growth practitioner who has watched funnels architecture compound and watched siloed funnel collections produce engagement metrics with no business impact. Practical, opinionated about the difference between collecting tools and architecting funnels, willing to call out when a team's growth program needs architecture rather than another tool.
+
+When to use this skill: architecting a funnel from scratch, auditing a growth program where tools work individually but conversion is flat, designing the cross-tool data flow that captures audience signal across touchpoints, or deciding which segments warrant which funnel paths.
+
+---
+
+## What this skill covers
+
+This skill spans cross-tool funnel architecture. The growth-tooling distinctions:
+
+- `lead-magnet-design`, `calculator-design`, `quiz-and-assessment-design`, `multi-step-form-design`, `chatbot-flow-design` are tools that LIVE INSIDE the funnel architecture this skill designs. They zoom into specific tool design.
+- `content-distribution` covers how content reaches audiences. This skill is what audiences DO once they reach content.
+- `experiment-design` validates funnel changes. This skill designs the architecture; experiment-design tests it.
+- `landing-page-copy` covers page-level copy. This skill is the cross-page architecture.
+- **`funnel-flow-architecture` (this skill)** is audience-and-stage segmentation, entry-point architecture, tool-to-funnel mapping, nurture sequence architecture, cross-tool data flow.
+
+The audience: growth marketing leads, product marketing leads, marketing directors at SMB and mid-market companies, agencies running funnel architecture for clients, founders architecting growth programs from scratch.
+
+Out of scope: specific tool design (covered by the 5 sister growth-tooling skills); content distribution mechanics (covered by `content-distribution`); A/B testing methodology (covered by `experiment-design`); page-level copy (covered by `landing-page-copy`).
+
+---
+
+## Silo-funnels vs kitchen-sink-funnels vs matched-funnels
+
+The keystone framing.
+
+**Silo-funnels.** Each tool (chatbot, calculator, lead magnet, quiz) lives independently. No coordinated flow; users hit one tool, leave, never enter the broader nurture sequence. Tools as orphans. Cost: each tool's investment does not compound; the audience that interacts with one tool is not connected to any next step; the team has tools but no architecture.
+
+**Kitchen-sink-funnels.** One funnel for everyone. Same nurture sequence regardless of audience or entry point. SMB and enterprise get the same emails. New visitors and bottom-of-funnel get the same CTAs. Conversion rates regress to mediocre on every segment. Cost: the funnel optimizes for the average; no segment is well-served; downstream conversion is uniformly low.
+
+**Matched-funnels.** Funnel architecture matches audience and stage. Different entry points lead to different nurture sequences; different stages get different CTAs; different tools serve different segments. Each tool is part of a larger architecture, not a standalone artifact. Cost: the design effort upfront is significant; the maintenance is real; downstream conversion is meaningfully higher per segment.
+
+The litmus test. Pick a recent visitor to the site. Can the team explain which segment the visitor falls into, which entry point they used, which nurture sequence they are in, and what the next-step CTA they will see is? If yes, the funnel is matched. If the answer is "they got the same flow as everyone else," the funnel is kitchen-sink. If the answer is "they used the calculator but I do not know what comes next," the funnel is silo.
+
+---
+
+## Audience and stage segmentation
+
+The foundation.
+
+**The principle.** Funnel architecture starts with audience and stage segmentation. Without segmentation, every visitor goes through the same path; the funnel cannot match.
+
+**Audience dimensions.**
+
+- **Company size or buyer type.** Solo, SMB, mid-market, enterprise.
+- **Industry or vertical.** Healthcare, finance, retail, technology.
+- **Use case.** What the audience is trying to accomplish.
+- **Role.** Founder, PM, marketer, executive, IC.
+- **Source.** Paid traffic, organic, referral, partner.
+
+**Stage dimensions.**
+
+- **Awareness.** Just discovered the brand or the topic.
+- **Consideration.** Evaluating options actively.
+- **Decision.** Choosing between specific options.
+- **Customer.** Already a customer; ongoing relationship.
+
+**The intersection.** Audience x stage produces the matrix the funnel architecture serves. An enterprise PM in consideration is a different segment from an SMB founder in awareness; each warrants a different path.
+
+**Segmentation discipline.** Start with 3-5 audiences and 3 stages. 9-15 cells in the matrix. Some cells may share paths; some may have unique paths. The discipline is naming the segments deliberately rather than treating "everyone" as the audience.
+
+Detail in `references/audience-and-stage-segmentation.md`.
+
+---
+
+## Entry-point architecture
+
+How visitors land vs how they're routed.
+
+**The principle.** The funnel architecture maps entry points (where visitors arrive) to segments and paths (what they do next).
+
+**Common entry points.**
+
+- **Paid landing page.** Visitor arrives via ad; high intent; specific to the ad's promise.
+- **Organic content page.** Visitor arrives via search or content discovery; awareness or research stage.
+- **Direct.** Visitor arrives by typing URL or via bookmark; often returning.
+- **Referral.** Visitor arrives via partner or word-of-mouth; warmer than paid.
+- **Social.** Visitor arrives via social post; awareness or interest.
+- **Tool entry.** Visitor arrives via a calculator, quiz, or chatbot directly.
+
+**Entry-point routing.**
+
+- Each entry point has expected segments and stages.
+- The first action available at the entry point should match likely segment and stage.
+- Different entry points may route to different downstream tools and sequences.
+
+**Worked example.** A visitor arriving via a paid ad about "B2B SaaS pricing" is likely in consideration stage looking for pricing information. The landing page should serve that need (clear pricing, comparison, calculator); the next-step offer should match consideration (demo, talk to sales). Same visitor arriving via an organic blog post about "B2B SaaS pricing strategy" is likely in awareness stage; the landing page should serve education (depth on pricing strategy); the next-step offer should match awareness (subscribe to content, get the framework).
+
+Detail in `references/entry-point-architecture-patterns.md`.
+
+---
+
+## Tool-to-funnel mapping
+
+Which tools serve which entry points.
+
+**The principle.** Each tool in the growth toolkit has a place in the funnel architecture. The tool serves specific segments at specific stages from specific entry points.
+
+**Mapping examples.**
+
+- **Lead magnet.** Often serves awareness-to-consideration transition. Captured email leads to nurture sequence.
+- **Calculator.** Often serves consideration stage. The audience evaluating options uses the calculator to defend a specific decision.
+- **Quiz.** Can serve any stage depending on design. Awareness quizzes for content marketing; consideration quizzes for product matching; decision quizzes for plan selection.
+- **Multi-step form.** Often serves decision or qualification stage. The form captures qualified intent.
+- **Chatbot.** Cross-cutting. Can serve any stage with intent recognition routing.
+
+**The tool-segment fit.** Tools should serve segments that match their value proposition. A calculator for solo founders may need different inputs and outputs than a calculator for enterprise buyers; the same calculator cannot serve both well.
+
+**The portfolio approach.** A team often has multiple tools serving different segments. The architecture maps each tool to its specific segments and stages.
+
+Detail in `references/tool-to-funnel-mapping.md`.
+
+---
+
+## Nurture sequence architecture
+
+Per-segment, per-stage.
+
+**The principle.** Different segments at different stages get different nurture sequences. The sequences match the audience's situation and stage.
+
+**Sequence variation by stage.**
+
+- **Awareness sequence.** Educational; broad value; brand-building. Soft offers if any.
+- **Consideration sequence.** Comparative; specific value; product-fit signals. Demo or trial CTAs.
+- **Decision sequence.** Confidence-building; risk-reversal; urgency cues. Direct purchase or commitment CTAs.
+
+**Sequence variation by audience.**
+
+- Enterprise audiences get different content (white papers, case studies, ROI analysis) than SMB audiences (templates, quick wins, peer testimonials).
+- Different roles get different framing (founder content emphasizes business outcomes; IC content emphasizes practitioner depth).
+- Different industries get different examples and language.
+
+**The kitchen-sink sequence failure.** One sequence for everyone. Generic enough to send to all; specific enough for none. Conversion uniformly mediocre.
+
+**The matched sequence win.** Sequence specific to segment-and-stage. The audience perceives the brand as understanding their situation; conversion compounds.
+
+Detail in `references/nurture-sequence-architecture.md`.
+
+---
+
+## Cross-tool data flow
+
+Capturing context from tool to tool.
+
+**The principle.** When the audience moves from one tool to another in the funnel, the audience signal travels with them. The chatbot conversation context informs the calculator's defaults; the calculator inputs inform the lead-magnet sequence; the quiz result informs the demo-request prefill.
+
+**Cross-tool data flow patterns.**
+
+- **Identity threading.** When the audience is identified at any point (logged in, opted in, identified by email), their identity carries forward across tools.
+- **Context capture.** Inputs from one tool (calculator values, quiz results, form submissions) feed into the next interaction.
+- **Segment tagging.** Each interaction tags the audience with segment information that informs future routing.
+- **Sequence-tool integration.** Email sequences include links to specific tools matched to the audience's segment.
+
+**The siloed-tool failure.** Each tool captures its own data; nothing flows between them. The chatbot conversation is forgotten when the user opens the calculator; the calculator inputs are forgotten when the user opens the lead magnet.
+
+**The integrated-funnel win.** Data flows. The audience experiences continuity; the brand can match content and offers to the audience's specific journey.
+
+Detail in `references/cross-tool-data-flow-patterns.md`.
+
+---
+
+## Funnel measurement
+
+What to measure, what is noise.
+
+**The principle.** Funnel measurement should reveal architecture quality, not just tool quality.
+
+**Architecture-level metrics.**
+
+- **Cross-tool conversion.** What percentage of audience that hits tool A then engages with tool B?
+- **Sequence-to-tool conversion.** What percentage of nurture sequence subscribers engage with downstream tools?
+- **Segment-level downstream conversion.** Per-segment conversion to the program's main goal (trial, demo, purchase).
+- **Funnel-stage progression.** What percentage of audience moves from awareness to consideration to decision over time?
+
+**Tool-level metrics.**
+
+- Conversion rate per tool (covered by each tool's skill).
+
+**Architecture-level vs tool-level.** Tool-level metrics tell you whether each tool is working; architecture-level metrics tell you whether the tools work together. Both matter; architecture is often the missing measurement.
+
+Detail in `references/funnel-measurement-patterns.md`.
+
+---
+
+## Funnel iteration discipline
+
+When to redesign, when to refine.
+
+**The principle.** Funnel architecture compounds when refined; collapses when constantly redesigned. The discipline is knowing when each is appropriate.
+
+**Refine when:**
+
+- Specific tools are underperforming relative to baseline.
+- Specific segments have lower conversion than peer segments.
+- Specific transitions in the funnel are producing drop-off.
+- Sequence engagement is declining for specific cohorts.
+
+**Redesign when:**
+
+- Audience composition has fundamentally shifted.
+- Product or service strategy has changed.
+- Competitive landscape has shifted significantly.
+- Multiple refine cycles have not produced expected results, suggesting architectural issues.
+
+**Continuous-redesign trap.** Teams that constantly redesign never benefit from architectural compounding. Each redesign resets the learning; nothing accumulates.
+
+**Frozen-architecture trap.** Teams that never iterate watch their architecture decay as audiences and markets evolve.
+
+The middle ground. Refine continuously; redesign infrequently and deliberately.
+
+Detail in `references/funnel-iteration-discipline.md`.
+
+---
+
+## Architecture anti-patterns
+
+Patterns that look like funnel architecture but degrade conversion.
+
+**The silo-funnels pattern.** Tools as orphans; no architecture.
+
+**The kitchen-sink-funnels pattern.** One funnel for everyone.
+
+**The over-segmented funnel.** So many segments that maintenance is impossible; segments are not actually distinguishable.
+
+**The unmaintained-funnel.** Architecture designed once, never reviewed; decay accumulates.
+
+**The tool-driven-architecture.** Architecture organized around tools rather than around audience-and-stage; each tool gets its own funnel regardless of whether that serves the audience.
+
+**The metric-blind-architecture.** Architecture without measurement; cannot diagnose where it works and where it does not.
+
+**The single-tool-funnel.** Architecture that depends on one tool (just the calculator, just the chatbot); no resilience if that tool underperforms.
+
+**The hand-off-broken-funnel.** Tools work individually but the transitions between them break.
+
+Detail in `references/architecture-anti-patterns.md`.
+
+---
+
+## The framework: 12 considerations for funnel flow architecture
+
+When designing or auditing a funnel architecture, walk these 12 considerations.
+
+1. **Matched-funnels, not silo or kitchen-sink.** Architecture matches audience-and-stage; each tool is part of the architecture, not a standalone artifact.
+2. **Audience and stage segmentation defined.** 3-5 audiences x 3 stages; the matrix the architecture serves.
+3. **Entry-point architecture mapped.** Each entry point routed to expected segments and stages.
+4. **Tool-to-funnel mapping documented.** Each tool serves specific segments at specific stages.
+5. **Nurture sequence architecture per segment.** Sequences vary by audience and stage; not one sequence for everyone.
+6. **Cross-tool data flow integrated.** Context travels across tools; the audience experiences continuity.
+7. **Architecture-level metrics tracked.** Cross-tool conversion, sequence-to-tool conversion, segment-level downstream conversion.
+8. **Funnel iteration discipline.** Refine continuously; redesign deliberately; avoid both extremes.
+9. **Tool portfolio balanced.** Multiple tools serving different segments; not over-reliant on any single tool.
+10. **Audience-fit honest.** The architecture serves the segments the brand can actually serve; out-of-fit audiences are filtered or routed elsewhere.
+11. **Maintenance ownership clear.** Someone owns the architecture; quarterly review is calendared.
+12. **Expansion plan defined.** When adding new tools, the architecture says where they fit; new tools earn their place rather than being added decoratively.
+
+The output of the framework is a funnel architecture that compounds over time, matches audience-and-stage segments, integrates tool data flows, and produces measurable downstream conversion.
+
+---
+
+## Reference files
+
+- [`references/audience-and-stage-segmentation.md`](references/audience-and-stage-segmentation.md) - The foundation. Audience dimensions, stage dimensions, the intersection matrix.
+- [`references/entry-point-architecture-patterns.md`](references/entry-point-architecture-patterns.md) - How visitors land vs how they're routed. Common entry points and their routing.
+- [`references/tool-to-funnel-mapping.md`](references/tool-to-funnel-mapping.md) - Which tools serve which entry points and segments.
+- [`references/nurture-sequence-architecture.md`](references/nurture-sequence-architecture.md) - Per-segment, per-stage sequence variation. The matched sequence win.
+- [`references/cross-tool-data-flow-patterns.md`](references/cross-tool-data-flow-patterns.md) - Identity threading, context capture, segment tagging, sequence-tool integration.
+- [`references/funnel-measurement-patterns.md`](references/funnel-measurement-patterns.md) - Architecture-level vs tool-level metrics. What to measure, what is noise.
+- [`references/funnel-iteration-discipline.md`](references/funnel-iteration-discipline.md) - When to refine, when to redesign. Avoiding the continuous-redesign and frozen-architecture traps.
+- [`references/architecture-anti-patterns.md`](references/architecture-anti-patterns.md) - The patterns that look like funnel architecture but degrade conversion.
+- [`references/common-funnel-architecture-failures.md`](references/common-funnel-architecture-failures.md) - 9+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: funnels are architecture, not collections
+
+The growth programs that compound are the ones that architect their funnels deliberately. Not collect tools. Not optimize one-tool-at-a-time. Architect.
+
+The architecture is the difference between tools that produce engagement and a funnel that produces business outcomes. The chatbot, the calculator, the quiz, the lead magnet, the multi-step form: each one is a tool. None of them are a funnel. The funnel is the architecture that makes them work together.
+
+That is the bar. Below the bar are silo-funnels (tools as orphans) and kitchen-sink-funnels (one path for everyone). Above the bar are matched-funnels where audience-and-stage segmentation drives entry-point routing, tool-to-funnel mapping, nurture sequence design, cross-tool data flow, and architecture-level measurement.
+
+## Closing: funnels earn investment when they compose
+
+Each tool in the growth toolkit costs investment to build and maintain. The investment compounds when the tools compose; the investment dilutes when the tools sit in silos. Architecture is the discipline of composition.
+
+The compounding mechanism. A visitor arrives. The architecture routes them based on entry point and observable signals. The first tool they encounter serves their segment-and-stage. The data they generate informs the next tool they encounter. The sequence they enter matches their context. Each interaction deepens the brand's understanding of the audience; each tool's contribution compounds with the others.
+
+When in doubt, ask: does each tool in the program serve a defined segment-and-stage, do the tools share data and context, can the team explain the architecture in one diagram, and does the team measure architecture-level outcomes (not just tool-level metrics)? If yes to all of those, the funnel is real architecture. If no to any, the gap is where the program's tools are failing to compose.

--- a/skills/funnel-flow-architecture/references/architecture-anti-patterns.md
+++ b/skills/funnel-flow-architecture/references/architecture-anti-patterns.md
@@ -1,0 +1,198 @@
+# Architecture anti-patterns
+
+The patterns that look like funnel architecture but degrade conversion. Anti-patterns are easy to ship; the cost shows up in downstream conversion, lead quality, and brand reputation over time.
+
+---
+
+## The silo-funnels pattern
+
+The pattern. Tools as orphans. No coordinated flow.
+
+The signal. Each tool's metrics look fine individually; cross-tool metrics non-existent or near-zero. Downstream conversion does not match the sum of tool conversions.
+
+The cost. Each tool's investment does not compound. The audience that interacts with one tool is not connected to any next step. The team has tools but no architecture.
+
+The cure. Add cross-tool data flow and explicit funnel architecture. Detail in `references/cross-tool-data-flow-patterns.md` and the broader skill.
+
+---
+
+## The kitchen-sink-funnels pattern
+
+The pattern. One funnel for everyone. Same nurture sequence regardless of audience or entry point.
+
+The signal. Conversion rates regress to mediocre on every segment. No segment is well-served.
+
+The cost. The funnel optimizes for the average; downstream conversion is uniformly low.
+
+The cure. Segment-and-stage architecture. Different paths for different cells in the matrix. Detail in `references/audience-and-stage-segmentation.md` and `references/nurture-sequence-architecture.md`.
+
+---
+
+## The over-segmented funnel
+
+The pattern. So many segments that maintenance is impossible. 60 cells in the matrix; 60 distinct paths; nobody can keep up.
+
+The signal. Specific paths get little attention; maintenance backlog grows; specific cells are theoretical with no real visitors.
+
+The cost. The architecture exists on paper but not in execution. Tools and sequences for theoretical cells cost effort without producing value.
+
+The cure. Reduce to 9-15 cells. Start with the minimum viable matrix; expand only when data justifies. Detail in `references/audience-and-stage-segmentation.md`.
+
+---
+
+## The unmaintained-funnel
+
+The pattern. Architecture designed once, never reviewed. Decay accumulates.
+
+The signal. Conversion declines slowly; tools age; sequences go stale; segments shift; the architecture does not respond.
+
+The cost. The architecture's value erodes. Audiences move on; the brand falls behind.
+
+The cure. Quarterly audit. Refinement cadence. Detail in `references/funnel-iteration-discipline.md`.
+
+---
+
+## The tool-driven-architecture
+
+The pattern. Architecture organized around tools rather than around audience-and-stage. Each tool gets its own funnel regardless of whether that serves the audience.
+
+The signal. The site has many tool-specific landing pages; users navigate to tools rather than tools serving users; the architecture is organized for the team, not the audience.
+
+The cost. Audiences cannot find what they need; tools cannibalize each other; the architecture cannot scale because each tool is its own funnel.
+
+The cure. Reorganize around audience-and-stage. The matrix drives the architecture; tools serve the matrix.
+
+---
+
+## The metric-blind-architecture
+
+The pattern. Architecture without measurement. Cannot diagnose where it works and where it does not.
+
+The signal. Decisions made on intuition; no data to validate; iteration is guesswork.
+
+The cost. The architecture cannot improve through measurement; refinement is random; redesign happens reactively.
+
+The cure. Architecture-level metrics. Cross-tool conversion, sequence-to-tool conversion, segment-level downstream conversion, funnel-stage progression. Detail in `references/funnel-measurement-patterns.md`.
+
+---
+
+## The single-tool-funnel
+
+The pattern. Architecture that depends on one tool. Just the calculator. Just the chatbot. No resilience if that tool underperforms.
+
+The signal. The tool's quarterly performance dictates overall funnel performance. A bad month for the tool is a bad month for the funnel.
+
+The cost. The architecture is fragile. Tool failures cascade; redesigns of the central tool are high-risk.
+
+The cure. Portfolio approach. Multiple tools serving different segments. The architecture's resilience comes from diversification.
+
+---
+
+## The hand-off-broken-funnel
+
+The pattern. Tools work individually but the transitions between them break.
+
+The signal. Each tool's metrics look fine; cross-tool conversion is low. The architecture's transitions are silently failing.
+
+The cost. The audience experiences the funnel as disconnected. Downstream conversion suffers because the bridges between tools are broken.
+
+The cure. Audit transitions. Cross-tool data flow. Sequence-tool integration. Detail in `references/cross-tool-data-flow-patterns.md`.
+
+---
+
+## The continuous-redesign funnel
+
+The pattern. Architecture redesigned every quarter. Each iteration starts over.
+
+The signal. Conversion does not improve over time. Each redesign resets the learning. Tools never reach maturity.
+
+The cost. Investment dilutes across redesigns. Compounding does not happen.
+
+The cure. Refine continuously; redesign infrequently and deliberately. Detail in `references/funnel-iteration-discipline.md` (continuous-redesign trap).
+
+---
+
+## The frozen-architecture funnel
+
+The pattern. Architecture designed once; never iterated; treated as finished.
+
+The signal. Conversion declines slowly; tools and sequences feel dated; segments no longer match the audience.
+
+The cost. The architecture's value erodes; the brand becomes uncompetitive.
+
+The cure. Set refinement cadences. Quarterly audits. Detail in `references/funnel-iteration-discipline.md` (frozen-architecture trap).
+
+---
+
+## The vanity-metric architecture
+
+The pattern. Architecture measured by surface metrics (tool engagement, total visitors, email signups) without measuring downstream outcomes.
+
+The signal. Metrics report looks healthy; business outcomes do not match.
+
+The cost. The team optimizes for the wrong metrics; the architecture appears successful while underperforming on what matters.
+
+The cure. Measure downstream conversion. Per-segment downstream conversion. Architecture-level metrics rather than tool-level activity.
+
+---
+
+## The over-personalized funnel
+
+The pattern. Architecture designed for personalization the team cannot actually deliver. Many entry points; many sequences; many tools; team capacity exceeded.
+
+The signal. Personalization in design; generic in execution. Specific paths exist on paper; default to generic in practice.
+
+The cost. The team built complexity that does not get used. Maintenance burden without payoff.
+
+The cure. Match architecture complexity to team capacity. Start simple; add personalization where it produces meaningful lift; do not personalize for its own sake.
+
+---
+
+## The under-personalized funnel
+
+The pattern. Architecture treats every visitor the same when meaningful personalization would lift conversion.
+
+The signal. Specific segments underperform; the audience's actual differences are not reflected in the funnel.
+
+The cost. Conversion stays at the average; no segment exceeds.
+
+The cure. Add personalization where data shows it would help. Start with segment-level differentiation; refine over time.
+
+---
+
+## The orphan-tool architecture
+
+The pattern. Tools added to the funnel without explicit segment-and-stage assignment. Each new tool exists; no architecture says where it fits.
+
+The signal. The funnel's tool count grows; the architecture's clarity does not.
+
+The cost. Tools compete for the same audience; users see overlapping options; conversion fragments.
+
+The cure. Each tool earns its place. Architecture documents which segments and stages the tool serves. New tools are added with explicit mapping.
+
+---
+
+## How to detect anti-patterns in a portfolio
+
+Audit cadence. Quarterly review of the architecture, looking specifically for these anti-patterns.
+
+**Audit questions.**
+
+- Do the tools work together (anti-pattern check: silo, hand-off-broken)?
+- Is there segment-and-stage architecture (anti-pattern check: kitchen-sink, tool-driven)?
+- Is the matrix maintainable (anti-pattern check: over-segmented, over-personalized)?
+- Are tools mapped to specific segments (anti-pattern check: orphan-tool, single-tool, under-personalized)?
+- Are architecture-level metrics tracked (anti-pattern check: metric-blind, vanity-metric)?
+- Is there iteration discipline (anti-pattern check: continuous-redesign, frozen-architecture, unmaintained)?
+
+**The retire decision.** Anti-pattern architectures often warrant redesign. Patching anti-patterns rarely produces a good architecture.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing for each. Cures matched to anti-patterns. The audit cadence and audit questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and the lessons learned. Specific portfolio audit results. Specific redesign decisions. The team's audit calendar and reviewer list. These vary by team.

--- a/skills/funnel-flow-architecture/references/audience-and-stage-segmentation.md
+++ b/skills/funnel-flow-architecture/references/audience-and-stage-segmentation.md
@@ -1,0 +1,200 @@
+# Audience and stage segmentation
+
+The foundation. Audience dimensions, stage dimensions, the intersection matrix.
+
+Funnel architecture starts with audience and stage segmentation. Without it, every visitor goes through the same path; the funnel cannot match. With it, the architecture has a definable map of who the audience is and where they are in their journey.
+
+---
+
+## The segmentation principle
+
+The funnel cannot be tailored without segments. Segments are the architecture's unit of design.
+
+**The discipline.** Define 3-5 audience segments and 3 stages. The intersection produces 9-15 cells; each cell is a potential funnel path.
+
+**The trap.** Over-segmenting. Defining 12 audiences x 5 stages produces 60 cells; the team cannot maintain that many distinct paths. Most cells end up sharing paths or being indistinguishable.
+
+**The discipline boundary.** Start with the minimum viable segmentation. 3-5 audiences and 3 stages is enough to start. Expand only if the data shows meaningful differentiation that justifies more cells.
+
+---
+
+## Audience dimensions
+
+The dimensions that distinguish meaningful audience segments.
+
+**Company size or buyer type.** Solo founders, SMB (10-50), mid-market (50-500), enterprise (500+). Different sizes have different buying processes, different budgets, different needs.
+
+**Industry or vertical.** Healthcare, finance, retail, technology, education. Different industries have different language, regulations, examples, competitors.
+
+**Use case.** What the audience is trying to accomplish. "Customer support automation," "sales pipeline management," "content production at scale."
+
+**Role.** Founder, PM, marketer, sales lead, executive, IC. Different roles have different perspectives and different content preferences.
+
+**Source or channel.** Paid traffic, organic search, content referral, partner referral, direct. Different sources signal different intent and stage.
+
+**Geography or language.** Domestic vs international; English-first vs other-language audiences. May warrant different funnels for compliance, currency, or cultural reasons.
+
+The audience dimensions to use depend on the brand's strategy. Most B2B brands segment primarily by company size and use case; most consumer brands segment by demographic and behavioral attributes.
+
+---
+
+## Stage dimensions
+
+The dimensions that distinguish where the audience is in their journey.
+
+**Awareness.** Just discovered the brand or the topic. Has not yet committed to research or evaluation. The audience is open but uncommitted.
+
+Content fit: educational, broad value, brand-building.
+CTAs that fit: subscribe to content, get a framework, follow.
+CTAs that do not fit: book a demo, start a trial, buy now.
+
+**Consideration.** Evaluating options actively. Has identified a need; comparing solutions. The audience is engaged but not yet decided.
+
+Content fit: comparative, specific value, product-fit signals.
+CTAs that fit: see a calculator, take a quiz, download a comparison, book a demo.
+CTAs that do not fit: just-published-content awareness asks; or hard sell.
+
+**Decision.** Choosing between specific options. The audience has narrowed the field; selecting is imminent.
+
+Content fit: confidence-building, risk-reversal, urgency cues.
+CTAs that fit: start a trial, talk to sales, sign up.
+CTAs that do not fit: top-of-funnel awareness; long-form education.
+
+**Customer.** Already a customer; ongoing relationship. Often left out of growth-funnel architecture even though it matters for retention and expansion.
+
+Content fit: success-deepening, capability-expanding, community.
+CTAs that fit: upgrade, refer, join community, attend event.
+
+The four stages cover most audiences. Some programs combine awareness-and-consideration or consideration-and-decision into 2-stage models; the principle is the same.
+
+---
+
+## The intersection matrix
+
+Audience x stage produces the matrix the funnel architecture serves.
+
+**Example matrix for a B2B SaaS company.**
+
+| Audience | Awareness | Consideration | Decision |
+|----------|-----------|---------------|----------|
+| Solo founder | Path A | Path B | Path C |
+| SMB team | Path D | Path E | Path F |
+| Mid-market | Path G | Path H | Path I |
+| Enterprise | Path J | Path K | Path L |
+
+12 cells. Some may share paths (Path A and Path D might be similar awareness content for solo and SMB). The matrix is the architecture's map.
+
+**Cell-sharing patterns.**
+
+- Awareness paths often share more than decision paths (broad content can serve multiple audience segments).
+- Consideration paths often diverge by audience (the comparison content for enterprise differs significantly from SMB).
+- Decision paths almost always diverge (the offer for enterprise is different from SMB).
+
+The matrix shows where the funnel architecture invests in unique paths and where it shares.
+
+---
+
+## Segmentation discipline
+
+The discipline boundaries.
+
+**Discipline 1: Define segments before designing paths.** Without segments, paths are arbitrary. Always start with the matrix.
+
+**Discipline 2: Name segments specifically.** "Solo founder pre-launch" beats "small business." Specific names reflect specific audiences.
+
+**Discipline 3: Validate segments with data.** A segment that does not appear in actual audience data is theoretical. Validate against site analytics, sales data, or audience research.
+
+**Discipline 4: Maintain the matrix.** Audiences shift; the matrix should be reviewed quarterly. Segments may merge or split over time.
+
+**Discipline 5: Avoid over-segmentation.** 60-cell matrices are not maintainable. Start with 9-15 cells; expand only with justification.
+
+---
+
+## Segmentation worked example
+
+A B2B SaaS analytics platform.
+
+**Audiences (4).**
+
+- Data analysts at SMB companies (50-200 employees).
+- Data leaders at mid-market companies (200-1000 employees).
+- Engineering leaders at enterprise companies (1000+ employees).
+- Solo data practitioners and consultants.
+
+**Stages (3).**
+
+- Awareness (researching the analytics topic).
+- Consideration (evaluating analytics platforms).
+- Decision (selecting and signing up).
+
+**Matrix (12 cells).**
+
+| Audience | Awareness | Consideration | Decision |
+|----------|-----------|---------------|----------|
+| Data analyst SMB | Educational content | Calculator, quiz | Trial, demo |
+| Data leader mid-market | Strategic content | Comparison, ROI calc | Demo, custom quote |
+| Engineering enterprise | Technical depth | Technical demo, security | Custom evaluation |
+| Solo practitioner | Practical content | Self-serve resources | Free tier signup |
+
+Each cell has a defined path. The architecture invests where the cells need unique treatment; shares where the cells can use the same path.
+
+---
+
+## Segmentation maintenance
+
+Segments decay.
+
+**What decays.**
+
+- Audience definitions that no longer match actual visitors.
+- Stage definitions that have shifted as buying processes evolved.
+- Cells that have become empty (no visitors fit the segment).
+- Cells that have become bloated (too many visitors fit one segment; needs sub-segmentation).
+
+**Maintenance cadence.** Quarterly review of the matrix against actual audience data.
+
+**The drift indicator.** Sales reports that the funnel-sourced leads do not match expected segments; analytics show segments combining or splitting unexpectedly.
+
+---
+
+## Segmentation and the rest of the architecture
+
+How segmentation drives the rest of the architecture.
+
+**Entry-point architecture.** Each entry point routes to expected segments. The matrix tells the architecture where each entry point's traffic likely lands.
+
+**Tool-to-funnel mapping.** Each tool serves specific cells in the matrix. The matrix tells the architecture which tools belong where.
+
+**Nurture sequence architecture.** Each cell may have its own sequence (or sequences may be shared across similar cells). The matrix is the sequence design map.
+
+**Cross-tool data flow.** As the audience moves through the matrix (awareness to consideration to decision), data flows with them. The matrix tracks the journey.
+
+**Funnel measurement.** Per-cell conversion is the architecture-level metric. The matrix is the measurement framework.
+
+---
+
+## Common segmentation failures
+
+**No segmentation.** "Everyone" treated as the audience. Funnel cannot match.
+
+**Theoretical segments.** Segments defined that do not exist in actual audience data.
+
+**Over-segmentation.** 60-cell matrix that the team cannot maintain.
+
+**Under-segmentation.** 4-cell matrix when the audience genuinely splits into more meaningful segments.
+
+**Stale segmentation.** Matrix designed once; audience shifted; matrix not updated.
+
+**Segments without paths.** Matrix defined but no funnel paths designed for the cells; segmentation is decorative.
+
+**Paths without segments.** Funnel paths designed without clear segment mapping; treatments are arbitrary.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The segmentation principle and discipline boundaries. Audience dimensions. Stage dimensions. The intersection matrix. Segmentation discipline (5 disciplines). Worked example. Segmentation maintenance. Segmentation and the rest of the architecture. Common failures.
+
+## Implementation choices that stay internal
+
+Specific segments for the team's audience. Specific tooling for segment tagging and analysis. The team's matrix maintenance calendar. Specific path designs per cell. These vary by team.

--- a/skills/funnel-flow-architecture/references/common-funnel-architecture-failures.md
+++ b/skills/funnel-flow-architecture/references/common-funnel-architecture-failures.md
@@ -1,0 +1,179 @@
+# Common funnel architecture failures
+
+9+ failure patterns with diagnoses and cures. The patterns that surface as "the funnel is not converting" or "tools work individually but conversion is flat" or "we cannot tell where the funnel is broken."
+
+---
+
+## "Tools work individually; conversion is flat."
+
+**The diagnosis.** Silo-funnels pattern. Tools as orphans; no architecture connects them.
+
+**The cure.** Add cross-tool data flow; map tools to specific segments; design transitions between tools. Detail in `references/cross-tool-data-flow-patterns.md` and `references/tool-to-funnel-mapping.md`.
+
+---
+
+## "Every audience gets the same nurture sequence."
+
+**The diagnosis.** Kitchen-sink-funnels pattern. One sequence for everyone.
+
+**The cure.** Segment-and-stage sequences. Different cells in the matrix get different sequences. Detail in `references/nurture-sequence-architecture.md`.
+
+---
+
+## "We have 12 tools and no clear architecture."
+
+**The diagnosis.** Tool-driven architecture. Tools accumulated without explicit segment mapping.
+
+**The cure.** Build the matrix; map each tool to specific cells; retire tools that do not have a mapping or that compete with better-mapped alternatives.
+
+---
+
+## "Specific segments convert at half the rate of others."
+
+**The diagnosis.** Architecture for those segments may be broken. Or the segments may not be served by the current tools and sequences.
+
+**The cure.** Audit those segments' funnel paths. Are tools mapped to them? Are sequences designed for them? If not, build for those segments. If yes, refine the existing path.
+
+---
+
+## "We cannot tell which tools or sequences are driving conversion."
+
+**The diagnosis.** Architecture-level metrics not tracked. Cannot attribute outcomes to architecture choices.
+
+**The cure.** Instrument cross-tool conversion, sequence-to-tool conversion, segment-level downstream conversion, funnel-stage progression. Detail in `references/funnel-measurement-patterns.md`.
+
+---
+
+## "We redesign every quarter; nothing improves."
+
+**The diagnosis.** Continuous-redesign trap. Each redesign resets learning; nothing compounds.
+
+**The cure.** Establish "no major redesign for X months" discipline. Refine continuously; redesign deliberately and rarely. Detail in `references/funnel-iteration-discipline.md`.
+
+---
+
+## "The funnel was great at launch; now conversion has dropped 40 percent."
+
+**The diagnosis.** Frozen-architecture trap. Designed once; never iterated; decay accumulated.
+
+**The cure.** Quarterly audit. Refinement cadence. Detail in `references/funnel-iteration-discipline.md`.
+
+---
+
+## "Specific transitions in the funnel have high drop-off."
+
+**The diagnosis.** Hand-off-broken pattern. Tools work but the bridges between them break.
+
+**The cure.** Audit transitions. Add cross-tool data flow so context travels. Promote downstream tools at upstream tools' exits. Detail in `references/cross-tool-data-flow-patterns.md`.
+
+---
+
+## "Our chatbot, calculator, and quiz all serve consideration-stage audiences."
+
+**The diagnosis.** Tool overlap without differentiation. Three tools competing for the same audience.
+
+**The cure.** Differentiate the tools' purposes. Calculator for ROI questions; quiz for product matching; chatbot for FAQ. Or consolidate to fewer tools with clearer roles.
+
+---
+
+## "Sales says quiz-sourced leads, calculator-sourced leads, and lead-magnet-sourced leads are different qualities."
+
+**The diagnosis.** Tools may be attracting different segments; the architecture's segmentation is working but the tools are not all matched to high-quality segments.
+
+**The cure.** Investigate which tools attract which segments. Optimize tool placement and design for the segments the brand serves best; deprioritize tools that attract low-quality segments.
+
+---
+
+## "We added a new tool last quarter; it does not seem to help conversion."
+
+**The diagnosis.** Orphan-tool pattern. Tool added without architecture mapping.
+
+**The cure.** Map the new tool to specific segments. Decide where it fits in the matrix. Promote it where it fits; remove it from places it does not.
+
+---
+
+## "Our funnel has 8 stages; visitors only complete 2."
+
+**The diagnosis.** Funnel may be over-architected. Too many steps; audience cannot or will not progress through them all.
+
+**The cure.** Simplify the funnel. Combine stages; remove unnecessary tools; align the funnel length to the audience's likely journey.
+
+---
+
+## "Cross-tool tracking is broken; we cannot tell who used what."
+
+**The diagnosis.** Identity threading or event tracking issue. Architecture's measurement infrastructure is broken.
+
+**The cure.** Audit identity threading. Verify event tracking. Fix the infrastructure before further iteration. Detail in `references/cross-tool-data-flow-patterns.md`.
+
+---
+
+## "Audiences arriving from paid traffic and organic traffic perform completely differently."
+
+**The diagnosis.** Either entry-point routing is not differentiating, or the funnel paths are not serving paid and organic audiences differently.
+
+**The cure.** Different routing for different entry points. Specific landing pages and sequences for paid vs organic. Detail in `references/entry-point-architecture-patterns.md`.
+
+---
+
+## "The team built personas; the funnel does not reflect them."
+
+**The diagnosis.** Segments defined but not implemented in the funnel architecture. Decorative segmentation.
+
+**The cure.** Map personas to funnel cells. Build paths for the cells. The personas should drive the architecture, not sit in a deck.
+
+---
+
+## "Our sequence-to-trial conversion is high; trial-to-paid is low."
+
+**The diagnosis.** Architecture handles funnel up to trial well; the trial-to-paid stage may need its own architecture (or may be a product issue rather than funnel issue).
+
+**The cure.** Treat trial-to-paid as its own funnel-stage progression. Build paths for trial users; nurture toward paid conversion.
+
+---
+
+## "We have 15 lead magnets; 3 produce most of the leads."
+
+**The diagnosis.** Magnet portfolio not maintained. Most magnets are dead but still on the site.
+
+**The cure.** Audit and retire dead magnets. Free capacity for the strong ones. Detail in `lead-magnet-design`.
+
+---
+
+## "We built a fancy architecture; the team cannot maintain it."
+
+**The diagnosis.** Over-architecture. Architecture exceeds team capacity.
+
+**The cure.** Simplify. Match architecture complexity to team capacity. Expand only when capacity grows.
+
+---
+
+## "Funnel-sourced leads are different from sales-sourced leads."
+
+**The diagnosis.** Likely fine. Funnel and direct sales serve different segments and stages. Both can be valuable.
+
+**The action.** Track them separately. Optimize each for its specific path.
+
+---
+
+## The pattern across failures
+
+Most funnel architecture failures fall into one of three patterns.
+
+**Pattern 1: Tools without architecture.** Silo, kitchen-sink, tool-driven, orphan-tool. The fix is to add explicit architecture (matrix, mapping, data flow).
+
+**Pattern 2: Architecture without measurement.** Metric-blind, vanity-metric, broken tracking. The fix is to instrument architecture-level metrics.
+
+**Pattern 3: Architecture without maintenance.** Frozen, decayed, unmaintained. The fix is iteration discipline (refine continuously, redesign rarely).
+
+The metric pattern: funnel architecture failures often look fine on tool-level metrics. The signal is in cross-tool conversion, segment-level outcomes, and funnel-stage progression. Programs that track only tool metrics keep shipping the same architectural patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (tools-without-architecture, architecture-without-measurement, architecture-without-maintenance). The principle that tool-level metrics alone are insufficient.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered and the lessons learned. Specific architecture-level dashboards. Specific cures the team applies. The team's audit and redesign processes. These vary by team.

--- a/skills/funnel-flow-architecture/references/cross-tool-data-flow-patterns.md
+++ b/skills/funnel-flow-architecture/references/cross-tool-data-flow-patterns.md
@@ -1,0 +1,252 @@
+# Cross-tool data flow patterns
+
+Identity threading, context capture, segment tagging, sequence-tool integration.
+
+When the audience moves from one tool to another in the funnel, the audience signal travels with them. Done well, cross-tool data flow makes the audience experience continuous and lets the brand match content to the audience's specific journey. Done poorly, every tool starts from scratch and the audience signal is lost.
+
+---
+
+## The continuity principle
+
+The audience experience should feel continuous across tools. Their interactions in one tool inform their experience in the next.
+
+**The win.** A visitor takes a quiz; the quiz tags them as "mid-market mid-funnel." When they later open the calculator, the defaults reflect mid-market context. When they download a lead magnet, the sequence delivered matches the segment. The visitor experiences a coordinated brand journey.
+
+**The fail.** The same visitor takes the quiz; the calculator does not know they took it; the lead magnet sequence is generic. Each tool is an island. The audience signal captured in one tool is wasted in the next.
+
+The discipline. Data flows. Each tool's interactions inform subsequent interactions.
+
+---
+
+## Pattern A: Identity threading
+
+When the audience is identified, their identity carries forward across tools.
+
+**How it works.**
+
+- The audience opts in (email submission, account creation, login).
+- Subsequent interactions are associated with that identity.
+- Tools across the funnel access the identity record to personalize.
+
+**Strengths.**
+
+- Most powerful continuity mechanism.
+- Lets all tools share context for the same person.
+
+**Weaknesses.**
+
+- Requires identity infrastructure (CRM, data warehouse, customer data platform).
+- Privacy considerations (handling identity data carefully).
+
+**When to use.** When the program has identity infrastructure and the audience is willing to be identified (typically post lead-magnet download or account creation).
+
+---
+
+## Pattern B: Context capture
+
+Inputs from one tool feed into the next interaction.
+
+**How it works.**
+
+- Tool A captures specific inputs (calculator values, quiz answers, form responses).
+- Those inputs are stored with the identity (or with an anonymous session token).
+- Tool B reads the inputs; uses them as defaults or context.
+
+**Example.**
+
+- Quiz captures "team size: 75."
+- Calculator's defaults reflect team size 75.
+- Lead magnet's recommended resource matches team size 75.
+
+**Strengths.**
+
+- Concrete continuity; the audience sees their inputs reflected.
+- Reduces re-entry friction.
+
+**Weaknesses.**
+
+- Requires structured data capture (not just behavioral signals).
+- Inputs from different tools must align (no conflict if quiz and calculator both capture team size).
+
+**When to use.** When tools capture overlapping or related context that benefits from shared use.
+
+---
+
+## Pattern C: Segment tagging
+
+Each interaction tags the audience with segment information that informs future routing.
+
+**How it works.**
+
+- Tool A determines the audience's segment based on inputs (the quiz result; the calculator's input pattern).
+- The segment tag attaches to the audience record.
+- Subsequent tools and sequences route based on the tag.
+
+**Example.**
+
+- Quiz result: "Mid-market operator."
+- Tag: segment = mid-market.
+- Subsequent: lead magnet sequence is the mid-market sequence; calculator defaults are mid-market; chatbot routing is mid-market-aware.
+
+**Strengths.**
+
+- Lightweight. The tag is small; the routing logic uses it.
+- Compatible with most marketing automation.
+
+**Weaknesses.**
+
+- Tag accuracy depends on the source tool's accuracy.
+- Tags can conflict (different tools assign different segments).
+- Tag staleness (the audience's segment may change over time).
+
+**When to use.** Default pattern for cross-tool routing.
+
+---
+
+## Pattern D: Sequence-tool integration
+
+Email sequences include links to specific tools matched to the audience's segment.
+
+**How it works.**
+
+- Sequence email includes a CTA: "based on your situation, this calculator can help you compare."
+- The CTA link includes parameters that pre-fill the calculator with the audience's known context.
+- Audience clicks; calculator opens with their context already populated.
+
+**Strengths.**
+
+- Explicit cross-tool connection; the audience sees the journey.
+- Reduces friction at the calculator (audience does not re-enter known information).
+
+**Weaknesses.**
+
+- Requires tooling for parameterized links and pre-fill.
+- The pre-fill must respect what the audience consented to share.
+
+**When to use.** When the sequence is steering the audience toward specific tools and pre-fill would meaningfully reduce friction.
+
+---
+
+## Conflict and source-of-truth
+
+When different tools capture different values for the same attribute.
+
+**The pattern.** The quiz says team size 75; the multi-step form says team size 60. Which is correct?
+
+**Approaches.**
+
+- **Latest wins.** The most recent capture overrides earlier captures.
+- **Source authority.** Specific tools are designated as authoritative for specific attributes (form > quiz for verified data).
+- **User confirmation.** Conflict surfaces a confirmation prompt: "We have you down as 75; is that still correct?"
+
+**The discipline.** Define source-of-truth for important attributes. Latest-wins is simple but can lose data; source authority is more disciplined but requires explicit definition.
+
+---
+
+## Privacy and consent
+
+Cross-tool data flow involves handling user data. Consent matters.
+
+**The principle.** The audience should know what data flows where. Pre-filling a calculator with previously captured information is fine if the audience expects it; surprising them with knowledge they did not consent to share breaks trust.
+
+**Consent patterns.**
+
+- Explicit opt-in to identity tracking ("save my progress").
+- Disclosure of data flow ("we use your quiz answers to personalize subsequent recommendations").
+- Easy data deletion or account closure.
+
+**Privacy regulations.** GDPR, CCPA, and other regulations affect what data can flow and how. Compliance is essential; the architecture must respect the regulations applicable to the audience.
+
+---
+
+## Anonymous-session continuity
+
+When the audience is not yet identified.
+
+**The pattern.** Browser-based continuity (cookies, local storage) lets tools share context within the same session even before identity capture.
+
+**Strengths.**
+
+- Continuity without requiring early opt-in.
+- Smooth experience across same-session tool interactions.
+
+**Weaknesses.**
+
+- Lost when the audience switches devices or clears cookies.
+- Limited persistence (typically days, not weeks).
+- Privacy considerations (cookies-based tracking has its own complications).
+
+**When to use.** As a supplement to identity-based continuity; for early-funnel interactions before opt-in.
+
+---
+
+## Cross-tool data flow architecture
+
+How to design the data flow at the architecture level.
+
+**The data layer.** A single data layer (CRM, customer data platform, data warehouse) holds the audience records. All tools read from and write to this layer.
+
+**The integration layer.** Tools integrate with the data layer either directly (API) or through a middleware (Zapier, Segment).
+
+**The privacy layer.** Consent and data-control mechanics live across the architecture; the data layer respects them.
+
+**Architecture-level discipline.** Cross-tool data flow is infrastructure work, not just tool work. Building the infrastructure is part of the funnel architecture investment.
+
+---
+
+## Cross-tool measurement
+
+Track how data flows across tools.
+
+**Metrics.**
+
+- **Cross-tool engagement.** What percentage of subscribers who engaged with tool A also engaged with tool B?
+- **Identity capture rate.** What percentage of visitors who interact with tools become identified?
+- **Pre-fill usage.** When pre-fill is offered, what percentage of users engage with the pre-filled tool?
+- **Segment tag accuracy.** Sample-based audit of whether segment tags match actual audience profiles.
+
+Diagnostic uses. Low cross-tool engagement signals tools are not connecting in the audience's journey; low pre-fill usage signals the pre-fill is not visible or not valued.
+
+---
+
+## Cross-tool data flow audit
+
+Periodically audit the data flow.
+
+**The audit.**
+
+- Walk through critical journeys end-to-end. Does data actually flow?
+- Verify identity threading works (logged-in user is recognized across tools).
+- Verify context capture works (inputs in tool A appear in tool B as expected).
+- Verify segment tagging works (quiz result tag triggers correct downstream sequences).
+- Verify sequence-tool integration works (sequence links pre-fill correctly).
+
+**The drift.** Integrations break silently. Tool updates change data formats. Audit catches the drift.
+
+---
+
+## Common data flow failures
+
+**No data flow.** Each tool isolated; identity and context lost between tools.
+
+**Identity threading broken.** Logged-in user not recognized across tools; same person treated as new visitor multiple times.
+
+**Context capture incomplete.** Tool A captures inputs but tool B does not access them.
+
+**Segment tag conflicts.** Different tools tag the same person differently; downstream routing inconsistent.
+
+**Pre-fill broken.** Sequence link includes parameters but the tool does not honor them; audience re-enters known information.
+
+**Privacy violations.** Cross-tool data flow happens without consent; audience surprised; trust damaged.
+
+**Stale data.** Audience's situation has changed but tools still use old captured data.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The continuity principle. Patterns A through D (identity, context, segment, sequence-tool integration). Conflict and source-of-truth. Privacy and consent. Anonymous-session continuity. Cross-tool data flow architecture. Cross-tool measurement. Audit cadence. Common failures.
+
+## Implementation choices that stay internal
+
+Specific data layer choices for the team's stack. Specific integration tooling. Specific consent flows and privacy disclosures. The team's audit calendars. These vary by team.

--- a/skills/funnel-flow-architecture/references/entry-point-architecture-patterns.md
+++ b/skills/funnel-flow-architecture/references/entry-point-architecture-patterns.md
@@ -1,0 +1,190 @@
+# Entry-point architecture patterns
+
+How visitors land vs how they're routed. Common entry points and their routing.
+
+The funnel architecture maps entry points (where visitors arrive) to segments and paths (what they do next). Without entry-point architecture, every visitor goes through the same first experience regardless of where they came from.
+
+---
+
+## The entry-routing principle
+
+Each entry point has expected segments and stages. The first action available at the entry point should match those expectations.
+
+**The win.** A visitor arrives via an ad about "B2B SaaS pricing." The landing page serves consideration-stage pricing content. The first available action is a pricing calculator and a demo CTA. The entry point's routing matches the visitor's likely intent.
+
+**The fail.** Same visitor arrives via the same ad. The landing page is the homepage. The visitor lands in awareness-stage content with no clear next step. The mismatch costs the conversion.
+
+The discipline. Each entry point's first experience matches the visitor's likely segment and stage.
+
+---
+
+## Common entry points
+
+The entry points most growth programs work with.
+
+**Paid landing page.** Visitor arrives via paid ad (search, social, display). High intent; specific to the ad's promise.
+
+Expected segment: usually narrow (the ad targeted specific audience).
+Expected stage: usually consideration or decision (paid traffic is rarely awareness-stage).
+Routing: landing page should serve the ad's specific promise; next-step action should match consideration or decision stage.
+
+**Organic content page.** Visitor arrives via search or content discovery; awareness or research stage.
+
+Expected segment: variable (organic search may surface multiple audience types).
+Expected stage: usually awareness or early consideration (research-driven).
+Routing: content should serve the search intent; secondary CTAs offer movement toward consideration.
+
+**Direct or returning visitor.** Visitor arrives by typing URL or via bookmark; often returning.
+
+Expected segment: variable (depends on prior interactions).
+Expected stage: variable (could be any stage).
+Routing: homepage should provide multiple entry paths to different segments and stages; navigation matters more than single CTA.
+
+**Referral.** Visitor arrives via partner or word-of-mouth; warmer than paid.
+
+Expected segment: variable (depends on referral source).
+Expected stage: usually consideration or decision (referrals indicate active interest).
+Routing: page should match the referral context; next-step action should reflect the warmth (free trial, demo, talk to sales often work).
+
+**Social.** Visitor arrives via social post; awareness or interest.
+
+Expected segment: variable (depends on social audience).
+Expected stage: usually awareness (social discovery is rarely buying intent).
+Routing: page should serve the social post's promise; soft CTAs (follow, subscribe, learn more) often work better than hard sells.
+
+**Tool entry.** Visitor arrives via a calculator, quiz, or chatbot directly (often via shared link or specific tool URL).
+
+Expected segment: matches the tool's audience.
+Expected stage: usually consideration (the tool is a consideration-stage artifact).
+Routing: tool should serve its specific value; next-step actions should connect tool output to broader funnel.
+
+---
+
+## Entry-point routing patterns
+
+How to route each entry point.
+
+**Pattern A: Direct match.** Entry point routes directly to a specific landing page and CTA. Simple; works when the entry point's segment and stage are well-defined.
+
+**Pattern B: Routing layer.** Entry point routes to a routing page that asks 1-2 questions and then sends to the matched destination. Useful when the entry point's segment is variable.
+
+**Pattern C: Personalized landing.** Entry point routes to a landing page that adapts based on visitor attributes (source, behavior, profile). Sophisticated; requires personalization infrastructure.
+
+**Pattern D: Quiz-as-router.** Entry point routes to a quiz that segments and recommends. Detail in `quiz-and-assessment-design`.
+
+The choice depends on entry-point variability and infrastructure. Most programs start with Pattern A and add complexity as data shows the need.
+
+---
+
+## Entry-point and segment matching
+
+Each entry point likely surfaces specific segments.
+
+**The discipline.** For each entry point, document the expected segments. The first experience should serve those segments.
+
+**Worked example.**
+
+- Entry point: paid ad targeting "data analytics for SaaS."
+- Expected segments: data analysts and data leaders at SaaS companies.
+- Expected stage: consideration.
+- Routing: landing page on data analytics for SaaS; calculator showing ROI; CTA to demo.
+
+The match is deliberate. Visitors arriving via this entry point get a first experience that fits their segment and stage.
+
+---
+
+## Entry-point and stage matching
+
+The first experience should match the visitor's likely stage.
+
+**Common mismatches.**
+
+- Awareness-stage visitor lands on a hard-sell decision-stage page; bounces because not ready.
+- Decision-stage visitor lands on awareness-stage content; bounces because oversold on what they already know.
+- Consideration-stage visitor lands on either; serves the wrong intent.
+
+**The cure.** Match the entry point's expected stage to the page's stage. Awareness pages serve awareness traffic; decision pages serve decision traffic.
+
+---
+
+## Multi-entry funnels
+
+When the same visitor arrives via different entry points across visits.
+
+**The pattern.** A visitor sees an ad on Tuesday (paid entry); reads a blog post on Wednesday (organic entry); types the URL on Thursday (direct entry). Each entry point may surface a different first experience.
+
+**Architecture implications.**
+
+- Personalization across visits requires identity threading.
+- Nurture sequences may need to acknowledge prior visits.
+- Cross-channel attribution becomes important.
+
+**The discipline.** Architecture should accommodate multi-entry without confusion. The visitor's progression through the funnel respects their cumulative interactions, not just the latest entry.
+
+---
+
+## Entry-point measurement
+
+Track per-entry-point performance.
+
+**The metric.** Per entry point: visitors, segment composition, stage composition, conversion to next action.
+
+**Diagnostic uses.**
+
+- Entry points with low conversion: routing may be mismatched.
+- Entry points with high conversion: investigate what is working; replicate to other entries.
+- Entry points whose segment composition does not match expectations: the source may have shifted; review.
+
+---
+
+## Entry-point and audience-segment audit
+
+Periodically audit entry-point routing.
+
+**The audit.**
+
+- For each entry point: what segments and stages are arriving?
+- Does the first experience match those segments and stages?
+- Is conversion at this entry point above or below baseline?
+
+**The drift.** Entry points decay as ad targeting shifts, content rankings change, partners evolve. Quarterly audit catches the drift.
+
+---
+
+## Entry-point anti-patterns
+
+**The single-funnel-for-every-entry.** All visitors go through the same first experience regardless of entry. Routing not matching segments or stages.
+
+**The over-personalized-entry.** Entry routing so specific that maintenance is impossible; many entries route to landing pages that exist only for one entry source.
+
+**The mismatched-entry.** Entry expects one segment; landing page serves a different one. Conversion suffers.
+
+**The unmeasured-entry.** Per-entry data not tracked; routing decisions are guesswork.
+
+**The orphan-entry.** Entry point exists; no landing page or routing defined; visitors land somewhere generic.
+
+---
+
+## Common entry-point failures
+
+**One landing page for everyone.** Different entry points get the same first experience; routing not matching variability.
+
+**Wrong stage routing.** Awareness traffic gets decision-stage CTAs; decision traffic gets awareness content.
+
+**Personalization without infrastructure.** Architecture designed for personalization that the team cannot actually implement.
+
+**Entry-point drift.** Entry sources shifted; routing not updated.
+
+**Single-tool entry.** Only one tool serves an entry point; if the tool fails, the entry has no recovery.
+
+**Entry-conversion attribution missing.** Cannot tell which entry points produce which downstream conversion.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The entry-routing principle. Common entry points (6 patterns). Entry-point routing patterns (4 patterns). Entry-point and segment matching. Entry-point and stage matching. Multi-entry funnels. Entry-point measurement. Audit cadence. Anti-patterns. Common failures.
+
+## Implementation choices that stay internal
+
+Specific entry points for specific programs. Specific routing logic per entry. Specific landing pages per entry. The team's audit calendars. These vary by team and program.

--- a/skills/funnel-flow-architecture/references/funnel-iteration-discipline.md
+++ b/skills/funnel-flow-architecture/references/funnel-iteration-discipline.md
@@ -1,0 +1,189 @@
+# Funnel iteration discipline
+
+When to refine, when to redesign. Avoiding the continuous-redesign and frozen-architecture traps.
+
+Funnel architecture compounds when refined; collapses when constantly redesigned. The discipline is knowing when each is appropriate.
+
+---
+
+## The compound-vs-reset distinction
+
+Refinement compounds. Redesign resets.
+
+**Refinement.** Targeted changes to specific tools, sequences, or transitions within the existing architecture. The architecture's bones stay; the muscles get stronger.
+
+**Redesign.** Overhaul of the architecture. Segments redefined; tool-to-funnel mapping changed; sequences rebuilt. The architecture restarts.
+
+**The discipline.** Refine continuously; redesign deliberately and rarely. Constant redesign prevents compounding; never iterating allows decay.
+
+---
+
+## When to refine
+
+Five conditions that signal refinement is appropriate.
+
+**Specific tools are underperforming relative to baseline.** A calculator with declining conversion benefits from input adjustment, default updates, or methodology refinement. The architecture is fine; the tool needs attention.
+
+**Specific segments have lower conversion than peer segments.** A segment that converts at 4 percent while peer segments convert at 10 percent has a fixable architecture issue. Refine the segment's path.
+
+**Specific transitions in the funnel are producing drop-off.** The transition from quiz to recommended product page has high drop-off. Audit the transition; fix.
+
+**Sequence engagement is declining for specific cohorts.** Newer subscribers to a sequence engage less than older subscribers. The sequence may have decayed; refresh content.
+
+**Specific entry points are routing wrong segments.** A paid ad source has shifted; visitors arriving from it no longer match the segment the landing page serves. Adjust the routing.
+
+These are refinements. The architecture is sound; specific elements need attention.
+
+---
+
+## When to redesign
+
+Four conditions that signal redesign is appropriate.
+
+**Audience composition has fundamentally shifted.** The brand pivots; the target audience changes; the segments are no longer accurate. The matrix needs redesign.
+
+**Product or service strategy has changed.** The brand offers a fundamentally different product line; the funnel that served the old products no longer fits. Redesign.
+
+**Competitive landscape has shifted significantly.** A new competitor reshapes the buying process; the funnel needs to respond. Redesign may follow.
+
+**Multiple refine cycles have not produced expected results.** The team has refined repeatedly; conversion has not moved. The issue may be architectural rather than tactical. Redesign worth considering.
+
+These are redesigns. The architecture's fundamentals need to change.
+
+---
+
+## The continuous-redesign trap
+
+Teams that constantly redesign never benefit from architectural compounding.
+
+**The pattern.** Every quarter, the team rethinks the funnel. New segments; new tools; new sequences. Each redesign is partially built before the next redesign starts.
+
+**The signal.** Conversion does not improve over time. Each iteration starts over. Learning does not accumulate because the structure keeps changing.
+
+**The cost.** The team's investment dilutes across redesigns. Tools never reach maturity. Sequences never stabilize.
+
+**The cure.** Redesign infrequently. Refine continuously between redesigns. Set a "no major redesign for X months" discipline if needed.
+
+---
+
+## The frozen-architecture trap
+
+Teams that never iterate watch their architecture decay.
+
+**The pattern.** The funnel was designed once; the team treats it as finished. No refinement; no redesign; no audit.
+
+**The signal.** Conversion declines slowly over months and years. Tools age; sequences go stale; segments shift. The architecture does not respond.
+
+**The cost.** The architecture's value erodes. Audiences move on; competitors improve; the brand falls behind.
+
+**The cure.** Set refinement cadences. Quarterly audit; targeted refinements based on data. Acknowledge that no architecture stays optimal forever.
+
+---
+
+## The middle ground
+
+Refine continuously; redesign infrequently and deliberately.
+
+**Refinement cadence.** Monthly or quarterly. Targeted; data-driven; small enough to test in isolation.
+
+**Redesign cadence.** Annually at most. Often longer. Major triggers (audience pivot, product change, competitive shift) drive redesign rather than calendar.
+
+**The discipline.** Both rhythms running in parallel. Refinement maintains; redesign responds to fundamental change.
+
+---
+
+## Refinement workflow
+
+How to iterate productively.
+
+**Step 1: Identify the gap.** Data-driven; specific to a tool, segment, transition, or sequence.
+
+**Step 2: Hypothesize the cause.** What might explain the gap?
+
+**Step 3: Design a treatment.** What change would address the hypothesis?
+
+**Step 4: Test if possible.** A/B test or before-after measurement when feasible.
+
+**Step 5: Validate.** Did the metric move? Did downstream metrics also benefit?
+
+**Step 6: Roll out or roll back.** Successful refinements stick; unsuccessful ones revert.
+
+The discipline. Each refinement is hypothesis-driven and validated. Random changes do not compound.
+
+---
+
+## Redesign workflow
+
+How to redesign without resetting everything.
+
+**Step 1: Articulate why.** What has fundamentally changed that warrants redesign?
+
+**Step 2: Preserve what works.** Identify elements of the current architecture that are still appropriate. Do not throw away learning.
+
+**Step 3: Design the new architecture.** Segment matrix; entry-point routing; tool-to-funnel mapping; sequence architecture. Document everything.
+
+**Step 4: Plan migration.** How to transition existing audience and tools to the new architecture without losing momentum.
+
+**Step 5: Pilot before full rollout.** Test the new architecture with a subset of audience or one segment before full deployment.
+
+**Step 6: Migrate.** Roll out the new architecture; retire the old one.
+
+**Step 7: Monitor closely.** Architecture-level metrics in the first months show whether the redesign delivered.
+
+The discipline. Redesign is a project, not a flip of a switch. Plan it; pilot it; migrate; monitor.
+
+---
+
+## The decay-driven redesign signal
+
+How to know decay has accumulated to redesign level.
+
+**Signals.**
+
+- Multiple refine cycles have not moved the metric.
+- Segments no longer describe the audience accurately.
+- Tools designed for one segment are being used by others (mapping has drifted).
+- The architecture diagram no longer matches the actual experience visitors have.
+- Quarterly audits surface the same issues quarter after quarter without fix.
+
+When these signals accumulate, refinement is not enough. Redesign is needed.
+
+---
+
+## Iteration measurement
+
+How to know iterations are working.
+
+**The metric.** Architecture-level metrics improving over time. Cross-tool conversion rising; segment-level conversion rising; funnel-stage progression accelerating.
+
+**The trap.** Improving one metric while others decline. A refinement that lifts cross-tool conversion but tanks lead quality is not net positive.
+
+**The discipline.** Watch the portfolio of metrics, not individual ones. Refinement should improve the architecture's overall outcomes, not just one measure.
+
+---
+
+## Common iteration failures
+
+**Continuous redesign.** Architecture never stabilizes; learning does not compound.
+
+**Frozen architecture.** Architecture never iterates; decay accumulates.
+
+**Random refinement.** Changes without hypothesis or testing; results are noise.
+
+**Refinement without measurement.** Cannot tell if changes are working.
+
+**Redesign without preserving learning.** Throws away what was working alongside what was not.
+
+**Redesign without migration plan.** Audience and tools left in transition; experience suffers.
+
+**Iteration without portfolio metrics.** Improving one metric while damaging others.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The compound-vs-reset distinction. When to refine (5 conditions). When to redesign (4 conditions). The continuous-redesign trap. The frozen-architecture trap. The middle ground. Refinement workflow. Redesign workflow. The decay-driven redesign signal. Iteration measurement. Common failures.
+
+## Implementation choices that stay internal
+
+Specific iteration calendars for the team. Specific refinement and redesign processes. Specific tooling for testing iterations. The team's iteration history and lessons. These vary by team.

--- a/skills/funnel-flow-architecture/references/funnel-measurement-patterns.md
+++ b/skills/funnel-flow-architecture/references/funnel-measurement-patterns.md
@@ -1,0 +1,222 @@
+# Funnel measurement patterns
+
+Architecture-level vs tool-level metrics. What to measure, what is noise.
+
+Funnel measurement should reveal architecture quality, not just tool quality. Tool-level metrics tell you whether each tool is working; architecture-level metrics tell you whether the tools work together.
+
+---
+
+## The architecture-vs-tool measurement distinction
+
+Two layers of measurement.
+
+**Tool-level metrics.** Each tool's individual performance (calculator conversion, quiz completion, lead-magnet downloads). Detail in each tool's skill.
+
+**Architecture-level metrics.** How the tools and sequences compose. Cross-tool conversion, sequence-to-tool conversion, segment-level downstream conversion, funnel-stage progression.
+
+**The discipline.** Measure both layers. Architecture-level metrics are often the missing measurement.
+
+---
+
+## Architecture-level metric: Cross-tool conversion
+
+What percentage of audience that hits tool A then engages with tool B.
+
+**The metric.** Count the visitors who interact with tool A (calculator, quiz, lead magnet, etc.). Of those, how many subsequently interact with tool B?
+
+**Why it matters.** Cross-tool engagement signals whether the funnel is composing. High cross-tool conversion means the architecture is working; low cross-tool conversion means tools are silos.
+
+**Measurement methods.**
+
+- Identity-based tracking (same identified user across tools).
+- Session-based tracking (same session sees multiple tools).
+- Cohort analysis (cohorts entering through tool A and their downstream tool engagement).
+
+**Diagnostic uses.**
+
+- Low cross-tool conversion: tools may not be promoted to each other's audiences; transitions may be broken.
+- Specific tool pairs underperforming: those transitions need design attention.
+
+---
+
+## Architecture-level metric: Sequence-to-tool conversion
+
+What percentage of nurture sequence subscribers engage with downstream tools.
+
+**The metric.** Count subscribers in a sequence. Of those, how many click through to a tool the sequence promoted?
+
+**Why it matters.** Sequences should drive subscribers toward tools matched to their segment-and-stage. Low sequence-to-tool conversion signals that the sequences are not effectively bridging to tools.
+
+**Diagnostic uses.**
+
+- Specific sequence emails with low click-through: the email's tool promotion may not match the audience.
+- Specific tools with low sequence-driven traffic: the sequences may not be promoting those tools enough.
+
+---
+
+## Architecture-level metric: Segment-level downstream conversion
+
+Per-segment conversion to the program's main goal.
+
+**The metric.** For each segment in the matrix: what percentage convert to the main goal (trial, demo, purchase) within a defined timeframe?
+
+**Why it matters.** Different segments will convert at different rates; segments significantly underperforming relative to peers signal architecture issues.
+
+**Diagnostic uses.**
+
+- Segments with low downstream conversion: the funnel architecture for that segment may be broken or under-developed.
+- Segments with high downstream conversion: investigate what is working; replicate to other segments.
+
+---
+
+## Architecture-level metric: Funnel-stage progression
+
+What percentage of audience moves from awareness to consideration to decision over time.
+
+**The metric.** Track audience as they progress through stages. Awareness audience this month; what percentage are in consideration next month; what percentage in decision the following.
+
+**Why it matters.** The funnel's job is to progress audience through stages. Low progression signals the nurture sequences and tools are not advancing the relationship.
+
+**Diagnostic uses.**
+
+- Slow progression: sequences may be too educational without enough advancement; or the audience may be getting stuck.
+- Fast progression but low conversion: progression without quality.
+
+---
+
+## Tool-level metrics
+
+Each tool has its own metrics. Detail in each tool's skill.
+
+**Calculator.** Conversion rate per visitor; tier-2 (email gate) conversion; downstream conversion of calculator-sourced leads.
+
+**Quiz.** Completion rate; per-segment downstream conversion; recommendation click-through.
+
+**Lead magnet.** Download rate; sequence engagement; downstream conversion of magnet-sourced subscribers.
+
+**Multi-step form.** Completion rate; per-step drop-off; lead quality.
+
+**Chatbot.** Resolution rate per intent; escalation rate; downstream conversion.
+
+The tool-level metrics tell you whether each tool is doing its job. The architecture-level metrics tell you whether the tools are doing the funnel's job.
+
+---
+
+## What is noise
+
+Metrics that look important but are not.
+
+**Total tool engagements.** Volume without context. A tool with 10000 engagements per month tells you nothing without conversion context.
+
+**Email open rate alone.** Open rate is a leading indicator at best; sequence-to-conversion is the metric that matters.
+
+**Time on page or session length.** Often correlates with confusion as much as engagement.
+
+**Bounce rate alone.** High bounce rate on awareness content may be normal; on decision content may signal a problem; aggregate bounce rate is noise.
+
+The discipline. Measure outcomes, not activity. Activity metrics are noise unless connected to outcome metrics.
+
+---
+
+## Measurement granularity
+
+How granular to measure.
+
+**Per-tool measurement.** Standard. Each tool tracked.
+
+**Per-segment-per-tool measurement.** Measure each tool's performance per segment. Surfaces segment-specific tool issues.
+
+**Per-segment-per-stage measurement.** Measure progression and conversion per cell in the matrix.
+
+**Per-cohort measurement.** Track cohorts (groups arriving in the same period) over time. Surfaces evolution and decay.
+
+**The discipline.** Granularity matters when it informs decisions. Per-segment-per-stage is often where the diagnostic value lives; per-cohort surfaces decay.
+
+---
+
+## Attribution
+
+Connecting outcomes to specific tools and sequences.
+
+**The challenge.** Audiences interact with multiple tools and sequences. Which one drove the conversion?
+
+**Approaches.**
+
+- **First-touch attribution.** Credit goes to the first interaction.
+- **Last-touch attribution.** Credit goes to the most recent interaction.
+- **Multi-touch attribution.** Credit distributed across interactions.
+- **Position-based attribution.** Credit weighted by position (often U-shaped or W-shaped).
+
+**The honest framing.** Attribution is a model. No model is perfectly accurate. Choose a model deliberately; understand its biases; report consistently.
+
+---
+
+## Measurement and architecture decisions
+
+How metrics inform architecture changes.
+
+**The pattern.** Metrics surface gaps; architecture decisions address them; subsequent metrics validate.
+
+**Examples.**
+
+- Cross-tool conversion low: redesign transitions; promote tool B in tool A's exit; measure improvement.
+- Specific segment underperforming: review segment's funnel path; adjust tools or sequences; measure.
+- Funnel-stage progression slow: review sequence design; add or refine; measure.
+
+**The discipline.** Metrics inform decisions; decisions are tested; results validated. Without measurement, architecture changes are guesswork.
+
+---
+
+## Measurement instrumentation
+
+What needs to be in place.
+
+**Identity tracking.** Identified users tracked across tools.
+**Event tracking.** Each tool interaction logged with event data.
+**Funnel definition.** The funnel stages and segments defined in the analytics tool.
+**Cohort capability.** Ability to define and track cohorts.
+**Reporting.** Dashboards or reports that surface architecture-level metrics.
+
+**The discipline.** Instrumentation should be in place before launch, not added later. Retrofitting measurement is harder than building it in.
+
+---
+
+## Measurement cadence
+
+How often to look at architecture-level metrics.
+
+**Weekly review.** For high-velocity programs or recently launched architectures. Catches regressions and informs rapid iteration.
+
+**Monthly review.** For stable programs. Tracks trends and surfaces gradual decay.
+
+**Quarterly review.** Comprehensive architecture audit. Per-cell analysis; segment-level deep dive; funnel-stage progression.
+
+**Triggered review.** When tools change, when segments shift, when external factors (market, competition) change.
+
+---
+
+## Common measurement failures
+
+**Tool-level only.** Architecture-level metrics not tracked; cannot diagnose composition issues.
+
+**Vanity metrics.** Volume metrics without conversion context.
+
+**No segment-level granularity.** Aggregate metrics hide segment-specific issues.
+
+**Attribution model not chosen.** Reports inconsistent because attribution is ad-hoc.
+
+**No cohort tracking.** Cannot see decay or evolution.
+
+**Metrics without action.** Metrics reviewed but no decisions follow.
+
+**Confounded data.** Multiple changes deployed without isolation; cannot attribute outcomes to changes.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The architecture-vs-tool measurement distinction. Architecture-level metrics (cross-tool, sequence-to-tool, segment-level, funnel-stage). Tool-level metrics (cross-reference). What is noise. Measurement granularity. Attribution approaches. Measurement and architecture decisions. Instrumentation requirements. Measurement cadence. Common failures.
+
+## Implementation choices that stay internal
+
+Specific dashboards for specific programs. Specific tooling for measurement. Specific attribution models. The team's reporting conventions. These vary by team.

--- a/skills/funnel-flow-architecture/references/nurture-sequence-architecture.md
+++ b/skills/funnel-flow-architecture/references/nurture-sequence-architecture.md
@@ -1,0 +1,256 @@
+# Nurture sequence architecture
+
+Per-segment, per-stage sequence variation. The matched sequence win.
+
+Different segments at different stages get different nurture sequences. The sequences match the audience's situation and stage. Done well, sequences compound the brand's relationship with the audience; done poorly, sequences treat everyone the same and convert no one well.
+
+---
+
+## The matched-sequence principle
+
+Each segment-and-stage cell warrants a sequence designed for that cell. Different cells get different sequences.
+
+**The win.** An SMB consideration-stage subscriber gets a 5-email sequence focused on SMB-relevant comparison content, ROI examples from similar SMB customers, and a soft demo invitation. The sequence reads as if written for them.
+
+**The fail (kitchen-sink sequence).** Every subscriber regardless of segment or stage gets the same 5-email sequence. The content is generic enough to send to all; specific enough for none. SMB subscribers see enterprise examples; enterprise subscribers see SMB examples; conversion uniformly low.
+
+The discipline. Sequences vary by segment and stage. The matrix from `audience-and-stage-segmentation` is the sequence design map.
+
+---
+
+## Sequence variation by stage
+
+Stage-specific sequence patterns.
+
+**Awareness sequence.**
+
+- Goal: build relationship; deepen brand association with the topic.
+- Content: educational, broad value, brand-building.
+- Frequency: typically lower (weekly to bi-weekly); the audience is not in active research.
+- Soft offers: subscribe to newsletter, follow on social, attend webinar.
+- Hard offers: rare; awareness audiences are not buying yet.
+
+**Consideration sequence.**
+
+- Goal: move from "evaluating" to "selecting."
+- Content: comparative, specific value, product-fit signals.
+- Frequency: higher (every 3-7 days); audience is actively evaluating.
+- Soft offers: see comparison guide, take quiz, calculator.
+- Hard offers: demo, trial, talk to sales (toward end of sequence).
+
+**Decision sequence.**
+
+- Goal: commit; sign up; purchase.
+- Content: confidence-building, risk-reversal, urgency cues, case studies of similar customers.
+- Frequency: high (every 2-4 days); audience is close to deciding.
+- Soft offers: rarely; mostly hard offers.
+- Hard offers: trial, signup, talk to sales, custom quote.
+
+**Customer sequence (often missed).**
+
+- Goal: deepen success; expand and retain.
+- Content: feature deep-dives, success stories from similar customers, community invitations.
+- Frequency: ongoing; matches product cadence.
+- Soft offers: attend events, refer others.
+- Hard offers: upgrade, add-on, expansion.
+
+---
+
+## Sequence variation by audience
+
+Audience-specific sequence patterns.
+
+**SMB audience.**
+
+- Tone: practical, fast-execution, peer-to-peer.
+- Examples: SMB customers; focus on quick wins and resource constraints.
+- Content depth: shorter, scannable, action-oriented.
+
+**Mid-market audience.**
+
+- Tone: strategic, considered, multi-stakeholder.
+- Examples: mid-market customers; focus on team adoption and process change.
+- Content depth: moderate; depth where it matters; summaries for executives.
+
+**Enterprise audience.**
+
+- Tone: rigorous, evidence-based, formal.
+- Examples: enterprise customers; focus on security, scale, integration.
+- Content depth: deep; white papers, technical documentation, case studies with metrics.
+
+**Solo or creator audience.**
+
+- Tone: personal, founder-to-founder.
+- Examples: similar solo practitioners; focus on individual impact and time savings.
+- Content depth: practical; templates and how-tos over strategy.
+
+---
+
+## Sequence design discipline
+
+How to design each sequence.
+
+**Step 1: Define the goal.** What conversion does this sequence drive? Awareness to consideration; consideration to demo; demo to decision; decision to purchase.
+
+**Step 2: Define the audience.** Which segment-and-stage cell does this sequence serve?
+
+**Step 3: Outline the arc.** What is the email-by-email progression? Each email should have a purpose; cumulatively the arc moves the subscriber toward the goal.
+
+**Step 4: Match content to arc.** What specific content (template, case study, framework, demo invitation) fits each step?
+
+**Step 5: Define triggers and cadence.** What triggers the sequence (lead magnet download, demo request, behavior signal)? What is the spacing?
+
+**Step 6: Define the soft and hard offers.** Where do soft offers appear? Where do hard offers appear? At what point does the sequence make a direct ask?
+
+**Step 7: Define the exit.** When does the sequence end? Where do subscribers go after (newsletter, segment-specific stream, retired)?
+
+The output is a documented sequence ready to build and ship.
+
+---
+
+## Sequence cadence
+
+How frequently to send.
+
+**Awareness cadence.** Weekly to bi-weekly typical. The audience is not in active research; over-sending feels intrusive.
+
+**Consideration cadence.** Every 3-7 days typical. The audience is actively evaluating; cadence matches their consideration pace.
+
+**Decision cadence.** Every 2-4 days typical. The audience is close to deciding; cadence reflects urgency.
+
+**Customer cadence.** Variable. Match product cadence and customer engagement patterns.
+
+The cadence-too-frequent risk. Daily sends can fatigue; unsubscribe rates climb.
+
+The cadence-too-infrequent risk. Weekly sends to consideration audiences can lose momentum; the audience moves on.
+
+---
+
+## Sequence content sourcing
+
+Where the content for sequences comes from.
+
+**Repurposed content.** Existing blog posts, case studies, white papers can populate sequences. Cost-effective; benefits from existing content investments.
+
+**Sequence-original content.** Content written specifically for the sequence. More effort; can be highly tailored to the audience and arc.
+
+**Hybrid.** Most sequences mix repurposed and original. Original content for the key arc moments; repurposed content for supplementary value.
+
+The discipline. Sequence content should fit the sequence's audience and stage; off-fit content (even good content) weakens the sequence.
+
+---
+
+## Sequence triggers
+
+What launches the sequence.
+
+**Trigger types.**
+
+- **Lead magnet download.** Most common trigger.
+- **Calculator completion.** With segment data captured.
+- **Quiz completion.** With segment matched to result.
+- **Multi-step form submission.** Demo request, qualification.
+- **Behavior signal.** Visited specific pages, viewed pricing, abandoned cart.
+- **Manual addition.** Sales team adds a contact.
+
+**The trigger discipline.** The trigger informs which sequence the subscriber enters. A lead-magnet download for an awareness-stage resource enters the awareness sequence; a calculator completion with consideration-stage signals enters the consideration sequence.
+
+**Trigger-segment routing.** Multiple triggers can route to multiple sequences based on captured segment information. The trigger is one signal; segment is another.
+
+---
+
+## Sequence intersection and routing
+
+When subscribers might enter multiple sequences.
+
+**The challenge.** A subscriber downloads two lead magnets in the same week. Each magnet has its own sequence. Should they enter both?
+
+**Approaches.**
+
+- **Override.** Latest trigger overrides; subscriber enters the latest sequence and exits prior ones.
+- **Concatenate.** Subscriber completes the first sequence, then enters the next.
+- **Pause.** Active sequence pauses other triggers; subscriber returns to queue after current sequence.
+- **Multi-path.** Subscriber enters multiple sequences simultaneously (risk of frequency overload).
+
+The choice depends on subscriber experience and sequence design. Most programs benefit from override or pause patterns to avoid frequency overload.
+
+---
+
+## Sequence and offer alignment
+
+The offers in the sequence must match the audience.
+
+**The principle.** A sequence for SMB consideration-stage subscribers should pitch SMB-appropriate offers. Pitching enterprise offers in this sequence wastes the audience signal.
+
+**Offer alignment failures.**
+
+- Magnet attracts SMB; sequence pitches enterprise.
+- Awareness sequence pitches hard sales offers prematurely.
+- Decision sequence pitches awareness content the subscriber outgrew.
+
+**The cure.** Sequence offers reflect the audience and stage the sequence serves.
+
+---
+
+## Sequence measurement
+
+Per-sequence metrics.
+
+**Open rate.** Per email; per sequence overall.
+
+**Click-through rate.** Per email; per sequence.
+
+**Conversion to next step.** What percentage of subscribers in this sequence completed the desired conversion?
+
+**Unsubscribe rate.** Per email; per sequence.
+
+**Sequence-to-customer conversion.** What percentage of subscribers in this sequence eventually became customers?
+
+Diagnostic uses. Low open rates per email signal subject-line issues; low click-through signals content fit issues; high unsubscribe rates signal cadence or content problems.
+
+---
+
+## Sequence maintenance
+
+Sequences decay.
+
+**What decays.**
+
+- Content references go stale (outdated case studies, retired products).
+- Offers change (new products, new pricing, new programs).
+- Audience composition shifts; sequence content no longer fits.
+- Email deliverability changes; subject lines that worked stop working.
+
+**Maintenance cadence.** Quarterly review of every active sequence. Update content; refresh offers; verify links.
+
+**The drift indicator.** Sequence performance declining over time signals decay; specific cohorts (newer subscribers vs older) performing differently signals audience shift.
+
+---
+
+## Common sequence failures
+
+**One sequence for everyone.** Kitchen-sink pattern; matches no segment specifically.
+
+**Sequence-trigger mismatch.** The trigger captured one segment; the sequence is designed for another.
+
+**Offer misalignment.** Sequence pitches offers that do not match the audience.
+
+**Cadence wrong for stage.** Awareness cadence on consideration audience; consideration cadence on awareness audience.
+
+**No trigger logic.** Subscribers enter the same default sequence regardless of how they were captured.
+
+**Sequence-orphan magnets.** Lead magnets without follow-up sequences; subscribers go cold.
+
+**Stale sequence content.** Sequence designed once; content no longer reflects the brand or product.
+
+**No sequence measurement.** Sequence performance unknown; maintenance is guesswork.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The matched-sequence principle. Sequence variation by stage (4 stages). Sequence variation by audience (4 audiences). Sequence design discipline (7 steps). Sequence cadence. Sequence content sourcing. Sequence triggers. Sequence intersection and routing (4 approaches). Sequence and offer alignment. Sequence measurement. Sequence maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific sequences for specific segments. Specific email content in brand voice. Specific tooling for sequence automation and measurement. The team's cadence baselines. These vary by team.

--- a/skills/funnel-flow-architecture/references/tool-to-funnel-mapping.md
+++ b/skills/funnel-flow-architecture/references/tool-to-funnel-mapping.md
@@ -1,0 +1,225 @@
+# Tool-to-funnel mapping
+
+Which tools serve which entry points and segments. Each tool in the growth toolkit has a place in the funnel architecture; the mapping makes the place explicit.
+
+Without explicit mapping, tools end up serving everyone (and serving no one well) or getting deployed where they do not fit. With explicit mapping, each tool serves the segments where it adds the most value.
+
+---
+
+## The mapping principle
+
+Each tool serves specific segments at specific stages from specific entry points. The mapping is documented, not implicit.
+
+**The win.** A team's calculator is mapped to consideration-stage SMB and mid-market visitors arriving via organic content. The calculator's design (inputs, defaults, methodology) reflects this segment. Other segments do not see the calculator featured prominently; they see tools matched to their segment.
+
+**The fail.** A team's calculator is featured on every page for every visitor. The calculator's design is generic to serve everyone. SMB visitors see enterprise inputs; enterprise visitors see SMB defaults. The calculator serves nobody well.
+
+The discipline. Each tool has a defined place. The architecture documents which segments and stages and entry points the tool serves.
+
+---
+
+## Common tool-to-funnel mappings
+
+How each growth tool typically maps.
+
+**Lead magnet.** Often serves awareness-to-consideration transition.
+
+- Audience: awareness-stage visitors who would benefit from a focused resource.
+- Entry points: blog posts, content discovery, paid ads on educational topics.
+- Position in funnel: captures email; routes to nurture sequence that bridges to consideration.
+- Detail in `lead-magnet-design`.
+
+**Calculator.** Often serves consideration stage.
+
+- Audience: visitors evaluating options who need to defend a specific decision.
+- Entry points: pricing pages, comparison content, paid ads on solution-evaluation.
+- Position in funnel: provides defensible numeric output; routes to demo or trial CTA.
+- Detail in `calculator-design`.
+
+**Quiz.** Variable depending on design.
+
+- Awareness quizzes: content marketing, brand-building. Captures email; routes to broad nurture sequence.
+- Consideration quizzes: product matching, fit assessment. Captures email; routes to product-specific sequence.
+- Decision quizzes: plan selection, configuration. Captures email and routes to specific sales motion or signup.
+- Detail in `quiz-and-assessment-design`.
+
+**Multi-step form.** Often serves decision or qualification stage.
+
+- Audience: visitors with high intent who need to provide structured information.
+- Entry points: demo CTAs, talk-to-sales pages, application flows.
+- Position in funnel: captures qualified intent; routes to sales or to next-stage automation.
+- Detail in `multi-step-form-design`.
+
+**Chatbot.** Cross-cutting; can serve any stage with intent recognition routing.
+
+- Audience: any visitor who has questions the bot can handle.
+- Entry points: any page where conversation might add value.
+- Position in funnel: handles in-conversation routing; escalates to humans for complex cases.
+- Detail in `chatbot-flow-design`.
+
+---
+
+## Mapping examples by audience segment
+
+How tools map for specific segments.
+
+**Solo founder, awareness stage.**
+
+- Lead magnet: practical template they can use today.
+- Quiz (optional): "what stage of growth are you in" with matched recommendations.
+- Chatbot: yes, for FAQ; lightweight routing.
+- Calculator, multi-step form: probably not at this stage.
+
+**SMB team, consideration stage.**
+
+- Calculator: ROI estimate matched to SMB context.
+- Lead magnet: comparison guide or worked example.
+- Multi-step form: demo request capture.
+- Chatbot: yes, for product-specific questions.
+- Quiz (optional): plan recommendation.
+
+**Mid-market team, consideration-to-decision.**
+
+- Calculator: ROI estimate with mid-market context.
+- Multi-step form: demo request with qualification.
+- Chatbot: yes, with escalation to sales for complex questions.
+- Lead magnet (optional): white paper or case study.
+- Quiz: probably not (mid-market buyers often skip quizzes).
+
+**Enterprise, decision stage.**
+
+- Multi-step form: enterprise demo request with detailed qualification.
+- Chatbot: lightweight; escalation-heavy.
+- Custom calculator: with enterprise-specific inputs and ROI factors.
+- Lead magnet, quiz: usually not (enterprise buyers expect direct human attention).
+
+The mapping is segment-aware. Tools that fit one segment may not fit another.
+
+---
+
+## Mapping examples by stage
+
+How tools map for specific stages.
+
+**Awareness stage.**
+
+- Lead magnets prominent. Quizzes can serve. Calculators less common (consideration is when calculators earn their value). Chatbots support.
+- Goal: capture awareness-stage email; route to nurture sequence.
+
+**Consideration stage.**
+
+- Calculators central. Quizzes useful for product matching. Lead magnets can deepen value. Chatbots support specific questions.
+- Goal: convert consideration into qualified intent; route to demo or trial.
+
+**Decision stage.**
+
+- Multi-step forms central (demo requests, qualified intent capture). Calculators support specific decisions. Chatbots route to sales.
+- Goal: convert decision-stage intent into commitment.
+
+**Customer stage.**
+
+- Onboarding flows (which can use multi-step forms). Chatbots for support. Lead magnets and quizzes less central; replaced by in-product education.
+- Goal: deepen customer success; expand and retain.
+
+---
+
+## Mapping discipline
+
+How to make the mapping rigorous.
+
+**Discipline 1: Document the mapping.** Write down which tools serve which segments and stages. The document is the architecture's reference.
+
+**Discipline 2: Match tool design to mapping.** A tool serving SMB should have SMB-relevant inputs and defaults; a tool serving enterprise should reflect enterprise context.
+
+**Discipline 3: Promote tools where they fit.** Show calculators on consideration-stage pages; show lead magnets on awareness-stage pages. Generic tool placement on every page dilutes their value.
+
+**Discipline 4: Retire tools that do not fit.** A tool that does not have a mapping is decorative. Either find its place or retire it.
+
+**Discipline 5: Audit the mapping quarterly.** Mappings decay as audience composition shifts. Quarterly review catches drift.
+
+---
+
+## Multi-tool segments
+
+Some segments use multiple tools across their journey.
+
+**The pattern.** A consideration-stage SMB visitor uses a lead magnet (awareness arrival), a calculator (consideration depth), then a multi-step demo form (decision intent). Three tools across the journey.
+
+**Architecture implications.**
+
+- Each tool serves a specific moment in the visitor's journey.
+- Cross-tool data flow lets each tool benefit from earlier interactions.
+- Tools should not duplicate each other's value.
+
+**The discipline.** Tools complement, not duplicate. Each tool earns its place in the segment's journey.
+
+---
+
+## Tool overlap and choice
+
+When multiple tools could serve the same segment-and-stage cell.
+
+**The pattern.** A team has both a calculator and a quiz that could serve consideration-stage SMB.
+
+**The decision.** Choose the tool that serves the segment best, or use both with clear differentiation.
+
+- Calculator: when the consideration involves a specific calculation (ROI, savings, sizing).
+- Quiz: when the consideration involves categorization or product matching.
+- Both: when the segment benefits from both, with clear positioning of when each helps.
+
+The discipline. Avoid having multiple tools competing for the same segment without clear differentiation. Audiences pick the most prominent; the others underperform.
+
+---
+
+## Tool gaps
+
+When the mapping reveals gaps.
+
+**The pattern.** The architecture documents which tools serve which segments. Some cells in the matrix have no tool; the audience there has no relevant tool to engage with.
+
+**The decision.** Either build a tool to fill the gap, or accept that some cells use generic content rather than tools.
+
+- Build when the segment is high-value and the tool would meaningfully improve conversion.
+- Accept when the segment is small or the tool would not earn its build cost.
+
+The architecture surfaces gaps; the team decides what to do about them.
+
+---
+
+## Tool-mapping audit
+
+Periodically audit which tools serve which segments and how well.
+
+**The audit.**
+
+- For each tool: which segments does it currently serve? Which segments does it actually attract?
+- For each cell in the matrix: which tools are mapped to it? Are they performing?
+- Are any tools serving segments outside their intended mapping (drift)?
+
+**The drift indicators.** Tool conversion drops; tool's audience composition changes; tool gets traffic from segments it was not designed for.
+
+---
+
+## Common mapping failures
+
+**No mapping.** Tools deployed without explicit segment-and-stage assignment.
+
+**Mismatched mapping.** Tool serving segments it was not designed for; tool's design does not fit the audience.
+
+**Decorative mapping.** Mapping documented but not enforced; tool appears everywhere regardless of mapping.
+
+**Stale mapping.** Mapping designed once; not updated as tools or audiences evolved.
+
+**Tool overlap without differentiation.** Multiple tools competing for the same segment; audience splits; none performs well.
+
+**Mapping gaps unaddressed.** Cells in the matrix have no tool support; the architecture has holes.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The mapping principle. Common tool-to-funnel mappings (5 tools). Mapping examples by audience segment (4 examples). Mapping examples by stage (4 examples). Mapping discipline (5 disciplines). Multi-tool segments. Tool overlap and choice. Tool gaps. Tool-mapping audit. Common failures.
+
+## Implementation choices that stay internal
+
+Specific tool-to-segment mappings for specific programs. Specific tool placement decisions on specific pages. The team's audit calendars. These vary by team and program.

--- a/skills/lead-magnet-design/SKILL.md
+++ b/skills/lead-magnet-design/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: lead-magnet-design
+description: "Designing lead magnets that earn the email. The discipline of building gated content (ebooks, templates, checklists, swipe files, mini-courses, free tools) that delivers genuine standalone value while qualifying the lead and warming them for what comes next. Honest about thin-bait (overpromises, underdelivers), kitchen-sink-resource (everything, helps with nothing), and earned-value-magnet (delivers standalone value while qualifying the lead). Triggers on lead magnet, gated content, opt-in offer, ebook, checklist, template, swipe file, mini-course, free tool, content upgrade, freebie, opt-in, list-building offer. Also triggers when an audience is being asked for an email and the offer attached to that ask needs design discipline, when previous lead magnets converted but did not produce qualified leads, or when a lead magnet is being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing gated content that earns the email. Distinguishes thin-bait (overpromises, underdelivers) from kitchen-sink-resource (everything, helps with nothing) from earned-value-magnet (delivers standalone value while qualifying the lead)"
+display_order: 1
+---
+
+# Lead Magnet Design
+
+A senior growth practitioner's playbook for designing lead magnets that earn the email. Templates, checklists, swipe files, mini-courses, free tools, ebooks. The discipline of building gated content that delivers genuine standalone value while qualifying the lead and warming them for the next conversation.
+
+Most lead magnets are bait. A vague headline, a thin PDF, an email gate, a follow-up sequence the reader resents. Conversion-rate metrics look fine because the form converted; the email list grows; and the unsubscribe rate climbs because the magnet was a transaction the reader regrets the moment they download.
+
+The lead magnets that work as compounding assets do something different. They deliver value the reader would have paid for if they had to. They qualify the lead by audience-fit, so the list that grows is the right list. They set up the next conversation honestly, so the follow-up sequence is a continuation rather than an apology.
+
+This skill is the parent-frame methodology for the growth tooling track. Calculators (`calculator-design`) and quizzes (`quiz-and-assessment-design`) are specific lead-magnet types covered as their own skills. This skill provides the methodology for deciding WHAT to build before deciding WHAT TYPE.
+
+The voice is the senior growth practitioner who has watched lead magnets earn long-term subscribers and watched them burn list trust within a single send. Practical, opinionated about format selection, willing to tell the reader when a lead magnet is the wrong investment for the goal.
+
+When to use this skill: scoping a lead magnet for the first time, auditing a lead magnet that converts but does not qualify, deciding which format fits a specific audience and offer, or designing the post-download sequence that turns the magnet into a relationship.
+
+---
+
+## What this skill covers
+
+This skill spans lead magnet design as the parent discipline. The growth-tooling distinctions:
+
+- **`lead-magnet-design` (this skill)** is the parent-frame methodology. WHAT a magnet is, when to invest in one, which format fits, how to qualify the lead, how to set up the follow-up.
+- `calculator-design` is one specific lead-magnet type with its own methodology (calculation transparency, tiered value, methodology disclosure).
+- `quiz-and-assessment-design` is another specific lead-magnet type (scoring algorithms, result categorization, recommendation matching).
+- `landing-page-copy` is the page-level discipline that wraps the magnet's offer.
+- `content-distribution` is how the magnet reaches its audience.
+- `content-strategy` is upstream: the topic decisions that earn investment in any one magnet.
+
+The audience: growth marketers, in-house product marketers, marketing teams, agencies running list-building work for clients, founders building their own funnels.
+
+Out of scope: long-form content marketing (covered by `content-strategy`); landing-page copy (covered by `landing-page-copy`); email sequence design at scale (covered by `email-sequences`); the specific tooling configurations that deliver the magnet (those stay implementation-side).
+
+---
+
+## The lead magnet decision: when to build one, when not to
+
+Before designing the magnet, decide whether a magnet is the right investment.
+
+**A lead magnet earns investment when:**
+
+- The audience exists in volume but is not yet on the list. Traffic without conversion is the gap a magnet fills.
+- The product or service has a long consideration cycle. The list builds the relationship across the consideration window.
+- The audience has a specific, immediate problem that a focused resource can address. Magnets work when the gap they fill is concrete.
+- The follow-up sequence has a real purpose. Without a sequence that turns subscribers into something (customers, community members, qualified leads), the magnet is list-building theater.
+
+**A lead magnet does NOT earn investment when:**
+
+- The audience would convert directly without a magnet. SaaS with a free trial, ecommerce with a discount code, or freemium with a low-friction signup may not need a magnet between the visitor and the product.
+- The team cannot commit to the follow-up. A list without a sequence is a list that decays.
+- The topic is too broad to focus a single resource. "Marketing" is not a magnet topic; "the welcome-email template that 4x'd our trial-to-paid rate" is.
+- Sales calls or demos are the next step. If the goal is a booked call, design the call-booking flow, not the magnet.
+
+The decision is not "should we have a magnet"; it is "is the magnet the right next investment for this specific audience and goal."
+
+Detail in `references/lead-magnet-decision-criteria.md`.
+
+---
+
+## Thin-bait vs kitchen-sink-resource vs earned-value-magnet
+
+The keystone framing.
+
+**Thin-bait.** "10 tips for X" PDFs that are 200 words of fluff behind an email gate. The headline overpromises; the contents underdeliver. The reader downloads, skims, deletes, and unsubscribes within a week. The conversion-rate metric looks fine; the list quality and brand trust both degrade. Cost: every subscriber acquired through thin-bait costs more than they appear to, because the unsubscribe rate, the reduced sender reputation, and the reduced list-trust each compound.
+
+**Kitchen-sink-resource.** 80-page "Ultimate Guide" containing everything anyone could want about the topic. Includes nothing the reader actually needs RIGHT NOW. Bookmarked, never read, eventually forgotten. Cost: the magnet does not produce the moment of "I needed this and got it," which is the moment the relationship starts. Subscribers stay on the list out of inertia; the relationship never deepens; future emails get ignored.
+
+**Earned-value-magnet.** Solves a specific, immediate problem the reader has. Genuine standalone value, the kind that would be worth paying for if it were not free. Qualifies the lead by audience-fit. Warms the reader for a specific related offer that follows. The reader downloads, uses the resource, gets the result, and remembers the brand as the source of that result.
+
+The litmus test. Hand the magnet to a non-subscriber in the target audience. Watch them use it. Does the resource produce the promised outcome inside the time the reader was willing to spend? If yes, the magnet is earned-value. If the reader downloads and never opens, the magnet is thin-bait or kitchen-sink-resource regardless of how the headline reads.
+
+---
+
+## Format selection
+
+Magnets come in formats. Each format has strengths, weaknesses, audience-fit signals, and conversion-rate baselines. Choosing the wrong format wastes the topic and the design effort.
+
+**Templates.** A starting artifact the reader fills in or adapts. Strong for audiences who need to produce a specific deliverable (a brief, a spec, a pitch deck, an email). Strong because the value is immediate and concrete. Weak when the template is too generic to feel custom.
+
+**Checklists.** A sequence of items to verify or complete. Strong for audiences executing a known process where the gap is comprehensiveness, not direction. Strong because the format signals "you can use this in 10 minutes." Weak when the checklist reads as marketing rather than as a working tool.
+
+**Swipe files.** A curated collection of examples (subject lines, headlines, ad copy, design references). Strong for audiences who learn from examples and need inspiration rather than instruction. Weak when the swipes are stale or unattributed.
+
+**Mini-courses.** A multi-part email or video sequence delivering structured learning. Strong for audiences willing to invest sequential attention; strong because the sequence creates multiple touchpoints. Weak when the course is filler or when each lesson does not stand on its own.
+
+**Free tools (calculators, quizzes, generators).** Interactive web tools that produce a result. Strong for audiences who want a personalized output rather than a generic resource. Strong because the interaction qualifies the lead by inputs. Detail in `calculator-design` and `quiz-and-assessment-design`.
+
+**Ebooks.** Long-form treatment of a topic. Strong for audiences researching a complex decision; strong when the ebook reads as a definitive resource. Weak when used as a default format for topics that would have served the reader better as a checklist or template.
+
+**Video series.** Sequential video content delivered behind a gate. Strong for topics that benefit from demonstration; strong for audiences who learn from video. Weak when the production overhead exceeds the topic's value or when the audience does not consume video content at the time-of-magnet moment.
+
+The choice depends on the audience's preferred consumption mode, the topic's natural shape, and the production overhead the team can sustain. A great template often outperforms a mediocre ebook on the same topic.
+
+Detail in `references/format-selection-patterns.md`.
+
+---
+
+## The "would they pay for this" test
+
+The single test that distinguishes earned-value from thin-bait.
+
+The question. If the magnet were not free, would someone in the target audience actually pay for it? Not pay enterprise pricing, not pay for a course, but pay something (5 dollars, 25 dollars, 100 dollars) because the value is concrete enough to justify the cost?
+
+The honest answer matters. A magnet that fails this test is signaling that the value is below the threshold of "I would pay for this," which means the reader's time investment to download and consume it is at the edge of "worth it."
+
+The test is not perfect. Some valuable resources are hard to price (how much is a great checklist worth?). But the test catches the magnets that exist primarily to capture an email rather than to deliver value.
+
+Three failure modes the test catches.
+
+- The 5-page PDF that summarizes blog content. Free elsewhere; not pay-worthy.
+- The "Ultimate Guide" that nobody finishes. Pay-worthy in theory; not delivered in usable form.
+- The template that is so generic it adds no value over starting from scratch. Pay-worthy framing; thin in execution.
+
+The test the magnet should pass.
+
+- A reader in the target audience would pay for this resource because it produces a result they need.
+- The resource is in a usable form (consumable in the time the reader is willing to spend, applicable to their specific situation).
+- The resource is hard to find elsewhere or hard to assemble at the same quality.
+
+If the magnet passes the test, it earns the email. If it fails, redesign before launching.
+
+Detail in `references/would-they-pay-for-this-test.md`.
+
+---
+
+## Audience-fit qualification
+
+The magnet as filter, not just bait.
+
+A great magnet does two things at once. It delivers value (which earns the email). It also filters for the right audience (which earns the long-term relationship).
+
+**Filter through the headline.** The headline tells the wrong audience to opt out. "The 5-step framework for B2B SaaS pricing decisions" filters out ecommerce founders, freelancers, and consumer-app PMs. The conversion rate from the visiting traffic drops; the conversion rate from the right segment of that traffic is what compounds.
+
+**Filter through the topic.** A magnet on a niche topic attracts a niche audience. Generic topics attract generic audiences who churn off the list. Specific topics attract specific audiences who stay.
+
+**Filter through the format.** A 60-minute video course filters out audiences who will not invest 60 minutes. A 2-page checklist filters in audiences who want quick wins. The format signals what the brand expects of the relationship.
+
+**Filter through the offer adjacent to the magnet.** The follow-up sequence often makes a soft offer for a related product or service. The magnet should be tightly enough scoped that the audience who downloads it is also the audience who would consider the adjacent offer.
+
+The filtering principle. A magnet that converts 50 percent of visitors but produces 5 percent qualified leads is worse than a magnet that converts 15 percent of visitors and produces 40 percent qualified leads. Optimize for the qualified lead, not for the surface conversion rate.
+
+Detail in `references/audience-fit-qualification.md`.
+
+---
+
+## Title and presentation discipline
+
+The magnet's title is the conversion lever and the qualification filter at the same time.
+
+**Title patterns that work.**
+
+- **Specific outcome + specific audience.** "The B2B onboarding email sequence that 3x'd our 14-day activation rate (for SaaS founders)."
+- **Specific deliverable + specific situation.** "The pricing one-pager for SaaS founders raising a seed round."
+- **Specific framework + specific problem.** "The 4-question framework for deciding whether to fire a customer."
+- **Specific count + specific value.** "23 onboarding emails, with the open and click rate for each."
+
+**Title patterns to avoid.**
+
+- "Ultimate Guide to X." Vague. Promises too much. Underdelivers reliably.
+- "The Complete X Playbook." Same failure mode. Promises completeness; delivers volume.
+- "Free [Topic] Resource." Generic. Tells the reader nothing about why this resource is the one to download.
+- "10 Tips for Better X." Listicle framing signals thin content.
+
+**Presentation discipline beyond the title.**
+
+- The cover or preview image should reinforce the specificity. A clean type-driven cover often outperforms a cluttered one.
+- The landing page (handled by `landing-page-copy`) should preview the magnet, not just describe it.
+- The first page of the magnet should deliver value within the first read, not warm up with author bio and brand-positioning.
+
+Detail in `references/title-and-presentation-discipline.md`.
+
+---
+
+## Delivery and follow-up sequence design
+
+The sequence is the magnet's second act. Without it, the magnet is one transaction; with it, the magnet starts a relationship.
+
+**The delivery moment.** The reader fills the form and expects the resource immediately. Delivery delay (manual review, scheduled send) breaks the moment. The first email should deliver the asset and confirm the next step.
+
+**The first 7 days.** The reader is most engaged in the days right after download. The sequence should make use of that window: a follow-up that helps them apply the resource, a related artifact that extends the value, a soft introduction to the brand and the next step.
+
+**The medium-term.** Days 8 to 30, the sequence transitions from "value-add" to "ongoing relationship." Newsletter signup, related-content rotation, or a soft offer for the adjacent product or service.
+
+**The honest offer.** When the sequence makes an offer, the offer should match the magnet's audience. A magnet on B2B onboarding should not pitch a consumer course; the audience signal would be wasted.
+
+**The opt-out.** A reader who unsubscribes from the magnet sequence is not a failure; they are a clean filter. The list quality stays higher when the unfit subscribers leave on their own.
+
+Detail in `references/delivery-and-follow-up-sequences.md`.
+
+---
+
+## Format-specific quality gates
+
+Each format has quality gates specific to that format. A great template fails different tests than a great mini-course.
+
+**Template gates.** Does the reader produce a usable artifact in under 30 minutes? Are the prompts specific enough to feel custom? Is the template adaptable across the segment of the audience or rigidly bound to one situation?
+
+**Checklist gates.** Is each item actionable today? Does the checklist sequence reflect actual workflow order? Is the checklist scoped narrowly enough to feel comprehensive within scope?
+
+**Swipe file gates.** Are the swipes attributed (where possible)? Are they current (not 5 years stale)? Is the curation visible (the reader can see why each swipe is included)?
+
+**Mini-course gates.** Does each lesson deliver standalone value (not "you will learn the answer in lesson 4")? Is the cumulative time commitment honest in the title? Does the course end with a clear next step (not just "thanks for taking the course")?
+
+**Calculator and quiz gates.** Detail in `calculator-design` and `quiz-and-assessment-design`.
+
+**Ebook gates.** Is the ebook navigable (table of contents, page numbers, summary boxes) such that a reader who does not finish still extracts value? Is the production quality consistent with the brand it represents?
+
+**Video series gates.** Is each video shot at a quality the brand can sustain? Is the audio consistently clear? Is the runtime honest in the listing?
+
+Each format's gates exist because thin-bait can hide in any format. The quality gates make hiding harder.
+
+Detail in `references/format-specific-quality-gates.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-lead-magnet-failures.md`.
+
+- "Conversion rate is great, list quality is terrible." Thin-bait pattern; magnet attracts the wrong audience or fails to deliver the promised value.
+- "We ship a magnet; nothing happens after." No follow-up sequence; the magnet is one transaction rather than the start of a relationship.
+- "Our 80-page Ultimate Guide gets downloaded but never read." Kitchen-sink-resource; comprehensive in scope, useless in application.
+- "We changed the format from PDF to webinar; conversion rate dropped." Format mismatched to audience; the audience would consume a PDF in 10 minutes but will not block 60 minutes for a webinar.
+- "The magnet works in paid traffic but not organic." The audience reaching the magnet through paid is different from the organic audience; the magnet may fit one but not the other.
+- "Subscribers go cold after the first email." Sequence absent or poorly designed; the value evaporates after delivery.
+- "We have 5 magnets; one converts well, the others are dead." Magnet portfolio not maintained; audiences move and topics decay; periodic audit missing.
+- "The follow-up offer mismatches the magnet's audience." Magnet attracted one segment; offer pitches a different one; conversion to the offer near zero.
+- "We cannot tell which traffic source produces qualified leads." Attribution missing or rolled up at the wrong level; lead-quality signal not connected back to source.
+- "The team built three magnets last quarter; the team avoids talking about results." Magnets shipped without success metric definition; results ambiguous or quietly underwhelming.
+
+---
+
+## The framework: 12 considerations for lead magnet design
+
+When designing or auditing a lead magnet, walk these 12 considerations.
+
+1. **The magnet decision.** Is a magnet the right investment for this audience and goal, or does the funnel work without one?
+2. **Earned-value, not thin-bait or kitchen-sink-resource.** The magnet would be worth paying for; it solves a specific problem in usable form.
+3. **Format matched to audience and topic.** The format reflects how the audience consumes content and how the topic naturally shapes.
+4. **The "would they pay for this" test.** Pass before launching.
+5. **Audience-fit qualification.** The magnet filters for the right audience, not just maximum conversion.
+6. **Title and presentation discipline.** Specific, honest, signals what is inside.
+7. **Delivery in the moment.** First email arrives immediately; the asset is in that email.
+8. **Follow-up sequence designed.** The 30 days after download have a purpose, an arc, and a soft offer that matches the audience.
+9. **Format-specific quality gates passed.** The format's specific tests verified before launch.
+10. **Lead quality measured, not just conversion rate.** What percentage of subscribers fit the audience the magnet was designed for?
+11. **Attribution to source.** The team can tell which source produced which leads at which quality.
+12. **Audit cadence.** The magnet portfolio gets reviewed periodically; underperformers retired.
+
+The output of the framework is a lead magnet that earns the email by delivering real value, qualifies the audience by filtering at the headline and topic level, and starts a relationship through a sequence the team has actually designed.
+
+---
+
+## Reference files
+
+- [`references/lead-magnet-decision-criteria.md`](references/lead-magnet-decision-criteria.md) - When a lead magnet is the right investment and when it is not. The conditions that make magnets worth the build.
+- [`references/format-selection-patterns.md`](references/format-selection-patterns.md) - Templates, checklists, swipe files, mini-courses, free tools, ebooks, video series. Per-format strengths, weaknesses, audience-fit, conversion baselines.
+- [`references/would-they-pay-for-this-test.md`](references/would-they-pay-for-this-test.md) - The pricing thought experiment that distinguishes earned-value from thin-bait. Worked examples and failure modes.
+- [`references/audience-fit-qualification.md`](references/audience-fit-qualification.md) - The magnet as filter. Filtering through headline, topic, format, and follow-up offer.
+- [`references/title-and-presentation-discipline.md`](references/title-and-presentation-discipline.md) - Title patterns that work and patterns that fail. Cover, landing-page preview, first-page discipline.
+- [`references/delivery-and-follow-up-sequences.md`](references/delivery-and-follow-up-sequences.md) - Delivery moment, first-7-days arc, medium-term sequence, honest offer, clean opt-out.
+- [`references/format-specific-quality-gates.md`](references/format-specific-quality-gates.md) - Per-format quality tests. Templates, checklists, swipes, mini-courses, ebooks, videos.
+- [`references/lead-magnet-anti-patterns.md`](references/lead-magnet-anti-patterns.md) - The patterns that look like lead magnets but do not behave like them.
+- [`references/common-lead-magnet-failures.md`](references/common-lead-magnet-failures.md) - 10+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: magnets earn the email when they earn the reader's afternoon
+
+The magnets that work as compounding assets are the ones the reader uses. Not downloads. Not bookmarks. Uses. The reader opens the resource, applies it, and gets a result they would have paid for if they had to.
+
+That is the bar. Below the bar is thin-bait (the resource is too thin to use) or kitchen-sink-resource (too much to consume). Above the bar is the relationship: the reader remembers the brand as the source of the result, opens the next email, and considers the offer when it comes.
+
+The discipline is in the design choices upstream of the form. The format matched to the audience and topic. The title that filters and earns. The pricing thought experiment that catches the thin magnets before launch. The follow-up sequence designed before the magnet ships, not after. The audit cadence that retires the magnets that stopped working.
+
+When in doubt, ask: would the audience pay for this if it were not free, and will the team commit to the sequence after the download? If yes to both, the magnet earns the email. If no to either, redesign or do not ship.

--- a/skills/lead-magnet-design/references/audience-fit-qualification.md
+++ b/skills/lead-magnet-design/references/audience-fit-qualification.md
@@ -1,0 +1,171 @@
+# Audience-fit qualification
+
+The magnet as filter, not just bait. Filtering through headline, topic, format, and follow-up offer.
+
+A great magnet does two things at once. It delivers value (which earns the email). It also filters for the right audience (which earns the long-term relationship). The filtering is the difference between a list that grows and a list that grows in the right direction.
+
+---
+
+## The filtering principle
+
+The magnet's job is not to maximize email captures. It is to maximize qualified email captures.
+
+A magnet that converts 50 percent of visitors but produces 5 percent qualified leads (visitors who match the audience the magnet was designed for) is worse than a magnet that converts 15 percent of visitors and produces 40 percent qualified leads. The qualified-lead-rate metric matters more than the surface conversion rate.
+
+The filtering happens at multiple points: the headline, the topic, the format, the landing-page copy, and the follow-up offer. Each is a filter that lets in the right audience and turns away the wrong one.
+
+---
+
+## Filter through the headline
+
+The headline is the first filter. The right audience self-selects in; the wrong audience self-selects out.
+
+**Specific outcome plus specific audience.** "The 5-step framework for B2B SaaS pricing decisions" filters out ecommerce founders, freelancers, consumer-app PMs. The conversion rate from visiting traffic drops; the conversion rate from the right segment of that traffic is what compounds.
+
+**Specific situation.** "The pricing one-pager for SaaS founders raising a seed round" filters out everyone except SaaS founders raising a seed round. That is a tiny audience; the audience that converts is exactly the audience the brand wants.
+
+**Specific deliverable.** "The 23-email sequence we send to trial signups who go cold" filters in PMs, growth marketers, and founders running SaaS funnels. Filters out everyone else.
+
+**The headline test.** Read the headline. Who in the broader audience self-selects out? If the answer is "no one, anyone might want this," the headline is not filtering. Generic headlines attract generic audiences; specific headlines attract specific audiences.
+
+---
+
+## Filter through the topic
+
+The topic itself filters before the headline polishes the message.
+
+**Niche topics attract niche audiences.** "Pricing for B2B SaaS founders raising a seed round" is a topic that filters by definition. The audience for this topic is small but precise.
+
+**Generic topics attract generic audiences.** "Marketing tips" attracts everyone, which means it attracts no one specifically. The list grows; the lead quality dilutes.
+
+**The topic-segmentation question.** What audience segment is this topic specifically valuable for? If the answer is "everyone," the topic is too broad. Narrow until the answer is "the segment we want to serve."
+
+**Topic-narrowing examples.**
+
+- Too broad: "Email marketing tips."
+- Narrowed: "Welcome-email sequences for B2B SaaS trials."
+- Narrowed further: "The 7-email welcome sequence for B2B SaaS trials in the 5-50 employee segment."
+
+Each narrowing reduces the addressable audience and increases the qualification of those who convert.
+
+---
+
+## Filter through the format
+
+The format signals what the brand expects of the relationship.
+
+**A 60-minute video course filters out audiences who will not invest 60 minutes.** This is sometimes the right filter (for high-investment audiences) and sometimes the wrong one (for skim-and-apply practitioners).
+
+**A 2-page checklist filters in audiences who want quick wins.** This is often the right filter for practitioners executing known processes.
+
+**A free tool with detailed inputs filters in audiences with concrete situations the tool addresses.** The inputs themselves qualify the lead.
+
+**An 80-page ebook filters in audiences researching a complex decision.** Filters out audiences seeking quick artifacts.
+
+The format choice should match the audience the magnet is designed to attract. A mismatch (a 60-minute course for a skim audience, a 2-page checklist for an in-depth research audience) breaks the filter.
+
+---
+
+## Filter through the landing-page copy
+
+The landing page is the magnet's marketing layer. It filters by amplifying the headline and topic signals.
+
+**Audience-specific copy.** "For SaaS founders" beats "For founders" beats "For everyone." Each audience-specific cue filters.
+
+**Situation-specific copy.** "If you are scaling from 100 to 1000 customers, here is the playbook." Filters by situation.
+
+**Result-specific copy.** "After implementing this template, our trial-to-paid rate moved from 8 percent to 14 percent." Filters by who cares about that result.
+
+**Anti-filter copy.** "This is for everyone in marketing." Generic. No filter. Attracts the wrong audience and dilutes the list.
+
+The landing page should sharpen the filter the headline and topic establish, not dilute it.
+
+---
+
+## Filter through the follow-up offer
+
+The follow-up offer is the late-stage filter. The audience who downloads the magnet and then engages with the offer is the audience the program needs to compound.
+
+**Offer-magnet alignment.** A magnet on B2B onboarding should be followed by an offer relevant to B2B teams. A misalignment (a magnet on B2B onboarding followed by an offer for consumer-app courses) wastes the qualification the magnet did.
+
+**Offer-audience alignment.** The offer should fit the audience the magnet attracted. If the magnet attracted SaaS founders and the offer is for enterprise sales teams, the audience signal is wasted.
+
+**Offer-stage alignment.** A top-of-funnel magnet should be followed by an offer at the right consideration stage (not "buy now" 3 emails after download for a high-ticket product).
+
+The follow-up offer's conversion rate is the qualification metric that matters most. A list that engages with the offer is a list the magnet qualified well.
+
+---
+
+## The qualified-lead metric
+
+Beyond conversion rate, qualified-lead rate is the metric the magnet's filter should be measured by.
+
+**Definition.** Of the subscribers acquired through the magnet, what percentage match the audience profile the magnet was designed for?
+
+**Measurement methods.**
+
+- **Self-reported segment data.** Capture audience-segment data on the form (company size, role, industry). Measure the percentage that match.
+- **Email engagement.** Measure open and click rates on follow-up emails relevant to the target audience. Low engagement signals audience mismatch.
+- **Downstream conversion.** Measure conversion to the next step (trial, demo, purchase). Low downstream conversion despite high upstream engagement signals audience mismatch.
+
+**The qualified-lead-rate target.** Programs vary, but 40-70 percent of subscribers matching the target audience is a reasonable bar for a well-filtered magnet. Below 30 percent suggests the filter is broken; above 70 percent suggests the filter may be too narrow (and the magnet may be missing audience the brand could serve).
+
+---
+
+## When to widen the filter, when to narrow
+
+Filter-tuning is part of the magnet's lifecycle.
+
+**Widen the filter when:**
+
+- Conversion rate is healthy but the audience the brand serves is broader than the magnet captures.
+- The qualified-lead rate is high (suggesting the filter could let in more without sacrificing quality).
+- The team is launching a broader product or service that fits a wider audience.
+
+**Narrow the filter when:**
+
+- Lead quality is diluting (the magnet attracts subscribers who do not match the brand's offering).
+- The follow-up sequence's engagement is low because the audience does not match the offers.
+- The team is focusing on a specific segment and wants the magnet to filter for it.
+
+The discipline. Filter tuning is iterative. The magnet's headline, topic, and follow-up can be adjusted to widen or narrow the filter as the program evolves.
+
+---
+
+## Common filter failures
+
+**The headline does not filter.** Generic title; attracts everyone; lead quality dilutes.
+
+**The topic is too broad.** "Marketing" rather than "B2B SaaS pricing." Generic topic; generic audience.
+
+**The format is mismatched.** A long-form video for a skim audience; the wrong audience self-selects.
+
+**The landing page softens the filter.** Audience-specific headline followed by generic landing-page copy that anyone could read; the filter weakens.
+
+**The follow-up offer mismatches.** Magnet attracts one audience; offer pitches a different one; downstream conversion drops.
+
+**The team measures conversion rate but not lead quality.** The surface metric looks fine; the real metric (qualified-lead rate) is unmeasured; the magnet looks like a success while the list quality degrades.
+
+The pattern across failures: the team optimizes for the easier metric (conversion rate) and loses the harder metric (qualified-lead rate). The discipline is to measure both and to tune for the lead quality the program needs.
+
+---
+
+## The high-conversion-low-quality trap
+
+A magnet can convert at exceptional rates while producing terrible lead quality. The trap surfaces when the team celebrates the conversion rate and ignores the downstream signal.
+
+**The pattern.** A generic, broadly-appealing magnet ("Marketing Tips for 2026") converts at 25 percent. The list grows quickly. The follow-up sequence sees low engagement; the offers convert at near-zero rates; the unsubscribe rate is high.
+
+**The diagnosis.** The magnet attracted everyone, including audiences the brand cannot serve. The high conversion rate masked the low lead quality.
+
+**The fix.** Narrow the magnet's filter. The conversion rate will drop; the lead quality will rise; the program's compounding metric (qualified-lead growth) will improve.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The filtering principle. Filter through headline, topic, format, landing-page, and follow-up offer. The qualified-lead metric and how to measure it. When to widen and when to narrow. The high-conversion-low-quality trap. Common filter failures.
+
+## Implementation choices that stay internal
+
+Specific filter-tuning conventions for the team's audience. Specific qualified-lead-rate baselines for specific magnets. Specific segment-data capture methods on forms. Specific tooling for engagement and downstream-conversion measurement. These vary by team.

--- a/skills/lead-magnet-design/references/common-lead-magnet-failures.md
+++ b/skills/lead-magnet-design/references/common-lead-magnet-failures.md
@@ -1,0 +1,187 @@
+# Common lead magnet failures
+
+10+ failure patterns with diagnoses and cures. The patterns that surface as "the magnet underperformed" or "the list is not converting" or "we cannot tell if the magnet worked."
+
+---
+
+## "Conversion rate is great, list quality is terrible."
+
+**The diagnosis.** Thin-bait pattern. The magnet attracts the wrong audience or fails to deliver promised value. Conversion-rate metric looks fine because the form converted; the lead quality metric (which is the metric that matters for downstream conversion) is poor.
+
+**The cure.** Apply the "would they pay for this" test (`references/would-they-pay-for-this-test.md`). Apply audience-fit qualification (`references/audience-fit-qualification.md`). Strengthen the magnet until it earns the email rather than baits it.
+
+---
+
+## "We ship a magnet; nothing happens after."
+
+**The diagnosis.** No follow-up sequence. The magnet is one transaction rather than the start of a relationship.
+
+**The cure.** Design the sequence before shipping the magnet (`references/delivery-and-follow-up-sequences.md`). The 30 days after download should have a purpose, an arc, and a soft offer.
+
+---
+
+## "Our 80-page Ultimate Guide gets downloaded but never read."
+
+**The diagnosis.** Kitchen-sink-resource pattern. Comprehensive in scope, useless in application. The reader cannot consume the resource in the time they were willing to spend.
+
+**The cure.** Narrow the topic until the magnet addresses one specific problem in usable form. The 80-page guide often becomes a 4-page checklist or a 12-page worked example. Conversion rate may drop; lead quality and downstream engagement rise.
+
+---
+
+## "We changed the format from PDF to webinar; conversion rate dropped."
+
+**The diagnosis.** Format mismatched to audience. The audience would consume a PDF in 10 minutes but will not block 60 minutes for a webinar.
+
+**The cure.** Format selection (`references/format-selection-patterns.md`). Match the format to the audience's preferred consumption mode and the topic's natural shape. The format change might still be right (if the new format better serves a different segment) but the metric drop is signal.
+
+---
+
+## "The magnet works in paid traffic but not organic."
+
+**The diagnosis.** The audience reaching the magnet through paid is different from the organic audience. The magnet may fit one but not the other.
+
+**The cure.** Understand the audience differences. Paid traffic often has different intent and different audience composition than organic. The magnet may need a separate version for each, or the magnet may need to be retitled to match the actual audience reaching it.
+
+---
+
+## "Subscribers go cold after the first email."
+
+**The diagnosis.** Sequence absent or poorly designed. The value evaporates after delivery.
+
+**The cure.** Design the first-7-days arc to add value progressively (`references/delivery-and-follow-up-sequences.md`). Each email should add something the reader can use; the cumulative arc deepens the relationship.
+
+---
+
+## "We have 5 magnets; one converts well, the others are dead."
+
+**The diagnosis.** Magnet portfolio not maintained. Audiences move and topics decay; the periodic audit is missing.
+
+**The cure.** Audit the portfolio (`references/lead-magnet-anti-patterns.md`, "How to detect anti-patterns in the portfolio"). Retire the dead magnets. Free capacity for the strong ones and for new magnets that earn investment.
+
+---
+
+## "The follow-up offer mismatches the magnet's audience."
+
+**The diagnosis.** Magnet attracted one segment; offer pitches a different one. The audience signal the magnet captured was wasted.
+
+**The cure.** Align the offer to the audience the magnet attracts (`references/delivery-and-follow-up-sequences.md`, "The offer-magnet alignment"). If the offer cannot be changed, change the magnet to attract the offer's audience.
+
+---
+
+## "We cannot tell which traffic source produces qualified leads."
+
+**The diagnosis.** Attribution missing or rolled up at the wrong level. Lead-quality signal is not connected back to source.
+
+**The cure.** Capture source attribution at the form level. Measure lead quality (audience-fit, downstream conversion) per source. The diagnostic data informs which sources warrant further investment.
+
+---
+
+## "The team built three magnets last quarter; the team avoids talking about results."
+
+**The diagnosis.** Magnets shipped without success metric definition. Results ambiguous or quietly underwhelming.
+
+**The cure.** Define the success metric before building (`references/lead-magnet-decision-criteria.md`, "The success metric is defined"). What does "the magnet worked" look like? Without the definition, evaluation is impossible and underperformers do not get retired.
+
+---
+
+## "Downloads are high; trial signups are unchanged."
+
+**The diagnosis.** The magnet captures emails but does not move the downstream metric the team cares about. Either the magnet's audience does not match the trial-buying audience, or the sequence does not bridge to the offer.
+
+**The cure.** Trace the funnel from magnet download to trial signup. Identify the drop. The drop is often at the offer step (audience misalignment) or at the sequence step (no clear path from magnet to offer).
+
+---
+
+## "The magnet got shared on social; we got 1000 subscribers; none converted."
+
+**The diagnosis.** The magnet's distribution outpaced its audience-fit. A viral magnet attracts an audience that does not match the brand's offer.
+
+**The cure.** This is a design tradeoff. Shareable magnets are great for reach but often produce diluted lead quality. Either accept the dilution and have a long path to qualification, or design the magnet to be less shareable but more audience-specific.
+
+---
+
+## "We tried 12 different titles; conversion rate did not move."
+
+**The diagnosis.** Title testing without addressing the underlying audience-fit. The title is the surface; the audience-fit is the substance. If the substance is wrong, no title fixes it.
+
+**The cure.** Step back from title testing. Apply the audience-fit qualification (`references/audience-fit-qualification.md`). The title can amplify a strong audience-fit; it cannot create one.
+
+---
+
+## "The magnet's references are stale and conversion is dropping."
+
+**The diagnosis.** Magnet decay. Screenshots, statistics, tooling references go out of date. The reader notices and engagement drops.
+
+**The cure.** Maintenance discipline (`references/lead-magnet-decision-criteria.md`, "When to retire a magnet"). Quarterly review for active magnets. Update or retire when references decay.
+
+---
+
+## "We have a great magnet; the landing page does not convert."
+
+**The diagnosis.** The magnet is strong but the landing page (which is `landing-page-copy`'s domain) does not preview the value, frame the audience, or close the visitor.
+
+**The cure.** Apply landing-page-copy discipline. Show pages from inside the magnet. Frame the audience explicitly. Make the conversion action obvious and the friction minimal.
+
+---
+
+## "The magnet got featured in [a major newsletter]; we lost the signal we built."
+
+**The diagnosis.** A traffic spike from a misaligned audience can dilute the qualified-lead-rate metric. The featured audience may not match the brand's offer.
+
+**The cure.** Distinguish "qualified subscriber" from "any subscriber" in the metric. The traffic spike grew the list; the qualified list grew less. The signal is intact; the metric needs disaggregation.
+
+---
+
+## "We cannot keep the sequence content fresh."
+
+**The diagnosis.** The sequence's content needs ongoing maintenance. The team did not budget for it.
+
+**The cure.** Either reduce the sequence to evergreen content the team can sustain, or accept the maintenance cost as part of the magnet's true cost. Quarterly review of every active sequence (`references/delivery-and-follow-up-sequences.md`, "The maintenance discipline").
+
+---
+
+## "The magnet had great reviews; the lead-quality metric is mediocre."
+
+**The diagnosis.** Reviews are signal about the resource's quality. Lead quality is signal about the audience-fit. The two are different. A great resource for the wrong audience produces good reviews and mediocre lead quality.
+
+**The cure.** Audience-fit qualification (`references/audience-fit-qualification.md`). The magnet may need a tighter filter at the title and topic level, even if the resource itself is strong.
+
+---
+
+## "We built a magnet for our PMM team's pet topic; nobody downloaded."
+
+**The diagnosis.** Vanity-magnet pattern. The topic was chosen for internal interest, not audience need.
+
+**The cure.** Audience-research the topic before building. Confirm the topic matches a specific problem the audience is actively trying to solve.
+
+---
+
+## "The team ships magnets every quarter; conversion rate is the only metric we track."
+
+**The diagnosis.** Single-metric tracking misses lead quality, sequence engagement, downstream conversion, and retention. The conversion rate can look fine while the broader signal is weak.
+
+**The cure.** Multi-metric tracking. Conversion rate, qualified-lead rate, sequence engagement, downstream conversion, and unsubscribe rate together tell the story. Single-metric tracking misleads.
+
+---
+
+## The pattern across failures
+
+Most lead magnet failures fall into one of three patterns.
+
+**Pattern 1: The magnet does not deliver value.** Thin-bait, kitchen-sink, undelivered-promise. The fix is to strengthen or kill the magnet.
+
+**Pattern 2: The magnet attracts the wrong audience.** Everyone-magnet, viral-but-misaligned, vanity-magnet. The fix is to tighten the filter or reframe the audience.
+
+**Pattern 3: The relationship after the download fails.** Orphan-magnet, sequence-too-short, misaligned-offer, follow-up-spam. The fix is to design the sequence with as much care as the magnet itself.
+
+The metric pattern: lead magnet failures often look fine on the conversion rate. The signal is in the lead quality, the sequence engagement, and the downstream conversion. Programs that track only the conversion rate keep shipping the same patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (delivery, audience-fit, relationship). The principle that conversion rate alone is insufficient as a success metric.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered and the lessons learned. Specific multi-metric dashboards the team uses. Specific cures the team applies. The team's audit and retirement processes. These vary by team.

--- a/skills/lead-magnet-design/references/delivery-and-follow-up-sequences.md
+++ b/skills/lead-magnet-design/references/delivery-and-follow-up-sequences.md
@@ -1,0 +1,188 @@
+# Delivery and follow-up sequences
+
+Delivery moment, first-7-days arc, medium-term sequence, honest offer, clean opt-out. The sequence is the magnet's second act; without it, the magnet is one transaction.
+
+A magnet without a sequence is a list with decay. The sequence is where the relationship deepens, the offer surfaces, and the lead-quality signal gets used. Teams that build the magnet but skip the sequence capture emails that go cold.
+
+---
+
+## The delivery moment
+
+The reader fills the form and expects the resource immediately. The first email confirms the moment.
+
+**What the delivery email should do.**
+
+- Deliver the asset directly (link, attachment, or in-line content). The reader did not opt in to wait.
+- Confirm the audience-fit signal. Acknowledge what the reader is here for.
+- Set up the next email. "I will send you [related artifact] tomorrow" creates a hook for the next touchpoint.
+- Avoid friction. No double opt-in unless required by jurisdiction. No survey-before-asset. The reader gets the resource first.
+
+**What the delivery email should NOT do.**
+
+- Make an offer. The reader has not yet experienced the magnet's value; offering anything is premature.
+- Bury the asset. The link or attachment should be near the top, not after three paragraphs of brand-positioning.
+- Apologize for the email. "Thanks for downloading, here is your resource" without filler is honest.
+
+**Delivery delay risk.** Delays of more than 5 minutes break the moment. Manual review, scheduled sends, or batch processing all introduce delay. Automate the delivery to minimize lag.
+
+---
+
+## The first 7 days arc
+
+The reader is most engaged in the days right after download. The sequence should make use of that window.
+
+**Day 0: Delivery.** Asset in hand. The reader can act on the magnet immediately.
+
+**Day 1-2: Application help.** A follow-up that helps the reader apply the resource. "The 3 things people miss when implementing the [magnet]" or "the worked example we use ourselves." Adds value to the magnet without yet pitching anything.
+
+**Day 3-4: Adjacent value.** A related artifact, case study, or insight that extends the magnet's value. Reinforces the brand as a source of useful resources.
+
+**Day 5-7: Soft introduction to the brand.** Who the team is, what they work on, what kinds of problems they solve. Soft framing of the next step (newsletter signup, related product, demo).
+
+**The 7-day arc principle.** Every email in the first 7 days should add value, not extract. The relationship is being built; extraction breaks the trust the magnet earned.
+
+---
+
+## The medium-term sequence
+
+Days 8-30, the sequence transitions from "value-add" to "ongoing relationship."
+
+**The transition options.**
+
+- **Newsletter signup.** Move the subscriber to the regular newsletter cadence. The relationship continues at the brand's normal pace.
+- **Related-content rotation.** A series of additional resources, case studies, or insights related to the magnet's topic. The subscriber stays engaged in the topic area.
+- **Soft offer for the adjacent product or service.** A demo invitation, a trial signup, a case study of a similar customer. The offer matches the audience the magnet attracted.
+
+**The honest offer principle.** The offer should match the magnet's audience. A magnet on B2B onboarding should not pitch a consumer course. The audience signal would be wasted.
+
+**The hard-sell trap.** Some sequences pivot too early to hard selling, before the reader has had time to recognize the value. The early hard sell breaks trust. The discipline is to earn the right to pitch through demonstrated value first.
+
+---
+
+## The offer-magnet alignment
+
+The offer that follows the magnet must match the audience the magnet attracted.
+
+**Worked example: aligned offer.**
+
+The magnet: "The 7-email welcome sequence for B2B SaaS trials."
+The audience attracted: SaaS founders, growth marketers, and PMs running SaaS funnels.
+The offer: a B2B SaaS lifecycle email tool with a 14-day trial.
+
+The audience the magnet attracted is the audience the offer serves. The conversion to trial is high relative to baseline.
+
+**Worked example: misaligned offer.**
+
+The magnet: "The 7-email welcome sequence for B2B SaaS trials."
+The audience attracted: as above.
+The offer: a marketing analytics platform aimed at enterprise marketing teams.
+
+The audience the magnet attracted is not the audience the offer serves. The conversion to demo is near zero. The audience signal was wasted.
+
+**The alignment discipline.** Before designing the magnet, identify the offer the magnet's audience will be pitched. If the offer does not exist or does not match, redesign the magnet (or the offer) before shipping.
+
+---
+
+## The clean opt-out
+
+A reader who unsubscribes from the magnet sequence is not a failure. They are a clean filter.
+
+**The principle.** The list quality stays higher when the unfit subscribers leave on their own. A subscriber who is not the right audience for the offer is a subscriber whose engagement will be low; their unsubscribe is signal, not loss.
+
+**The mechanics.**
+
+- Make unsubscribe easy. One-click is honest; multi-step is friction the brand pays for in trust.
+- Do not interrogate on the way out. "We are sorry to see you go, please answer 3 questions" is friction.
+- Acknowledge the unsubscribe gracefully. The reader was a subscriber; they should leave with the brand intact.
+
+**The unsubscribe-as-feedback loop.** High unsubscribe rates after specific emails signal that the email did not match the audience or the value proposition. The signal informs sequence revision.
+
+---
+
+## Sequence cadence considerations
+
+How frequently to send.
+
+**Day 0-7: daily or every-other-day is honest.** The reader just downloaded; engagement is high; the sequence can use the window without feeling spammy.
+
+**Day 8-30: 2-4 emails per week is reasonable.** Frequency depends on the value being delivered; if each email adds value, higher frequency is sustained.
+
+**Day 30+: settle into the brand's normal cadence.** Newsletter weekly, monthly, or per-publication. Whatever the brand sustains.
+
+**Cadence-too-frequent risk.** Daily emails for 30+ days exhaust the reader. The unsubscribe rate climbs.
+
+**Cadence-too-infrequent risk.** Weekly cadence in the first 7 days lets the magnet's momentum fade. The reader downloads, applies, and forgets the brand.
+
+---
+
+## Sequence-engagement measurement
+
+The sequence's metrics surface whether the magnet did its qualifying job.
+
+**Open rates.** The audience opens what is interesting to them. Low open rates after the first email signal audience mismatch or sequence-content mismatch.
+
+**Click-through rates.** Clicks signal interest in specific content or offers. Low click-through on the offer email signals offer-magnet misalignment.
+
+**Conversion to next step.** Trials, demos, purchases. The downstream metric that matters most. Low conversion despite high engagement signals offer mismatch or pricing-mismatch.
+
+**Unsubscribe rates.** A reasonable rate (2-5 percent over the first 30 days) is normal. Higher rates signal cadence mismatch or audience mismatch.
+
+The metrics together tell the story. The sequence either qualifies and converts the audience the magnet attracted, or it surfaces the mismatch the magnet missed.
+
+---
+
+## When the sequence fails
+
+The sequence sends; engagement drops; conversion is low. The diagnosis often surfaces magnet-side failures.
+
+**Diagnosis: the magnet attracted the wrong audience.** The sequence's content is right for the audience the magnet was designed for, but the audience the magnet actually attracted is different. The fix is upstream: tighten the magnet's filter.
+
+**Diagnosis: the offer is misaligned.** The audience is right; the offer does not match. The fix is to change the offer (or the magnet, if the offer is fixed).
+
+**Diagnosis: the sequence is too long or too frequent.** Engagement starts strong and drops as fatigue sets in. The fix is to trim the sequence or space the emails.
+
+**Diagnosis: the sequence's value drops off.** The first emails added value; the later emails became repetitive or extractive. The fix is to redesign the later emails to continue adding value.
+
+**Diagnosis: the sequence's tone shifted.** The early emails were honest; the later emails became salesy. The fix is to restore the honest tone.
+
+The sequence is part of the magnet's design. Failures in the sequence often surface as conversion-rate or engagement metrics, but the fix is sometimes upstream in the magnet itself.
+
+---
+
+## The maintenance discipline
+
+Sequences decay. Email links break, references go stale, offers change.
+
+**The maintenance cadence.** Quarterly review of every active sequence. Are links working? Are references current? Does the offer at the end still match the brand's current product or service?
+
+**Stale-sequence risk.** A subscriber who clicks a broken link or sees a reference to a discontinued product disengages immediately. The brand looks careless.
+
+**The retire decision.** Sequences for retired magnets should be retired. Subscribers acquired through the magnet should be moved to the appropriate ongoing sequence (newsletter or other).
+
+---
+
+## Common sequence failures
+
+**No sequence.** The magnet ships; subscribers download; nothing follows. The list goes cold.
+
+**Sequence too short.** 2-3 emails and done. The relationship does not deepen.
+
+**Sequence too long.** 30+ emails over months. Subscribers fatigue.
+
+**Sequence pivots to hard sell too early.** The trust the magnet earned gets spent before the value has been demonstrated.
+
+**Offer misaligned.** Magnet attracts one audience; offer pitches another.
+
+**Stale references.** Links break; product names changed; case studies outdated.
+
+**Cadence mismatch.** Too frequent or too infrequent for the engagement the audience can sustain.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The delivery moment principles. The first-7-days arc. The medium-term transition. The offer-magnet alignment principle. The clean opt-out. Cadence considerations. Sequence-engagement measurement. Diagnostic patterns when the sequence fails. The maintenance discipline.
+
+## Implementation choices that stay internal
+
+Specific email copy for specific magnets. Specific sequence templates the team uses. Specific tooling for delivery automation, sequence platforms, and engagement measurement. The team's cadence baselines. Specific offer-design choices for specific products. These vary by team.

--- a/skills/lead-magnet-design/references/format-selection-patterns.md
+++ b/skills/lead-magnet-design/references/format-selection-patterns.md
@@ -1,0 +1,245 @@
+# Format selection patterns
+
+Templates, checklists, swipe files, mini-courses, free tools, ebooks, video series. Per-format strengths, weaknesses, audience-fit signals, and conversion-rate baselines. Choosing the wrong format wastes the topic and the design effort.
+
+A great template often outperforms a mediocre ebook on the same topic. The format is half the design decision; the topic is the other half.
+
+---
+
+## Templates
+
+A starting artifact the reader fills in or adapts.
+
+**Strengths.**
+
+- Immediate, concrete value. The reader produces a usable artifact in minutes.
+- High perceived value because the artifact is practical.
+- Strong audience signal: people who download templates are people who execute, not just consume.
+- Sustainable production: a single template, well-designed, can serve thousands of downloads with minimal updating.
+
+**Weaknesses.**
+
+- Generic templates feel useless; the bar for "custom enough" is high.
+- The format does not work when the deliverable is non-standardizable (the reader's context varies too much for a template to fit).
+- Distribution can be tricky if the template requires specific tools (a Notion template is unusable to teams not on Notion).
+
+**Audience-fit signals.**
+
+- Strong fit: practitioners who produce specific deliverables (specs, briefs, plans, decks, sequences).
+- Weak fit: strategic readers who want frameworks rather than artifacts.
+
+**Conversion-rate baseline.** Templates often convert 3-12 percent on landing pages with reasonable traffic-fit. The high end is for templates that signal exceptional specificity in the title.
+
+**Production overhead.** Moderate. A polished template often takes 8-20 hours including design, instructions, and worked example.
+
+---
+
+## Checklists
+
+A sequence of items to verify or complete.
+
+**Strengths.**
+
+- Fast to consume, fast to apply. Reader gets value in 10-20 minutes.
+- Format signals "you can use this today."
+- Strong for processes where the gap is comprehensiveness rather than direction (the reader knows what to do; the checklist verifies they did not miss steps).
+
+**Weaknesses.**
+
+- Easy to make thin. A 12-item generic checklist reads as marketing rather than a working tool.
+- Sequence matters; an unordered checklist on a process is less useful than the same items in workflow order.
+- Limited topic range; checklists fit verification-style tasks, not strategy-style decisions.
+
+**Audience-fit signals.**
+
+- Strong fit: practitioners executing known processes who need verification (launch checklists, audit checklists, onboarding checklists).
+- Weak fit: strategic decisions where each situation differs.
+
+**Conversion-rate baseline.** Strong checklists convert 5-15 percent. The format signals quick wins, which lifts conversion.
+
+**Production overhead.** Low to moderate. 4-12 hours including design and field-testing.
+
+---
+
+## Swipe files
+
+A curated collection of examples (subject lines, headlines, ad copy, design references, email templates).
+
+**Strengths.**
+
+- High perceived value. The reader gets a body of work to study and adapt.
+- Strong for audiences who learn from examples rather than instruction.
+- Often shareable; readers tell peers about a strong swipe file.
+
+**Weaknesses.**
+
+- Requires curation discipline; a 200-item swipe file with no commentary is less useful than 30 swipes with curation notes.
+- Decays faster than templates or frameworks; swipes go stale as conventions change.
+- Attribution matters; uncredited swipes can be perceived as theft.
+
+**Audience-fit signals.**
+
+- Strong fit: copywriters, designers, marketers, and creators who need inspiration plus example.
+- Weak fit: audiences seeking instruction or process.
+
+**Conversion-rate baseline.** Strong swipe files convert 4-12 percent.
+
+**Production overhead.** Moderate to high. 12-30 hours including curation, attribution, and commentary.
+
+---
+
+## Mini-courses
+
+A multi-part email or video sequence delivering structured learning.
+
+**Strengths.**
+
+- Multiple touchpoints, which deepens the relationship.
+- Sequential structure can take the reader from "novice" to "competent" on a topic.
+- The course format can charge implicit time investment, which qualifies the lead as serious.
+
+**Weaknesses.**
+
+- Each lesson must stand on its own; "the answer is in lesson 4" loses the reader by lesson 2.
+- Production overhead is significant.
+- Completion rates are honestly low (often 10-30 percent finish), which limits the cumulative value delivered.
+
+**Audience-fit signals.**
+
+- Strong fit: audiences willing to invest sequential attention and seeking structured learning.
+- Weak fit: audiences who want quick wins or specific artifacts.
+
+**Conversion-rate baseline.** 3-10 percent. Lower than templates or checklists because the perceived time commitment is higher.
+
+**Production overhead.** High. 30-100 hours for a 5-7 lesson course depending on format.
+
+---
+
+## Free tools (calculators, quizzes, generators, configurators)
+
+Interactive web tools that produce a personalized result.
+
+**Strengths.**
+
+- Highest perceived value among magnet types when the tool genuinely helps.
+- Personalization makes the result feel custom.
+- Often shareable; results can drive earned traffic.
+- Lead-quality signal embedded in the inputs (a calculator's inputs reveal the lead's situation).
+
+**Weaknesses.**
+
+- Build cost is significant; a quality tool is engineering work, not just copy.
+- Maintenance is ongoing as inputs and methodology evolve.
+- Easy to fall into vanity-tool patterns (inputs and outputs that do not produce a meaningful result).
+
+**Audience-fit signals.**
+
+- Strong fit: audiences with concrete decisions or calculations the tool can address.
+- Weak fit: topics that do not naturally produce a personalized output.
+
+**Conversion-rate baseline.** Wide range, 5-25 percent depending on tool quality and audience-fit.
+
+**Production overhead.** High. 40-150+ hours for a polished tool.
+
+Detail in `calculator-design` and `quiz-and-assessment-design`.
+
+---
+
+## Ebooks
+
+Long-form treatment of a topic.
+
+**Strengths.**
+
+- Comprehensive coverage when comprehensiveness matters.
+- Authority signal; a well-produced ebook positions the brand as a definitive source.
+- Bookmarkable; readers may return over time.
+
+**Weaknesses.**
+
+- Easy to default to ebook for topics that would have been better as a checklist or template.
+- Completion rates are honestly low; many ebooks are downloaded and never read.
+- Production overhead and design overhead are high.
+- The format invites kitchen-sink-resource patterns ("we have to cover everything").
+
+**Audience-fit signals.**
+
+- Strong fit: audiences researching a complex decision who want depth.
+- Weak fit: practitioners who want immediate-use artifacts.
+
+**Conversion-rate baseline.** 2-8 percent. Lower than other formats because the perceived time investment to read is high and many readers know they will not finish.
+
+**Production overhead.** High. 40-120 hours for a 30-50 page ebook.
+
+---
+
+## Video series
+
+Sequential video content delivered behind a gate.
+
+**Strengths.**
+
+- Strong for topics that benefit from demonstration (UI walkthroughs, design critique, code review).
+- Personality and brand presence land more directly in video than in text.
+- Audiences who prefer video learning are well-served.
+
+**Weaknesses.**
+
+- Production overhead is high; video quality has to match the brand it represents.
+- Audiences who do not consume video at the moment of magnet delivery underuse the resource.
+- Updates require re-recording, which is more expensive than updating text.
+
+**Audience-fit signals.**
+
+- Strong fit: audiences who consume video for learning and have time to watch.
+- Weak fit: practitioners who want skim-and-apply content.
+
+**Conversion-rate baseline.** 3-9 percent.
+
+**Production overhead.** Very high. 50-200+ hours for a 4-6 video series at quality.
+
+---
+
+## Hybrid formats
+
+Some magnets combine formats. A template plus a worked-example video. A checklist plus a 5-day email mini-course that walks through it.
+
+**Strengths.**
+
+- Multiple consumption modes serve broader audience preferences.
+- The hybrid often outperforms either format alone.
+
+**Weaknesses.**
+
+- Production overhead compounds.
+- Risk of confusing the reader about what they are getting.
+
+**When hybrids work.** When the second format genuinely extends the first. A template that includes a video walkthrough adds value; a template that includes a 60-page ebook the reader did not ask for adds bloat.
+
+---
+
+## Format-decision frame
+
+When choosing the format for a specific topic and audience.
+
+**Step 1: Audience consumption mode.** How does this audience consume content? Do they read long-form? Skim PDFs? Watch video? Use templates?
+
+**Step 2: Topic shape.** Does the topic naturally produce an artifact (template), a verification (checklist), inspiration (swipe), instruction (course), a calculation (tool), depth (ebook), or demonstration (video)?
+
+**Step 3: Production capacity.** What can the team sustain? A great template the team can ship beats a mediocre ebook the team is straining to finish.
+
+**Step 4: Conversion-rate target.** Templates and checklists generally convert higher; ebooks and courses convert lower. The expected conversion rate informs the topic-volume calculation.
+
+**Step 5: Maintenance overhead.** Some formats decay faster than others. Swipes go stale; templates with software-specific instructions decay; videos with UI screenshots decay. Choose formats the team can maintain.
+
+The right format is the one that fits the topic, the audience, the team's capacity, and the maintenance reality. There is no universal best format; there is only the format that fits the situation.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+Per-format strengths, weaknesses, audience-fit signals, conversion-rate baselines, and production overhead. The hybrid format consideration. The format-decision frame. The principle that there is no universal best format.
+
+## Implementation choices that stay internal
+
+Specific format choices for specific topics in the team's catalog. Specific production benchmarks for the team's capacity. Specific tooling for each format. The team's audit baselines for conversion rate and lead quality. These vary by team, topic, and audience.

--- a/skills/lead-magnet-design/references/format-specific-quality-gates.md
+++ b/skills/lead-magnet-design/references/format-specific-quality-gates.md
@@ -1,0 +1,196 @@
+# Format-specific quality gates
+
+Per-format quality tests. Templates, checklists, swipes, mini-courses, ebooks, videos. Each format has gates specific to that format. A great template fails different tests than a great mini-course.
+
+The quality gates exist because thin-bait can hide in any format. The gates make hiding harder. Apply them before launch; if the magnet fails a gate, redesign before shipping.
+
+---
+
+## Template gates
+
+A template earns the email when the reader produces a usable artifact in minimal time.
+
+**Gate 1: Time-to-usable-artifact.** Can the reader produce a usable artifact in under 30 minutes? If the template requires hours of customization to be useful, the format is failing.
+
+**Gate 2: Specificity of prompts.** Are the prompts specific enough to feel custom? "Insert your unique value proposition here" is too generic. "What is the specific outcome your customer needs in the first week" is specific enough to guide the reader.
+
+**Gate 3: Adaptability across the segment.** Is the template adaptable across the segment of the audience, or rigidly bound to one situation? A template for "B2B SaaS pricing one-pager" should work across multiple B2B SaaS situations; a template that only fits one company's exact circumstances is too rigid.
+
+**Gate 4: Worked example included.** Does the template include a worked example showing what a completed version looks like? Worked examples reduce the time-to-usable-artifact and signal that the template was real-tested.
+
+**Gate 5: Tooling honesty.** If the template requires specific tools (a Notion template, a Figma file, an Airtable base), is the tool dependency honestly disclosed in the title? Surprise dependencies frustrate readers who do not have the tool.
+
+---
+
+## Checklist gates
+
+A checklist earns the email when each item is actionable today.
+
+**Gate 1: Each item actionable today.** No "consult your team about X" or "decide on the strategy for Y." Each item should be something the reader can verify or complete.
+
+**Gate 2: Workflow order.** Does the checklist sequence reflect actual workflow order? An out-of-order checklist forces the reader to mentally re-sort, which costs the speed advantage the format promised.
+
+**Gate 3: Scope discipline.** Is the checklist scoped narrowly enough to feel comprehensive within scope? "Pre-launch checklist for B2B SaaS" is narrower than "Pre-launch checklist for any product" and produces a tighter, more useful resource.
+
+**Gate 4: Item count sanity.** Strong checklists are usually 12-30 items. Fewer than 8 items often signals thin-bait; more than 50 often signals that the format should have been an ebook or playbook instead.
+
+**Gate 5: Verification cues.** Does each item include enough cue for the reader to know they actually verified it? "Email sequence tested in production" is verifiable; "Email sequence reviewed" is not.
+
+---
+
+## Swipe file gates
+
+A swipe file earns the email when the swipes are real, attributed, and curated.
+
+**Gate 1: Real swipes.** The swipes should be examples actually used in the wild, not invented for the magnet. Real swipes have specificity that invented ones lack.
+
+**Gate 2: Attribution where possible.** Each swipe attributed to source where the source is public. Unattributed swipes can read as theft.
+
+**Gate 3: Currency.** Are the swipes current? Swipes from 5 years ago may have specific dating cues that signal staleness. Periodic refresh is part of the swipe-file discipline.
+
+**Gate 4: Curation visible.** Is the curation visible? The reader can see why each swipe is included? A 200-swipe dump with no commentary is less useful than 30 curated swipes with notes on why each was included.
+
+**Gate 5: Categorization.** Are the swipes categorized by use case (subject lines, headlines, ad copy, design references)? A flat list of unsorted swipes is harder to extract value from than a categorized collection.
+
+---
+
+## Mini-course gates
+
+A mini-course earns the email when each lesson stands on its own and the cumulative arc adds up.
+
+**Gate 1: Each lesson standalone.** A reader who only completes lesson 1 should still extract value. "You will learn the answer in lesson 4" loses readers who do not make it to lesson 4.
+
+**Gate 2: Cumulative time honesty.** Is the total time commitment honestly disclosed in the title or landing page? "5-day course" should mean 5 days of meaningful engagement, not 5 days of one paragraph emails.
+
+**Gate 3: Production consistency.** Are all lessons at consistent production quality? Courses that decay in production quality across lessons signal that the team ran out of capacity.
+
+**Gate 4: Clear next step at end.** Does the course end with a clear next step (related product, related resource, ongoing community)? "Thanks for taking the course" without a next step is a missed opportunity.
+
+**Gate 5: Completion tracking.** Does the course include progress markers ("Lesson 3 of 5") so the reader knows where they are? Lack of progress markers correlates with low completion.
+
+**Gate 6: Each lesson's central insight.** Can the team articulate the central insight of each lesson in one sentence? Lessons without a central insight are filler.
+
+---
+
+## Free tool gates
+
+Free tools (calculators, quizzes, generators) earn the email when the result is meaningful.
+
+**Gate 1: Meaningful result.** The output should help the reader make a decision or understand a situation. "Your score is 73" without interpretation is meaningless. Detail in `calculator-design` and `quiz-and-assessment-design`.
+
+**Gate 2: Calculation transparency or methodology disclosure.** Detail in `calculator-design`.
+
+**Gate 3: Email-capture honesty.** Detail in `calculator-design`.
+
+---
+
+## Ebook gates
+
+An ebook earns the email when the resource produces value for readers who do not finish.
+
+**Gate 1: Navigability.** Table of contents, page numbers, summary boxes. A reader who jumps to chapter 3 should be able to extract value without reading 1 and 2.
+
+**Gate 2: Production quality consistent with the brand.** A poorly-produced ebook (typos, inconsistent formatting, low-resolution images) signals that the brand did not invest. The reader's expectation of the brand drops.
+
+**Gate 3: Length honesty.** Is the page count honestly disclosed? "30-page guide" should mean 30 pages of substance, not 30 pages including 12 of brand-positioning.
+
+**Gate 4: Chapter summaries.** Each chapter ends with a summary that lets a reader who skimmed extract the key insight. Summaries reduce the cost of skimming, which raises the value the reader gets even if they do not finish.
+
+**Gate 5: First-chapter discipline.** The first chapter should deliver value, not warm up. Author bio and brand-positioning belong in the appendix or the about-the-author note, not chapter 1.
+
+---
+
+## Video series gates
+
+A video series earns the email when production quality and consumption shape match the audience.
+
+**Gate 1: Production quality consistent.** Audio clear, video stable, lighting reasonable. Production quality the brand can sustain across all videos.
+
+**Gate 2: Runtime honesty.** Total runtime disclosed honestly. "5-video series" with one video 30 seconds and another 45 minutes is dishonest.
+
+**Gate 3: Audio-first viability.** Many video viewers consume in audio-only contexts (commutes, exercise). Does the video work as audio? If the video has heavy on-screen reading required, the audio-only viewer loses the value.
+
+**Gate 4: Transcripts available.** A transcript reaches the audience that prefers reading and improves accessibility.
+
+**Gate 5: Each video standalone.** Same as the mini-course gate. A viewer who only watches video 1 should extract value.
+
+---
+
+## Cross-format gates
+
+Some gates apply regardless of format.
+
+**Gate A: The "would they pay for this" test.** Detail in `references/would-they-pay-for-this-test.md`.
+
+**Gate B: Audience-fit signal.** Does the magnet attract the audience the brand serves? Detail in `references/audience-fit-qualification.md`.
+
+**Gate C: Title-content alignment.** Does the magnet deliver on the title's specific promise? Detail in `references/title-and-presentation-discipline.md`.
+
+**Gate D: First-impression quality.** Whatever the format, does the first impression (first page, first lesson, first calculator output) deliver something useful immediately?
+
+**Gate E: Update cadence.** Is the magnet updated when references go stale, screenshots change, or methodology evolves? Stale magnets degrade the brand.
+
+---
+
+## When a magnet fails a gate
+
+The magnet fails a gate. Now what.
+
+**Option 1: Fix the magnet.** Add the worked example, narrow the scope, improve the production quality. Often the right answer.
+
+**Option 2: Change the format.** Sometimes the topic is wrong for the chosen format. A topic that fails ebook gates might pass checklist gates.
+
+**Option 3: Do not ship.** Some magnets should not exist. Killing the magnet at the gate stage is honest; shipping a failing magnet costs more than killing it.
+
+The team's response to gate failures is the discipline marker. Strong programs fix or kill at the gate; weak programs ship despite failed gates and accept the downstream cost.
+
+---
+
+## The gate review process
+
+Gates are most useful when applied as a structured pre-launch review.
+
+**The review.**
+
+- Identify the format.
+- List the gates for that format (plus the cross-format gates).
+- For each gate, score pass / fail / marginal.
+- Marginal gates warrant strengthening before launch.
+- Failed gates require redesign before launch.
+
+**Who reviews.**
+
+- The magnet's author should self-review.
+- A second person (outside the magnet's authoring team) should also review. Outside-in honesty catches what the authoring team rationalizes.
+
+**Document the review.** A short note on which gates passed and which were strengthened. Useful for future magnet design and team learning.
+
+---
+
+## Common gate failures
+
+**Templates.** Generic prompts; no worked example; tool dependency hidden.
+
+**Checklists.** Items that are not actionable; out-of-workflow order; thin item count.
+
+**Swipe files.** Invented swipes; no attribution; uncategorized dump.
+
+**Mini-courses.** Lessons that depend on each other; production quality decays; no clear next step.
+
+**Free tools.** Vanity outputs without interpretation; misleading methodology; manipulative gates.
+
+**Ebooks.** Poor navigability; production quality below brand standard; length padded with brand-positioning.
+
+**Video series.** Inconsistent production; no transcripts; long runtime hidden.
+
+The pattern across formats: the gates surface the failures that conversion-rate metrics hide. A magnet can convert at high rates while failing the gates; the gate failures show up downstream as poor lead quality and poor sequence engagement.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+Per-format quality gates with specific tests. Cross-format gates. The gate review process. The decision tree when a magnet fails a gate. Common gate failures.
+
+## Implementation choices that stay internal
+
+Specific gate-scoring conventions for the team. Specific review processes and reviewers. Specific worked-example libraries. Specific production-quality benchmarks. Specific update-cadence calendars. These vary by team.

--- a/skills/lead-magnet-design/references/lead-magnet-anti-patterns.md
+++ b/skills/lead-magnet-design/references/lead-magnet-anti-patterns.md
@@ -1,0 +1,197 @@
+# Lead magnet anti-patterns
+
+The patterns that look like lead magnets but do not behave like them. Anti-patterns are easy to ship and easy to celebrate; the cost shows up in lead quality, sequence engagement, and brand trust over time.
+
+---
+
+## The thin-bait magnet
+
+The pattern. A vague-headline PDF that contains 200 words of fluff behind an email gate.
+
+The signal. Conversion-rate metric looks fine; unsubscribe rate after delivery is high; subsequent email open rates collapse.
+
+The cost. Every subscriber acquired through thin-bait costs more than they appear to. Reduced sender reputation, reduced list trust, and the brand reputation as a source of bait all compound.
+
+The cure. Apply the "would they pay for this" test before launch. Strengthen the resource until it would be worth paying for. If it cannot be strengthened, do not ship.
+
+---
+
+## The kitchen-sink-resource magnet
+
+The pattern. An 80-page "Ultimate Guide" that covers everything anyone could want about the topic. Nothing the reader needs RIGHT NOW.
+
+The signal. Strong conversion rate (the title sounds comprehensive); low usage rate (the resource is too long to consume); no traceable downstream conversion.
+
+The cost. The magnet does not produce the moment of "I needed this and got it." The relationship never starts. Subscribers stay on the list out of inertia; future emails get ignored.
+
+The cure. Narrow the topic until the magnet addresses one specific problem. The 80-page guide becomes a 4-page checklist or a 12-page worked example. Conversion rate may drop; lead quality and downstream engagement rise.
+
+---
+
+## The undelivered-promise magnet
+
+The pattern. A title that promises a specific outcome ("the framework that doubled our conversion rate") followed by a magnet that delivers something less specific ("here is general advice on conversion rate optimization").
+
+The signal. Reader downloads, opens, encounters the gap, and unsubscribes (or stays subscribed but disengages).
+
+The cost. The brand becomes the source of the gap. Future titles by the same brand are less trusted; conversion rates on future magnets decay.
+
+The cure. Either deliver on the title's promise (which often requires strengthening the magnet) or revise the title to be honest about what the magnet contains.
+
+---
+
+## The bait-and-switch magnet
+
+The pattern. The magnet promises one resource and delivers another. "Free template" that turns out to be a 10-email mini-course; "calculator" that turns out to be a contact-sales form.
+
+The signal. Reader engagement collapses; the brand earns "deceptive" descriptors in support tickets and social mentions.
+
+The cost. Trust damage that extends beyond the magnet. The brand becomes harder to trust on any future offering.
+
+The cure. Match the title to what the magnet actually delivers. If the team wants to deliver a mini-course, title the magnet as a mini-course. If the team wants to gate a sales form, do not call it a calculator.
+
+---
+
+## The orphan-magnet (no sequence)
+
+The pattern. The magnet ships; subscribers download; nothing follows. No sequence, no offer, no relationship-building.
+
+The signal. List grows; engagement on subsequent emails (when they happen) is low; downstream conversion to anything is near zero.
+
+The cost. The list is a list of cold contacts. The brand has the email but not the relationship.
+
+The cure. Design the sequence before shipping the magnet. The 30 days after download should have a purpose, an arc, and a soft offer.
+
+---
+
+## The misaligned-offer magnet
+
+The pattern. The magnet attracts one audience; the follow-up offer pitches a different one. Magnet on B2B onboarding; offer for consumer-app courses.
+
+The signal. Magnet conversion is fine; offer conversion is near zero; the audience signal the magnet captured was wasted.
+
+The cost. The team builds the magnet, runs the sequence, and gets no downstream conversion. The investment does not pay back.
+
+The cure. Align the offer to the audience the magnet attracts. If the offer cannot be changed, change the magnet to attract the offer's audience.
+
+---
+
+## The dead-magnet portfolio
+
+The pattern. The team has shipped 12 magnets over 3 years. 3 still convert; 9 are dead but still on the site. Maintenance attention spreads thin; nothing is great.
+
+The signal. Aggregate conversion-rate metrics look fine; per-magnet metrics show 75 percent of the portfolio underperforming.
+
+The cost. Maintenance overhead on dead magnets; brand looks cluttered; team capacity diluted across underperformers.
+
+The cure. Audit the portfolio. Retire the dead magnets. Free capacity for the strong ones and for new magnets that earn investment.
+
+---
+
+## The everyone-magnet
+
+The pattern. A magnet titled to attract "everyone in marketing" or "any founder." Generic by design.
+
+The signal. Conversion rate may be high; lead quality is low; downstream engagement is mixed because the audience is too broad to serve coherently.
+
+The cost. List grows fast; sequence engagement underwhelms; offers convert poorly because the audience is not aligned to any specific offer.
+
+The cure. Narrow the magnet's audience. Specific magnets attract specific audiences who convert well to specific offers. The everyone-magnet is the wrong tool for any specific goal.
+
+---
+
+## The vanity-magnet
+
+The pattern. A magnet built because the team wanted to ship a magnet, not because the audience needed one. The topic was chosen for "we should write about this" rather than "the audience would download this."
+
+The signal. Low conversion rate; few signs that the audience cares about the topic; the magnet collects dust.
+
+The cost. Sunk effort; team morale drop; the team learns that magnets do not work (when in fact this specific magnet did not work because the topic was wrong).
+
+The cure. Audience-research the topic before building. Confirm the topic matches a specific problem the audience is actively trying to solve. Vanity-magnets often fail at the topic-validation step.
+
+---
+
+## The follow-up-spam magnet
+
+The pattern. The magnet ships; the sequence follows; the sequence is 30 emails over 14 days, all of them sales-driven.
+
+The signal. Strong unsubscribe rate; high spam-complaint rate; the brand earns "spammy" descriptors.
+
+The cost. Sender reputation damage that affects all future emails. The brand's email program degrades.
+
+The cure. Redesign the sequence to add value rather than extract it. Cadence should match the audience's tolerance; content should be honest.
+
+---
+
+## The interrogation-form magnet
+
+The pattern. The form before the magnet asks for 12 fields (name, company, role, company size, current tools, biggest challenge, etc.) before delivering the resource.
+
+The signal. Conversion rate collapses; the audience self-selects out at the form.
+
+The cost. The magnet's reach drops dramatically. The team gets rich data on the few who convert; the team loses the broader audience the magnet could have served.
+
+The cure. Ask only for what is needed (often just an email). Capture additional data later in the sequence as the relationship deepens.
+
+---
+
+## The hidden-cost magnet
+
+The pattern. The magnet promises a free resource; the resource includes upselling, integrated ads, or links to paid offerings on every page.
+
+The signal. Reader downloads expecting a resource; experiences the upsells as bait; engagement collapses.
+
+The cost. The magnet is perceived as commercial-disguised-as-resource. Trust damages.
+
+The cure. Keep the magnet substantive. Soft offers can appear at the end or in the follow-up sequence; the body of the magnet should deliver the promised value.
+
+---
+
+## The unfindable-asset magnet
+
+The pattern. The magnet is delivered as a link to a Google Drive folder, a Notion page, or some other location that the reader has to navigate to find the actual asset. The asset is buried 2-3 clicks away.
+
+The signal. Reader downloads the email link; cannot find the asset; abandons.
+
+The cost. The download metric counts but the consumption metric collapses. The reader's experience is friction.
+
+The cure. Deliver the asset directly (attachment or in-line link). Click count from email to asset should be 1.
+
+---
+
+## The team-pat-on-the-back magnet
+
+The pattern. The magnet is content the team wanted to make (a thought-leadership piece, a brand statement, a manifesto) gated behind a form. The audience may not specifically want it.
+
+The signal. Conversion rate underwhelms; the team rationalizes ("brand-building is hard to measure"); the magnet does not produce relationship signal.
+
+The cost. The team builds the wrong thing for the audience and learns the wrong lesson.
+
+The cure. Design magnets for the audience's needs, not for the team's preferences. Brand-building content can exist as ungated content; gated content should be magnet-shaped.
+
+---
+
+## How to detect anti-patterns in the portfolio
+
+Audit cadence. Quarterly review of every active magnet, looking specifically for these anti-patterns.
+
+**Audit questions per magnet.**
+
+- Is the conversion rate consistent with the audience-fit, or is it suspiciously high (suggesting thin-bait or everyone-magnet)?
+- Is the lead quality consistent with the audience the magnet was designed for, or is it diluted (suggesting weak filters)?
+- Does the sequence's engagement match the magnet's promise, or is there a drop (suggesting an undelivered-promise or misaligned-offer)?
+- Is the asset usable in the form delivered, or is it hard to find (suggesting unfindable-asset)?
+- Does the magnet have a sequence at all, or is it orphaned?
+
+**The retire decision.** Anti-pattern magnets often warrant retirement. Maintaining them costs more than the diminishing returns they produce.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing for each. Cures matched to anti-patterns. The audit cadence and audit questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and the lessons learned. Specific portfolio audit results. Specific retirement decisions and successor-magnet plans. The team's audit calendar and reviewer list. These vary by team.

--- a/skills/lead-magnet-design/references/lead-magnet-decision-criteria.md
+++ b/skills/lead-magnet-design/references/lead-magnet-decision-criteria.md
@@ -1,0 +1,137 @@
+# Lead magnet decision criteria
+
+When a lead magnet is the right investment for the funnel and when it is not. The conditions that make magnets worth the build, and the funnels where the magnet is friction the audience does not need.
+
+A lead magnet is a long-lived asset. The build cost is upfront; the conversion lift compounds across visitors. But the long-lived asset only compounds if the audience and the goal warrant it. Magnets built without the conditions in place become dead PDFs in CMS folders.
+
+---
+
+## When a magnet earns the build
+
+Five conditions that, when present, make a magnet a strong investment.
+
+**Traffic exists but conversion is missing.** The audience reaches the site (organic, paid, referral, social) but does not convert to the primary action (signup, purchase, demo). The magnet fills the gap between "interested enough to land" and "ready to commit." Without traffic, the magnet has no audience; without a conversion gap, the magnet adds friction.
+
+**The consideration cycle is long.** B2B SaaS, high-ticket services, and considered consumer purchases share the trait that buyers research over weeks or months before committing. The list-building motion lets the brand stay present across the consideration window. Short-cycle purchases (impulse ecommerce, low-stakes signups) often do not need a magnet between visitor and conversion.
+
+**The audience has a specific, immediate problem the magnet can address.** Generic problems do not focus a magnet. "Improve my marketing" is too broad; "the email sequence I send to trial signups who go cold" is specific enough to focus a checklist or template. The magnet lives or dies on specificity.
+
+**The team can commit to the follow-up sequence.** A magnet without a sequence is a list with decay. The sequence is where the relationship deepens, the offer surfaces, and the lead-quality signal gets used. Teams without sequence-building capacity should fix that before building the magnet.
+
+**The success metric is defined.** What does "the magnet works" look like? List growth at quality, lead-quality signal, conversion to the next step, downstream revenue attribution. Without a defined success metric, the magnet's results cannot be evaluated, and underperformers do not get retired.
+
+When all five are present, the magnet is a strong investment. When two or fewer are present, the magnet is probably the wrong tool.
+
+---
+
+## When a magnet does NOT earn the build
+
+Funnels where the magnet adds friction the audience does not need.
+
+**Frictionless conversion already exists.** A SaaS with a 14-day free trial, no credit card required, may not need a magnet between the visitor and the trial. The magnet adds a step where the trial alone would convert.
+
+**The next step is a sales call or demo.** When the goal is a booked call, design the call-booking flow rather than a magnet that delays the call. The magnet might still serve a separate audience (top-of-funnel readers not ready for a call), but the primary funnel is the call.
+
+**The audience is too small for list-building economics.** Building, hosting, and maintaining a magnet (plus the sequence) costs ongoing time. For very small target audiences, direct outreach or a simpler conversion path may be more efficient.
+
+**The team has no sequence capacity.** If the team cannot design and maintain the post-download sequence, the magnet captures emails that decay into unsubscribes. The list grows on paper and shrinks in trust.
+
+**No specific topic that focuses a magnet.** When the topic is "we do everything," no single magnet focuses. The honest move is to narrow the audience first (which produces the topic that focuses) rather than build a generic magnet.
+
+**The current funnel is already converting at a rate the magnet would not improve.** If the visitor-to-customer rate is already strong, the magnet adds steps without lifting the outcome.
+
+The honest assessment matters more than the default. "Should we have a lead magnet" is not the question. "Is the magnet the right investment for this audience and goal" is.
+
+---
+
+## The opportunity-cost frame
+
+A magnet's cost is not just the build. It is the build plus the maintenance plus the sequence plus the team attention diverted from other work.
+
+**The build cost.** Format selection, copy, design, asset production, landing page, form integration, delivery automation. A meaningful magnet often takes 20-80 hours from scoping to launch.
+
+**The maintenance cost.** Magnets decay. References go stale, screenshots get outdated, the topic moves on. Maintenance often runs 2-4 hours per quarter per active magnet.
+
+**The sequence cost.** The post-download sequence is itself a build. 5-12 emails, copy and integration. 10-30 hours upfront.
+
+**The opportunity cost.** What else could the team have built with that time? A funnel improvement, a content piece, a paid-traffic optimization, a product improvement. The magnet's success has to clear the bar of those alternatives.
+
+The decision frame. The magnet earns investment when it produces more lift than the alternatives, accounting for the full cost of build plus maintenance plus sequence.
+
+---
+
+## The audience precondition
+
+Without an audience, the magnet has no one to convert.
+
+The chicken-and-egg pattern. Teams sometimes build magnets to "drive traffic." That works only if the magnet itself is shareable enough to attract traffic (rare) or if the team has a separate plan to drive traffic to the magnet's landing page.
+
+The realistic frame. The magnet converts traffic that already exists. Driving traffic is a separate problem (covered by `content-distribution`, paid media, SEO, and partnerships). Build the magnet for the traffic that already lands; do not expect the magnet to do the traffic-driving work.
+
+The exception. Genuinely shareable magnets (free tools, viral calculators, definitive industry reports) can drive their own traffic. But these are the minority of magnets, and the design effort to reach shareability is significant.
+
+---
+
+## The portfolio frame
+
+A team often has multiple magnets, not one. The portfolio earns more thought than any individual magnet.
+
+**The audience-segmentation frame.** Different magnets for different audience segments. The B2B SaaS founder magnet does not need to also serve the consumer marketer; segment-specific magnets often outperform generic ones.
+
+**The funnel-stage frame.** Magnets for top-of-funnel readers, magnets for middle-of-funnel evaluators, magnets for bottom-of-funnel near-buyers. Each stage has different value to deliver and different next-step offers.
+
+**The maintenance frame.** A portfolio of 4-6 active magnets is often more sustainable than 12 mediocre ones. Periodic audit retires the underperformers and frees capacity for the strong magnets.
+
+**The cross-magnet promotion frame.** The follow-up sequence from one magnet can promote another. Subscribers who downloaded the templates checklist may also want the pricing one-pager.
+
+The portfolio approach amplifies the value of each strong magnet and makes maintenance manageable.
+
+---
+
+## The decision worked example
+
+A B2B SaaS targeting product managers at mid-market companies.
+
+**Conditions check.**
+
+- Traffic: 8000 monthly organic visitors, 1200 paid visitors. Yes.
+- Consideration cycle: typical PM tool evaluation takes 6-12 weeks. Yes.
+- Specific problem: PMs at mid-market companies struggle to define product metrics that the engineering team can instrument quickly. Yes.
+- Sequence capacity: marketing team has built two prior sequences; capacity exists. Yes.
+- Success metric: list growth at audience-fit (PMs at 50-500 person companies), conversion to product trial within 60 days. Yes.
+
+**Decision.** Build the magnet. The conditions warrant it.
+
+**Format selection.** Template plus worked example. The PM produces a usable artifact (the metric definition spec) inside 30 minutes.
+
+**Sequence.** 7-email arc over 21 days. Email 1 delivers the asset. Emails 2-4 deepen the value with related artifacts. Email 5 introduces the product as the next step. Emails 6-7 case study and offer.
+
+**Audit cadence.** Quarterly review of conversion rate, lead quality, sequence open and click rates, downstream trial conversion.
+
+The decision was not "should we have a magnet" but "given these conditions, this is the magnet to build."
+
+---
+
+## When to retire a magnet
+
+Magnets decay. Retiring them is part of the discipline.
+
+**Retire when:**
+
+- Conversion rate has dropped below baseline for two consecutive quarters.
+- The topic has shifted (the audience no longer cares about the problem the magnet solves).
+- A newer magnet on the same topic is outperforming and the older one is cannibalizing.
+- The follow-up sequence is no longer maintained and the leads go cold.
+- The references and screenshots are stale and updating them costs more than retiring.
+
+The retiring discipline frees capacity. A portfolio of dead magnets costs maintenance attention without producing results. Honest retirement is part of the program.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The decision conditions for whether to build a magnet. The opportunity-cost frame. The audience precondition. The portfolio frame. The retirement discipline. The decision worked example. The honest "no" cases where a magnet adds friction.
+
+## Implementation choices that stay internal
+
+Specific magnet topics for specific audiences. The team's capacity benchmarks for build, maintenance, and sequence work. Specific tooling for landing pages, forms, delivery, and sequence. Specific success-metric definitions and baselines. The team's portfolio composition and audit calendar. These vary by team and audience.

--- a/skills/lead-magnet-design/references/title-and-presentation-discipline.md
+++ b/skills/lead-magnet-design/references/title-and-presentation-discipline.md
@@ -1,0 +1,190 @@
+# Title and presentation discipline
+
+Title patterns that work and patterns that fail. Cover, landing-page preview, first-page discipline.
+
+The magnet's title is the conversion lever and the qualification filter at the same time. Beyond the title, the cover, the landing-page preview, and the first page each carry signal about whether the resource will deliver. Get any of these wrong and the rest of the magnet's design effort is wasted.
+
+---
+
+## Title patterns that work
+
+Specific, honest, signals what is inside.
+
+**Specific outcome plus specific audience.** "The B2B onboarding email sequence that 3x'd our 14-day activation rate (for SaaS founders)."
+
+What works: the specific outcome (3x'd, 14-day activation), the specific audience (SaaS founders), the specific deliverable (email sequence). The reader knows exactly what they get and can predict whether it applies.
+
+**Specific deliverable plus specific situation.** "The pricing one-pager for SaaS founders raising a seed round."
+
+What works: the artifact (pricing one-pager), the situation (raising a seed round). Niche by design; the audience that converts is exactly the audience the brand wants to engage.
+
+**Specific framework plus specific problem.** "The 4-question framework for deciding whether to fire a customer."
+
+What works: the framework's structure (4 questions), the specific decision (fire a customer). Promises a tool, not a treatise.
+
+**Specific count plus specific value.** "23 onboarding emails, with the open and click rate for each."
+
+What works: the count (signals scope), the value-add (real metrics, not just templates). The reader knows the resource includes evidence.
+
+**Specific transformation.** "The audit that took our trial-to-paid rate from 8 percent to 14 percent."
+
+What works: the before-state (8 percent), the after-state (14 percent), the mechanism (the audit). The reader can imagine running their own version.
+
+---
+
+## Title patterns to avoid
+
+Vague, overpromising, or generic. These titles correlate with thin-bait and kitchen-sink-resource patterns.
+
+**"Ultimate Guide to X."** Vague. Promises completeness; underdelivers reliably. The "Ultimate" qualifier signals that the team did not narrow the topic.
+
+**"The Complete X Playbook."** Same failure mode. Promises volume; suggests the resource is big and unfocused.
+
+**"Free X Resource."** Generic. Tells the reader nothing about what makes this resource the one to download. The "free" framing implies the resource has to apologize for asking for the email.
+
+**"10 Tips for Better X."** Listicle framing signals thin content. "10 tips" is rarely a useful resource; "the 1 specific change that doubled our X" is.
+
+**"X 101" or "Beginner's Guide to X."** Targets a low-investment audience. The list that grows from these titles tends to convert poorly to anything beyond the magnet.
+
+**"The Definitive X Resource."** Self-aggrandizing. Definitive is the reader's judgment, not the marketer's claim.
+
+**Vague verbs.** "Master," "Unlock," "Transform." Without specificity about what or how, these are filler.
+
+---
+
+## The honesty discipline in titles
+
+The title should not promise more than the magnet delivers.
+
+**The check.** Read the title. Then open the magnet. Does the magnet deliver on the title's specific promise? If yes, the title is honest. If the title overpromises, redesign the title (or strengthen the magnet) before launching.
+
+**The consequence of dishonesty.** Readers download, find the gap between title and content, and unsubscribe. Worse, they remember the brand as the source of the gap. The conversion-rate metric looks fine; the brand reputation degrades.
+
+**The conservative title.** A title that slightly under-promises and then delivers more is better than a title that overpromises and disappoints.
+
+---
+
+## Cover and visual presentation
+
+The cover is the second visual the reader processes (after the landing page hero). It should reinforce the title's specificity.
+
+**Strong cover patterns.**
+
+- **Type-driven covers.** The title in clean, large type. Color-blocked. Reads at thumbnail size.
+- **Single-image covers.** A specific image (a screenshot, a diagram, a person) that signals what the magnet contains.
+- **Brand-consistent covers.** Visual style matches the brand the magnet represents.
+
+**Weak cover patterns.**
+
+- **Stock-image covers.** Generic stock photos signal generic content.
+- **Cluttered covers.** Too many visual elements; the title gets lost.
+- **Off-brand covers.** Cover that does not match the brand the reader saw on the landing page; signals inconsistency.
+
+**The cover-as-thumbnail test.** The cover will be displayed at thumbnail size in social shares, in landing-page previews, and in delivery emails. Does it read at thumbnail size? If not, redesign.
+
+---
+
+## Landing-page preview
+
+The landing page (which is the `landing-page-copy` skill's domain) should preview the magnet, not just describe it.
+
+**Strong preview patterns.**
+
+- **Show pages from inside.** Screenshots of actual pages from the magnet. The reader sees the resource before they download.
+- **Show worked examples.** A specific page from the template, the checklist, or the swipe file. Concreteness lifts conversion.
+- **Show the table of contents.** For longer magnets, show what is inside. The reader can predict whether the resource will help.
+
+**Weak preview patterns.**
+
+- **Stock-image hero only.** The landing page shows nothing of the actual magnet. The reader has to trust the marketing without evidence.
+- **Generic descriptions.** "Learn the framework that..." without showing the framework.
+- **Hidden contents.** "You will learn..." without showing what learning looks like in the resource.
+
+The preview is the second-best evidence that the magnet delivers (the best evidence is post-download, but the preview is the pre-download proxy). Strong previews lift conversion and reduce post-download disappointment.
+
+---
+
+## First-page discipline
+
+The first page of the magnet is what the reader sees on opening. It sets the expectation for the rest.
+
+**The first page should deliver value within the first read.** The reader has just downloaded; they are most engaged in the first 30 seconds. Use the first page to deliver the headline insight, the first checklist item, the template's first prompt, the calculator's first input.
+
+**The first page should NOT.**
+
+- Warm up with author bio. The reader did not download the magnet to read about the author.
+- Spend space on brand-positioning. The reader knows whose brand they downloaded from; they want the value.
+- Recap the marketing. The landing page already sold the magnet; the first page should deliver, not re-sell.
+- Defer the value. "In Chapter 3, you will learn..." loses the reader who wanted the value now.
+
+**The first-page test.** Open the magnet. Does the first page deliver something useful? If yes, the first-page discipline holds. If no, redesign the first page to deliver value upfront.
+
+---
+
+## Title-magnet alignment audit
+
+Periodically audit titles against the magnets they represent. Drift accumulates: titles get polished while magnets remain unchanged, and the gap between promise and delivery widens.
+
+**The audit.**
+
+- For each active magnet, read the title and open the magnet.
+- Does the magnet deliver on the title's specific promise?
+- If not, the gap is either a title that overpromises (fix the title) or a magnet that underdelivers (strengthen the magnet).
+
+**The audit cadence.** Quarterly is reasonable for active magnets. Drift detection is part of magnet portfolio maintenance.
+
+---
+
+## Worked title revisions
+
+**Original title: "Marketing Automation Guide."**
+
+Failure: vague, generic, overpromises (which guide?).
+
+**Revised title: "The 7-email re-engagement sequence we send to trial signups who go cold (with open and click rates)."**
+
+What changed: specific deliverable (7-email sequence), specific situation (trial signups who go cold), specific evidence (open and click rates).
+
+**Original title: "B2B Lead Generation Playbook."**
+
+Failure: "Playbook" suggests volume without focus. "B2B Lead Generation" is too broad to focus a single resource.
+
+**Revised title: "The cold-email template for B2B SaaS founders selling into mid-market product teams."**
+
+What changed: specific format (template), specific audience (B2B SaaS founders), specific buyer (mid-market product teams). Niche by design.
+
+**Original title: "The Complete Pricing Guide."**
+
+Failure: "Complete" overpromises; "Pricing Guide" suggests volume; the guide will likely be a kitchen-sink-resource.
+
+**Revised title: "The pricing one-pager template for SaaS founders raising a seed round."**
+
+What changed: specific deliverable (one-pager template), specific situation (raising a seed round). Tight scope; usable immediately.
+
+The pattern: replace vague nouns and adjectives with specific deliverables, audiences, and situations. The revision often shrinks the addressable audience and improves the qualified-lead rate.
+
+---
+
+## Common title and presentation failures
+
+**Title overpromises.** The reader downloads, opens, finds less than expected, and unsubscribes.
+
+**Title is generic.** Anyone could want this; no one specifically wants it.
+
+**Cover signals stock content.** Generic visual; reader's expectation drops before opening.
+
+**Landing page hides the magnet.** The reader has no evidence the resource will deliver; conversion suffers.
+
+**First page warms up instead of delivering.** Author bio, brand statement, table of contents. The reader's engagement drops.
+
+**Drift between title and content.** The title was strong at launch; the magnet has not been updated; the gap has widened over time.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+Title patterns that work and fail. The honesty discipline. Cover and visual presentation patterns. Landing-page preview discipline. First-page discipline. The title-magnet alignment audit. Worked title revisions. Common failures.
+
+## Implementation choices that stay internal
+
+Specific titles for the team's magnets. Specific cover-design conventions and brand application. Specific landing-page templates and layout choices. Specific first-page templates and brand voice. The team's audit calendar and revision processes. These vary by team.

--- a/skills/lead-magnet-design/references/would-they-pay-for-this-test.md
+++ b/skills/lead-magnet-design/references/would-they-pay-for-this-test.md
@@ -1,0 +1,158 @@
+# The "would they pay for this" test
+
+The pricing thought experiment that distinguishes earned-value from thin-bait. A single test the magnet either passes or fails before launch.
+
+The question is simple. If the magnet were not free, would someone in the target audience actually pay for it? Not pay enterprise pricing, not pay for a course, but pay something (5 dollars, 25 dollars, 100 dollars) because the value is concrete enough to justify the cost?
+
+The honest answer matters. A magnet that fails the test is signaling that the value is below "I would pay for this," which means the reader's time investment to download and consume is at the edge of "worth it." The unsubscribe rate, the reduced trust, and the wasted email gate all follow from a failed test.
+
+---
+
+## How to apply the test
+
+The test is a thought experiment, not a market study. Run it before the magnet ships.
+
+**Step 1: Imagine a stranger in the target audience.** Not the team's existing customer; not someone already on the list. A stranger who has not yet committed to the brand.
+
+**Step 2: Imagine showing them the magnet (the actual content, not the marketing).** Not the landing page; not the headline; the resource itself in the form they would receive it.
+
+**Step 3: Ask: would this person, having seen this resource, pay something for it?** A small amount, an honest amount.
+
+**Step 4: Be specific about the price.** Would they pay 5 dollars? 25 dollars? 100 dollars? The specific number forces an honest answer.
+
+The test fails when the honest answer is "no, they would not pay for this; they would expect it to be free or to come bundled with something else." The test passes when the honest answer is "yes, this is worth paying for, even at a small price, because the value is concrete."
+
+---
+
+## What the test catches
+
+Three failure modes the test catches reliably.
+
+**The 5-page PDF that summarizes blog content.** Free elsewhere, available without a gate, worth 0 dollars in a paid context. Fails.
+
+**The "Ultimate Guide" that nobody finishes.** Pay-worthy in theory (comprehensive coverage), not delivered in usable form. The reader pays for the resource and never extracts the value because the resource is too long to consume. The test surfaces this when the team imagines whether the reader would actually use what they paid for.
+
+**The template that is so generic it adds no value over starting from scratch.** Pay-worthy framing (templates feel valuable), thin in execution (the template's content is "Insert your value here" 30 times). The test catches this when the team imagines the reader's reaction on opening the template.
+
+The test catches these failures because the question forces honesty about the resource's actual value rather than the resource's marketing claim.
+
+---
+
+## What the test the magnet should pass looks like
+
+A magnet that passes is one where:
+
+- A reader in the target audience would pay for this resource because it produces a result they need.
+- The resource is in a usable form (consumable in the time the reader is willing to spend, applicable to their specific situation).
+- The resource is hard to find elsewhere or hard to assemble at the same quality.
+
+The first criterion is about value. The second is about usability. The third is about uniqueness or curation. A magnet that hits all three earns the email reliably.
+
+**Worked example: A passing magnet.**
+
+The B2B SaaS founder magnet "the welcome-email template that 4x'd our trial-to-paid rate."
+
+- Pay-worthy: a SaaS founder would pay 25-50 dollars for a template that demonstrably 4x'd a real trial-to-paid rate. The specificity (4x, real metric, real source) makes the payment plausible.
+- Usable: 7 emails, copy-paste ready, with sender-side context for each. A founder can implement in 60 minutes.
+- Unique: the specific template plus the specific result is not freely available elsewhere.
+
+The magnet passes. It is worth the email.
+
+**Worked example: A failing magnet.**
+
+The "Marketing Trends 2026" PDF.
+
+- Pay-worthy: a generic trends roundup is not worth paying for. Freely available analyses cover the same ground. The specificity is missing.
+- Usable: a 30-page PDF of trend descriptions does not produce a result; it produces awareness, which the reader could have gotten elsewhere.
+- Unique: marketing trend roundups are commoditized; this one is not differentiated.
+
+The magnet fails. It captures emails that decay because the resource did not earn the relationship.
+
+---
+
+## When the test surfaces "almost passes"
+
+Sometimes the answer is "they might pay 5 dollars but not 25 dollars." This is signal, not failure.
+
+**The action.** Strengthen the resource until the answer becomes "yes, they would pay 25 dollars." This often means adding the specific worked example, the specific case study, or the specific tooling that makes the resource concretely useful.
+
+**The risk of skipping.** Shipping the "5 dollar" version saves time but produces conversion-rate metrics that look fine and lead-quality metrics that disappoint. The strengthened version costs more upfront and pays back in lead quality and downstream conversion.
+
+The test surfaces the gap between the magnet as built and the magnet at value-strong. The work to close the gap is often the difference between thin-bait and earned-value-magnet.
+
+---
+
+## When the test surfaces "this should not be a magnet"
+
+Sometimes the honest answer is that the resource would not be paid for at any price.
+
+**The action.** Do not ship the magnet. Either redesign the resource until it would be paid for, or accept that the resource is content (not a magnet) and publish it ungated.
+
+**The release valve.** Not every piece of content has to be gated. Free, ungated content has its own value (SEO, distribution, brand). Forcing a gate onto thin content costs more than it adds.
+
+The test sometimes leads to "this should not be a magnet at all." That outcome is fine; it prevents shipping a thin-bait magnet that costs list trust.
+
+---
+
+## When the test surfaces "this is so valuable we should sell it"
+
+Occasionally the honest answer is that the resource would be paid for at a meaningful price (200 dollars, 500 dollars).
+
+**The decision.** The team has a choice. Sell the resource (and use a different, more right-sized magnet for list-building) or use the high-value resource as the magnet (which signals exceptional generosity and often produces strong conversion at high lead quality).
+
+**The high-value-as-magnet pattern.** Some brands give away exceptionally valuable resources as magnets specifically to signal expertise and generosity. The conversion to paid offerings often increases because the magnet establishes credibility.
+
+The test surfaces this opportunity. The team's decision depends on the broader strategy.
+
+---
+
+## The team-honesty discipline
+
+The test only works if the team answers honestly. Pressure to ship, sunk cost in production, attachment to the magnet's framing all bias the answer toward "yes."
+
+**The discipline.**
+
+- Have someone outside the magnet's authoring team apply the test. Outside-in honesty often catches what the authoring team rationalizes.
+- Show the actual resource, not the marketing. The pretty landing page is not the test; the PDF or the template is.
+- Be specific about the price. "Would they pay something" is too vague; "would they pay 25 dollars" forces specificity.
+- Take the answer seriously. If the team applies the test and answers no, do not ship the magnet without redesign.
+
+The test's value is in the honesty it surfaces. A team that applies it and ignores the answer is worse off than a team that does not apply it at all.
+
+---
+
+## What to do when the test fails
+
+The magnet fails the test. Now what.
+
+**Option 1: Strengthen the magnet.** Add the specific worked example, case study, tooling, or framework that brings the value to pay-worthy. This is often the right answer.
+
+**Option 2: Redesign as a different format.** The topic might not be magnet-shaped in the current format. A 30-page ebook on a topic might fail; a 2-page checklist on the same topic might pass.
+
+**Option 3: Reframe the audience.** The magnet's value depends on the audience. A magnet that fails for the broad audience might pass for a narrower segment that genuinely needs the resource.
+
+**Option 4: Do not ship.** Some magnets should not exist. Killing the magnet is honest; shipping a thin one costs more in list trust than killing it costs in sunk effort.
+
+The team's response to a failed test is the discipline marker. Strong programs redesign or kill; weak programs ship anyway.
+
+---
+
+## Common test failure modes
+
+**The team rationalizes the failure.** "It is good enough; readers will appreciate it being free." This is the path to thin-bait.
+
+**The team applies the test to the wrong audience.** "Would a generalist marketer pay for this" when the magnet is for SaaS founders. The test must use the actual target audience.
+
+**The team applies the test to the marketing, not the resource.** The landing page sounds great; the resource is thin. The test surfaces this when applied to the actual content.
+
+**The team skips the test under deadline pressure.** The magnet ships, the metrics look fine, the unsubscribe rate quietly climbs. The test was the protection against this; skipping it costs trust.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The test as a thought experiment with specific steps. The failure modes the test catches. The criteria a passing magnet meets. The team-honesty discipline. The decision tree when the test fails. The test failure modes.
+
+## Implementation choices that stay internal
+
+Specific magnets the team has tested and the outcomes. Specific price-point conventions for the team's audience. The team's outside-team review process. Specific redesign patterns the team uses for failing magnets. These vary by team and audience.

--- a/skills/multi-step-form-design/SKILL.md
+++ b/skills/multi-step-form-design/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: multi-step-form-design
+description: "Designing forms with multiple steps, progress indicators, conditional logic, and save-and-resume mechanics. The discipline of breaking complex data collection into stages that respect cognitive load while maintaining completion intent. Honest about kitchen-sink-single-page (overwhelms before the user starts), progress-theater (steps without genuine staging), and genuinely-staged (each step earns its own page) patterns. Triggers on multi-step form, multi-page form, form wizard, signup wizard, lead form, application form, intake form, configurator, onboarding form. Also triggers when a long form is converting poorly, when an audience is dropping off mid-form, or when a multi-step form is being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing multi-step forms that respect cognitive load while maintaining completion intent. Distinguishes kitchen-sink-single-page (overwhelms) from progress-theater (steps without genuine staging) from genuinely-staged (each step earns its own page)"
+display_order: 4
+---
+
+# Multi-Step Form Design
+
+A senior growth practitioner's playbook for designing forms with multiple steps, progress indicators, conditional logic, and save-and-resume mechanics. The discipline of breaking complex data collection into stages that respect cognitive load while maintaining completion intent.
+
+Most multi-step forms are either kitchen-sink-single-pages dressed up as steps or arbitrary chunking that adds friction without adding clarity. The form looks more sophisticated; the completion rate does not move; the audience is no better served than before.
+
+The multi-step forms that work do something different. Each step represents a coherent unit of cognitive work the user can complete with confidence. Progress indicators reinforce momentum. Conditional logic responds to earlier answers and removes irrelevant fields. The form feels like a guided process, not an obstacle course.
+
+The voice is the senior growth practitioner who has watched multi-step forms convert at twice the single-page rate and watched them collapse to half. Practical, opinionated about when steps add value and when they add friction, willing to call out arbitrary chunking that does not earn its complexity.
+
+When to use this skill: scoping a multi-step form for the first time, auditing a long single-page form that converts poorly, deciding when to break a form into steps and when to keep it on one page, or designing the conditional logic that makes the form feel adaptive.
+
+---
+
+## What this skill covers
+
+This skill spans multi-step form design across acquisition, onboarding, and intake contexts. The growth-tooling distinctions:
+
+- `lead-magnet-design` covers lead-magnet methodology; forms are one delivery surface for lead magnets but this skill is about the form itself.
+- `landing-page-copy` is the page wrapping the form. This skill is the form itself.
+- `accessibility-audit` covers accessibility deeply; forms have specific accessibility requirements; this skill references but does not replace accessibility-audit.
+- `pm-spec-writing` is the spec for engineers building the form. This skill is about WHAT to build; pm-spec-writing is about communicating it.
+- **`multi-step-form-design` (this skill)** is the form's structure, step architecture, progression, and validation.
+
+The audience: growth marketers, product marketers, marketing teams designing acquisition forms, in-house teams designing onboarding flows, agencies running form-based growth tooling for clients.
+
+Out of scope: form-builder platform configurations (those stay implementation-side); deep accessibility audits (covered by `accessibility-audit`); landing-page copy that wraps the form (covered by `landing-page-copy`).
+
+---
+
+## The multi-step decision: when to break into steps vs keep single-page
+
+Before designing the steps, decide whether the form should be multi-step at all.
+
+**Multi-step earns the build when:**
+
+- The form has more than 8-10 fields. Single-page forms beyond this point overwhelm the audience visually.
+- The fields naturally group into logical categories. Personal info, then situation, then preferences. Steps that reflect real groupings respect cognitive load.
+- The audience benefits from progressive commitment. Each step builds investment; the user is more likely to complete after they have engaged with step 2 than they would have been if they had seen step 5's complexity upfront.
+- Different paths through the form make sense based on early answers. Conditional logic that adapts the form to the user is hard to do on a single page.
+
+**Multi-step does NOT earn the build when:**
+
+- The form has 4-6 fields. A single-page form is faster to complete and faster to maintain.
+- The fields do not group naturally. Arbitrary chunking is friction.
+- The audience expects speed. Quick contact forms, simple lead-capture forms, and high-intent CTAs often convert better as single-page.
+- The team cannot maintain the multi-step complexity. Multi-step forms have more failure modes; the maintenance overhead is real.
+
+The decision is not "should the form be multi-step"; it is "is multi-step the right structure for this specific data collection and audience."
+
+Detail in `references/multi-step-decision-criteria.md`.
+
+---
+
+## Kitchen-sink-single-page vs progress-theater vs genuinely-staged
+
+The keystone framing.
+
+**Kitchen-sink-single-page.** 30 fields on one page. Overwhelms before the user even starts. Drop-off near 100 percent on anything beyond a contact form. The audience scrolls, sees the length, and leaves. Cost: the form's data collection scope is correct; the structure is wrong; nobody completes it.
+
+**Progress-theater.** The form is broken into 5 steps but the steps are arbitrary. "Step 1: name. Step 2: email. Step 3: phone. Step 4: company. Step 5: role." The progress bar exists; the staging logic does not. Cost: the form feels broken; users reach step 3 wondering why they did not just fill a single page; the completion rate may be slightly better than kitchen-sink but the audience perceives the format as gimmicky.
+
+**Genuinely-staged.** Each step represents a coherent unit of cognitive work. The user finishes a step and feels they accomplished something. Steps progress from low-friction to higher-commitment as intent compounds. Cost: the design effort upfront is significant; the maintenance is real; the conversion rate often outperforms both alternatives meaningfully.
+
+The litmus test. Ask a user who completed step 2 what they just did. Can they describe the unit of work as something coherent ("I gave you the basics about my company") or is the answer atomized ("I typed my company name in a field")? Coherent answers signal genuinely-staged; atomized answers signal progress-theater.
+
+---
+
+## Step architecture: what belongs on each step
+
+The structure that makes steps coherent.
+
+**The principle.** Each step should represent a coherent unit of work from the user's perspective.
+
+**Common step patterns.**
+
+- **Identity step.** Who the user is. Name, email, basic role. Low-friction; opens the form.
+- **Context step.** What the user's situation is. Company size, industry, current setup. Medium-friction; user shares context.
+- **Need step.** What the user is trying to accomplish. Goals, challenges, priorities. Higher-friction; user articulates intent.
+- **Detail step.** Specifics needed to act on the user's request. Budget, timeline, specific requirements. Highest-friction; saved for last.
+- **Confirmation step.** Review and submit. Summarizes what the user provided.
+
+**Step sequencing principle.** Low-friction first; commitment compounds; high-friction at the end after the user has invested.
+
+**Step coherence test.** Can each step be described in one sentence as a unit of work? "Step 2: tell us about your company's situation" beats "Step 2: company name, size, industry, and revenue range."
+
+Detail in `references/step-architecture-patterns.md`.
+
+---
+
+## Progress indicator design
+
+When to show progress, what to show, how it builds momentum.
+
+**The principle.** Progress indicators reinforce momentum and reduce uncertainty about how much is left.
+
+**Progress indicator patterns.**
+
+- **Step counter.** "Step 2 of 4." Simple, common, effective for short forms (3-6 steps).
+- **Progress bar.** Visual fill showing percentage complete. Effective for forms with variable-length steps where step count alone is misleading.
+- **Step list.** Named steps shown with the current one highlighted. Useful when the user benefits from seeing what comes next.
+- **No indicator.** Sometimes appropriate for very short forms (2-3 steps) where the indicator overhead exceeds its value.
+
+**Progress indicator failures.**
+
+- **Indicator that shifts mid-form.** "Step 4 of 5" becomes "Step 4 of 7" because conditional logic added steps. The user feels misled.
+- **Indicator that hides remaining work.** Showing "almost done" when 5 fields remain on the next step.
+- **Indicator that is decorative without being honest.** Progress that looks fast but the next step is the longest one.
+
+**Progress indicator discipline.** The indicator must reflect the actual remaining work, not flatter the user.
+
+Detail in `references/progress-indicator-patterns.md`.
+
+---
+
+## Conditional logic
+
+Branching that responds to earlier answers.
+
+**The principle.** Show only fields that are relevant to the user's situation. Skip fields that do not apply.
+
+**Conditional logic patterns.**
+
+- **Show or hide fields based on previous answers.** "If user selected 'enterprise,' show enterprise-specific fields."
+- **Skip entire steps.** "If user does not have a current CRM, skip the 'CRM details' step."
+- **Adapt the language.** "If user is in healthcare, use healthcare-specific terminology in subsequent fields."
+- **Adapt the destination.** "If user selected 'integration question,' route to the integration team after submission."
+
+**Conditional logic strengths.**
+
+- Removes irrelevant friction.
+- Makes the form feel adaptive and intelligent.
+- Reduces drop-off because users do not abandon over fields that did not apply.
+
+**Conditional logic risks.**
+
+- Maintenance complexity grows quickly.
+- Testing becomes harder (more paths through the form).
+- Progress indicators must adapt or honestly disclose the variability.
+
+**The simplicity preference.** Add conditional logic only when it produces real value. Conditional logic for decoration adds maintenance without lift.
+
+Detail in `references/conditional-logic-patterns.md`.
+
+---
+
+## Save-and-resume mechanics
+
+When to offer save-and-resume, how to communicate trust.
+
+**The principle.** Save-and-resume reduces drop-off for forms that take more than 5 minutes to complete or that require information the user may not have at hand.
+
+**When save-and-resume helps.**
+
+- Forms that require document uploads or specific information (W-2, financial details, technical configurations).
+- Forms that are part of multi-touchpoint workflows (loan applications, enrollment forms).
+- Forms where the user benefits from coming back to verify or update.
+
+**When save-and-resume does not help.**
+
+- Quick lead-capture forms (under 60 seconds to complete).
+- Single-session forms where save-and-resume adds complexity without lift.
+
+**Save-and-resume mechanics.**
+
+- **Email-link recovery.** "Save your progress; we will email you a link to continue." The most common pattern.
+- **Account-based persistence.** Forms that require account creation persist by default.
+- **Anonymous-session save.** Browser-based save without identification. Lowest friction but limited to the same browser/device.
+
+**Trust communication.** Users hesitate to save partial sensitive information. The form should communicate clearly: what is saved, how long it persists, who can access it, how to resume.
+
+Detail in `references/save-and-resume-mechanics.md`.
+
+---
+
+## Validation strategy
+
+Per-step vs end-only.
+
+**Per-step validation.** Each step's fields are validated before allowing progression. The user catches errors early.
+
+**Strengths.**
+
+- Errors caught at the point of input.
+- User does not invest in completing later steps only to discover an early error.
+- Form feels responsive.
+
+**Weaknesses.**
+
+- Can feel intrusive if validation is too strict on every keystroke.
+- May block the user from progressing when they want to revise later.
+
+**End-only validation.** All validation runs at submission.
+
+**Strengths.**
+
+- User completes uninterrupted.
+- Validation logic is simpler.
+
+**Weaknesses.**
+
+- User invests in entire form only to discover an early error.
+- Errors at the end can lose the user.
+
+**The hybrid pattern.** Required-field validation per step; full validation at end. The user gets immediate feedback on critical issues; nuanced validation runs at submission.
+
+**Validation message discipline.**
+
+- Helpful messages: "Phone number must include area code" beats "Invalid phone number."
+- Inline placement: errors appear next to the field, not in a banner.
+- Specific guidance: "Try a value between 1 and 1000" beats "Out of range."
+
+Detail in `references/validation-strategy-patterns.md`.
+
+---
+
+## Drop-off measurement and remediation
+
+Where users abandon, and how to fix it.
+
+**Step-by-step drop-off tracking.** Track the percentage of users who reach each step and the percentage who complete it. The diagnostic data informs which steps need redesign.
+
+**Common drop-off points.**
+
+- **First field.** User clicked into the form, looked at it, and left. Often signals the form is too long or the value of completing is not clear.
+- **Mid-form.** User abandoned mid-process. Often signals fatigue, sensitive questions, or unclear progress.
+- **Final submission.** User completed all fields but did not submit. Often signals submission anxiety, validation error fear, or unclear next-step.
+
+**Remediation patterns.**
+
+- **First-field drop-off.** Reduce form length; clarify the value of completing; add social proof or trust signals.
+- **Mid-form drop-off.** Audit the specific step where drop-off concentrates; add progress indicator; reduce field count on that step; reword sensitive questions.
+- **Final-submission drop-off.** Add a confirmation step; reduce final-step requirements; clarify what happens after submission.
+
+**The instrumentation requirement.** Without per-step tracking, drop-off remediation is guesswork. Set up tracking before the form launches.
+
+Detail in `references/drop-off-measurement-and-remediation.md`.
+
+---
+
+## Form anti-patterns
+
+Patterns that look like multi-step forms but degrade conversion.
+
+**The kitchen-sink-single-page.** 30 fields on one page. Detail in keystone framing.
+
+**The progress-theater form.** Steps without genuine staging. Detail in keystone framing.
+
+**The arbitrary-chunking form.** Each step has 1-2 fields; user wonders why this is multi-step.
+
+**The hidden-length form.** No progress indicator; user does not know how long the form is; abandonment climbs.
+
+**The interrogation-form-with-steps.** 25 fields across 5 steps; the format is multi-step but the data collection is excessive.
+
+**The validation-strict form.** Validation that rejects too aggressively, frustrating users with valid inputs.
+
+**The mobile-broken form.** Form works on desktop, breaks on mobile.
+
+**The trust-broken form.** Save-and-resume offered without clear trust communication; user does not save because they distrust persistence.
+
+**The variable-step form.** Conditional logic that changes the step count visibly; user feels misled about remaining work.
+
+Detail in `references/form-anti-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-multi-step-form-failures.md`.
+
+- "Form converts at 4 percent; we expected 12 percent." Likely too long, or the value of completing is not clear, or the form is mobile-broken.
+- "Drop-off concentrates at step 3." Specific-step issue; audit step 3's field count, sensitivity, and clarity.
+- "Mobile completion is half of desktop." Mobile design issue; audit form behavior on actual devices.
+- "Validation rejects valid inputs." Validation strictness; relax the validation or improve the input formats accepted.
+- "Users abandon at submission." Final-step anxiety; add confirmation, reduce final requirements, clarify next step.
+- "Save-and-resume is offered but nobody uses it." Trust communication missing; users do not save because they distrust persistence.
+- "We added conditional logic; the form feels confusing." Conditional logic complexity outweighs benefit; simplify.
+- "We split the form into more steps; conversion did not change." Steps were not coherent; progress-theater pattern.
+- "Progress indicator shifts mid-form." Conditional logic added steps unexpectedly; either fix the indicator or fix the conditional logic.
+
+---
+
+## The framework: 12 considerations for multi-step form design
+
+When designing or auditing a multi-step form, walk these 12 considerations.
+
+1. **The multi-step decision.** Is multi-step the right structure for this data and audience, or would single-page serve?
+2. **Genuinely-staged, not kitchen-sink or progress-theater.** Each step represents a coherent unit of work from the user's perspective.
+3. **Step architecture sound.** Identity, context, need, detail, confirmation. Low-friction first; commitment compounds.
+4. **Progress indicator honest.** Reflects actual remaining work; does not shift mid-form.
+5. **Conditional logic adds value.** Removes irrelevant fields without adding maintenance overhead.
+6. **Save-and-resume mechanics fit the form.** Offered when the form length warrants; trust clearly communicated.
+7. **Validation strategy matched to form.** Per-step for required fields; end-only for nuanced validation.
+8. **Drop-off measurement instrumented.** Per-step tracking from launch.
+9. **Mobile experience tested.** Form works on the devices the audience uses.
+10. **Field count audited.** Each field necessary; non-essential fields removed.
+11. **Final-step clear.** Submission action obvious; what happens after submission communicated.
+12. **Maintenance discipline.** Quarterly review of conversion, drop-off, validation, and conditional logic.
+
+The output of the framework is a multi-step form that respects cognitive load, maintains completion intent, and converts the audience into the action the form is designed to capture.
+
+---
+
+## Reference files
+
+- [`references/multi-step-decision-criteria.md`](references/multi-step-decision-criteria.md) - When to break into steps vs keep single-page. The conditions that warrant the multi-step structure.
+- [`references/step-architecture-patterns.md`](references/step-architecture-patterns.md) - What belongs on each step. Identity, context, need, detail, confirmation. Sequencing principles.
+- [`references/progress-indicator-patterns.md`](references/progress-indicator-patterns.md) - Step counter, progress bar, step list. When each works. Indicator failures.
+- [`references/conditional-logic-patterns.md`](references/conditional-logic-patterns.md) - Show/hide fields, skip steps, adapt language. Strengths, risks, simplicity preference.
+- [`references/save-and-resume-mechanics.md`](references/save-and-resume-mechanics.md) - When to offer save-and-resume. Email-link, account-based, anonymous-session patterns. Trust communication.
+- [`references/validation-strategy-patterns.md`](references/validation-strategy-patterns.md) - Per-step vs end-only vs hybrid. Validation message discipline.
+- [`references/drop-off-measurement-and-remediation.md`](references/drop-off-measurement-and-remediation.md) - Step-by-step tracking. Common drop-off points and remediation patterns.
+- [`references/form-anti-patterns.md`](references/form-anti-patterns.md) - The patterns that look like multi-step forms but degrade conversion.
+- [`references/common-multi-step-form-failures.md`](references/common-multi-step-form-failures.md) - 9+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: multi-step forms earn completion when each step earns its place
+
+The multi-step forms that work as compounding assets are the ones the audience completes without resentment. Not because the form is short. Not because the steps are decorative. Because each step represented a coherent unit of cognitive work the user could complete with confidence, and the cumulative experience felt guided rather than obstructed.
+
+That is the bar. Below the bar are kitchen-sink-single-pages (overwhelm before the user starts) and progress-theater forms (decorative steps without coherence). Above the bar are genuinely-staged forms where the structure earns its complexity.
+
+The discipline is in the design choices upstream of the form. The decision to make the form multi-step (or not). The step architecture that makes each step coherent. The progress indicator that reflects honest progress. The conditional logic that removes friction without adding confusion. The validation that catches errors helpfully. The drop-off measurement that informs ongoing improvement.

--- a/skills/multi-step-form-design/references/common-multi-step-form-failures.md
+++ b/skills/multi-step-form-design/references/common-multi-step-form-failures.md
@@ -1,0 +1,187 @@
+# Common multi-step form failures
+
+9+ failure patterns with diagnoses and cures. The patterns that surface as "the form did not convert" or "audiences abandon mid-form" or "we cannot tell what is going wrong."
+
+---
+
+## "Form converts at 4 percent; we expected 12 percent."
+
+**The diagnosis.** Likely one of: too long, value of completing not clear, mobile-broken, or the audience-fit is wrong.
+
+**The cure.** Audit the form length (`references/multi-step-decision-criteria.md`); audit the value proposition on the landing page (`landing-page-copy`); test on mobile devices; verify the audience matches the form's purpose.
+
+---
+
+## "Drop-off concentrates at step 3."
+
+**The diagnosis.** Specific-step issue. Audit step 3's field count, sensitivity, and clarity.
+
+**The cure.** Per-step audit. Reduce field count if step 3 has too many; reword sensitive questions; clarify why step 3 is needed; consider whether step 3's content belongs there at all. Detail in `references/drop-off-measurement-and-remediation.md`.
+
+---
+
+## "Mobile completion is half of desktop."
+
+**The diagnosis.** Mobile design issue. The form was designed for desktop and breaks on mobile.
+
+**The cure.** Mobile-first redesign. Touch-friendly inputs, single question per screen on long steps, sliders sized for thumb interaction, progress indicator visible without scroll. Test on actual devices.
+
+---
+
+## "Validation rejects valid inputs."
+
+**The diagnosis.** Validation strictness. Rules are over-specified, rejecting inputs the system can handle.
+
+**The cure.** Audit validation rules (`references/validation-strategy-patterns.md`). Email with plus-signs, international phone formats, non-Latin names should all pass.
+
+---
+
+## "Users abandon at submission."
+
+**The diagnosis.** Final-step anxiety. The CTA is unclear; the user does not know what happens; the final field requires information they did not have.
+
+**The cure.** Clarify the CTA ("Get my PDF" beats "Submit"). Add post-submission preview. Add a confirmation step. Move final-field demands earlier if the user needs time to gather info.
+
+---
+
+## "Save-and-resume is offered but nobody uses it."
+
+**The diagnosis.** Trust communication missing. Users do not save because they distrust persistence.
+
+**The cure.** Trust copy alongside the save option. What is saved, how long, who can access. Detail in `references/save-and-resume-mechanics.md`.
+
+---
+
+## "We added conditional logic; the form feels confusing."
+
+**The diagnosis.** Conditional logic complexity outweighs benefit. Either too many rules or rules that change the user's experience visibly without explanation.
+
+**The cure.** Simplify the conditional logic. Remove rules that do not justify their value. Communicate variability if it remains. Detail in `references/conditional-logic-patterns.md`.
+
+---
+
+## "We split the form into more steps; conversion did not change."
+
+**The diagnosis.** Steps were not coherent. Progress-theater pattern. Splitting fields without grouping them into meaningful units does not produce the multi-step benefit.
+
+**The cure.** Restructure into genuinely-staged steps. Each step should represent a coherent unit of cognitive work. Detail in `references/step-architecture-patterns.md`.
+
+---
+
+## "Progress indicator shifts mid-form."
+
+**The diagnosis.** Conditional logic added or removed steps unexpectedly.
+
+**The cure.** Either fix the indicator to handle conditional steps honestly, or fix the conditional logic to not change step counts visibly. Detail in `references/progress-indicator-patterns.md`.
+
+---
+
+## "We cannot tell where users abandon."
+
+**The diagnosis.** Instrumentation missing. No per-step tracking.
+
+**The cure.** Add per-step tracking before any further changes. Without data, remediation is guesswork. Detail in `references/drop-off-measurement-and-remediation.md` (instrumentation requirement).
+
+---
+
+## "Conversion is fine; lead quality is poor."
+
+**The diagnosis.** The form is converting the wrong audience. Either the audience-fit on the landing page is broad, or the form does not filter for the audience the team needs.
+
+**The cure.** Tighten the audience-fit upstream. The form may need fewer fields (less interrogation) but more qualifying fields (audience-segmentation). Detail in `lead-magnet-design`'s audience-fit qualification.
+
+---
+
+## "Conversion was strong at launch; it has declined 30 percent over a year."
+
+**The diagnosis.** Form decay. Stale references, broken integrations, validation rules that no longer match reality.
+
+**The cure.** Quarterly maintenance audit. Update references, fix broken integrations, refresh validation rules.
+
+---
+
+## "We A/B tested adding a progress indicator; conversion did not change."
+
+**The diagnosis.** Either the form was already short enough that an indicator was not needed, or the indicator was poorly designed (dishonest, hidden, or confusing).
+
+**The cure.** Audit the indicator's design. If the form is genuinely short (3-4 steps), the indicator may not lift conversion much. If the form is longer, the indicator should help; redesign if it is not.
+
+---
+
+## "The form looks great in QA; users complain it is broken."
+
+**The diagnosis.** QA tested with the team's devices and browsers; users have different setups.
+
+**The cure.** Cross-browser, cross-device, cross-network testing. Consider real-world conditions (slow connections, older devices, accessibility tools).
+
+---
+
+## "The form's submit button is gray; we cannot figure out why."
+
+**The diagnosis.** Validation logic is preventing submission but the error is not surfaced. Common cause: a hidden required field or a cross-field validation that fails silently.
+
+**The cure.** Surface all validation errors visibly. Submit button state should follow form state visibly; the user should see why submit is disabled.
+
+---
+
+## "We added save-and-resume; nobody resumes."
+
+**The diagnosis.** Either users save but the recovery link does not arrive, or the resume experience is broken, or the form's value did not persist (the user's interest faded).
+
+**The cure.** Test the recovery email deliverability. Test the resume experience end-to-end. Consider whether save-and-resume is genuinely needed or whether it is decorative.
+
+---
+
+## "Sales says the form-sourced leads are wrong type."
+
+**The diagnosis.** Audience-fit mismatch. The form is converting the wrong segment.
+
+**The cure.** Audit the form's qualifying fields and the landing page that drives traffic. Either tighten the audience filter at the landing page, or add qualifying fields to the form that route based on segment.
+
+---
+
+## "We made the form shorter; submissions went up but lead quality went down."
+
+**The diagnosis.** The fields removed were qualifying fields. Conversion improved because friction dropped; quality dropped because the qualifying signal was lost.
+
+**The cure.** Decide whether quality or quantity matters more. Restore qualifying fields if quality matters; accept the lower quality if volume is the priority. Often the right answer is to restore some fields and accept some conversion impact.
+
+---
+
+## "The form works on Chrome desktop; it crashes on Safari mobile."
+
+**The diagnosis.** Browser/device-specific bugs. The form was tested on the team's primary platform.
+
+**The cure.** Cross-browser, cross-device testing. The audience uses what they use.
+
+---
+
+## "We translated the form to Spanish; conversion is half what English is."
+
+**The diagnosis.** Translation quality, cultural mismatch, or audience-fit issue specific to the Spanish-speaking audience. Often a combination.
+
+**The cure.** Audit the translation quality (idiomatic vs literal). Audit cultural assumptions (date formats, phone formats, name conventions). Verify the audience matches.
+
+---
+
+## The pattern across failures
+
+Most multi-step form failures fall into one of three patterns.
+
+**Pattern 1: The form is the wrong structure.** Kitchen-sink-single-page, progress-theater, arbitrary-chunking, hidden-length. The fix is structural.
+
+**Pattern 2: The form does not match the audience or the device.** Mobile-broken, validation-strict-against-international-inputs, audience-fit weak. The fix is matching the form to where the audience actually is.
+
+**Pattern 3: The form decays.** Stale references, broken integrations, drift in conditional logic, instrumentation drift. The fix is maintenance discipline.
+
+The metric pattern: form failures often look fine on submission count alone. The signal is in completion rate, drop-off per step, lead quality, and downstream conversion. Programs that track only submission counts keep shipping the same patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (structure, audience-device match, decay). The principle that submission count alone is insufficient as a success metric.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered and the lessons learned. Specific multi-metric dashboards the team uses. Specific cures the team applies. The team's audit and retirement processes. These vary by team.

--- a/skills/multi-step-form-design/references/conditional-logic-patterns.md
+++ b/skills/multi-step-form-design/references/conditional-logic-patterns.md
@@ -1,0 +1,270 @@
+# Conditional logic patterns
+
+Show/hide fields, skip steps, adapt language. Strengths, risks, simplicity preference.
+
+Conditional logic responds to earlier answers and removes irrelevant fields. Done well, it makes the form feel adaptive and intelligent. Done poorly, it adds maintenance complexity without improving the user experience.
+
+---
+
+## The relevance principle
+
+Show only fields that are relevant to the user's situation. Skip fields that do not apply.
+
+**The principle's win.** A user who answered "no, I do not have a CRM today" should not be asked "what CRM do you use today" three steps later. The conditional logic removes the friction.
+
+**The principle's risk.** Conditional logic adds maintenance complexity. Each branch has to be tested. Each branch can break. The simplicity preference: add conditional logic only when it produces real value.
+
+---
+
+## Pattern A: Show or hide fields based on previous answers
+
+The most common conditional logic pattern.
+
+**How it works.**
+
+- A field appears or disappears based on the answer to an earlier question.
+- "If user selected 'enterprise,' show enterprise-specific fields."
+- "If user selected 'has current solution,' show 'current solution name' field."
+
+**Example.**
+
+Question: "Do you currently use a CRM?"
+- Yes → show field "Which CRM do you use today?"
+- No → hide that field; show "What is your current process for managing customer data?"
+
+The form adapts to the user's situation in real time.
+
+**Strengths.**
+
+- Removes irrelevant fields.
+- Makes the form feel intelligent.
+- Reduces drop-off because users do not abandon over fields that did not apply.
+
+**Weaknesses.**
+
+- Each branch needs testing.
+- Late additions to the form can break conditional logic in unexpected ways.
+
+**When to use.** When showing all fields would be confusing or when irrelevant fields cause significant drop-off.
+
+---
+
+## Pattern B: Skip entire steps
+
+Conditional logic at the step level.
+
+**How it works.**
+
+- Based on early answers, an entire step is skipped or included.
+- "If user does not have a current CRM, skip the 'CRM details' step entirely."
+- "If user is in healthcare, include the 'compliance requirements' step."
+
+**Strengths.**
+
+- Removes whole sections of irrelevant content.
+- Form length adapts to the user.
+
+**Weaknesses.**
+
+- Progress indicators must adapt or honestly disclose variability.
+- The user may notice the form's variability and feel confused.
+
+**When to use.** When entire categories of fields are irrelevant to some users (e.g., enterprise-only fields for non-enterprise users).
+
+---
+
+## Pattern C: Adapt the language
+
+Conditional logic that changes terminology based on user context.
+
+**How it works.**
+
+- The form's wording adapts to the user's industry, role, or context.
+- "If user is in healthcare, use 'patient' terminology in subsequent fields."
+- "If user is technical, use technical terms; if non-technical, use plain language."
+
+**Strengths.**
+
+- Form feels personalized.
+- Reduces cognitive load on the user (they see terminology that matches their context).
+
+**Weaknesses.**
+
+- Significantly more copy to maintain.
+- Risk of inconsistent or awkward language.
+
+**When to use.** When the audience spans contexts where terminology genuinely differs (B2C vs B2B, technical vs non-technical, regulated vs unregulated industries).
+
+---
+
+## Pattern D: Adapt the destination
+
+Conditional logic that affects what happens after submission.
+
+**How it works.**
+
+- Based on answers, the form routes to different teams or triggers different follow-ups.
+- "If user selected 'integration question,' route to the integration team after submission."
+- "If user selected 'enterprise,' trigger an enterprise-sales follow-up sequence."
+
+**Strengths.**
+
+- The user gets matched to the right team or sequence.
+- Sales and support efficiency improve.
+
+**Weaknesses.**
+
+- Routing complexity grows; failure modes (wrong team, missed routing) increase.
+- The user does not see the routing logic; mistakes are invisible to the user but visible in downstream impact.
+
+**When to use.** When the form serves multiple downstream paths and the routing materially affects the user's experience.
+
+---
+
+## Pattern E: Branching forms
+
+Different paths through the form for different users.
+
+**How it works.**
+
+- Based on early answers, the user takes a different path entirely.
+- "If user selects 'individual,' show the individual flow; if 'team,' show the team flow."
+
+**Strengths.**
+
+- Highly tailored experience.
+- Each user only sees fields relevant to them.
+
+**Weaknesses.**
+
+- Significantly more complex to build and test.
+- Hard to compare paths because users took different forms.
+- Maintenance is hard.
+
+**When to use.** When the audience genuinely splits into distinct groups that need fundamentally different forms. Use sparingly.
+
+---
+
+## The simplicity preference
+
+Add conditional logic only when it produces real value.
+
+**The discipline.** For each piece of conditional logic, ask:
+- Does this remove genuine friction?
+- Is the maintenance cost justified by the friction removed?
+- Could a simpler approach (single-page with sectioned design) achieve the same goal?
+
+**The over-conditional form.** A form with 25 conditional rules across 8 fields. Each rule individually justifiable; cumulatively, the form is fragile and hard to maintain.
+
+**The cure.** Audit conditional logic periodically. Remove rules that do not justify their maintenance overhead.
+
+---
+
+## Conditional logic and progress indicators
+
+The interaction matters.
+
+**The challenge.** A form with conditional steps may have variable total step count. The progress indicator must accommodate.
+
+**Approaches.**
+
+- **Variable indicator.** "Step 2 of 5-7" or "Step 2 (about halfway)." Communicates the variability.
+- **Range indicator.** "Step 2 of about 5." Approximate but honest.
+- **Dynamic indicator.** Updates as the user's answers determine the path. Risk of feeling unstable.
+- **Step-list indicator.** Shows all possible steps; current step highlighted. Variability visible upfront.
+
+The discipline. Choose an approach that does not lie about progress.
+
+---
+
+## Conditional logic testing
+
+Test every branch of conditional logic.
+
+**The challenge.** A form with 5 conditional rules has 32 possible paths through the form. Testing all paths is infeasible at scale; testing critical paths is the discipline.
+
+**Critical paths.**
+
+- The most common path (most frequent user type).
+- Each conditional rule's branch (one path that triggers it, one that does not).
+- Edge cases (combinations that could produce unexpected behavior).
+
+**Testing methods.**
+
+- **Manual testing.** Walk through critical paths.
+- **Automated testing.** Programmatic tests for each branch.
+- **User testing.** Watch users complete the form; surface confusion or paths that break.
+
+**Production monitoring.** Track which paths users take. Sudden shifts may indicate logic issues.
+
+---
+
+## Conditional logic and analytics
+
+Track which conditional branches trigger.
+
+**Why.** Understanding which branches are common informs maintenance priorities. A branch nobody triggers may not be worth maintaining; a branch everyone triggers may not need to be conditional.
+
+**The metric.** Per-branch trigger rate. Per-branch conversion rate.
+
+**The discipline.** Periodically review the data. Retire conditional rules that do not pay off.
+
+---
+
+## Conditional logic and form maintenance
+
+Conditional logic decays.
+
+**What decays.**
+
+- Rules that point to fields that have been renamed or removed.
+- Rules that produce paths now unused as the audience shifts.
+- Rules whose triggering questions have been reworded.
+
+**Maintenance cadence.** Quarterly audit alongside the broader form audit.
+
+**The drift indicator.** Bug reports about specific paths failing; analytics showing unexpected branching behavior; testing surfaces broken rules.
+
+---
+
+## Common conditional logic failures
+
+**Hidden complexity.** Many rules silently affecting many fields; the form's behavior is hard to reason about.
+
+**Unintended interactions.** Two rules that work individually but conflict when combined.
+
+**Stale rules.** Rules that point to fields no longer in the form.
+
+**Dead branches.** Conditional paths nobody triggers; maintenance overhead with no payoff.
+
+**Indicator-rule mismatch.** Progress indicator that does not handle conditional step count.
+
+**Untested edge cases.** Unusual answer combinations that produce broken paths.
+
+**Rule-driven layout shifts.** Fields appearing and disappearing causing visual jumpiness.
+
+**Over-conditional forms.** 25+ rules across the form; the maintenance burden exceeds the friction-reduction value.
+
+---
+
+## When NOT to use conditional logic
+
+Some situations work better without conditional logic.
+
+**Short forms.** Adding conditional logic to a 5-field form rarely justifies the complexity.
+
+**Forms with stable audiences.** When everyone takes roughly the same path, conditional logic adds variability without value.
+
+**Forms in early stages.** A new form benefits from simplicity before adding complexity. Launch simple; add conditional logic when data shows where it would help.
+
+**Forms with high maintenance constraints.** Teams that cannot maintain complex forms should default to simpler designs.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The relevance principle. Patterns A through E with strengths, weaknesses, and when-to-use guidance. The simplicity preference. Conditional logic and progress indicators. Conditional logic testing. Conditional logic and analytics. Maintenance considerations. Common failures. When NOT to use conditional logic.
+
+## Implementation choices that stay internal
+
+Specific conditional rules for specific forms. Specific tooling for rule implementation and testing. The team's audit calendars and rule-retirement processes. These vary by team.

--- a/skills/multi-step-form-design/references/drop-off-measurement-and-remediation.md
+++ b/skills/multi-step-form-design/references/drop-off-measurement-and-remediation.md
@@ -1,0 +1,263 @@
+# Drop-off measurement and remediation
+
+Step-by-step tracking. Common drop-off points and remediation patterns.
+
+Drop-off is where the form fails. Measuring drop-off per step is the diagnostic that informs every other improvement. Without per-step tracking, drop-off remediation is guesswork.
+
+---
+
+## The instrumentation requirement
+
+Set up per-step tracking before the form launches.
+
+**The minimum tracking.**
+
+- **Step start.** User landed on this step.
+- **Step completion.** User completed this step (clicked Next).
+- **Step abandonment.** User left without completing.
+
+**The derived metrics.**
+
+- **Step completion rate.** Of users who reached this step, what percentage completed it?
+- **Step drop-off rate.** Of users who reached this step, what percentage abandoned at this step?
+- **Funnel completion rate.** Of users who started the form, what percentage submitted?
+
+**Why instrumentation matters.** Drop-off remediation requires knowing where users abandon. Aggregate "the form converts at 8 percent" tells you something is wrong; per-step data tells you where.
+
+---
+
+## Common drop-off points
+
+Three patterns recur across multi-step forms.
+
+**First-field drop-off.** User clicked into the form, looked at it, and left at the first field.
+
+Common causes.
+- Form is too long; user saw the length and bounced.
+- The value of completing is not clear; user does not know what they get.
+- Form is mobile-broken; user could not interact.
+- Form looks suspicious or untrustworthy.
+
+**Mid-form drop-off.** User abandoned partway through.
+
+Common causes.
+- Fatigue; the form is too long and the user lost interest.
+- Sensitive question they did not want to answer.
+- Confusion about what is being asked.
+- Loading delay or technical issue.
+- The form's value did not justify the continued effort.
+
+**Final-submission drop-off.** User completed all fields but did not submit.
+
+Common causes.
+- Submission anxiety; the user is not sure what happens next.
+- Validation errors at submission lost them.
+- The submission CTA is not clear.
+- Final field requires information they did not have ready.
+
+---
+
+## Remediation: first-field drop-off
+
+When users abandon at the first field.
+
+**Diagnostic questions.**
+
+- Is the form's value proposition clear at the start?
+- Is the form length visible (creating bounce-on-length behavior)?
+- Does the form work on mobile?
+- Are trust signals present (privacy policy, security badges where appropriate)?
+
+**Remediation patterns.**
+
+- **Clarify the value.** "Get a personalized PDF in 5 minutes" beats "Fill out this form."
+- **Hide the length.** Multi-step forms hide subsequent steps; the user does not see "this will take 20 minutes" upfront.
+- **Add social proof.** "Trusted by 5000 teams" or "Used by [recognizable customer]" reduces hesitation.
+- **Add trust signals.** Privacy assurance, security indicators, or testimonial near the form.
+- **Reduce form to single page.** Sometimes the right answer is to revert from multi-step to single-page.
+
+**The diagnostic test.** A/B test variations. The treatment that improves first-field completion validates the diagnosis.
+
+---
+
+## Remediation: mid-form drop-off
+
+When users abandon partway through.
+
+**Diagnostic.**
+
+- Which specific step has the highest drop-off?
+- Are there sensitive questions on that step?
+- How long does that step take to complete?
+- Is the step's relevance clear?
+
+**Remediation patterns.**
+
+- **Reduce field count on the high-drop-off step.** Audit each field; remove non-essential fields.
+- **Reword sensitive questions.** "How much do you spend on this today" beats "What is your annual budget?" Soft framing reduces abandonment.
+- **Add progress indicator if missing.** Users abandon less when they know how much remains.
+- **Add encouragement at the high-drop-off step.** "You are halfway there; just a few more questions to get your personalized result."
+- **Restructure the step architecture.** If step 3 is a drop-off black hole, the architecture may be wrong; reconsider whether step 3's content belongs there at all.
+
+**The diagnostic test.** Watch real users complete the form (usability testing). The behavior often reveals the cause.
+
+---
+
+## Remediation: final-submission drop-off
+
+When users complete fields but do not submit.
+
+**Diagnostic.**
+
+- Is the submission CTA clear?
+- Does the user know what happens after submission?
+- Are there validation errors at submission?
+- Is the final field demanding information they did not have ready?
+
+**Remediation patterns.**
+
+- **Clarify the submission CTA.** "Get my personalized PDF" beats "Submit." The CTA should describe what the user gets.
+- **Add post-submission preview.** "When you submit, we will email you within 5 minutes with..." sets expectations.
+- **Move final-field demands earlier.** If the final field requires hard-to-find information, move it earlier so users gather it during the form.
+- **Add a confirmation step.** A review-and-submit step where the user verifies their inputs reduces submission anxiety.
+- **Validation pre-submission.** Surface errors before the user clicks Submit; do not let submission fail with surprise errors.
+
+---
+
+## Tracking conditional-logic paths
+
+Multi-step forms with conditional logic have multiple paths through the form.
+
+**Per-path tracking.**
+
+- Tag each user's path through the form.
+- Measure completion rate per path.
+- Identify paths that drop off disproportionately.
+
+**Path-specific remediation.**
+
+- A path that drops off at step 4 may need step-4 redesign for users on that path.
+- A path that drops off rarely may not need attention.
+
+**The instrumentation challenge.** Conditional-logic paths multiply quickly. Track at the granularity that informs decisions, not at the granularity that overwhelms.
+
+---
+
+## Drop-off and audience segmentation
+
+Different audiences may drop off at different points.
+
+**Segment-level tracking.**
+
+- Tag users by source, device, or other relevant segment.
+- Measure drop-off per segment.
+- Identify segment-specific issues.
+
+**Common segment patterns.**
+
+- Mobile users drop off more at long steps; desktop users push through.
+- Paid-traffic users drop off earlier than organic; the audience-fit may be weaker.
+- New visitors drop off more than returning visitors; trust matters.
+
+**Remediation by segment.** Sometimes the right answer is segment-specific. Mobile users may benefit from a shorter form variant; paid traffic may benefit from stronger trust signals.
+
+---
+
+## Drop-off and time-of-completion
+
+Some drop-off correlates with how long the form takes.
+
+**Time-to-complete tracking.**
+
+- Average time per step.
+- Total time across the form.
+- Time-to-completion distribution.
+
+**Patterns.**
+
+- Forms taking more than 10 minutes typically see significant drop-off.
+- Steps taking more than 2 minutes typically see step-level drop-off.
+- Distribution skew (some users fast, some users slow) often signals usability issues that affect the slow users.
+
+**Remediation by time.** Forms taking too long should be shortened; steps taking too long should be split or simplified.
+
+---
+
+## Drop-off audit cadence
+
+How often to audit drop-off data.
+
+**Weekly review.** For high-volume forms or recently launched forms. Catches regressions and informs rapid iteration.
+
+**Monthly review.** For stable forms. Tracks trends and surfaces gradual decay.
+
+**Quarterly review.** For all active forms as part of the broader form audit.
+
+**Triggered review.** When form structure changes, when traffic source shifts, or when conversion drops. Ad-hoc reviews catch specific issues.
+
+The cadence depends on traffic volume and the form's importance. High-traffic forms warrant more frequent attention.
+
+---
+
+## A/B testing for drop-off remediation
+
+Test remediation hypotheses rather than guessing.
+
+**The discipline.** Hypothesize the cause of drop-off; design a treatment; A/B test treatment vs control; measure both step-level drop-off and overall conversion.
+
+**Common test types.**
+
+- Form length: shorter vs longer.
+- Step count: fewer vs more steps.
+- Field count: fewer vs more fields per step.
+- Validation strictness: stricter vs looser.
+- Progress indicator: present vs absent.
+- Trust signals: present vs absent.
+
+**Test discipline.**
+
+- One treatment variable per test.
+- Long enough to capture statistical significance.
+- Measure both the targeted metric and downstream metrics.
+
+The data informs which remediation actually moves the metric.
+
+---
+
+## When drop-off is signal, not failure
+
+Some drop-off is healthy.
+
+**The signal.** The wrong audience self-selecting out is honest filtering. A multi-step form that drops 60 percent of visitors but produces 5x the qualified leads vs a single-page form is doing its job.
+
+**The discipline.** Distinguish drop-off from unfit audience (good) from drop-off from fit audience (bad). The downstream metrics (lead quality, conversion to next step) reveal which is happening.
+
+The decision. Optimize for completed-by-fit-audience, not for raw completion rate. Sometimes the right answer is to accept higher drop-off in exchange for higher qualification.
+
+---
+
+## Common measurement failures
+
+**No instrumentation.** Form launched without per-step tracking; drop-off data unavailable.
+
+**Aggregate-only tracking.** Conversion rate tracked but not step-by-step; remediation requires guesswork.
+
+**Instrumentation drift.** Tracking implemented at launch; field renames or step changes broke the tracking.
+
+**Confounded data.** Multiple changes deployed simultaneously; cannot attribute conversion change to any one change.
+
+**Vanity metrics.** Tracking number of starts without tracking completion; the high-volume forms look successful even when conversion is poor.
+
+**Segment-blind tracking.** Aggregate data hides segment-specific issues.
+
+**Time-blind tracking.** No data on time-to-complete; cannot diagnose fatigue-driven drop-off.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The instrumentation requirement. Common drop-off points (first-field, mid-form, final-submission) with diagnoses and remediation patterns. Tracking conditional-logic paths. Drop-off and audience segmentation. Drop-off and time-of-completion. Audit cadence. A/B testing for drop-off remediation. When drop-off is signal not failure. Common measurement failures.
+
+## Implementation choices that stay internal
+
+Specific drop-off baselines for specific forms. Specific tooling for tracking and analysis. Specific A/B test designs and treatments. The team's audit calendars. These vary by team and form.

--- a/skills/multi-step-form-design/references/form-anti-patterns.md
+++ b/skills/multi-step-form-design/references/form-anti-patterns.md
@@ -1,0 +1,224 @@
+# Form anti-patterns
+
+The patterns that look like multi-step forms but degrade conversion. Anti-patterns are easy to ship; the cost shows up in completion rates, lead quality, and brand reputation over time.
+
+---
+
+## The kitchen-sink-single-page
+
+The pattern. 30 fields on one page. Overwhelms before the user starts.
+
+The signal. First-field drop-off near 100 percent on anything beyond a contact form. Users scroll, see the length, and leave.
+
+The cost. The form's data collection is correct; the structure is wrong; nobody completes it.
+
+The cure. Multi-step the form; group fields into coherent steps. Detail in `references/multi-step-decision-criteria.md` and `references/step-architecture-patterns.md`.
+
+---
+
+## The progress-theater form
+
+The pattern. The form is broken into steps but the steps are arbitrary. "Step 1: name. Step 2: email. Step 3: phone."
+
+The signal. Completion rate marginally better than kitchen-sink; users feel the form is gimmicky; some abandon mid-form because each step feels pointless.
+
+The cost. The build effort produced a form that is no better than the alternative. The audience perceives the format as decorative.
+
+The cure. Restructure into genuinely-staged steps. Detail in `references/step-architecture-patterns.md`.
+
+---
+
+## The arbitrary-chunking form
+
+The pattern. Each step has 1-2 fields; the user wonders why this is multi-step.
+
+The signal. Quick completions but high abandonment; the format adds friction without value.
+
+The cost. The user perceives the form as gimmicky; trust degrades.
+
+The cure. Either consolidate to single-page (if the form has only 4-6 fields) or expand the staging to coherent units (if the form has more fields that group naturally).
+
+---
+
+## The hidden-length form
+
+The pattern. No progress indicator; the user does not know how long the form is.
+
+The signal. Mid-form drop-off climbs as users lose patience; abandonment correlates with time spent.
+
+The cost. Users who would have completed if they knew the length abandon out of uncertainty.
+
+The cure. Add an honest progress indicator. Detail in `references/progress-indicator-patterns.md`.
+
+---
+
+## The interrogation-form-with-steps
+
+The pattern. 25 fields across 5 steps; the format is multi-step but the data collection is excessive.
+
+The signal. Drop-off at every step; cumulative completion rate is poor; the form earns "interrogation" reputation.
+
+The cost. The audience that completes is over-disclosed and may resent the friction; the audience that does not complete walks away with a negative impression.
+
+The cure. Audit the field set. Remove fields that are not necessary for the form's purpose. The right field count is often half what teams initially design.
+
+---
+
+## The validation-strict form
+
+The pattern. Validation rejects valid inputs because the rules are over-specified. Email validation rejects plus-sign aliases; phone validation rejects international formats; name validation rejects non-Latin characters.
+
+The signal. Users with valid but unusual inputs abandon when validation fails. Reports of "the form would not let me submit."
+
+The cost. The form filters out valid users. The team perceives the form as working because submissions look clean; the team does not see the audience that could not get past validation.
+
+The cure. Audit validation rules against actual business requirements. Detail in `references/validation-strategy-patterns.md`.
+
+---
+
+## The mobile-broken form
+
+The pattern. Form works on desktop; breaks on mobile. Sliders impossible to grab; dropdowns overflow; touch targets too small.
+
+The signal. Mobile completion drops to half of desktop or worse.
+
+The cost. The mobile audience either bounces or has a worse experience that misrepresents the brand. Mobile is often the majority of traffic.
+
+The cure. Mobile-first design and testing. Test on actual devices, not just dev tools.
+
+---
+
+## The trust-broken form
+
+The pattern. Save-and-resume offered without clear trust communication. Users do not save because they distrust persistence.
+
+The signal. Save-rate is low; users abandon mid-form rather than save.
+
+The cost. The save mechanism's investment produces no value; the audience that would have saved instead leaves permanently.
+
+The cure. Trust communication. What is saved, what is not, how long it persists, who can access it. Detail in `references/save-and-resume-mechanics.md`.
+
+---
+
+## The variable-step form
+
+The pattern. Conditional logic that changes the step count visibly. "Step 4 of 5" becomes "Step 4 of 7" mid-form.
+
+The signal. Users feel misled; abandonment climbs at the moment the indicator shifts.
+
+The cost. Trust damage. The user trusted the indicator; the indicator lied.
+
+The cure. Either avoid conditional steps that change the count, or communicate the variability upfront ("This form has 5-7 steps depending on your answers"). Detail in `references/progress-indicator-patterns.md`.
+
+---
+
+## The submission-anxiety form
+
+The pattern. The submit button is unclear, or the user does not know what happens after submission, or the final step demands information they did not have ready.
+
+The signal. Final-submission drop-off is high; users completed all fields but did not submit.
+
+The cost. The form gets near-completion and loses the conversion at the last step.
+
+The cure. Clear submission CTA, explicit post-submission preview, optional confirmation step. Detail in `references/drop-off-measurement-and-remediation.md`.
+
+---
+
+## The popup-interrupted form
+
+The pattern. The user is mid-form; a popup appears (newsletter signup, chat invitation, special offer). The user's flow breaks.
+
+The signal. Drop-off spikes at the popup moment; users complain about the interruption.
+
+The cost. The form's user experience is hostile. The brand earns "annoying" reputation.
+
+The cure. Suppress popups during form completion. Save promotional content for after submission or for the next visit.
+
+---
+
+## The reset-on-error form
+
+The pattern. The user submits; validation fails; the form resets, losing the user's inputs.
+
+The signal. Users who hit the error do not retry; they leave.
+
+The cost. The form treats errors punitively. Trust collapses.
+
+The cure. Preserve inputs on error. Show the error inline; let the user fix and resubmit without re-entering everything.
+
+---
+
+## The slow-validation form
+
+The pattern. Real-time validation that lags. The user types; validation runs; the form feels sluggish.
+
+The signal. Users feel the form is slow; abandonment climbs at long-validation steps.
+
+The cost. The form's perceived performance damages the brand.
+
+The cure. Move validation to on-blur (when the user leaves the field) instead of on every keystroke. Reserve real-time validation for instant checks (format, character count).
+
+---
+
+## The incompatible-with-autofill form
+
+The pattern. Form does not support browser autofill. The user has to type every field manually.
+
+The signal. Mobile completion is worse than desktop; users with password managers abandon.
+
+The cost. The form treats users as if autofill does not exist. Friction without justification.
+
+The cure. Support standard autofill attributes. Use semantic HTML input types. Test with browser autofill enabled.
+
+---
+
+## The save-but-lose-on-resume form
+
+The pattern. Save-and-resume offered; user saves; resume returns the user to the start of the form, losing their progress.
+
+The signal. Resume rate is high (users click the recovery link) but completion rate from resume is low (users abandon when they see they have to redo work).
+
+The cost. The save mechanism's apparent value disappears at resume; trust collapses worse than if save had not been offered.
+
+The cure. Test the resume experience. Verify that resuming returns the user to their actual progress with inputs preserved. Detail in `references/save-and-resume-mechanics.md` (resume experience section).
+
+---
+
+## The over-conditional form
+
+The pattern. 25 conditional rules across 8 fields. Each rule individually justifiable; cumulatively the form is fragile and hard to maintain.
+
+The signal. Bug reports about specific paths failing; testing surfaces broken rules; conditional logic decays unnoticed.
+
+The cost. Maintenance burden compounds. Form behavior becomes hard to reason about.
+
+The cure. Audit conditional logic. Remove rules that do not justify their maintenance overhead. Detail in `references/conditional-logic-patterns.md`.
+
+---
+
+## How to detect anti-patterns in a portfolio
+
+Audit cadence. Quarterly review of every active form, looking specifically for these anti-patterns.
+
+**Audit questions per form.**
+
+- Does the form have natural step groupings (anti-pattern check: progress-theater, arbitrary-chunking)?
+- Is the progress indicator honest and stable (anti-pattern check: hidden-length, variable-step)?
+- Does each field affect the form's outcome (anti-pattern check: interrogation-form)?
+- Is validation calibrated to actual requirements (anti-pattern check: validation-strict)?
+- Does the form work on mobile (anti-pattern check: mobile-broken)?
+- Is save-and-resume tested end-to-end (anti-pattern check: save-but-lose-on-resume, trust-broken)?
+- Are inputs preserved on error (anti-pattern check: reset-on-error)?
+- Is conditional logic maintained (anti-pattern check: over-conditional)?
+
+**The retire decision.** Anti-pattern forms often warrant retirement or redesign. Maintaining broken forms costs more than the diminishing returns they produce.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing for each. Cures matched to anti-patterns. The audit cadence and audit questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and the lessons learned. Specific portfolio audit results. Specific retirement and redesign decisions. The team's audit calendar and reviewer list. These vary by team.

--- a/skills/multi-step-form-design/references/multi-step-decision-criteria.md
+++ b/skills/multi-step-form-design/references/multi-step-decision-criteria.md
@@ -1,0 +1,159 @@
+# Multi-step decision criteria
+
+When to break a form into steps vs keep it on a single page. The conditions that warrant the multi-step structure, and the funnels where multi-step adds friction without lift.
+
+A multi-step form is a meaningful build. Step architecture, progress indicators, conditional logic, validation, save-and-resume, drop-off instrumentation. The multi-step form earns this investment only when specific conditions are present.
+
+---
+
+## When multi-step earns the build
+
+Five conditions that, when present, make multi-step the right structure.
+
+**The form has more than 8-10 fields.** Single-page forms beyond this point overwhelm the audience visually. The user scrolls, sees the length, and leaves. Multi-step breaks the visual length into manageable pieces.
+
+**The fields naturally group into logical categories.** Personal info, then situation, then preferences, then specifics. Steps that reflect real groupings respect cognitive load. Arbitrary chunking does not.
+
+**The audience benefits from progressive commitment.** Each step builds investment. The user is more likely to complete after engaging with step 2 than they would have been if they had seen step 5's complexity upfront.
+
+**Different paths through the form make sense based on early answers.** Conditional logic that adapts the form to the user is hard to do on a single page; multi-step makes the adaptation feel natural.
+
+**The success metric warrants the build.** Higher completion rate, lower drop-off, better lead quality, faster review for the receiving team. Without a defined success metric, the build is hard to justify.
+
+When all five are present, multi-step is a strong structure. When two or fewer are present, single-page often serves better.
+
+---
+
+## When multi-step does NOT earn the build
+
+Funnels where multi-step is the wrong structure.
+
+**The form has 4-6 fields.** A single-page form is faster to complete and faster to maintain. Multi-step adds friction (step transitions, progress indicators, save-and-resume mechanics) without adding clarity.
+
+**The fields do not group naturally.** Arbitrary chunking is friction. "Step 1: name. Step 2: email. Step 3: phone." The user wonders why this is multi-step and the question itself signals friction.
+
+**The audience expects speed.** Quick contact forms, simple lead-capture forms, and high-intent CTAs often convert better as single-page. The multi-step format implies "this will take a while," which depresses high-intent users.
+
+**The team cannot maintain the multi-step complexity.** Multi-step forms have more failure modes (conditional logic bugs, progress indicator drift, validation issues across steps). The maintenance overhead is real; teams that cannot commit to it should choose single-page.
+
+**The form is a follow-up to a hot conversation.** A demo-request form right after a sales call should be quick. Multi-step here adds friction the audience is not ready for.
+
+The honest assessment matters more than the default. "Should the form be multi-step" is not the question. "Is multi-step the right structure for this specific data collection and audience" is.
+
+---
+
+## The opportunity-cost frame
+
+A multi-step form is meaningful work. Account for the cost honestly.
+
+**The build cost.** Step architecture, progress indicators, conditional logic, save-and-resume, validation across steps, drop-off instrumentation. A meaningful multi-step form often takes 30-80 engineering hours plus design.
+
+**The maintenance cost.** Steps decay as the brand evolves; conditional logic bugs surface; progress indicators need updating. Quarterly review and maintenance run 2-6 hours per active form.
+
+**The opportunity cost.** What else could the team have built? A simpler form that converts adequately, a different growth-tooling investment, a content piece. The multi-step form's success has to clear the bar of those alternatives.
+
+The decision frame. The multi-step form earns investment when it produces more conversion than the single-page alternative, accounting for the full cost of build plus maintenance.
+
+---
+
+## The grouping precondition
+
+Without natural field groupings, multi-step is arbitrary.
+
+**The check.** Can the fields be grouped into 3-5 coherent categories? Each category representing a unit of cognitive work the user can describe in one sentence?
+
+If yes, multi-step has natural step boundaries.
+
+If no (the fields do not group; the only structure is "first half" and "second half"), multi-step will feel arbitrary. Either restructure the data collection (some fields may not be needed) or choose single-page.
+
+**Examples of natural groupings.**
+
+- Identity (name, email, role) + Context (company size, industry, current setup) + Need (goal, challenge, timeline) + Confirmation.
+- Personal info + Loan details + Property details + Financial verification + Submission (mortgage application).
+- Account info + Use case + Plan selection + Payment + Confirmation (signup wizard).
+
+**Examples of forced groupings.**
+
+- Page 1 (name, email, phone) + Page 2 (company, role, source, industry, size). The page break is arbitrary; nothing groups these fields meaningfully.
+- Page 1 (most fields) + Page 2 (one final field). The split is purely decorative.
+
+The discipline. If the team cannot articulate the unit of work each step represents, the steps are arbitrary; either rework the steps or use single-page.
+
+---
+
+## The decision worked example
+
+A B2B SaaS company considering whether to make a "Talk to sales" form multi-step.
+
+**Conditions check.**
+
+- Field count: 12 fields (name, work email, company name, company size, industry, role, current solution, primary use case, timeline, budget range, source attribution, additional context). Above the 8-10 threshold; multi-step is on the table.
+- Natural groupings: yes. Identity (name, email, role), company context (name, size, industry), current state (current solution, use case), buying intent (timeline, budget), additional (source, context). 5 natural groups.
+- Progressive commitment: yes. The audience giving budget at the end after engaging with the early steps is more likely to give it than if asked upfront.
+- Conditional logic value: yes. If the audience selects "evaluating" timeline, additional fields appear; if "active project," different additional fields appear.
+- Success metric: defined. Conversion rate to submission, lead quality (audience-fit at SaaS companies above 25 employees), downstream conversion to demo within 21 days.
+
+**Decision.** Build multi-step. The conditions warrant it.
+
+**Step architecture.** 5 steps: Identity, Company, Current State, Buying Intent, Submission Confirmation.
+
+**Maintenance commitment.** Quarterly audit of conversion, drop-off per step, and conditional logic.
+
+The decision was not "should we make this multi-step" but "given these conditions, this is the multi-step structure to build."
+
+---
+
+## The single-page worked example
+
+The same B2B SaaS company considering whether to make a "Subscribe to newsletter" form multi-step.
+
+**Conditions check.**
+
+- Field count: 2 fields (email, name). Below the 8-10 threshold.
+- Natural groupings: no. Two fields do not group.
+- Progressive commitment: no. The audience subscribing benefits from speed.
+- Conditional logic value: no. No branching needed.
+- Success metric: simple conversion rate.
+
+**Decision.** Single-page. Multi-step would add friction without value.
+
+The decision was "what is the right structure" and the answer was single-page even though multi-step was nominally available.
+
+---
+
+## The hybrid pattern
+
+Some forms work best with a "main" single-page form plus one optional follow-up step.
+
+**The pattern.** A short single-page form (3-5 fields) gets the user committed; an optional follow-up appears after submission for users who want personalization.
+
+**When this works.** When the primary action is fast (signup, lead-capture) but a richer follow-up benefits some users.
+
+**When this does not work.** When the follow-up has to be required for the primary action to be useful.
+
+The hybrid avoids both kitchen-sink-single-page and forced multi-step. It serves the speed-seeking audience and the depth-seeking audience separately.
+
+---
+
+## When to retire a multi-step form (or convert to single-page)
+
+Multi-step forms can become wrong as the form evolves.
+
+**Retire-or-convert when:**
+
+- Field count has dropped below 6 over time as fields were removed.
+- Conditional logic has been simplified out, leaving the steps with no real differentiation.
+- Drop-off concentrates uniformly across steps, suggesting the staging is not working.
+- A simpler single-page form might convert better.
+
+**The conversion-to-single-page move.** Sometimes the right answer is to revert. The multi-step format earned the build at one point; conditions changed; single-page is now better. Honest reversion is part of the discipline.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The conditions that warrant multi-step. The opportunity-cost frame. The grouping precondition. The decision worked example. The single-page worked example. The hybrid pattern. The retire-or-convert decision.
+
+## Implementation choices that stay internal
+
+Specific multi-step decisions for specific forms. The team's capacity benchmarks for build and maintenance. Specific tooling for form engineering. Specific success-metric definitions and baselines. These vary by team.

--- a/skills/multi-step-form-design/references/progress-indicator-patterns.md
+++ b/skills/multi-step-form-design/references/progress-indicator-patterns.md
@@ -1,0 +1,289 @@
+# Progress indicator patterns
+
+Step counter, progress bar, step list. When each works. Indicator failures.
+
+The progress indicator reinforces momentum and reduces uncertainty about how much is left. Bad indicators flatter or mislead; good indicators reflect honest progress.
+
+---
+
+## The honesty principle
+
+The progress indicator must reflect actual remaining work. Indicators that flatter the user or hide remaining complexity break trust.
+
+**The honest indicator.** "Step 3 of 5" when there are exactly 5 steps and the user is on step 3.
+
+**The dishonest indicator.**
+
+- "Almost done" when 5 fields remain on the next step.
+- Progress bar that fills to 80 percent when 50 percent of fields remain.
+- Step counter that shifts from "5 of 7" to "5 of 9" because conditional logic added steps.
+
+The honesty discipline. Match the indicator to the actual work; do not flatter; communicate variability when it exists.
+
+---
+
+## Pattern A: Step counter
+
+"Step 2 of 4." Simple, common, effective for short forms.
+
+**How it works.**
+
+- The current step number is shown.
+- The total step count is shown.
+- The format is consistent across the form.
+
+**Strengths.**
+
+- Easy to implement.
+- Easy to understand.
+- Compact.
+
+**Weaknesses.**
+
+- Does not reflect within-step progress.
+- Misleading when step lengths vary significantly.
+- Breaks if conditional logic changes the total step count.
+
+**When to use.** Forms with 3-6 steps where step lengths are roughly similar.
+
+---
+
+## Pattern B: Progress bar
+
+Visual fill showing percentage complete.
+
+**How it works.**
+
+- A bar fills from left to right (or follows other visual progression).
+- The fill represents percentage of fields completed (or percentage of weight in some weighted scheme).
+- Optionally includes a percentage label.
+
+**Strengths.**
+
+- Reflects continuous progress.
+- Handles variable-length steps better than step counter.
+- Visually engaging.
+
+**Weaknesses.**
+
+- More complex to design and implement.
+- Risk of dishonest fill (bar fills fast, last 10 percent represents most of the remaining work).
+
+**When to use.** Forms with variable step lengths or where the user benefits from continuous-progress signal.
+
+---
+
+## Pattern C: Step list
+
+Named steps shown with the current one highlighted.
+
+**How it works.**
+
+- All step names visible (often in a sidebar or header).
+- Current step highlighted.
+- Completed steps marked (checkmark or different color).
+- Future steps indicated.
+
+**Strengths.**
+
+- Shows the user the full form path.
+- Reduces uncertainty about what is coming.
+- Lets the user navigate back to specific steps.
+
+**Weaknesses.**
+
+- Takes more screen real estate.
+- Can overwhelm if there are many steps.
+- Forces the form to commit to step names upfront.
+
+**When to use.** Forms with 3-7 well-named steps where the user benefits from seeing the structure.
+
+---
+
+## Pattern D: No indicator
+
+Sometimes appropriate for very short forms.
+
+**When to use.**
+
+- Forms with 2-3 steps where the indicator overhead exceeds its value.
+- Forms where the user's expectation is "this is short" and the indicator would imply length.
+
+**Risks.**
+
+- Without indication, longer forms can feel endless.
+- Users may abandon because they cannot predict the form's length.
+
+**The discipline.** No indicator is rarely the right answer for forms with more than 3 steps.
+
+---
+
+## Pattern E: Hybrid
+
+Combining patterns. A step counter plus a progress bar; or a step list plus a percentage.
+
+**Strengths.**
+
+- Multiple signals reinforce each other.
+- Different users benefit from different indicators.
+
+**Weaknesses.**
+
+- Visual complexity grows.
+- Risk of redundant or conflicting signals.
+
+**When to use.** Long forms (5+ steps) where rich indication helps the user understand the form's shape.
+
+---
+
+## Indicator failures
+
+Patterns that break trust.
+
+**Failure 1: Indicator that shifts mid-form.**
+
+The form starts as "Step 4 of 5"; conditional logic adds steps; the form is now "Step 4 of 7." The user feels misled.
+
+The cure. Either avoid conditional steps that change the count, or communicate the variability upfront ("This form has 5-7 steps depending on your answers").
+
+**Failure 2: Indicator that hides remaining work.**
+
+"Almost done" when 5 fields remain on the next step. The user trusted the indicator and now feels betrayed.
+
+The cure. Calibrate the indicator to reflect remaining fields, not just remaining steps.
+
+**Failure 3: Indicator that fills fast and slows down.**
+
+Progress bar fills to 70 percent in the first 2 steps; the remaining 30 percent takes the next 5 steps. The user expects the form to end soon and is frustrated when it does not.
+
+The cure. Weight the progress bar by actual work, not just step count. If step 5 represents most of the remaining work, the bar should reflect that.
+
+**Failure 4: Indicator with no current-step context.**
+
+The progress bar shows 50 percent but the user does not know what the current step is about. Reduces orientation.
+
+The cure. Include both progress (where you are) and current-step name (what you are doing).
+
+**Failure 5: Indicator that is decorative without being honest.**
+
+Progress that looks fast but the next step is the longest one. The indicator misleads about pacing.
+
+The cure. Honest pacing. The indicator should reflect actual time-to-complete, not just step count.
+
+---
+
+## Indicator placement
+
+Where the indicator lives on the page.
+
+**Top placement.** Above the form fields. Common; user sees it on every step.
+
+**Sidebar placement.** Alongside the form. Good for step-list patterns; takes more space.
+
+**Bottom placement.** Below the form fields. Less common; user has to scroll to see it on long steps.
+
+**Sticky placement.** Indicator stays visible as the user scrolls within a step. Useful for long steps.
+
+The choice depends on form length per step and visual hierarchy. Top placement is the safe default.
+
+---
+
+## Indicator and mobile
+
+The indicator must work on mobile.
+
+**Mobile-specific considerations.**
+
+- Step counter: easy to mobile (small footprint).
+- Progress bar: easy (full-width fits).
+- Step list: harder; may need to collapse to step counter on mobile.
+- Hybrid: simplify on mobile; do not stack multiple indicators.
+
+**The mobile discipline.** Ensure the indicator is visible without scrolling. Mobile users should see "Step 2 of 5" or the progress bar without searching for it.
+
+---
+
+## Indicator messaging
+
+Optional language alongside the indicator.
+
+**Encouragement messages.** "Halfway there!" or "Almost done!" Can boost motivation; can also feel patronizing.
+
+**Time estimates.** "About 2 minutes left." Useful when honest; misleading when wrong.
+
+**Step-name labels.** "Step 2: Your Company." Useful when steps have meaningful names.
+
+**The discipline.** Encouragement and estimates should be honest. Patronizing or wrong messaging breaks trust faster than no messaging.
+
+---
+
+## Indicator updating
+
+When the indicator updates.
+
+**On step transition.** The indicator updates as the user moves to the next step. Common pattern.
+
+**On field completion.** The indicator updates as fields within a step are filled. More granular; less common.
+
+**Smooth animation.** Subtle animation on transition reinforces progress.
+
+**No animation.** Instant update is fine; flashy animation can be distracting.
+
+---
+
+## When indicators add no value
+
+Some forms work without indicators.
+
+**Very short forms.** 2-step forms often do not need indication. The user knows it is short.
+
+**High-frequency forms.** Forms the user fills repeatedly may not need indication after the first time.
+
+**Single-action forms.** A subscription form with email and submit does not need a progress indicator.
+
+The discipline. Default to including an indicator for multi-step forms. Skip only when the form is genuinely simple enough that the indicator adds noise.
+
+---
+
+## Indicator audit
+
+Periodically audit the indicator.
+
+**The audit.**
+
+- Read the indicator on each step. Does it reflect honest progress?
+- Test the form with conditional logic. Does the indicator handle the variability?
+- Check mobile rendering. Does the indicator work on touch devices?
+- Check accuracy. Does "almost done" actually mean almost done?
+
+**The drift.** Indicators decay as forms evolve. Steps get added; conditional logic gets added; the indicator falls out of sync.
+
+**The cure.** Quarterly audit alongside form audit. Update the indicator when the form structure changes.
+
+---
+
+## Common indicator failures
+
+**No indicator on a long form.** User does not know how much remains; abandons.
+
+**Indicator shifts mid-form.** Conditional logic surprised the user.
+
+**Dishonest pacing.** Bar fills fast, work remains slow.
+
+**Indicator without current-step context.** Progress without orientation.
+
+**Indicator overflowing on mobile.** Step list designed for desktop; cramped on mobile.
+
+**Patronizing language.** "Almost done" repeatedly when the user is at step 2 of 6.
+
+**Wrong time estimates.** "About 1 minute left" when 5 minutes remain.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The honesty principle. Patterns A through E with strengths, weaknesses, and when-to-use guidance. Indicator failures (5 patterns). Indicator placement, mobile considerations, messaging, updating. When indicators add no value. Indicator audit. Common failures.
+
+## Implementation choices that stay internal
+
+Specific indicator designs for specific forms. Specific tooling for indicator implementation. Specific brand-voice messaging alongside indicators. The team's mobile testing benchmarks. These vary by team.

--- a/skills/multi-step-form-design/references/save-and-resume-mechanics.md
+++ b/skills/multi-step-form-design/references/save-and-resume-mechanics.md
@@ -1,0 +1,267 @@
+# Save-and-resume mechanics
+
+When to offer save-and-resume. Email-link, account-based, anonymous-session patterns. Trust communication.
+
+Save-and-resume reduces drop-off for forms that take more than 5 minutes to complete or that require information the user may not have at hand. Done well, it earns the user's trust and recovers what would otherwise be lost completions.
+
+---
+
+## When save-and-resume helps
+
+Three conditions that, when present, make save-and-resume valuable.
+
+**Form length warrants it.** Forms taking more than 5 minutes to complete benefit. Below 5 minutes, the user can usually push through; above, the cost of starting over is high.
+
+**Information may not be at hand.** Forms requiring documents, technical configurations, or specific data the user may need to gather. Save-and-resume lets the user collect the information and return.
+
+**Multi-session use is expected.** Forms that are part of multi-touchpoint workflows (loan applications, enrollment forms, complex onboarding). Save-and-resume is required, not optional.
+
+When all three are present, save-and-resume is a strong investment. When none are present, the mechanic adds complexity without lift.
+
+---
+
+## When save-and-resume does not help
+
+**Quick lead-capture forms.** Under 60 seconds to complete. The save mechanic adds complexity; the audience does not need it.
+
+**Single-session forms.** Forms designed to be completed in one sitting. Save-and-resume can encourage abandonment ("I will come back later") that becomes permanent.
+
+**Forms that require trust.** Sensitive information may not be safe to persist; the user may not save because they distrust persistence. Adding save-and-resume without addressing trust degrades the form.
+
+**Forms with strict expiration.** Application deadlines or session timeouts may make save-and-resume confusing or counterproductive.
+
+---
+
+## Pattern A: Email-link recovery
+
+The most common save-and-resume pattern.
+
+**How it works.**
+
+- The user clicks "Save and resume later."
+- A form appears asking for an email address.
+- The user enters email; a recovery link is sent.
+- The user opens the email later, clicks the link, returns to the form with progress preserved.
+
+**Strengths.**
+
+- Familiar pattern; users understand it.
+- Works across devices (user can save on desktop, resume on mobile).
+- Simple to implement.
+
+**Weaknesses.**
+
+- Requires the user to give an email address before completing the form (which may itself be friction).
+- Depends on email deliverability.
+- Recovery link can expire or get lost.
+
+**When to use.** Default for most save-and-resume needs. The familiar UX reduces friction.
+
+---
+
+## Pattern B: Account-based persistence
+
+Forms that require account creation persist by default.
+
+**How it works.**
+
+- The user creates an account at the start.
+- Form progress saves automatically as the user completes fields.
+- The user logs back in to resume.
+
+**Strengths.**
+
+- Persistence is automatic; user does not have to choose to save.
+- Works across devices.
+- Account integration may extend to other features beyond the form.
+
+**Weaknesses.**
+
+- Account creation is significant friction at the start.
+- Adds engineering complexity.
+- May not be appropriate for one-shot forms.
+
+**When to use.** Forms that are part of an account-based product or service where account creation is justified by ongoing use.
+
+---
+
+## Pattern C: Anonymous-session save
+
+Browser-based save without identification.
+
+**How it works.**
+
+- Form progress saves to browser local storage as the user completes fields.
+- The user returns to the same browser, picks up where they left off.
+
+**Strengths.**
+
+- Lowest friction; no email or account required.
+- Automatic; user does not have to choose to save.
+
+**Weaknesses.**
+
+- Works only on the same browser/device.
+- Lost if the user clears cookies or switches devices.
+- Limited persistence (typically days, not weeks).
+
+**When to use.** Forms where the audience likely returns from the same device within a short window. Often used as a fallback or supplement to other patterns.
+
+---
+
+## Pattern D: Hybrid
+
+Combining patterns. Anonymous-session save by default; email-link recovery as a backup.
+
+**How it works.**
+
+- Form auto-saves to browser as user completes.
+- A "save and resume from any device" option offers email-link recovery.
+
+**Strengths.**
+
+- Lowest-friction default; user benefits even without explicit action.
+- Cross-device option for users who want it.
+
+**Weaknesses.**
+
+- More complex to design and explain.
+- Multiple save mechanisms can confuse the user.
+
+**When to use.** Forms with significant length where many users return same-device but some need cross-device.
+
+---
+
+## Trust communication
+
+Users hesitate to save partial sensitive information. The form must communicate clearly.
+
+**What to communicate.**
+
+- **What is saved.** "Your answers so far will be saved."
+- **What is not saved.** "We do not save passwords or payment information until submission."
+- **How long it persists.** "Your progress will be available for 7 days."
+- **Who can access it.** "Only you can access your saved progress through the link we email you."
+- **How to delete.** "You can clear your saved progress by completing or abandoning the form."
+
+**Trust copy patterns.**
+
+- "We never share your saved information."
+- "Your progress is encrypted at rest."
+- "You control whether to come back."
+
+**Trust copy that fails.**
+
+- Generic privacy boilerplate.
+- Long legal text the user will not read.
+- Vague reassurances without specifics.
+
+The discipline. Trust copy should be specific, scannable, and honest. Generic privacy text does not earn trust.
+
+---
+
+## When in the form to offer save-and-resume
+
+Timing matters.
+
+**Pattern: Always available.** A "Save and resume" link visible on every step. The user can save at any moment.
+
+**Pattern: Triggered by inactivity.** After 60-90 seconds of inactivity, prompt the user to save. Risk: the prompt feels intrusive.
+
+**Pattern: Offered at logical breakpoints.** Save prompts at the end of each step or at known long-pause points. Less intrusive than continuous availability.
+
+**Pattern: Offered before high-friction steps.** "The next step requires document uploads. You can save now and come back when you have your documents."
+
+The choice depends on form length and the audience's likely pause points. Always-available is the safe default for long forms.
+
+---
+
+## Resume experience
+
+The user clicks the recovery link or logs in. What happens next.
+
+**The principle.** The resume experience should be uninterrupted. The user lands on the step they were on; their previous answers are preserved; they can continue without re-doing work.
+
+**The resume page.**
+
+- Welcome back message confirming the resume.
+- Preserved progress visible (the user sees what they had done).
+- Clear path to continue (button to proceed to current step).
+
+**Resume failures.**
+
+- The user lands at the start; previous answers lost. Trust collapses.
+- The user lands at the right step but answers are wrong. Worse than starting over.
+- The recovery link expires; the user is told their progress is gone. The save mechanism failed.
+
+The discipline. Test the resume experience as carefully as the form itself. A broken resume is worse than no save.
+
+---
+
+## Save-and-resume measurement
+
+Track how many users save and resume.
+
+**The metrics.**
+
+- **Save rate.** What percentage of users who reach the save option choose to save?
+- **Resume rate.** What percentage of users who saved actually resume?
+- **Resume-to-completion rate.** What percentage of users who resumed complete the form?
+
+**Diagnostic uses.**
+
+- Low save rate: the option is not visible or trust is missing.
+- Low resume rate: the recovery email failed or the user lost interest.
+- Low resume-to-completion: the resume experience is broken or the form is too long.
+
+**The decision.** If save-and-resume is offered but rarely used, audit whether the offering is justified or whether the mechanic adds complexity without payoff.
+
+---
+
+## Save-and-resume for sensitive information
+
+Some forms collect sensitive information. Save-and-resume requires extra care.
+
+**The principle.** Sensitive information may not be safe to persist. Audit what is saved and what is not.
+
+**Common patterns.**
+
+- **Save non-sensitive only.** Names, emails, situational information saved; passwords, SSNs, payment details not saved.
+- **Encrypt at rest.** Saved data encrypted in storage; only retrievable through recovery flow.
+- **Limit persistence window.** Sensitive forms may save only for 24-48 hours rather than 7+ days.
+
+**Compliance considerations.**
+
+- Some jurisdictions or regulations restrict what can be persisted.
+- The form's save behavior should be reviewed against applicable compliance.
+- Trust copy should disclose persistence honestly.
+
+The discipline. Sensitive forms warrant more conservative save behavior. The convenience of save-and-resume is not worth privacy or compliance risk.
+
+---
+
+## Common save-and-resume failures
+
+**Save offered without trust communication.** Users do not save because they distrust persistence.
+
+**Recovery link expires too quickly.** User receives the link, intends to come back, finds the link expired by the time they do.
+
+**Resume to wrong step.** User clicks recovery link, lands at the start, has to redo everything.
+
+**Saved answers corrupted.** User resumes, answers are wrong or partial.
+
+**Save mechanic decays.** Storage backend changes; saved data becomes inaccessible.
+
+**Multiple save mechanisms confuse.** Anonymous-session and email-link both offered; user does not know which to use.
+
+**Save offered on a form that does not need it.** Quick form gets save mechanic; complexity without payoff.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+When save-and-resume helps and does not. Patterns A through D with strengths, weaknesses, and when-to-use guidance. Trust communication discipline. Timing of save offering. Resume experience. Measurement. Save-and-resume for sensitive information. Common failures.
+
+## Implementation choices that stay internal
+
+Specific save-and-resume implementations for specific forms. Specific persistence backends and expiration policies. Specific trust copy in brand voice. The team's compliance review processes. These vary by team.

--- a/skills/multi-step-form-design/references/step-architecture-patterns.md
+++ b/skills/multi-step-form-design/references/step-architecture-patterns.md
@@ -1,0 +1,279 @@
+# Step architecture patterns
+
+What belongs on each step. Identity, context, need, detail, confirmation. Sequencing principles.
+
+The architecture is the structure that makes steps coherent. Bad architecture produces progress-theater (decorative steps); good architecture produces genuinely-staged forms (each step is a coherent unit of work).
+
+---
+
+## The coherence principle
+
+Each step should represent a coherent unit of work from the user's perspective.
+
+**The test.** Can the user describe what they just did at the end of the step in one sentence?
+
+- Coherent: "I told you the basics about my company."
+- Atomized: "I typed my company name in a field."
+
+Coherent answers signal genuinely-staged. Atomized answers signal progress-theater.
+
+The discipline. Each step should bundle related fields into a single cognitive unit. The user processes the step as a whole, not as 5 isolated fields.
+
+---
+
+## Common step patterns
+
+Patterns that recur across acquisition, onboarding, and intake forms.
+
+**Identity step.** Who the user is.
+
+- Fields: name, email, role.
+- Friction level: low.
+- Position: opens the form.
+- The user provides minimal commitment; the form earns the right to ask for more.
+
+**Context step.** What the user's situation is.
+
+- Fields: company size, industry, current setup, current tools.
+- Friction level: medium.
+- Position: after Identity, before Need.
+- The user shares context that lets the form (or the receiving team) understand them.
+
+**Need step.** What the user is trying to accomplish.
+
+- Fields: goal, challenge, timeline, urgency.
+- Friction level: medium-to-high.
+- Position: middle of the form.
+- The user articulates intent. This step often includes the highest-value fields for the receiving team.
+
+**Detail step.** Specifics needed to act on the user's request.
+
+- Fields: budget, specific requirements, constraints, integrations.
+- Friction level: high.
+- Position: late in the form.
+- The user shares specifics. By this point, commitment is built; the user is more willing to share.
+
+**Confirmation step.** Review and submit.
+
+- Fields: review summary, submission action, optional final fields (preferences, follow-up).
+- Friction level: low.
+- Position: last.
+- The user reviews what they provided and submits.
+
+---
+
+## Sequencing principles
+
+The order of steps matters as much as the steps themselves.
+
+**Principle 1: Low-friction first.** The opening step should be easy to complete. The user invests their first 30-60 seconds in something simple; commitment compounds.
+
+**Principle 2: Commitment compounds.** Each step builds on the previous. The user who completed step 2 is more invested than they were before step 1; later steps can ask for more.
+
+**Principle 3: High-friction at the end.** The most demanding fields (budget, specific requirements, sensitive info) belong later. By that point, the user has invested enough to push through.
+
+**Principle 4: Confirmation explicit.** A final review-and-submit step lets the user verify their inputs. Reduces submission anxiety.
+
+**Anti-pattern: high-friction first.** Asking for budget in step 1 depresses completion. The user has not yet committed; the high-friction question feels premature.
+
+**Anti-pattern: commitment-resetting.** A late step that requires the user to make decisions they thought they had already made. The user feels their earlier work was wasted.
+
+---
+
+## Step coherence test
+
+For each step, ask: can this step be described in one sentence as a unit of work?
+
+**Coherent step examples.**
+
+- "Step 1: tell us who you are." (Identity)
+- "Step 2: tell us about your company." (Context)
+- "Step 3: tell us what you are trying to accomplish." (Need)
+- "Step 4: tell us the specifics so we can help." (Detail)
+- "Step 5: review and submit." (Confirmation)
+
+Each step has a coherent description. The user can predict what is coming and feel they accomplished something at the end of each step.
+
+**Incoherent step examples (progress-theater).**
+
+- "Step 1: name and email."
+- "Step 2: phone and company."
+- "Step 3: role and industry."
+
+Each step is two fields. The fields are unrelated. The grouping is arbitrary. The user wonders why this is multi-step.
+
+---
+
+## Field count per step
+
+How many fields per step is too many or too few.
+
+**Too few.** 1-2 fields per step often signals over-staging. The user wonders why this needed its own step.
+
+**Right range.** 3-7 fields per step. Enough to represent a coherent unit of work; few enough to complete in 30-60 seconds.
+
+**Too many.** 10+ fields per step starts to recreate the kitchen-sink-single-page problem within a step. Audit for non-essential fields.
+
+**The variance.** Some steps may have more fields than others; that is fine if each step's fields cohere. The Detail step often has more fields than the Identity step because it captures more specific information.
+
+---
+
+## Step length variability
+
+Steps do not have to be the same length.
+
+**The pattern.** Identity step: 3 fields. Context step: 5 fields. Need step: 4 fields. Detail step: 7 fields. Confirmation step: 1 action.
+
+The variability is fine because each step represents a coherent unit. The user does not expect equal length; they expect coherence.
+
+**The progress indicator implication.** A step counter ("Step 2 of 5") may not reflect time-to-complete accurately when steps vary. A progress bar based on percentage of fields complete reflects the variability better.
+
+---
+
+## Conditional step inclusion
+
+Some forms include or exclude steps based on earlier answers.
+
+**The pattern.** "If user has a current CRM, include the 'CRM details' step. If not, skip it."
+
+**Strengths.**
+
+- Removes irrelevant fields entirely.
+- Makes the form feel adaptive.
+
+**Risks.**
+
+- Progress indicators must accommodate the variability honestly.
+- The user may notice the variability and feel confused.
+
+**The discipline.** Use conditional steps when the variability genuinely benefits the user; communicate the dynamic nature in the progress indicator if it shifts.
+
+---
+
+## Step transitions
+
+How the user moves from one step to the next.
+
+**The forward transition.** A clear "Next" or "Continue" button. Validation runs before the transition.
+
+**The backward transition.** A "Back" or "Previous" button. The user can return to earlier steps without losing later inputs.
+
+**The skip transition.** Some forms allow skipping optional steps. Use sparingly; skipping creates inconsistent paths.
+
+**Transition friction.** Each transition should feel snappy. Loading delays at transitions break the flow.
+
+**Transition cues.** Brief visual confirmation that the step changed (slide animation, fade transition). Helps the user understand the navigation.
+
+---
+
+## Step naming
+
+Each step should have a clear name visible to the user.
+
+**Strong step names.**
+
+- "Tell us about you."
+- "About your company."
+- "What you are looking for."
+- "The details."
+- "Review and submit."
+
+**Weak step names.**
+
+- "Step 1," "Step 2," "Step 3." (Numbers without names; user does not know what each represents.)
+- "Personal Info," "Company Info," "Other Info." (Generic; does not signal what the step is about.)
+- "Contact," "Business," "Submission." (Truncated; does not warm the user.)
+
+**The voice match.** Step names should match the brand voice. Casual brands use casual names; serious brands use serious names.
+
+---
+
+## Step architecture for specific use cases
+
+How the architecture varies by form purpose.
+
+**Lead-capture form (5-8 fields).**
+
+- Identity (name, email)
+- Context (company, role)
+- Need (use case, urgency)
+
+3 steps; the form moves quickly.
+
+**Demo-request form (10-15 fields).**
+
+- Identity (name, work email, role)
+- Company (name, size, industry)
+- Current state (current solution, key pain points)
+- Buying intent (timeline, budget range)
+- Confirmation
+
+5 steps; meaningful staging.
+
+**Application form (20+ fields with documents).**
+
+- Identity
+- Eligibility (qualifying questions)
+- Personal details
+- Financial details
+- Document upload
+- Review
+- Submit
+
+7+ steps; long form benefits significantly from staging.
+
+**Onboarding wizard (configuration-driven).**
+
+- Welcome
+- Account setup
+- Use-case selection
+- Preferences
+- Connect-your-tools
+- Confirmation
+
+6 steps; each step represents a coherent setup unit.
+
+---
+
+## Step architecture audit
+
+Periodically audit the step architecture.
+
+**The audit.**
+
+- Read each step's name. Does it represent a coherent unit?
+- Read each step's fields. Do they cohere?
+- Check field count per step. Within the 3-7 range?
+- Check conversion per step. Are some steps disproportionately drop-off-heavy?
+
+**The drift.** Steps decay as the form evolves. New fields get added to the wrong step; steps become incoherent; field counts drift.
+
+**The cure.** Quarterly audit. Re-group fields into the right steps; remove non-essential fields; restructure if the original architecture no longer fits.
+
+---
+
+## Common architecture failures
+
+**Arbitrary chunking.** Steps that group fields by visual length rather than coherence.
+
+**Atomized steps.** Each step has 1-2 fields; the user wonders why it is multi-step.
+
+**Field-count overload.** Some steps have 15+ fields; recreates the kitchen-sink problem within a step.
+
+**High-friction-first.** Budget or sensitive question in step 1; user is not committed enough to push through.
+
+**Commitment-resetting steps.** Late steps that require the user to make decisions they thought were already made.
+
+**Generic step names.** "Step 1, Step 2" without descriptive names; user cannot predict the form.
+
+**No confirmation step.** Form ends at the data-collection step; user is not given the chance to review.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The coherence principle. Common step patterns. Sequencing principles. The step-coherence test. Field count per step. Step length variability. Conditional step inclusion. Step transitions. Step naming. Step architecture for specific use cases. Step-architecture audit. Common failures.
+
+## Implementation choices that stay internal
+
+Specific step architectures for specific forms. Specific step naming in brand voice. Specific tooling for step transitions and validation. The team's audit calendars. These vary by team and form.

--- a/skills/multi-step-form-design/references/validation-strategy-patterns.md
+++ b/skills/multi-step-form-design/references/validation-strategy-patterns.md
@@ -1,0 +1,288 @@
+# Validation strategy patterns
+
+Per-step vs end-only vs hybrid. Validation message discipline.
+
+The validation strategy determines when errors are caught and how they are communicated. Done well, validation catches errors helpfully and protects the form from invalid submissions. Done poorly, validation rejects valid inputs or surfaces errors at the worst time.
+
+---
+
+## The catch-helpful principle
+
+Validation should catch errors at the point where helping the user is most efficient. Errors caught too early feel intrusive; errors caught too late waste the user's investment.
+
+**The win.** A user enters an invalid email; inline validation catches it immediately; the user fixes it and continues.
+
+**The fail (too early).** A user is mid-typing an email; "must contain @" appears before they have finished typing.
+
+**The fail (too late).** A user completes 5 steps; submission fails because of a step-1 error they did not see flagged.
+
+The strategy choice depends on the form's length, the audience, and the validation complexity.
+
+---
+
+## Pattern A: Per-step validation
+
+Each step's fields are validated before allowing progression to the next step.
+
+**How it works.**
+
+- The user completes the current step.
+- Validation runs on all fields in the step.
+- If errors exist, they are shown; the Next button does not advance.
+- The user fixes errors and proceeds.
+
+**Strengths.**
+
+- Errors caught at the point of input.
+- User does not invest in completing later steps only to discover an early error.
+- Form feels responsive.
+
+**Weaknesses.**
+
+- Can feel intrusive if validation is too strict on every step transition.
+- May block the user from progressing when they want to revise the field later.
+
+**When to use.** Default for most multi-step forms. Each step's data is validated as a coherent unit.
+
+---
+
+## Pattern B: End-only validation
+
+All validation runs at submission.
+
+**How it works.**
+
+- The user completes all steps.
+- Validation runs only when the user clicks Submit.
+- All errors surface at once.
+
+**Strengths.**
+
+- User completes uninterrupted.
+- Validation logic is simpler (one validation pass).
+
+**Weaknesses.**
+
+- User invests in entire form only to discover an early error.
+- Errors at the end can lose the user.
+- Errors that span multiple steps are confusing to surface.
+
+**When to use.** Rarely. Sometimes appropriate for very short forms where per-step validation overhead is not worth it.
+
+---
+
+## Pattern C: Hybrid
+
+Required-field validation per step; full validation at end.
+
+**How it works.**
+
+- Per-step: critical errors (missing required fields, malformed email format) catch immediately.
+- End: nuanced validation (cross-field consistency, business rules) catches at submission.
+
+**Strengths.**
+
+- Combines the responsiveness of per-step with the simplicity of end-only.
+- The user gets immediate feedback on critical issues.
+- Complex validation logic does not interrupt the flow.
+
+**Weaknesses.**
+
+- More complex to design (two validation tiers).
+- Risk of inconsistent user experience if the tiers are not well-coordinated.
+
+**When to use.** When validation has both critical-immediate components (required fields, format checks) and nuanced-end components (cross-field rules, business logic). The default pattern for most multi-step forms with significant validation needs.
+
+---
+
+## Pattern D: Real-time validation
+
+Validation runs as the user types or interacts with each field.
+
+**How it works.**
+
+- As the user types, validation runs on the field.
+- Errors appear inline as soon as they are detectable.
+- Some implementations validate on field blur (when the user leaves the field) rather than every keystroke.
+
+**Strengths.**
+
+- Earliest possible error detection.
+- User sees the result of their input immediately.
+
+**Weaknesses.**
+
+- Can feel intrusive if validation appears before the user finishes typing.
+- Real-time validation on complex rules can lag.
+- Easy to surface errors prematurely.
+
+**When to use.** When the validation is simple enough to run instantly (format checks) and when the audience benefits from immediate feedback. Best practice: validate on blur rather than every keystroke.
+
+---
+
+## Validation message discipline
+
+The error messages themselves matter.
+
+**Helpful messages.**
+
+- "Phone number must include area code" (specific guidance).
+- "Try a value between 1 and 1000" (specific range).
+- "Email must include @ and a domain" (specific format).
+- "This field is required" (when blank).
+
+**Unhelpful messages.**
+
+- "Invalid input" (generic).
+- "Error" (no information).
+- "Out of range" (no range specified).
+- "You must enter..." (scolding tone).
+
+**Tone discipline.** Messages should be helpful, not scolding. "Try a value between 1 and 1000" beats "You must enter a value between 1 and 1000."
+
+**Specificity.** "Phone number must be 10 digits" beats "Invalid phone number." Specific guidance lets the user fix the issue immediately.
+
+---
+
+## Inline placement
+
+Where errors appear matters.
+
+**Inline placement.** Errors appear next to the field that triggered them. The user sees the error in context.
+
+**Banner placement.** Errors appear in a banner at the top of the step. Easy to miss; less helpful.
+
+**Mixed placement.** Some errors inline, some in a banner. Confusing.
+
+The discipline. Inline placement is the default. Banners can supplement (summarizing all errors on the step) but should not replace inline.
+
+---
+
+## Validation timing
+
+When validation triggers.
+
+**On blur.** Validation runs when the user leaves the field. Default for most field types.
+
+**On change.** Validation runs as the user types. Useful for some real-time feedback (password strength, character count) but intrusive for most validation.
+
+**On submit.** Validation runs when the user clicks the Next or Submit button. Always required as the final check.
+
+The combination matters. Most fields work well with on-blur for individual validation plus on-submit for final check.
+
+---
+
+## Cross-field validation
+
+Validation that depends on multiple fields.
+
+**Examples.**
+
+- "End date must be after start date."
+- "Sum of allocations must equal 100 percent."
+- "If selected 'enterprise,' company size must be above 200."
+
+**The challenge.** Cross-field validation does not fit per-field timing. The validation can only run when both fields have values.
+
+**Approaches.**
+
+- **End-only validation for cross-field rules.** The cross-field check runs at submission.
+- **End-of-step validation.** The cross-field check runs when the step containing both fields is completed.
+- **Reactive cross-field validation.** Each time either field changes, the cross-field check runs.
+
+The choice depends on the form's complexity and the user's likely workflow.
+
+---
+
+## Validation strictness
+
+How aggressively to reject inputs.
+
+**Too strict.** Rejects valid inputs because the validation is over-specified. "Email format invalid" for an email with a plus-sign alias.
+
+**Too loose.** Accepts invalid inputs that fail at submission. The user finds out late.
+
+**The right strictness.** Match validation rules to actual business requirements. Do not reject inputs the system can handle; do not accept inputs the system will choke on.
+
+**Common over-strictness mistakes.**
+
+- Email validation that rejects plus-sign aliases.
+- Phone validation that rejects international formats.
+- Name validation that rejects non-Latin characters.
+- Address validation that rejects valid international addresses.
+
+The discipline. Validation should reflect what the system actually requires, not what is stereotypical.
+
+---
+
+## Validation and accessibility
+
+Validation must work for users with assistive technology.
+
+**Screen reader announcements.** Errors should be announced when they appear. ARIA live regions for inline errors; focus management for error summaries.
+
+**Keyboard navigation.** Users should be able to navigate to error messages with keyboard alone.
+
+**Visual cues alongside text.** Color-coding for errors should not be the only signal; text labels and icons help users who cannot perceive color.
+
+Detail in `accessibility-audit` for deeper accessibility coverage.
+
+---
+
+## Validation and mobile
+
+Mobile validation has specific considerations.
+
+**Touch-friendly error states.** Error indicators should be visible without pinch-zoom.
+
+**Inline placement on mobile.** Errors appearing below or above the field; do not push critical content off-screen.
+
+**Mobile keyboards.** Use input types (email, tel, number) so mobile keyboards adapt; this also helps validation.
+
+**Real-time validation latency.** On mobile, real-time validation can lag and feel sluggish; default to on-blur for performance.
+
+---
+
+## Validation testing
+
+Test validation across edge cases.
+
+**Test cases to include.**
+
+- Empty required fields.
+- Format-invalid inputs (malformed emails, invalid phone numbers).
+- Format-valid but business-invalid inputs (email without account, valid date in the past for a future-only field).
+- Boundary inputs (minimum, maximum, just-outside).
+- Special characters and international inputs.
+
+**The discipline.** Validation should pass valid inputs and reject invalid ones consistently. Test with realistic edge cases the audience will encounter.
+
+---
+
+## Common validation failures
+
+**Generic error messages.** "Invalid input" without guidance.
+
+**Over-strict validation.** Rejecting valid inputs that fall outside narrow expectations.
+
+**Late validation.** Errors caught only at submission for issues that should have surfaced earlier.
+
+**Banner-only error placement.** User cannot see which field has the issue.
+
+**Validation that rejects internationally.** US-only formatting rules applied to international audiences.
+
+**Inconsistent validation rules.** Same field validated differently in different contexts.
+
+**Validation without accessibility.** Errors invisible to screen readers; color-only cues.
+
+**Validation that interrupts typing.** Real-time validation surfacing errors before the user finishes typing.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catch-helpful principle. Patterns A through D with strengths, weaknesses, and when-to-use guidance. Validation message discipline (helpful vs unhelpful). Inline placement. Validation timing. Cross-field validation. Validation strictness. Validation and accessibility (cross-reference). Validation and mobile. Validation testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific validation rules for specific forms. Specific tooling for validation implementation. Specific brand-voice error messages. The team's accessibility review processes. These vary by team.

--- a/skills/quiz-and-assessment-design/SKILL.md
+++ b/skills/quiz-and-assessment-design/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: quiz-and-assessment-design
+description: "Designing quizzes, personality assessments, and recommendation tools that segment users into actionable categories rather than generating clicks for clicks' sake. Question architecture, scoring algorithms, result categorization, recommendation mapping, lead capture integration. Honest about clickbait-quiz (engagement only), vanity-result (entertaining, not useful), and actionable-segmentation (genuine categorization that drives next-step recommendations) patterns. Triggers on quiz, assessment, personality test, recommendation tool, scorecard, diagnostic, fit evaluator, what-type-of-X-are-you, persona quiz. Also triggers when an audience needs a categorization-driven lead magnet, when a vanity quiz is producing engagement but no qualified leads, or when an assessment is being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing quizzes and assessments that produce actionable segmentation. Distinguishes clickbait-quiz (engagement only) from vanity-result (entertaining, not useful) from actionable-segmentation (genuine categorization that drives next-step recommendations)"
+display_order: 3
+---
+
+# Quiz and Assessment Design
+
+A senior growth practitioner's playbook for designing quizzes and assessments that produce actionable segmentation rather than generating clicks for clicks' sake. Question architecture, scoring algorithms, result categorization, recommendation mapping. The discipline of building a quiz the audience actually uses to make a decision.
+
+Most quizzes on the web are clickbait. "What kind of pizza are you?" energy applied to brand-building, with results that flatter the taker but drive no specific next step. The quiz captures emails because the format implies fun; the leads are unqualified because the result told them nothing they could act on.
+
+The quizzes that work as compounding assets do something different. They categorize the taker into a defined segment with a specific recommendation matched to that segment. The taker comes away knowing what to do next, not just what they are. The brand becomes the source of the recommendation the audience acted on.
+
+This skill is one of the specific lead-magnet types covered as its own skill. The parent-frame methodology lives in `lead-magnet-design`; the quiz-specific methodology (scoring algorithms, result categorization, recommendation matching) lives here.
+
+The voice is the senior growth practitioner who has watched quizzes earn long-term subscribers and watched them produce engagement metrics with no downstream impact. Practical, opinionated about the difference between fun-quiz and decision-quiz, willing to call out when a quiz is the wrong format for the goal.
+
+When to use this skill: scoping a quiz or assessment for the first time, auditing a quiz that produces engagement but no qualified leads, designing the result categories that drive specific recommendations, or deciding which inputs warrant the lead-capture step.
+
+---
+
+## What this skill covers
+
+This skill spans quiz and assessment design as one specific lead-magnet type. The growth-tooling distinctions:
+
+- `lead-magnet-design` is the parent-frame methodology. Quizzes are one specific lead-magnet type.
+- `calculator-design` is a sister tool type. Calculators give numbers; quizzes give categories. The methodology differs.
+- **`quiz-and-assessment-design` (this skill)** is quiz-specific methodology (question architecture, scoring algorithms, result categorization, recommendation matching).
+- `discovery-research-synthesis` is customer-research synthesis (this skill is user-facing assessment, not internal research).
+- `landing-page-copy` is the quiz landing page (downstream of quiz design).
+
+The audience: growth marketers, product marketers, content marketers, agencies running quiz-based growth tooling for clients.
+
+Out of scope: lead-magnet design at the parent-frame level (covered by `lead-magnet-design`); calculator design (covered by `calculator-design`); landing-page copy (covered by `landing-page-copy`); the engineering implementation of the quiz (handed off via `pm-spec-writing`).
+
+---
+
+## The quiz/assessment decision: when this format earns investment
+
+Before designing the quiz, decide whether a quiz is the right tool for the audience and the goal.
+
+**Quizzes earn investment when:**
+
+- The audience faces a decision that benefits from categorization. "Which of our products fits my situation," "what is my readiness for X," "what type of Y am I." The categorization has to map to a real next step.
+- The categorization can be derived from a small number of questions. 5-12 questions can produce meaningful segmentation; 30 questions stops being a quiz and becomes a survey.
+- The brand has a portfolio of recommendations that match the segments. A quiz that produces 5 segments and only one recommendation does not justify the format; the segment-recommendation mapping is the value.
+- The result format suits the audience. Audiences who enjoy quizzes (consumers, B2B mid-market, certain creator audiences) engage; audiences who do not (technical buyers, enterprise) often see quizzes as gimmicks.
+
+**Quizzes do NOT earn investment when:**
+
+- The categorization is trivial. "What plan is right for you" with two plans does not need a quiz; a comparison table works.
+- The categorization is irrelevant to the next step. A personality quiz with no product-recommendation tie-in entertains but does not convert.
+- The brand has no varied recommendations. A quiz with one outcome is bait; the segmentation is decorative.
+- The audience disrespects quizzes in this context. Enterprise buyers often see quizzes as unprofessional; the format choice has to fit the audience.
+
+The decision is not "should we have a quiz"; it is "is the quiz the right next investment for this specific audience and decision."
+
+Detail in `references/quiz-investment-criteria.md`.
+
+---
+
+## Clickbait-quiz vs vanity-result vs actionable-segmentation
+
+The keystone framing.
+
+**Clickbait-quiz.** "What kind of pizza are you?" energy. Generates engagement (shares, comments, brief virality), segments nothing useful. Fun but not strategic. Cost: the engagement metric looks fine; the leads have no qualification signal because the quiz did not reveal anything actionable about them.
+
+**Vanity-result.** Elaborate-feeling result that flatters the taker but does not drive any specific next step. "You are an INTJ visionary entrepreneur" with a description that reads like horoscope, no actionable follow-up. Cost: the taker enjoyed the result, did not act on it, did not return. The quiz produced a moment of attention, not a relationship.
+
+**Actionable-segmentation.** Result places the taker into a defined category with a specific recommendation matched to that category. The result tells them what to DO next, not just what they ARE. The category and the recommendation are the value; the taker comes away with a next step.
+
+The litmus test. After taking the quiz, can a stranger in the target audience name the next thing they should do? Can they describe the recommendation matched to their result? If yes, the quiz is actionable-segmentation. If they got a flattering description with no clear next step, the quiz is vanity-result. If they got entertainment with no segmentation, the quiz is clickbait.
+
+---
+
+## Question architecture
+
+The questions are the mechanism that produces the segmentation. Bad questions produce bad segmentation regardless of how clever the scoring algorithm is.
+
+**Question count.** Most effective quizzes use 5-10 questions. Fewer than 5 rarely produces meaningful segmentation; more than 12 stops feeling like a quiz and starts feeling like an interrogation.
+
+**Question types.**
+
+- **Multiple-choice (single-select).** The most common. Each option maps to a segment or scoring weight.
+- **Multiple-select.** Useful when multiple attributes apply. Care needed; multi-select complicates scoring.
+- **Slider or scale.** "On a scale of 1-5, how often do you..." Useful for intensity questions; less useful for categorical segmentation.
+- **Yes/no.** Useful for binary qualifying questions; rarely produces nuanced segmentation alone.
+- **Free text.** Avoid in quizzes. Free text breaks the scoring flow and adds friction.
+
+**Question ordering.** Start with engaging, low-friction questions. Save more revealing or sensitive questions for later when commitment has built. Demographic or qualifying questions belong at the end, not the start.
+
+**Question phrasing.**
+
+- Plain language. Avoid jargon.
+- Specific situations the audience recognizes.
+- Avoid leading questions ("How much do you struggle with X" presumes struggle).
+- Avoid double-barreled questions ("How much do you value speed AND simplicity" mixes two dimensions).
+
+**Question-segment mapping.** Each question should contribute to the segmentation in a defined way. Questions that do not affect the result are filler; remove them.
+
+Detail in `references/question-architecture-patterns.md`.
+
+---
+
+## Scoring algorithms
+
+The math that turns answers into a segment.
+
+**Pattern A: Direct mapping.** Each answer corresponds directly to a segment. The dominant answer choice determines the result. Simple, transparent, easy to explain.
+
+**Pattern B: Weighted scoring.** Each answer adds points to one or more segments. The highest-scoring segment wins. Allows for nuance; one answer can contribute to multiple segments.
+
+**Pattern C: Multi-dimensional.** The quiz produces scores across multiple axes (e.g., introvert/extrovert AND analytical/intuitive). The result combines the scores into a 2D or 3D segment. Common in personality assessments.
+
+**Pattern D: Branching logic.** The next question depends on the previous answer. Allows for adaptive questioning; complicates scoring.
+
+**Choice criteria.**
+
+- Direct mapping when the segments are well-defined and the questions clearly distinguish them.
+- Weighted scoring when nuance matters and most answers contribute to multiple segments.
+- Multi-dimensional when the segmentation is genuinely multi-axis (personality, fit-evaluation).
+- Branching when later questions make sense only in the context of earlier answers.
+
+**Scoring transparency.** Some quizzes show the score during or after the quiz; others present only the segment. The choice depends on whether the score is meaningful to the user. Personality assessments benefit from showing dimensions; recommendation quizzes often do not.
+
+Detail in `references/scoring-algorithm-patterns.md`.
+
+---
+
+## Result categorization
+
+How many segments, named how, distinguishable from each other.
+
+**Segment count.** Most quizzes work well with 4-8 result categories. Fewer than 4 makes the categorization feel coarse; more than 8 makes individual segments feel under-developed.
+
+**Segment naming.**
+
+- Memorable. The taker should be able to describe their segment to a friend.
+- Specific. "The Strategic Planner" beats "Type 3."
+- Honest. Names should not flatter universally; some segments are more flattering than others, which is honest segmentation.
+- Brand-voice consistent. The names should sound like the brand the quiz represents.
+
+**Segment distinguishability.** Each segment should be meaningfully different. If two segments have similar descriptions and similar recommendations, the segmentation is fake.
+
+**Segment balance.** The quiz should not always route 80 percent of takers to one segment. Balanced segmentation (each segment receives a meaningful share of takers) signals that the questions actually distinguish.
+
+Detail in `references/result-categorization-patterns.md`.
+
+---
+
+## Result-to-recommendation mapping
+
+The action attached to each category. This is where the quiz earns its conversion.
+
+**The principle.** Each segment maps to a specific recommendation. The recommendation is what the taker does next.
+
+**Mapping examples.**
+
+- B2B SaaS quiz: "Which CRM tier fits your team" maps each segment to a recommended plan.
+- Content quiz: "What kind of marketer are you" maps each segment to a different content series matched to that maturity level.
+- Onboarding quiz: "What is your readiness for X" maps each segment to a different onboarding path or resource.
+
+**The recommendation has to be real.** The brand should actually offer the recommended next step; the recommendation should match the segment specifically; the recommendation should be valuable to the segment.
+
+**Mapping discipline.**
+
+- Each segment has a distinct recommendation. No two segments share the same next step.
+- Each recommendation is actionable. The taker can act on it without additional research.
+- Each recommendation is valuable to that specific segment. Generic recommendations for one segment do not earn the segmentation.
+- The recommendation is delivered in context of the result. Not buried 3 emails later.
+
+**The vanity-result failure.** Result describes the segment without a recommendation. "You are a Strategic Planner" with a description but no next step. The taker enjoys the segment, does nothing.
+
+**The actionable-segmentation win.** Result describes the segment, then says: "Strategic Planners benefit most from [specific resource or product or path]. Here is the next step." The taker has a specific action.
+
+Detail in `references/result-to-recommendation-mapping.md`.
+
+---
+
+## Lead capture integration
+
+When and where to ask for the email, with what value-add.
+
+**The principle.** Capture the email in exchange for the personalized result delivery, not in exchange for seeing the result at all.
+
+**Pattern A: Email after questions, before result.** "Enter your email to see your personalized result." Common; works when the perceived value of the result is high. Risk: lead-trap pattern if the result was already calculated and is being held hostage.
+
+**Pattern B: Email after result, for personalized delivery.** "See your result here. Want a PDF with personalized recommendations matched to your segment? Enter your email." Honest; the result is free, the additional value justifies the email.
+
+**Pattern C: Email integrated with optional features.** "See your result. Save this scenario, get notified when new content for your segment is available, or download a personalized resource." Gradual opt-in; less aggressive.
+
+**The value-add at lead capture.** What the user gets for their email matters. A personalized PDF report, a follow-up email series matched to their segment, a curated resource list specific to their result. Generic delivery (just sending the same result by email) does not justify the gate.
+
+**Conversion vs lead quality.** Pattern A converts higher; Pattern B and C produce higher lead quality. Pattern choice depends on what the program optimizes for.
+
+Detail in `references/lead-capture-integration-patterns.md`.
+
+---
+
+## Quiz anti-patterns
+
+Patterns that look like quizzes but degrade trust.
+
+**The clickbait-quiz.** Engagement-driven framing with no actionable segmentation. "What kind of marketer are you" with 4 personality types and no recommendations.
+
+**The vanity-result quiz.** Flattering descriptions for every segment; no honest segmentation; no specific recommendations.
+
+**The forced-result quiz.** Every taker routes to the same recommendation regardless of answers. The segmentation is decorative; the recommendation was predetermined.
+
+**The interrogation-quiz.** 25 questions that feel like a survey rather than a quiz. The audience drops off mid-quiz.
+
+**The leading-question quiz.** Questions phrased to push the taker toward a specific result. "Don't you sometimes wish you had..." is leading.
+
+**The black-box quiz.** No explanation of how the result was determined. The taker gets a label with no insight into why.
+
+**The no-recommendation quiz.** Result categories exist; no next step is offered. The quiz produces awareness of the segment without action.
+
+**The mismatched-recommendation quiz.** Recommendation does not match the segment. Audience that catches the mismatch loses trust.
+
+Detail in `references/quiz-anti-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-quiz-failures.md`.
+
+- "Quiz gets shared widely; lead quality is poor." Clickbait pattern; the audience taking and sharing is not the audience the brand serves.
+- "Engagement is high; downstream conversion is near zero." Vanity-result pattern; takers enjoyed the segment but had no next step.
+- "Most takers route to the same segment." Question architecture not distinguishing; algorithm needs review.
+- "Drop-off mid-quiz is high." Too many questions; or questions feel uncomfortable; or the value of finishing is not clear.
+- "Segments feel similar." Distinguishability problem; segments need more divergent descriptions and recommendations.
+- "Recommendations feel generic." Mapping problem; each segment needs a specific recommendation, not a default.
+- "We cannot tell which segment converts best downstream." Attribution missing; segments need tracking through the funnel.
+- "Audience comments that the result was wrong." Either question or scoring problem; the segments do not match audience self-perception.
+
+---
+
+## The framework: 12 considerations for quiz and assessment design
+
+When designing or auditing a quiz, walk these 12 considerations.
+
+1. **The quiz decision.** Is a quiz the right format for this audience and decision, or would a comparison table or assessment-as-content serve better?
+2. **Actionable-segmentation, not clickbait or vanity.** The result places the taker into a category with a specific recommendation.
+3. **Question architecture sound.** 5-12 questions; each contributes to segmentation; phrased plainly without leading.
+4. **Scoring algorithm fits the segmentation.** Direct mapping, weighted scoring, multi-dimensional, or branching as appropriate.
+5. **Result categories distinguishable and balanced.** 4-8 segments; each meaningfully different; each receives a meaningful share of takers.
+6. **Segment naming memorable and brand-consistent.** Names the taker can describe to a friend.
+7. **Recommendations specific to each segment.** No two segments share the same recommendation; each recommendation is valuable to that segment.
+8. **Lead capture honest.** Email exchange for personalized delivery, not for seeing the result.
+9. **Result delivery in context.** Recommendation appears with the result, not buried 3 emails later.
+10. **Drop-off measured.** Question-by-question drop-off tracked; questions that lose audience flagged for review.
+11. **Lead quality measured by segment.** Downstream conversion tracked per segment; some segments may be more valuable than others.
+12. **Audit cadence.** Periodic review of segment balance, recommendation alignment, and conversion-by-segment.
+
+The output of the framework is a quiz that segments the audience meaningfully, produces specific recommendations, and converts the segments into action.
+
+---
+
+## Reference files
+
+- [`references/quiz-investment-criteria.md`](references/quiz-investment-criteria.md) - When a quiz is the right tool for the audience and goal, and when a comparison table or other format would serve.
+- [`references/question-architecture-patterns.md`](references/question-architecture-patterns.md) - Question count, types, ordering, phrasing, and segment mapping discipline.
+- [`references/scoring-algorithm-patterns.md`](references/scoring-algorithm-patterns.md) - Direct mapping, weighted scoring, multi-dimensional, branching. Choice criteria and tradeoffs.
+- [`references/result-categorization-patterns.md`](references/result-categorization-patterns.md) - Segment count, naming, distinguishability, balance.
+- [`references/result-to-recommendation-mapping.md`](references/result-to-recommendation-mapping.md) - The action attached to each category. Mapping discipline and worked examples.
+- [`references/lead-capture-integration-patterns.md`](references/lead-capture-integration-patterns.md) - When and where to ask for the email. Pattern choices and tradeoffs.
+- [`references/quiz-anti-patterns.md`](references/quiz-anti-patterns.md) - The patterns that look like quizzes but degrade trust.
+- [`references/clickbait-vs-actionable-distinctions.md`](references/clickbait-vs-actionable-distinctions.md) - Detailed treatment of the keystone framing with worked examples and counter-examples.
+- [`references/common-quiz-failures.md`](references/common-quiz-failures.md) - 8+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: quizzes earn engagement when they earn the next step
+
+The quizzes that work as compounding assets are the ones the audience acts on. Not shares. Not engagement metrics. Action. The taker runs the quiz, gets a segment with a matched recommendation, and does the recommendation.
+
+That is the bar. Below the bar are clickbait-quizzes (engagement without action) and vanity-results (flattery without action). Above the bar are actionable-segmentation tools that produce specific next steps the taker actually takes.
+
+The discipline is in the design choices. The questions that genuinely distinguish segments. The scoring algorithm that maps answers to meaningful categories. The recommendations that match each segment specifically. The result-delivery that surfaces the recommendation in context, not 3 emails later.

--- a/skills/quiz-and-assessment-design/references/clickbait-vs-actionable-distinctions.md
+++ b/skills/quiz-and-assessment-design/references/clickbait-vs-actionable-distinctions.md
@@ -1,0 +1,192 @@
+# Clickbait vs actionable distinctions
+
+Detailed treatment of the keystone framing with worked examples and counter-examples. The single distinction that separates quizzes that compound credibility from quizzes that produce engagement without action.
+
+---
+
+## The three-state framing
+
+Three states a quiz can land in. Only one of them produces compounding value.
+
+**State 1: Clickbait.** The quiz exists primarily to generate engagement. "What kind of pizza are you?" energy. The result is fun but means nothing. No segmentation that maps to a decision. No recommendation. Engagement metrics look healthy; downstream metrics are zero.
+
+**State 2: Vanity-result.** The quiz produces a result that feels meaningful but does not drive action. "You are an INTJ visionary entrepreneur." The taker reads the description, may share it, does not act on it. The result is descriptive without being prescriptive.
+
+**State 3: Actionable-segmentation.** The quiz produces a result that includes a specific recommendation matched to that segment. The taker can act immediately on the recommendation. The result is both descriptive (this is who you are) and prescriptive (this is what to do next).
+
+The states are not always obvious from the outside. A quiz can look polished and still be vanity-result; a quiz can look simple and still be actionable-segmentation. The distinction is in the design, not the surface.
+
+---
+
+## What separates the states
+
+The three differences that separate actionable-segmentation from the others.
+
+**Difference 1: The result includes a recommendation.**
+
+- Clickbait: result is a label or description. "You are a 'Strategic Visionary'."
+- Vanity: result is an elaborate description. "You are a 'Strategic Visionary': big-picture thinker, comfortable with ambiguity, drawn to long-term impact..."
+- Actionable: result is a description plus a recommendation. "You are a 'Strategic Visionary'. The next step that fits this profile: [specific resource, product, or path]."
+
+**Difference 2: The recommendation is specific to the segment.**
+
+- Clickbait: no recommendation, so the question does not apply.
+- Vanity: every segment may get a similar generic next step ("read our blog"); the recommendation is decorative.
+- Actionable: each segment gets a distinct recommendation matched to that segment specifically.
+
+**Difference 3: The recommendation is actionable today.**
+
+- Clickbait: no recommendation.
+- Vanity: recommendation is aspirational ("consider whether you might be ready for X someday").
+- Actionable: recommendation is concrete and immediate ("start your trial here," "book a 30-minute call here," "download the playbook here").
+
+The pattern. Clickbait has no recommendation. Vanity has decorative recommendation. Actionable has specific, matched, concrete recommendation.
+
+---
+
+## Worked example: the same topic in three states
+
+A quiz on "what kind of marketer are you" treated three ways.
+
+**Clickbait version.**
+
+- 5 questions about content preferences and personality.
+- Result: "You are 'The Storyteller'." Description: "Storytellers love narrative and connect deeply with their audience."
+- Action: share the result.
+
+The taker enjoys the result, may share it, learns nothing actionable. The quiz produces engagement; the brand earns no qualified leads.
+
+**Vanity-result version.**
+
+- 8 questions about marketing approach, content, audience interaction.
+- Result: "You are 'The Storyteller': a marketer who values narrative, audience connection, and emotional resonance. Storytellers thrive in brands that prioritize voice and depth..."
+- Action: 3 paragraphs of description; soft CTA at the bottom: "Want more? Subscribe to our newsletter."
+
+The taker reads the elaborate description; may subscribe to the newsletter; does not take a specific action that converts. The quiz produces a moment of attention; the brand earns subscribers but no qualified leads.
+
+**Actionable-segmentation version.**
+
+- 7 questions about marketing approach, content, audience interaction, current tools, current challenges.
+- Result: "You are 'The Storyteller'. Storytellers benefit most from our 4-part 'Brand Voice Workshop' series. Here is the first lesson; the next 3 arrive over the following week. Or, if you prefer, start with our 'Brand Voice Audit Template' [direct download]."
+- Action: clear next step with two options matched to the segment's likely preference (sequence or self-serve).
+
+The taker gets a matched recommendation. The taker who wants the sequence opts in; the taker who wants the template downloads. Either way, action is taken; the brand earns a qualified lead.
+
+The same topic, three quizzes, three different outcomes. The actionable version compounds value; the others do not.
+
+---
+
+## How to evaluate which state a quiz is in
+
+Diagnostic questions to apply to any quiz.
+
+**Question 1: Does the result include a specific recommendation?**
+
+- No: the quiz is clickbait or vanity.
+- Yes: continue.
+
+**Question 2: Does each segment have a distinct recommendation, or do all segments share the same recommendation?**
+
+- All same: the quiz is forced-result; segmentation is decorative.
+- Distinct: continue.
+
+**Question 3: Is the recommendation actionable today?**
+
+- No (aspirational, vague, "consider"): the quiz is vanity.
+- Yes (specific link, button, or action): the quiz is actionable-segmentation.
+
+**Question 4: Does the recommendation match the segment specifically (not a generic offer)?**
+
+- No: the quiz is vanity with decorative recommendations.
+- Yes: the quiz is actionable-segmentation.
+
+When all four questions get the right answer, the quiz is actionable-segmentation. When any fails, the quiz is somewhere between clickbait and vanity.
+
+---
+
+## The compounding-value mechanism
+
+Why actionable-segmentation compounds and the others do not.
+
+**Actionable-segmentation compounds.**
+
+- The taker acts on the recommendation; the brand becomes the source of the action.
+- The taker sees results from the action; the brand earns credit.
+- The taker returns or refers; the brand's reach grows.
+- The brand's recommendations become trusted; future quizzes earn more conversion.
+
+**Clickbait does not compound.**
+
+- The taker engages; the engagement does not convert.
+- The brand's quiz is one of many forgotten amusements.
+- No relationship deepens; no credibility builds.
+
+**Vanity does not compound.**
+
+- The taker enjoys; the enjoyment does not convert.
+- The brand's quiz is one of many flattering distractions.
+- The newsletter subscription (if any) decays without engagement.
+
+The compounding effect is the difference between quizzes that earn ongoing investment and quizzes that get retired.
+
+---
+
+## Why teams build clickbait and vanity quizzes
+
+The patterns are easy to ship. Understanding why teams default to them helps teams choose actionable-segmentation instead.
+
+**Reason 1: Engagement metrics are easier to measure.** Conversion rate to email, share counts, time on page are all available immediately. Downstream conversion takes weeks or months to measure. Teams optimize what they measure.
+
+**Reason 2: Designing recommendations is hard.** Each segment needs a matched recommendation; the brand has to have the recommendations to give. Designing the segment-recommendation mapping is more work than designing the quiz alone.
+
+**Reason 3: Templates default to clickbait.** Many quiz-platform templates are designed for engagement, not for segmentation-driven action. Using a template often produces clickbait by default.
+
+**Reason 4: The vanity-result feels safer.** Flattering descriptions feel safer than honest segmentation; teams worry about "telling someone they are not a fit." Honest segmentation is harder but produces more trust.
+
+**Reason 5: Short-term thinking.** Engagement is immediate; downstream conversion is delayed. Teams optimizing for the next quarter default to engagement.
+
+The cure. Track downstream conversion as the primary metric. Build the recommendation portfolio before designing the quiz. Avoid templates that default to engagement. Practice honest segmentation.
+
+---
+
+## Counter-example: when engagement is the goal
+
+Some quizzes are intentionally engagement-driven, and that is fine.
+
+**The legitimate engagement-quiz.** A consumer brand running a viral quiz to drive social shares and brand awareness. The goal is reach, not lead-capture. The quiz is intentionally entertainment.
+
+**The pattern.** Light, fun, shareable. No email gate. Result is shareable. Brand association is the value.
+
+**Why this is fine.** The brand has chosen reach as the metric. The quiz delivers on that goal. The quiz is not pretending to be something it is not.
+
+**The discipline.** Be honest about the goal. If the goal is engagement, do not pretend the quiz is for lead-capture; do not include a half-hearted email gate that produces neither real engagement nor real leads.
+
+The clickbait pattern fails when teams pretend it is something else. When teams own the engagement goal and design for it explicitly, the quiz can serve that goal well.
+
+---
+
+## Common patterns by industry
+
+How clickbait, vanity, and actionable-segmentation play differently across industries.
+
+**Consumer brands.** Consumer brands often run engagement-quizzes successfully when the brand-association goal is the value. Lead-capture quizzes are harder; consumer audiences resist email gates more.
+
+**B2B SaaS.** B2B SaaS audiences expect actionable-segmentation. Clickbait and vanity are read as unprofessional. Actionable quizzes that route to specific plans or resources work well.
+
+**Education and creators.** Mixed. Some audiences engage with personality-style quizzes; some want practical assessment. The audience the brand serves determines which works.
+
+**Enterprise.** Enterprise audiences usually skip quizzes entirely. When they engage, only actionable-segmentation works; clickbait or vanity is read as unserious.
+
+**Ecommerce.** Recommendation quizzes ("which of our products fits you") work well as actionable-segmentation when the product portfolio supports it.
+
+The discipline. Match the quiz pattern to the audience expectation. Audiences that expect actionable-segmentation will reject anything else; audiences that engage with personality quizzes will not be converted by overly-formal segmentation.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The three-state framing. The three differences that separate actionable-segmentation from clickbait and vanity. The diagnostic questions. The compounding-value mechanism. Why teams default to clickbait and vanity. The counter-example for legitimate engagement-quizzes. Industry patterns.
+
+## Implementation choices that stay internal
+
+Specific quiz topics for specific audiences. Specific recommendation portfolios. Specific tracking for downstream conversion per pattern. The team's measurement framework for engagement vs action. These vary by team.

--- a/skills/quiz-and-assessment-design/references/common-quiz-failures.md
+++ b/skills/quiz-and-assessment-design/references/common-quiz-failures.md
@@ -1,0 +1,187 @@
+# Common quiz failures
+
+8+ failure patterns with diagnoses and cures. The patterns that surface as "the quiz did not produce qualified leads" or "engagement is high but nothing converts" or "we cannot tell if the quiz worked."
+
+---
+
+## "Quiz gets shared widely; lead quality is poor."
+
+**The diagnosis.** Clickbait pattern. The audience taking and sharing is not the audience the brand serves; the quiz attracts engagement from a broader audience than the brand's target.
+
+**The cure.** Tighten the quiz's audience-fit. Specific titles, specific topics, specific recommendations matched to the brand's actual buyers. Detail in `references/quiz-investment-criteria.md` (recommendation-portfolio precondition) and `lead-magnet-design`'s audience-fit qualification.
+
+---
+
+## "Engagement is high; downstream conversion is near zero."
+
+**The diagnosis.** Vanity-result pattern. Takers enjoyed the segment but had no next step. The quiz produced moments of attention without action.
+
+**The cure.** Add specific recommendations to each segment. Detail in `references/result-to-recommendation-mapping.md`. Each result page must include a clear next step.
+
+---
+
+## "Most takers route to the same segment."
+
+**The diagnosis.** Question architecture not distinguishing. Either the questions do not actually capture differentiating signals, or the scoring algorithm biases toward one segment.
+
+**The cure.** Audit the question-segment mapping (`references/question-architecture-patterns.md`). Ensure each question contributes meaningfully to multiple segments. Audit the scoring weights for unintended bias.
+
+---
+
+## "Drop-off mid-quiz is high."
+
+**The diagnosis.** Too many questions, or questions feel uncomfortable, or the value of finishing is not clear.
+
+**The cure.** Reduce question count if over 12. Audit questions for those that feel sensitive or repetitive. Add a progress indicator and a teaser of the result ("almost done; see your result next") to reduce late-stage drop-off.
+
+---
+
+## "Segments feel similar."
+
+**The diagnosis.** Distinguishability problem. Either over-segmentation (more segments than the questions can support) or weak descriptions that do not differentiate.
+
+**The cure.** Reduce segment count to what the questions can distinguish (`references/result-categorization-patterns.md`). Strengthen the descriptions to make each segment meaningfully different.
+
+---
+
+## "Recommendations feel generic."
+
+**The diagnosis.** Mapping problem. Each segment needs a specific recommendation, not a default.
+
+**The cure.** Audit the segment-to-recommendation mapping (`references/result-to-recommendation-mapping.md`). Verify each segment has a distinct, valuable, actionable recommendation.
+
+---
+
+## "We cannot tell which segment converts best downstream."
+
+**The diagnosis.** Attribution missing. Segments need tracking through the funnel.
+
+**The cure.** Tag leads by segment at capture. Track downstream conversion per segment. The data informs which segments warrant continued investment and which segments may need different recommendations.
+
+---
+
+## "Audience comments that the result was wrong."
+
+**The diagnosis.** Either question or scoring problem. The segments do not match audience self-perception.
+
+**The cure.** Persona testing. Have personas representing each segment take the quiz; verify each persona reaches the intended segment. Adjust questions or scoring weights to align.
+
+---
+
+## "The quiz earns 5000 takers; the email list grows by 200."
+
+**The diagnosis.** Either the result is not perceived as valuable enough to opt in for additional value (Pattern B failure), or the email gate is for the result itself with no value-add (lead-trap risk).
+
+**The cure.** Design a substantive value-add for the email opt-in (PDF, sequence, resource). Make the value-add visible at the result. Detail in `references/lead-capture-integration-patterns.md`.
+
+---
+
+## "We added a quiz; our other lead magnets stopped converting."
+
+**The diagnosis.** Cannibalization. The quiz absorbed the audience that previously converted via other magnets.
+
+**The cure.** This may not be a failure. If the quiz-sourced leads are higher quality than the previous magnets, the cannibalization is portfolio improvement. If not, the quiz may have replaced a working magnet with a worse one; audit and decide.
+
+---
+
+## "Sales says quiz-sourced leads are low-fit."
+
+**The diagnosis.** Either the audience-fit at the quiz is wrong (the quiz attracts non-target audiences) or the recommendation-mapping routes audiences to wrong products.
+
+**The cure.** First, audit the audience-fit. If the quiz is attracting the wrong audience, tighten the targeting (title, topic, distribution channels). Second, audit the recommendation-mapping. If the audience-fit is right but the recommendation is wrong, fix the mapping.
+
+---
+
+## "The quiz looks great; nobody completes it."
+
+**The diagnosis.** Either the topic does not engage the audience (audience-fit weak) or the question count is too high (drop-off too early).
+
+**The cure.** First, validate the topic with audience research. If the topic is right, audit the question count and question phrasing.
+
+---
+
+## "Engagement was great at launch; conversion has dropped 40 percent over a year."
+
+**The diagnosis.** Decay. Recommendations have shifted; segments have evolved; references are stale.
+
+**The cure.** Audit and refresh. Update recommendations to match current portfolio; verify segments still describe the audience accurately; refresh any stale references in question phrasing or result descriptions.
+
+---
+
+## "We made the quiz shorter; conversion went up but downstream conversion went down."
+
+**The diagnosis.** Question removal removed differentiating signals. The quiz now produces engagement faster but the segmentation is weaker.
+
+**The cure.** Restore the questions that contributed to segmentation. Speed-of-completion is a metric; segmentation quality is a separate metric. Optimize for the right one.
+
+---
+
+## "The result page is fine; the email follow-up sequence converts terribly."
+
+**The diagnosis.** Sequence does not match the segment. Either the sequence is generic across segments, or the sequence does not deepen the matched recommendation.
+
+**The cure.** Design segment-specific sequences (or at least segment-specific opening emails). The sequence should extend the result's recommendation, not start over with generic content.
+
+---
+
+## "We tried branching logic; the quiz felt confusing."
+
+**The diagnosis.** Branching added complexity without value. Different takers got different question sets; comparison across takers became hard.
+
+**The cure.** Revert to linear quiz unless branching is genuinely warranted. The simplicity often produces better outcomes.
+
+---
+
+## "The quiz works on Chrome; it breaks on Safari mobile."
+
+**The diagnosis.** Browser/device-specific bugs. The quiz was tested on the team's primary platform; the audience's actual devices were not covered.
+
+**The cure.** Cross-browser, cross-device testing. The audience uses what they use; the quiz has to work there.
+
+---
+
+## "The recommendation links to a product we discontinued."
+
+**The diagnosis.** Maintenance lapse. The quiz's recommendation drifted out of sync with the brand's actual offering.
+
+**The cure.** Set a maintenance trigger: when products are discontinued or pricing changes, the quiz updates are part of the change. Quarterly review at minimum.
+
+---
+
+## "Audiences take the quiz multiple times to get different results."
+
+**The diagnosis.** This is fine, often. Audiences exploring the segmentation may take it multiple times to understand how the algorithm works. Track unique users vs total completions.
+
+**The action.** Make sure the algorithm is stable enough that repeated takes with consistent answers produce consistent results. Inconsistency at this level signals algorithm issues.
+
+---
+
+## "The quiz produces good leads; the sales team does not follow up."
+
+**The diagnosis.** Sequence or routing missing. Quiz-sourced leads should be tagged, routed to sales, and prioritized appropriately.
+
+**The cure.** Design the post-conversion flow. Calculator-sourced leads should be tagged with their segment, routed to the appropriate sales rep, and the sales rep should know which segment the lead represents.
+
+---
+
+## The pattern across failures
+
+Most quiz failures fall into one of three patterns.
+
+**Pattern 1: The quiz does not deliver actionable segmentation.** Clickbait, vanity-result, no-recommendation, mismatched-recommendation. The fix is to add or correct the recommendations.
+
+**Pattern 2: The quiz does not match the audience.** Audience-fit weak, topic-audience mismatch, format-audience mismatch (e.g., quizzes for enterprise audiences who reject the format). The fix is to align the quiz to the audience the brand serves.
+
+**Pattern 3: The quiz decays.** Recommendations point to retired products; segments no longer describe the audience; references are stale. The fix is maintenance discipline.
+
+The metric pattern: quiz failures often look fine on engagement metrics. The signal is in lead quality, downstream conversion, and audience self-recognition. Programs that track only engagement keep shipping the same patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (delivery, audience-fit, decay). The principle that engagement alone is insufficient as a success metric.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered and the lessons learned. Specific multi-metric dashboards the team uses. Specific cures the team applies. The team's audit and retirement processes. These vary by team.

--- a/skills/quiz-and-assessment-design/references/lead-capture-integration-patterns.md
+++ b/skills/quiz-and-assessment-design/references/lead-capture-integration-patterns.md
@@ -1,0 +1,240 @@
+# Lead capture integration patterns
+
+When and where to ask for the email. Pattern choices and tradeoffs. The decision that affects both conversion and lead quality.
+
+The lead-capture integration is where the quiz earns its email. Done well, the audience opts in for personalized value; done poorly, the quiz becomes a lead-trap that the audience resents.
+
+---
+
+## The capture-honest principle
+
+Capture the email in exchange for personalized result delivery, not in exchange for seeing the result at all.
+
+**The honest pattern.** The taker completes the quiz; the result is shown; an offer is made for additional value (PDF, follow-up sequence, saved scenario) that requires the email.
+
+**The dishonest pattern.** The taker completes the quiz; the result is calculated but hidden; the email is required to reveal it. This is the lead-trap pattern (described in `calculator-design`'s email-capture-decision-tree but applies equally to quizzes).
+
+---
+
+## Pattern A: Email after questions, before result
+
+The taker completes the quiz; before the result is shown, an email gate appears.
+
+**How it works.**
+
+- The taker answers all questions.
+- A form appears: "Enter your email to see your personalized result."
+- The taker enters email; the result is shown.
+
+**Strengths.**
+
+- Highest conversion to email opt-in.
+- Common pattern; audiences are familiar.
+
+**Weaknesses.**
+
+- Lead-trap pattern. The audience that recognizes the manipulation feels resentment.
+- Lead quality is lower; some takers enter throwaway emails.
+- Downstream conversion suffers because some leads are unqualified or actively annoyed.
+
+**When to use.** When the quiz is genuinely entertainment-driven and the audience expects the format (consumer brands sometimes work here). For B2B and considered purchases, this pattern often degrades trust.
+
+---
+
+## Pattern B: Email after result, for personalized delivery
+
+The result is shown; an offer is made for personalized PDF or follow-up.
+
+**How it works.**
+
+- The taker answers all questions.
+- The result is shown immediately, including segment description and matched recommendation.
+- Below or alongside the result, an offer: "Want this as a PDF you can share?" or "Want a personalized 5-day sequence with deeper resources for your segment?"
+- The taker who wants the additional value enters email.
+
+**Strengths.**
+
+- Honest. The audience gets what they came for.
+- Lead quality is higher; takers who opt in are signaling real interest.
+- Trust is preserved; audience that does not opt in still leaves with positive brand association.
+
+**Weaknesses.**
+
+- Lower conversion rate to email than Pattern A.
+- Requires designing additional value (PDF, sequence) that justifies the email.
+
+**When to use.** Default pattern for B2B and considered purchases. The honest exchange compounds trust over time.
+
+---
+
+## Pattern C: Email integrated with optional features
+
+The result is shown; multiple optional opt-ins are offered.
+
+**How it works.**
+
+- The taker answers all questions.
+- The result is shown.
+- Multiple opt-in options appear, each with distinct value: "Save this scenario for later," "Get notified when new content for your segment is available," "Download a personalized resource."
+- The taker chooses which (if any) to opt into.
+
+**Strengths.**
+
+- Most flexibility for the audience.
+- Allows different audience segments to engage at different levels.
+- Lead quality is high because each opt-in is for specific value.
+
+**Weaknesses.**
+
+- More complex to design and implement.
+- Multiple options can dilute conversion ("paradox of choice").
+- Requires the brand to actually deliver on each opt-in.
+
+**When to use.** When the quiz has multiple legitimate value-add follow-ups and the audience benefits from choice.
+
+---
+
+## Pattern D: Progressive opt-in across the quiz
+
+Email is captured early but only used after the quiz completes.
+
+**How it works.**
+
+- The quiz starts with optional email entry ("get a personalized PDF report when you finish").
+- Takers can enter email upfront or skip.
+- The quiz proceeds; the result is shown for everyone.
+- Takers who entered email get the PDF; others see the result and an opt-in offer.
+
+**Strengths.**
+
+- Captures highly committed takers early.
+- Does not gate the result.
+- Provides a soft opt-in path for less-committed takers.
+
+**Weaknesses.**
+
+- Asking for email upfront can depress quiz starts.
+- Two-path design (email-given vs not-given) adds complexity.
+
+**When to use.** When the audience benefits from setting expectations upfront and when the brand can deliver value differently to opted-in vs walk-up takers.
+
+---
+
+## The value-add at lead capture
+
+What the user gets for their email matters as much as when the email is asked.
+
+**Strong value-adds.**
+
+- A personalized PDF report matched to the segment.
+- A follow-up email series that deepens the segment-matched content.
+- A curated resource list specific to the result.
+- Notifications about new resources, products, or events relevant to the segment.
+
+**Weak value-adds.**
+
+- Just sending the same result by email (no value-add over what is on screen).
+- A generic newsletter signup (not personalized to the result).
+- A "join our community" offer with no clear value.
+
+**The discipline.** The value-add should be substantively better than what the audience saw on screen. If it is not, the email gate is not justified.
+
+---
+
+## Conversion vs lead quality
+
+The patterns trade off these two metrics.
+
+**Conversion-optimized.** Pattern A captures the most emails but produces lower lead quality. Suitable when the goal is volume or when the audience is highly aligned (every taker is a target lead).
+
+**Quality-optimized.** Pattern B and C capture fewer emails but produce higher lead quality. Suitable when the goal is downstream conversion or when the audience is mixed (only some takers are target leads).
+
+**The choice.** Depends on what the program optimizes for. Brands optimizing for downstream revenue often choose Pattern B or C. Brands optimizing for list growth may default to Pattern A.
+
+**The trap.** Optimizing for conversion at the expense of lead quality is short-term thinking. The conversion metric looks fine; the downstream metrics suffer; the program quietly underperforms.
+
+---
+
+## The "no email needed" alternative
+
+Some quizzes do not capture email at all.
+
+**When this works.** When the quiz's purpose is brand-building, SEO, or audience-engagement rather than lead-capture. The quiz's existence and shareability are the value; the email is incidental.
+
+**The pattern.** The taker takes the quiz; the result is shown; share buttons are prominent; no email gate.
+
+**Why it can work.** Some brands earn more from a widely-shared quiz than from a gated quiz that captures fewer emails. The brand association is the value.
+
+**When it fails.** When the program needs leads and the no-gate design produces nothing for the funnel.
+
+---
+
+## Lead-capture form design
+
+The form itself matters.
+
+**Field count.** Email only is the strong default. Each additional field reduces conversion.
+
+**Field justification.** If additional fields are required (name for personalization, company for B2B sales context), justify them inline. "We use your name to personalize your follow-up" is honest; uncontextualized fields feel like sales-form padding.
+
+**Form placement.** Inline with the result is honest; popup that interrupts the result viewing is hostile.
+
+**CTA copy.** "Get my personalized PDF" beats "Submit." Specific value statement beats generic action.
+
+**Loading state.** After submission, show progress and confirm receipt. "Sending your PDF now... check your inbox in 2 minutes."
+
+---
+
+## Post-capture experience
+
+What happens after the email is captured.
+
+**Immediate delivery.** The promised PDF, sequence, or resource arrives within minutes. Delays break trust.
+
+**Confirmation message.** On the result page or in the email, confirm what was sent and what to expect next.
+
+**Sequence integration.** If a follow-up sequence was offered, the first email arrives within 24 hours. The sequence delivers the promised cadence.
+
+**Opt-out clarity.** Easy unsubscribe from the start. Audiences that find unsubscribe friction lose trust permanently.
+
+---
+
+## Capture-pattern testing
+
+Test pattern choice with real metrics.
+
+**Test design.** A/B test Pattern A vs Pattern B with the same quiz. Measure both conversion to email and downstream conversion (trial signup, demo request, purchase).
+
+**The metric that matters.** Downstream conversion per visitor, not conversion to email. A pattern that captures fewer emails but produces more downstream conversion is the better pattern.
+
+**Test duration.** Long enough to capture downstream signal (often 30-60 days minimum, depending on consideration cycle).
+
+---
+
+## Common capture failures
+
+**Lead-trap pattern.** Result hidden behind email; downstream conversion drops; trust degrades.
+
+**Email gate without value.** Email required for the same content; gate is not justified; conversion drops.
+
+**Too many fields.** Form asks for name, company, role, phone in addition to email; conversion plummets.
+
+**Generic CTA copy.** "Submit" rather than "Get my personalized PDF"; conversion suffers.
+
+**Popup that interrupts.** Result loads; popup appears; user's flow breaks.
+
+**Slow delivery.** PDF arrives 30 minutes later; trust drops.
+
+**No confirmation.** User submits, sees no acknowledgment, wonders if it worked.
+
+**Hard unsubscribe.** Multi-step or hidden unsubscribe; trust degrades.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The capture-honest principle. Pattern A through D with strengths, weaknesses, and when-to-use guidance. The value-add at lead capture. The conversion-vs-quality tradeoff. The no-email-needed alternative. Lead-capture form design. Post-capture experience. Capture-pattern testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific capture pattern choices for specific quizzes. Specific PDF templates and sequence designs. Specific form copy and CTAs in brand voice. The team's downstream-conversion benchmarks. These vary by team.

--- a/skills/quiz-and-assessment-design/references/question-architecture-patterns.md
+++ b/skills/quiz-and-assessment-design/references/question-architecture-patterns.md
@@ -1,0 +1,212 @@
+# Question architecture patterns
+
+Question count, types, ordering, phrasing, and segment mapping discipline. The questions are the mechanism that produces the segmentation; bad questions produce bad segmentation regardless of how clever the scoring algorithm is.
+
+---
+
+## Question count
+
+Most effective quizzes use 5-10 questions.
+
+**Fewer than 5 questions.** Rarely produces meaningful segmentation. The taker reaches the result quickly, but the result feels arbitrary because too few signals were captured. Useful only for very simple categorizations (binary or 3-segment outcomes).
+
+**5-7 questions.** The sweet spot for most quizzes. Enough to produce nuanced segmentation; few enough that the audience completes without fatigue.
+
+**8-12 questions.** Acceptable when the segmentation is genuinely multi-dimensional or when the audience has high commitment. Watch drop-off carefully; the last few questions are where audiences abandon.
+
+**13+ questions.** Stops feeling like a quiz; starts feeling like a survey. Drop-off rises sharply. If the segmentation truly needs this many questions, consider whether quiz is the right format.
+
+---
+
+## Question types
+
+Choose the type that fits the variable being captured.
+
+**Multiple-choice (single-select).** The most common quiz question type. Each option maps to a segment or scoring weight.
+
+When to use: when the answer space is well-defined and mutually exclusive.
+When to avoid: when the audience genuinely could choose multiple answers; forcing single-select frustrates the taker.
+
+**Multiple-select.** Useful when multiple attributes apply to the taker.
+
+When to use: when the answer space includes overlapping options ("which features matter most" with multiple selections).
+When to avoid: when scoring complexity outweighs the value; multi-select complicates segmentation.
+
+**Slider or scale.** "On a scale of 1-5, how often do you..." Useful for intensity questions.
+
+When to use: when the variable is continuous (frequency, importance, satisfaction).
+When to avoid: when the categorization is genuinely categorical; sliders force false continuity.
+
+**Yes/no.** Useful for binary qualifying questions.
+
+When to use: as part of a broader question set when one binary attribute matters (does the team use a CRM today, yes or no).
+When to avoid: as the primary question type; quizzes built only on yes/no questions feel coarse.
+
+**Free text.** Avoid in quizzes. Free text breaks the scoring flow and adds friction. The few quizzes that genuinely need free text often work better as forms or assessments.
+
+---
+
+## Question ordering
+
+The order matters as much as the questions themselves.
+
+**Open with engaging, low-friction questions.** "What kind of role best describes you?" or "What size is your team?" These warm up the taker and build commitment.
+
+**Mid-quiz: substantive segmentation questions.** The questions that most influence the segmentation belong in the middle. The taker has invested enough to commit; you have not yet exhausted their patience.
+
+**Late-quiz: more revealing or sensitive questions.** "How effective is your current process?" or "What is your biggest challenge?" These questions benefit from the trust built earlier.
+
+**End: qualifying questions, if needed.** Demographic data, company-size confirmation, or contact-channel preferences. These belong at the end, not the start. Asking demographic questions first signals "this is a sales form" and depresses completion.
+
+---
+
+## Question phrasing
+
+Plain language. No jargon. No leading.
+
+**Plain language.** Avoid technical terms the audience may not know. If the quiz is for SaaS founders, "ARR" is fine; if it is for general business owners, "annual revenue" is clearer.
+
+**Specific situations.** Frame questions around situations the audience recognizes. "When you onboard a new customer, do you..." beats "What is your customer-onboarding maturity."
+
+**Avoid leading questions.** Phrasing that pushes toward a specific answer biases the result.
+
+- Leading: "How much do you struggle with X?" (presumes struggle)
+- Honest: "How would you describe your experience with X?"
+
+**Avoid double-barreled questions.** Questions that mix two dimensions confuse scoring.
+
+- Double-barreled: "How much do you value speed AND simplicity?"
+- Cleaned up: split into two questions if both dimensions matter.
+
+**Avoid "all of the above" or "none of the above" defaults.** These options are escape valves that produce uninterpretable answers.
+
+---
+
+## Question-segment mapping
+
+Each question should contribute to the segmentation in a defined way.
+
+**The principle.** For each question, document which answer choices map to which segments and with what weight.
+
+**Example: "What size is your team?"**
+
+- 1-5 employees → segment "Solo or small" (+3 to that segment)
+- 6-25 employees → segment "Growing team" (+3)
+- 26-100 employees → segment "Mid-market" (+3)
+- 101+ employees → segment "Enterprise" (+3)
+
+**Example: "What is your sales process maturity?"**
+
+- "Founder-led, no defined process" → "Solo or small" (+2), "Growing team" (+1)
+- "Some defined steps, owner driven" → "Growing team" (+2), "Mid-market" (+1)
+- "Defined sales playbook, multiple reps" → "Mid-market" (+2), "Enterprise" (+1)
+- "Multi-stage enterprise sales process" → "Enterprise" (+3)
+
+The mapping is explicit. Each question contributes specific weight to specific segments. The mapping should be documented so future maintenance can verify it.
+
+**Filler questions.** Questions that do not affect the segmentation are filler. They add friction without adding value. Audit and remove.
+
+---
+
+## Question count vs segmentation depth
+
+The relationship between question count and segmentation accuracy.
+
+**Few questions, broad segments.** A 5-question quiz produces 4-5 segments reliably; trying to produce 10 segments from 5 questions makes each segment poorly distinguished.
+
+**More questions, narrower segments.** An 8-question quiz can produce 6-8 segments with enough distinction.
+
+**The over-segmentation trap.** Too many segments produced from too few questions creates segments that are not really different. The audience that lands in different segments gets similar recommendations; the segmentation is fake.
+
+**The right ratio.** Roughly 1.5-2 questions per segment is a useful baseline. 5-7 segments from 8-12 questions; 4-5 segments from 5-7 questions.
+
+---
+
+## Conditional questions and branching
+
+Whether to ask different questions based on earlier answers.
+
+**Branching when it helps.** Later questions make sense only in the context of earlier ones. "If you have a CRM today, which one?" is a useful follow-up to "Do you use a CRM today?"
+
+**Branching when it hurts.** When branching adds complexity without value, when the branching makes the quiz feel different for different takers in confusing ways, when the scoring becomes hard to reason about.
+
+**The simplicity preference.** Linear quizzes (everyone gets the same questions in the same order) are easier to maintain, easier to test, and easier for the audience to predict. Use branching only when the value justifies the complexity.
+
+---
+
+## Drop-off considerations
+
+Where audiences abandon, and why.
+
+**The first question.** Some takers click into the quiz and leave at question 1. Often the question or the format made them realize this is not for them. This is fine; honest filtering.
+
+**Mid-quiz (questions 4-7).** Drop-off here usually signals fatigue or discomfort. Audit the questions; are they too long, too sensitive, too repetitive?
+
+**Late-quiz (final questions).** Drop-off here often signals that the user got bored or the value of finishing was not clear. A progress indicator and a teaser of the result ("almost done; see your result next") can reduce late-stage drop-off.
+
+**Question-by-question tracking.** Tracking drop-off per question is the diagnostic. Questions with disproportionate drop-off warrant review.
+
+---
+
+## Mobile question design
+
+Most quiz takers are on mobile. The question UX has to work there.
+
+**Mobile-specific considerations.**
+
+- Touch-friendly answer options (minimum 44x44 pixel touch targets).
+- Single question per screen on mobile (multi-question screens cramp).
+- Progress indicator visible without scroll.
+- Answer options large enough to tap accurately; spacing prevents accidental taps.
+- Sliders sized for thumb interaction.
+
+**Mobile testing.** Test the quiz on actual devices. Real-device behavior often differs from browser dev-tools simulation.
+
+---
+
+## Question-mapping audit
+
+Periodically audit the question-segment mapping.
+
+**The audit.** For each segment, verify that the questions actually produce that segment for takers who should get it. Run the quiz with personas representing each segment; confirm each persona reaches the right result.
+
+**The audit cadence.** When the recommendation portfolio changes, when the audience composition shifts, or at least quarterly.
+
+**Drift indicators.**
+
+- One segment now receives 70+ percent of takers.
+- Another segment receives less than 5 percent.
+- Specific personas reach the wrong segment when audited.
+- Audience comments that the result was wrong.
+
+These signals warrant question or scoring revision.
+
+---
+
+## Common question architecture failures
+
+**Too many questions.** 15+ questions feels like a survey; drop-off climbs.
+
+**Filler questions.** Questions that do not affect segmentation; audit and remove.
+
+**Leading questions.** Phrasing that biases the answer.
+
+**Double-barreled questions.** Two dimensions in one question; scoring becomes ambiguous.
+
+**Demographic questions first.** Signals "sales form"; depresses completion.
+
+**Vague answer options.** "Sometimes" vs "often" without anchors; the taker cannot calibrate.
+
+**Inconsistent question types.** Mixing 5-point sliders with yes/no without coherent rationale; the rhythm breaks.
+
+**Mobile-broken questions.** Sliders that do not work on touch; answer options that overflow.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+Question count, types, ordering, phrasing. Question-segment mapping discipline. Question count vs segmentation depth. Conditional questions and branching. Drop-off considerations. Mobile question design. Question-mapping audit. Common failures.
+
+## Implementation choices that stay internal
+
+Specific question sets for specific quizzes. Specific scoring weights and segment mappings. Specific tooling for quiz engineering and analytics. The team's drop-off benchmarks and audit calendars. These vary by team.

--- a/skills/quiz-and-assessment-design/references/quiz-anti-patterns.md
+++ b/skills/quiz-and-assessment-design/references/quiz-anti-patterns.md
@@ -1,0 +1,223 @@
+# Quiz anti-patterns
+
+The patterns that look like quizzes but degrade trust. Anti-patterns are easy to ship; the cost shows up in lead quality, downstream conversion, and brand reputation over time.
+
+---
+
+## The clickbait-quiz
+
+The pattern. Engagement-driven framing with no actionable segmentation. "What kind of marketer are you?" with 4 personality types and no recommendations.
+
+The signal. Engagement metrics are high (shares, completions); downstream metrics are flat. The quiz is fun; it does not produce qualified leads or conversions.
+
+The cost. The build cost is wasted on entertainment that does not compound business value. The brand earns "fun but not useful" association.
+
+The cure. Add actionable segmentation. Each segment maps to a specific recommendation matched to that segment. Detail in `references/result-to-recommendation-mapping.md`.
+
+---
+
+## The vanity-result quiz
+
+The pattern. Flattering descriptions for every segment. No honest characterization. No specific recommendations.
+
+The signal. Takers enjoy the result; do not act on it; do not return. The quiz produces a moment of attention without a relationship.
+
+The cost. The audience associates the brand with horoscope-style content. The quiz does not differentiate the brand from competitors offering similar entertainment.
+
+The cure. Honest segmentation. Some segments are more flattering than others; honest descriptions produce respect; recommendations that match each segment specifically produce action.
+
+---
+
+## The forced-result quiz
+
+The pattern. Every taker routes to the same recommendation regardless of answers. The segmentation is decorative; the recommendation was predetermined.
+
+The signal. Sales team or product team notices that quiz-sourced leads all look the same; the segmentation is not differentiating.
+
+The cost. The quiz misleads the audience. Takers who answered honestly believing they would get a matched recommendation get a generic one; trust degrades.
+
+The cure. Real segmentation that produces real different recommendations per segment. If the brand only has one recommendation, do not use a quiz format; use a clear landing page.
+
+---
+
+## The interrogation-quiz
+
+The pattern. 25 questions that feel like a survey rather than a quiz. The audience drops off mid-quiz.
+
+The signal. High drop-off rate, especially at questions 8-15. Few takers reach the result.
+
+The cost. The build effort produces a quiz few people complete. The audience that drops off remembers the brand as the source of the long form they abandoned.
+
+The cure. Reduce question count. 5-12 questions is the working range. Audit questions for those that do not affect segmentation; remove them.
+
+---
+
+## The leading-question quiz
+
+The pattern. Questions phrased to push the taker toward a specific result. "Don't you sometimes wish you had..." is leading.
+
+The signal. The result distribution is biased; takers report that the result felt predetermined; analytical audiences notice the leading.
+
+The cost. The audience that catches the leading loses trust. The result is artificially produced rather than reflecting the taker's actual situation.
+
+The cure. Plain phrasing without bias. "How would you describe your experience with X?" beats "How much do you struggle with X?"
+
+---
+
+## The black-box quiz
+
+The pattern. No explanation of how the result was determined. The taker gets a label with no insight into why.
+
+The signal. Audience comments asking how the result was calculated; some takers question whether the result is real or random.
+
+The cost. The quiz feels arbitrary. Even when the segmentation is real, the audience cannot verify; trust suffers.
+
+The cure. Some transparency about the methodology. "Your result reflects your answers to questions 2, 4, and 6" or a brief explanation of what the segments represent.
+
+---
+
+## The no-recommendation quiz
+
+The pattern. Result categories exist; no next step is offered. The quiz produces awareness of the segment without action.
+
+The signal. Strong engagement; near-zero downstream conversion; the quiz captures a moment without converting it.
+
+The cost. The brand has the audience's attention and does nothing with it. The quiz produces brand impression without business impact.
+
+The cure. Every result page must include a specific next step. Detail in `references/result-to-recommendation-mapping.md`.
+
+---
+
+## The mismatched-recommendation quiz
+
+The pattern. The recommendation does not match the segment. A taker classified as "enterprise" gets a "starter plan" recommendation, or vice versa.
+
+The signal. Sales team feedback that quiz-sourced leads do not match the recommended product. Audience feedback that the recommendation felt wrong.
+
+The cost. Trust damage. The taker who notices the mismatch feels misled; the brand earns "doesn't get me" reputation.
+
+The cure. Audit the segment-to-recommendation mapping. Verify each segment's recommendation actually fits.
+
+---
+
+## The over-segmentation quiz
+
+The pattern. 12+ segments produced from 5 questions. Most segments end up similar; segmentation is fake.
+
+The signal. Segments that read the same; segments that get the same recommendation; segments that receive less than 3 percent of takers each.
+
+The cost. Design and copy effort wasted on segments that do not really exist. The audience that lands in similar segments cannot tell them apart.
+
+The cure. Reduce segment count to what the questions can actually distinguish. 4-7 segments from 5-7 questions; 6-8 segments from 8-10 questions.
+
+---
+
+## The under-segmentation quiz
+
+The pattern. 2 segments that could have been a yes/no question. The quiz format is over-engineering.
+
+The signal. The audience completes the quiz quickly; the result feels obvious; the quiz adds friction without adding value.
+
+The cost. Build effort wasted on a quiz that did not need to be a quiz. The audience that recognizes the over-engineering questions the brand's judgment.
+
+The cure. Either expand the segmentation to justify the format or replace the quiz with a simpler tool (yes/no qualifier, comparison table).
+
+---
+
+## The lead-trap quiz
+
+The pattern. The result is calculated but hidden behind an email gate. The taker enters 8 fields, hits Calculate, sees "enter your email to see your result."
+
+The signal. Email-form conversion is high; downstream conversion is low; audience that recognizes the pattern bounces immediately.
+
+The cost. Lead quality suffers. The brand earns "lead-trap" reputation. Detail in `references/lead-capture-integration-patterns.md`.
+
+The cure. Show the result freely; gate the additional value (PDF, follow-up sequence) instead.
+
+---
+
+## The cookie-cutter quiz
+
+The pattern. The quiz looks and behaves like every other quiz from a template platform. Generic UI, generic question style, generic result format.
+
+The signal. The quiz does not differentiate; the audience does not associate it specifically with the brand.
+
+The cost. The quiz becomes commodity. The brand's investment does not compound credibility because the tool does not stand out.
+
+The cure. Custom design that reflects the brand. Question phrasing in brand voice. Result presentation that feels distinct.
+
+---
+
+## The mobile-broken quiz
+
+The pattern. Quiz works on desktop; breaks on mobile. Answer options that overflow; sliders impossible to grab; result hidden below the fold.
+
+The signal. High mobile bounce rate; mobile completion drops below desktop.
+
+The cost. The mobile audience either bounces or has a worse experience that misrepresents the brand. Mobile is often the majority of traffic.
+
+The cure. Mobile-first design and testing. Detail in `references/question-architecture-patterns.md` (mobile section).
+
+---
+
+## The popup-interrupted quiz
+
+The pattern. The result loads; the user starts reading; a popup appears asking for email or offering a different magnet.
+
+The signal. Bounce rate spikes at the result moment; users complain about the interruption.
+
+The cost. The quiz's user experience is hostile. The brand earns "annoying" reputation.
+
+The cure. Offers in context with the result, not as popups that interrupt.
+
+---
+
+## The orphan-quiz
+
+The pattern. The quiz exists; no follow-up sequence; no integration with the broader funnel. Takers complete; nothing happens.
+
+The signal. Email captures sit on a list with no engagement; downstream conversion is near zero.
+
+The cost. The lead-capture work was for nothing. The brand has emails but no relationship.
+
+The cure. Design the post-quiz sequence as part of the quiz design (similar to the lead-magnet sequence discipline in `lead-magnet-design`).
+
+---
+
+## The everyone-quiz
+
+The pattern. Quiz designed to appeal to "everyone." Generic segments; generic recommendations.
+
+The signal. Conversion may be high; lead quality is low; downstream conversion is mixed because the audience is too broad to serve coherently.
+
+The cost. List grows fast; sequence engagement underwhelms; offers convert poorly.
+
+The cure. Narrow the audience the quiz serves. Specific quizzes for specific segments produce specific recommendations that convert.
+
+---
+
+## How to detect anti-patterns in a portfolio
+
+Audit cadence. Quarterly review of every active quiz, looking specifically for these anti-patterns.
+
+**Audit questions per quiz.**
+
+- Does each segment have a specific, distinct recommendation (anti-pattern check: forced-result, mismatched-recommendation)?
+- Is segment distribution balanced across takers (anti-pattern check: over-segmentation, under-segmentation)?
+- Is drop-off concentrated at specific questions (anti-pattern check: interrogation, leading questions)?
+- Does the result page include a clear next step (anti-pattern check: no-recommendation, vanity-result)?
+- Is the result accessible without email gate (anti-pattern check: lead-trap)?
+- Does the quiz feel branded or templated (anti-pattern check: cookie-cutter)?
+- Does the quiz work on mobile (anti-pattern check: mobile-broken)?
+
+**The retire decision.** Anti-pattern quizzes often warrant retirement. Maintaining them costs more than the diminishing returns they produce.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing for each. Cures matched to anti-patterns. The audit cadence and audit questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and the lessons learned. Specific portfolio audit results. Specific retirement decisions and successor-quiz plans. The team's audit calendar and reviewer list. These vary by team.

--- a/skills/quiz-and-assessment-design/references/quiz-investment-criteria.md
+++ b/skills/quiz-and-assessment-design/references/quiz-investment-criteria.md
@@ -1,0 +1,145 @@
+# Quiz investment criteria
+
+When a quiz is the right tool for the audience and the goal, and when a comparison table or other format would serve. The conditions that warrant the quiz format.
+
+A quiz is a meaningful build. Question architecture, scoring algorithm, result categorization, recommendation mapping, lead-capture integration. The quiz earns this investment only when specific conditions are present.
+
+---
+
+## When a quiz earns the build
+
+Five conditions that, when present, make a quiz a strong investment.
+
+**The audience faces a decision that benefits from categorization.** "Which of our products fits my situation," "what is my readiness for X," "what type of Y am I." The categorization has to map to a real next step.
+
+**The categorization can be derived from a small number of questions.** 5-12 questions can produce meaningful segmentation. If the categorization needs 30+ questions, the format is closer to a survey or assessment than a quiz; the audience drop-off makes the format wrong.
+
+**The brand has a portfolio of recommendations that match the segments.** A quiz that produces 5 segments and only one recommendation is decorative; the segment-recommendation mapping is the value.
+
+**The result format suits the audience.** Audiences who enjoy quizzes (consumers, B2B mid-market, certain creator audiences) engage well. Audiences who do not (technical buyers, enterprise sales) often see quizzes as gimmicks.
+
+**The success metric is defined.** Lead volume from the quiz, lead quality by segment, downstream conversion per segment, the audience acting on the recommendation. Without the success metric defined, evaluation is impossible.
+
+When all five are present, the quiz is a strong investment. When two or fewer are present, a different format (comparison table, worked example, calculator) often serves better.
+
+---
+
+## When a quiz does NOT earn the build
+
+Funnels where the quiz is the wrong tool.
+
+**The categorization is trivial.** "What plan is right for you" with two plans does not need a quiz; a comparison table works. Quizzes earn investment when the categorization is non-trivial.
+
+**The categorization is irrelevant to the next step.** A personality quiz with no product-recommendation tie-in entertains but does not convert. The categorization needs to map to action.
+
+**The brand has no varied recommendations.** A quiz with one outcome is bait; the segmentation is decorative. Without a portfolio of segment-matched recommendations, the quiz cannot deliver the actionable-segmentation value.
+
+**The audience disrespects quizzes in this context.** Enterprise buyers often see quizzes as unprofessional. Technical decision-makers often skip quizzes in favor of direct documentation. The format choice has to fit the audience the brand wants to serve.
+
+**The team cannot maintain the quiz.** Quizzes decay as recommendations change, segments evolve, and audience preferences shift. Without maintenance commitment, the quiz becomes stale.
+
+**The audience would convert without the quiz.** When the funnel is already producing the conversion the quiz would serve, the quiz adds friction without lift.
+
+The honest assessment matters more than the default. "Should we have a quiz" is not the question. "Is the quiz the right investment for this audience and decision" is.
+
+---
+
+## The opportunity-cost frame
+
+A quiz is a meaningful build. Account for the cost honestly.
+
+**The build cost.** Question design, scoring algorithm, result categorization, recommendation mapping, UI design, mobile responsiveness, integration. A meaningful quiz often takes 30-100 engineering hours plus design, copy, and content for the recommendations.
+
+**The maintenance cost.** Recommendations change; segments evolve; question phrasing decays. Quarterly review and updates run 3-8 hours per active quiz.
+
+**The recommendation portfolio cost.** Each segment needs a matched recommendation. Building or curating those recommendations is itself work.
+
+**The opportunity cost.** What else could the team have built? A funnel improvement, a content piece, a paid-traffic optimization. The quiz's success has to clear the bar of those alternatives.
+
+The decision frame. The quiz earns investment when it produces more lift than the alternatives, accounting for the full cost of build plus maintenance plus recommendation portfolio.
+
+---
+
+## The recommendation-portfolio precondition
+
+Without a portfolio of segment-matched recommendations, the quiz cannot deliver actionable segmentation.
+
+The check. For the segmentation the quiz will produce, does the brand have a distinct, valuable recommendation for each segment?
+
+If yes, the quiz can deliver actionable segmentation. The takers get matched to a recommendation that fits their result.
+
+If no (the brand has one product, one resource, one recommendation regardless of segment), the quiz becomes vanity. The segmentation is decorative; the recommendation was predetermined.
+
+**How to assess the recommendation portfolio.**
+
+- Does the brand have multiple products, services, or content paths that fit different audience segments?
+- Can the brand articulate which recommendation fits which segment specifically?
+- Are the recommendations valuable enough to that segment to justify the quiz?
+
+If yes to most of these, the recommendation portfolio supports the quiz. If no, the quiz is the wrong format until the portfolio exists.
+
+---
+
+## The decision worked example
+
+A B2B SaaS company considering a "What CRM fits your team" quiz.
+
+**Conditions check.**
+
+- Decision benefits from categorization: yes. Prospects evaluate CRMs based on team size, use case, sales process maturity, integration needs. The categorization is non-trivial.
+- Small number of questions sufficient: yes. 6-8 questions can capture team size, use case, sales process, integration needs.
+- Recommendation portfolio: yes. The brand offers 3 plan tiers plus 2 industry-specific configurations. Each segment can map to a distinct recommendation.
+- Audience-fit for quiz format: yes. B2B mid-market PMs and sales leads engage with quizzes when the recommendation is genuinely useful.
+- Success metric: yes. Lead volume from the quiz, lead quality (audience-fit at SaaS companies above 25 employees), downstream conversion to demo or trial within 60 days.
+
+**Decision.** Build the quiz. The conditions warrant it.
+
+**Result categorization.** 5 segments: "Solo founder just starting," "Growing team without CRM," "Mid-market with multiple sales reps," "Enterprise with complex sales cycles," "Integration-heavy team."
+
+**Recommendation per segment.** Each segment maps to a specific plan and onboarding path. The segment description explains why that recommendation fits.
+
+**Lead capture.** Email after result for personalized PDF showing the recommendation, alternative options considered, and case study from a similar customer.
+
+The decision was not "should we have a quiz" but "given these conditions, this is the quiz to build."
+
+---
+
+## When to choose a different format
+
+The quiz is the wrong tool. What works.
+
+**Comparison table.** When the choice is between 2-4 well-defined options with clear distinguishing features, a comparison table often serves better. The audience compares directly without going through questions.
+
+**Worked-example resource.** When the audience benefits from seeing how others in their situation chose, a 2-page worked-example resource often serves better than a quiz. The audience identifies which example matches them.
+
+**Calculator.** When the decision benefits from a calculation rather than a categorization, a calculator serves better. Detail in `calculator-design`.
+
+**Direct documentation.** When the audience prefers self-directed research, a clear documentation page about which option fits which situation often serves better than a quiz.
+
+The pattern. Many "we need a quiz" intuitions are actually "we need a clear way to communicate which option fits which audience." Often the simpler format works as well or better, at lower build cost.
+
+---
+
+## When to retire a quiz
+
+Quizzes decay. Retiring them is part of the discipline.
+
+**Retire when:**
+
+- Lead volume has dropped below baseline for two consecutive quarters.
+- The recommendation portfolio has shifted enough that the quiz routes to outdated recommendations.
+- One segment now receives 80 percent of takers, suggesting the question architecture no longer distinguishes.
+- A newer tool or magnet on the same topic is outperforming.
+- The maintenance cost exceeds the lead value.
+
+The retiring discipline frees capacity. Stale quizzes route audience to outdated recommendations and damage trust.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The investment conditions for whether to build a quiz. The opportunity-cost frame. The recommendation-portfolio precondition. The decision worked example. When to choose a different format. The retirement discipline.
+
+## Implementation choices that stay internal
+
+Specific quiz topics for specific audiences. The team's capacity benchmarks for build, maintenance, and recommendation curation. Specific tooling for quiz engineering and integration. Specific recommendation portfolios per segment. These vary by team.

--- a/skills/quiz-and-assessment-design/references/result-categorization-patterns.md
+++ b/skills/quiz-and-assessment-design/references/result-categorization-patterns.md
@@ -1,0 +1,233 @@
+# Result categorization patterns
+
+Segment count, naming, distinguishability, balance. The shape of the result categories that the quiz produces.
+
+The categorization is the quiz's segmentation product. Bad categorization produces results that feel arbitrary or that fail to help the audience act. Good categorization produces results the audience recognizes and uses.
+
+---
+
+## Segment count
+
+Most quizzes work well with 4-8 result categories.
+
+**Fewer than 4 segments.** The categorization feels coarse. Two-segment quizzes (e.g., "is this for you, yes or no") rarely earn the quiz format; a comparison or qualifying form serves better.
+
+**4-6 segments.** The sweet spot for most quizzes. Enough segments to feel nuanced; few enough that each gets adequate development.
+
+**7-8 segments.** Acceptable when the segmentation is genuinely multi-dimensional. Each segment needs a distinct description, distinct recommendation, and clear distinguishability.
+
+**9+ segments.** Often a sign of over-segmentation. Many segments end up similar in description and recommendation; the segmentation becomes fake.
+
+---
+
+## Segment naming
+
+Memorable. Specific. Honest. Brand-voice consistent.
+
+**Memorable.** The taker should be able to describe their segment to a friend. "The Strategic Planner" is memorable; "Type 3" is not.
+
+**Specific.** Names should distinguish the segment from others.
+
+- Specific: "The Hands-On Builder" (vs "Type B")
+- Specific: "Solo founder just starting" (vs "Beginner")
+- Specific: "Mid-market operator with multiple sales reps" (vs "Mid-tier user")
+
+**Honest.** Names should not flatter universally. Some segments are more flattering than others; honest segmentation reflects this.
+
+- Honest: "Just exploring" alongside "Already executing" alongside "Mature operator." Each describes a real position.
+- Dishonest: every segment named with a flattering descriptor regardless of where the taker actually is.
+
+**Brand-voice consistent.** The names should sound like the brand the quiz represents. A serious brand uses serious names; a playful brand can use playful names. Consistency matters.
+
+---
+
+## Segment distinguishability
+
+Each segment should be meaningfully different from the others.
+
+**The test.** Read the descriptions of two adjacent segments. Are they meaningfully different in:
+- Who the segment describes?
+- What the segment's situation is?
+- What the segment's recommendation is?
+
+If yes, the segments are distinguished. If no (the descriptions are similar, the recommendations overlap), the segmentation is fake.
+
+**The fake-segmentation pattern.** A quiz produces 5 segments, but segments 2, 3, and 4 are described in similar terms with similar recommendations. The audience that lands in different segments gets indistinguishable results; the segmentation is decorative.
+
+**The cure.** Either reduce the segment count (if the segmentation does not support 5 segments, do not pretend it does) or strengthen the distinctions (rewrite descriptions and recommendations so each segment is distinct).
+
+---
+
+## Segment balance
+
+Each segment should receive a meaningful share of takers.
+
+**Balanced segmentation.** Each segment receives roughly 10-30 percent of takers (depending on segment count). The audience is genuinely distributed across segments.
+
+**Imbalanced segmentation.** One segment receives 70+ percent of takers; another receives less than 5 percent. The segmentation is not working; the questions do not distinguish meaningfully.
+
+**Why balance matters.**
+
+- Imbalance signals the segmentation is broken.
+- The unused segments waste design and copy effort.
+- The dominant segment becomes a default that does not really categorize anyone.
+
+**The cure.** Audit the question architecture (`references/question-architecture-patterns.md`). Often the questions do not produce balanced segmentation because they bias toward one segment. Adjust questions or weights to produce more even distribution.
+
+**The exception.** Some quizzes intentionally produce imbalanced segmentation because the audience genuinely skews. A "what is your team size" quiz may produce 60 percent "small team" because the audience is mostly small teams. Honest imbalance reflecting real audience composition is fine; imbalance from broken questions is not.
+
+---
+
+## Segment description
+
+What appears at the result, beyond the segment name.
+
+**The description should include:**
+
+- A 2-3 sentence summary of the segment (who they are, what their situation is).
+- Specific characteristics the audience will recognize.
+- The matched recommendation (what to do next).
+- Optional: case study or worked example of someone in this segment.
+
+**Example segment description.**
+
+```
+Segment: "The Mid-Market Operator"
+
+You are running a sales team of 5-25 people across multiple
+products or regions. You have a defined sales process but
+inconsistent execution; some reps follow it, others freelance.
+Your top priority is unifying the team's process without
+slowing your fastest performers.
+
+Recommendation: Our Growth plan with the multi-region
+playbook configuration. We have a 30-day onboarding path
+for teams in your situation.
+
+[Link to PDF: see how 3 mid-market operators implemented
+this and the results]
+```
+
+The description is specific. The recommendation is matched. The next step is clear.
+
+**Description antipatterns.**
+
+- Generic descriptions that could fit multiple segments.
+- Flattering descriptions with no honest characterization.
+- Descriptions that describe but do not recommend.
+- Recommendations that are the same across segments.
+
+---
+
+## Segment naming patterns
+
+Common patterns and their tradeoffs.
+
+**Pattern A: Role-based names.** "The Strategic Planner," "The Hands-On Builder." Useful when segments correspond to functional roles.
+
+**Pattern B: Maturity-based names.** "Just Starting," "Growing," "Mature." Useful when segments correspond to stages of development.
+
+**Pattern C: Style-based names.** "The Optimizer," "The Connector," "The Visionary." Common in personality assessments. Risk of feeling horoscope-like.
+
+**Pattern D: Situation-based names.** "Solo founder pre-launch," "Mid-market operator with multi-region team." Useful when segments correspond to specific situations the audience recognizes.
+
+**Pattern E: Outcome-based names.** "Cost-focused buyer," "Time-saver-focused buyer." Useful when segments correspond to what the buyer is optimizing for.
+
+The pattern choice depends on the quiz's purpose and the audience the brand serves. The discipline is that whatever pattern is chosen, names should be specific and honest.
+
+---
+
+## Result-page composition
+
+What the result page contains beyond the segment description.
+
+**The standard structure.**
+
+- The segment name and key visual.
+- The segment description (2-3 sentences).
+- The matched recommendation.
+- The clear next step (CTA: download PDF, talk to team, explore product).
+- Optional: comparison to other segments (so the taker sees the full picture).
+- Optional: share button (if the quiz is shareable).
+
+**The clear-next-step principle.** Every result page must include a specific next step. Without it, the quiz produces awareness without action.
+
+**The optional comparison.** Showing the other segments lets the taker see the full segmentation. Useful when the audience benefits from understanding where they sit; less useful when the segments would distract from the matched recommendation.
+
+---
+
+## Result-page mobile design
+
+The result page must work on mobile.
+
+**Mobile considerations.**
+
+- Segment name and recommendation visible without scroll.
+- Visual elements sized for mobile screens.
+- CTA button large and prominent.
+- Share buttons functional on mobile platforms.
+
+**Common mobile failures.**
+
+- Result hidden below the fold; user does not know it loaded.
+- Recommendation buried after a long scroll.
+- CTA button tiny or hard to tap.
+
+---
+
+## Segment maintenance
+
+Segments decay along with the quiz.
+
+**What decays.**
+
+- Segment descriptions that no longer match the audience composition.
+- Recommendations that point to retired products or content.
+- Brand voice that has shifted.
+
+**Maintenance cadence.** Quarterly review of segment descriptions and recommendations. Update as the recommendation portfolio evolves.
+
+**The retire-segment decision.** A segment that receives less than 3 percent of takers consistently may not warrant maintenance. Either restructure the segmentation to merge underused segments or accept that the segmentation has segments that exist but are rarely produced.
+
+---
+
+## The segmentation-recommendation alignment audit
+
+Periodically verify that each segment's recommendation still matches.
+
+**The audit.** For each segment:
+- Does the recommendation still exist (not pointing to a retired product)?
+- Does the recommendation still match the segment's situation?
+- Does the recommendation deliver value to that specific segment?
+
+**The drift.** Recommendations decay. Products are retired, content is updated, the brand evolves. Audit cadence catches the drift.
+
+---
+
+## Common categorization failures
+
+**Too few segments.** Categorization feels coarse; quiz earns no segmentation value.
+
+**Too many segments.** Over-segmentation; segments end up similar; categorization feels fake.
+
+**Generic segment names.** Names that could apply to multiple segments; not memorable.
+
+**Flattering-everyone descriptions.** No honest segmentation; all segments feel positive.
+
+**Indistinguishable segments.** Two segments that read the same; categorization is decorative.
+
+**Imbalanced distribution.** One segment dominates; segmentation is broken.
+
+**Result without recommendation.** Description but no next step; quiz produces awareness without action.
+
+**Recommendations all the same.** Different segments routed to the same product or path; segmentation is decorative.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+Segment count guidance. Naming patterns and discipline (memorable, specific, honest, brand-voice consistent). Distinguishability test. Balance principle. Segment description structure. Naming patterns A through E. Result-page composition. Mobile design. Segment maintenance. Segmentation-recommendation alignment audit. Common failures.
+
+## Implementation choices that stay internal
+
+Specific segment names for specific quizzes. Specific descriptions in brand voice. Specific recommendations matched to segments. Specific result-page layouts. The team's audit calendars. These vary by team.

--- a/skills/quiz-and-assessment-design/references/result-to-recommendation-mapping.md
+++ b/skills/quiz-and-assessment-design/references/result-to-recommendation-mapping.md
@@ -1,0 +1,255 @@
+# Result-to-recommendation mapping
+
+The action attached to each category. Mapping discipline and worked examples. The recommendation is what the taker does next; without it, the quiz produces awareness without action.
+
+The mapping is where the quiz earns its conversion. A great segmentation produces nothing if each segment lacks a matched, actionable recommendation.
+
+---
+
+## The mapping principle
+
+Each segment maps to a specific recommendation. The recommendation is what the taker does next.
+
+**The principle's three requirements.**
+
+- The recommendation is real (the brand actually offers the recommended next step).
+- The recommendation matches the segment specifically (no two segments share the same recommendation).
+- The recommendation is valuable to that specific segment (not a generic offer applied to everyone).
+
+Quizzes that hit all three produce action. Quizzes that miss any of the three produce vanity-result patterns.
+
+---
+
+## What a recommendation can be
+
+The next step the taker should take. Many forms.
+
+**Product or service.** "Solo founders benefit most from our Starter plan with the founder-led onboarding path." The recommendation is a specific tier or configuration matched to the segment.
+
+**Content or resource.** "Mid-market operators benefit most from our 30-day playbook for unifying multi-rep teams." The recommendation is a specific resource matched to the segment.
+
+**Conversation or consultation.** "Enterprise buyers benefit most from a 30-minute conversation with our team." The recommendation is a specific human touchpoint.
+
+**Path or sequence.** "Creators just starting benefit most from our 4-part onboarding sequence." The recommendation is a structured next experience.
+
+**Configuration or setup.** "Teams using Salesforce benefit most from our integration setup wizard." The recommendation is a specific technical configuration.
+
+The form depends on the brand's offerings and the segment's situation. The discipline is that the recommendation is specific, not generic.
+
+---
+
+## The mapping discipline
+
+Each segment-to-recommendation mapping should pass these tests.
+
+**Test 1: Does the recommendation actually exist?** The brand currently offers it; it is not aspirational or in development.
+
+**Test 2: Does the recommendation match the segment specifically?** Other segments would not benefit from this recommendation as much; the matching is real.
+
+**Test 3: Does the recommendation deliver value to this segment?** The segment that gets this recommendation can act on it and benefit from it.
+
+**Test 4: Is the recommendation deliverable?** The brand can provide what is being recommended in the timeframe and form the taker expects.
+
+**Test 5: Does the recommendation include a clear action?** The taker knows what to do (click here, start here, talk to someone, download this).
+
+When all five pass, the mapping is honest. When any fails, the mapping is decorative or misleading.
+
+---
+
+## Worked example: B2B SaaS pricing quiz
+
+A SaaS platform offering 4 plan tiers with industry-specific configurations.
+
+**Segments and recommendations.**
+
+**Segment 1: "Solo founder just starting"**
+- Description: 1-person team, exploring options, pre-revenue or early revenue.
+- Recommendation: Starter plan ($X / month) with the founder-led onboarding path. Free for first 30 days; no credit card required.
+- Action: "Start your 30-day trial." Direct link to signup pre-filled with the recommended plan.
+
+**Segment 2: "Growing team without CRM"**
+- Description: 2-15 people, no CRM today, sales process is informal but starting to need structure.
+- Recommendation: Growth plan ($Y / month) with the team-onboarding path. 30-day setup support included.
+- Action: "Talk to our team about your setup." Calendar booking link.
+
+**Segment 3: "Mid-market with multiple reps"**
+- Description: 16-100 people, multiple sales reps, defined process but inconsistent execution.
+- Recommendation: Business plan ($Z / month) with multi-rep configuration and 60-day implementation support.
+- Action: "Get a custom demo." Form for demo request.
+
+**Segment 4: "Enterprise with complex sales cycles"**
+- Description: 100+ people, multi-stage sales process, integration-heavy environment.
+- Recommendation: Enterprise plan (custom pricing) with dedicated implementation manager.
+- Action: "Talk to enterprise sales." Direct line to enterprise contact.
+
+**Segment 5: "Integration-heavy team"**
+- Description: Any size, but the primary need is integrating with their existing tool stack.
+- Recommendation: Any plan plus the integration setup wizard. Detailed integration documentation linked.
+- Action: "Explore our integrations." Integration catalog page.
+
+Each segment maps to a distinct, specific recommendation. Each recommendation includes a clear action.
+
+---
+
+## Worked example: content-marketing quiz
+
+A content-marketing brand offering multiple content paths.
+
+**Segments and recommendations.**
+
+**Segment 1: "Just starting in content"**
+- Recommendation: 4-part email course covering content fundamentals.
+- Action: "Get the 4-part course." Signup form.
+
+**Segment 2: "Producing content but inconsistent results"**
+- Recommendation: Content audit template + worked-example case study.
+- Action: "Download the audit template." Direct download.
+
+**Segment 3: "Scaling a content team"**
+- Recommendation: Team-management playbook + interview with a content director.
+- Action: "Read the playbook." Resource page with playbook and interview.
+
+**Segment 4: "Optimizing for distribution"**
+- Recommendation: Distribution-strategy framework + 5 worked examples.
+- Action: "Read the framework." Resource page.
+
+Each segment routes to a distinct content path matched to where the audience is.
+
+---
+
+## Worked example: readiness-assessment quiz
+
+A consultancy offering readiness assessments before engagement.
+
+**Segments and recommendations.**
+
+**Segment 1: "Not yet ready"**
+- Description: Foundation work needed before the consultancy's offering would help.
+- Recommendation: Self-serve resources for foundation work. Honest acknowledgment that engagement is not warranted yet.
+- Action: "Explore the foundation library." Free resources.
+
+**Segment 2: "Ready for assessment"**
+- Description: Foundation in place; specific gaps need addressing.
+- Recommendation: 60-minute assessment call to identify specific engagement scope.
+- Action: "Book the assessment call." Calendar link.
+
+**Segment 3: "Ready for full engagement"**
+- Description: Foundation in place; clear gaps; ready to engage.
+- Recommendation: Direct engagement conversation.
+- Action: "Talk to our partner." Direct contact.
+
+**Segment 4: "Ongoing support"**
+- Description: Already engaged, looking for continued partnership.
+- Recommendation: Continuity-engagement options.
+- Action: "Discuss your next phase." Direct contact.
+
+The honest segmentation includes a "not yet ready" segment. This is honest and earns trust; not every taker should be sold to immediately.
+
+---
+
+## The "not for you" segment
+
+Honest segmentation sometimes includes a segment that is not the brand's audience.
+
+**The pattern.** A segment for takers who are not a fit. The recommendation acknowledges the lack of fit and offers something useful (a referral, a different brand's resource, a self-serve path).
+
+**Why it works.**
+
+- The taker who would have churned anyway leaves with respect for the brand.
+- The brand earns "honest" reputation that compounds across audience segments.
+- The unfit taker may refer fit takers later.
+
+**The dishonest alternative.** Pretending every taker is a fit; routing everyone to a sales contact regardless of segment. Audiences that catch the dishonesty disengage.
+
+---
+
+## Recommendation freshness
+
+Recommendations decay; the mapping needs maintenance.
+
+**What decays.**
+
+- Recommendations pointing to retired products.
+- Recommendations referencing outdated pricing or features.
+- Recommendations linking to broken pages or moved resources.
+- Recommendations that no longer match the brand's strategic priorities.
+
+**Maintenance cadence.** Quarterly review of every active recommendation. Update or replace as the brand's portfolio evolves.
+
+**The drift indicator.** Sales-team feedback that quiz-sourced leads are landing on the wrong recommendation. The mapping has drifted; refresh.
+
+---
+
+## Recommendation testing
+
+Test the recommendations as part of quiz launch and updates.
+
+**Click-through testing.** What percentage of takers in each segment click the recommendation's CTA? Low click-through suggests the recommendation does not feel matched.
+
+**Conversion testing.** What percentage of takers in each segment complete the recommended action (sign up, book a call, download the resource)? Low conversion suggests the recommendation does not deliver expected value.
+
+**Feedback testing.** Direct user feedback ("does this recommendation feel right for you?"). Useful for early validation; rarely scalable.
+
+---
+
+## The recommendation-as-CTA discipline
+
+The recommendation is also the call to action.
+
+**The pattern.** The recommendation includes a specific button or link that takes the taker to the next step.
+
+**Specific CTAs.**
+
+- "Start your 30-day trial" (specific action, specific timeframe).
+- "Book a 30-minute assessment call" (specific format, specific duration).
+- "Download the audit template" (specific deliverable).
+
+**Generic CTAs to avoid.**
+
+- "Learn more" (about what?).
+- "Get started" (started doing what?).
+- "Click here" (no value statement).
+
+The recommendation deserves a specific CTA matched to the action.
+
+---
+
+## Multi-recommendation results
+
+Some quizzes produce multiple recommendations per segment.
+
+**The pattern.** The result includes a primary recommendation and one or more secondary recommendations.
+
+**When this works.** When the segment genuinely benefits from multiple paths (e.g., "you can start with X, or if you have specific need Y, consider Z instead").
+
+**When this fails.** When multiple recommendations dilute the call to action; the taker does not know which to choose.
+
+**The discipline.** Default to one primary recommendation. Add secondary recommendations only when the segment genuinely benefits from a choice.
+
+---
+
+## Common mapping failures
+
+**Same recommendation across segments.** Different segments route to the same product or path; segmentation is decorative.
+
+**Generic recommendations.** "Talk to our team" for every segment without segment-specific framing.
+
+**Aspirational recommendations.** Recommendations for products or services not yet available; the taker tries the action and hits dead ends.
+
+**Mismatched recommendations.** Recommendation does not match the segment's situation; takers feel unheard.
+
+**Buried recommendations.** Recommendation appears 3 emails after the result rather than in the result itself.
+
+**No clear CTA.** Recommendation describes what to do without providing the link or button to do it.
+
+**No "not for you" segment.** Every taker routed toward sales; the audience that does not fit is treated as fitting; trust degrades.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The mapping principle and three requirements. Forms a recommendation can take. The mapping discipline (5 tests). Worked examples across quiz types. The "not for you" segment. Recommendation freshness. Recommendation testing. Recommendation-as-CTA discipline. Multi-recommendation results. Common failures.
+
+## Implementation choices that stay internal
+
+Specific segment-to-recommendation mappings for specific quizzes. Specific recommendation copy and CTAs in brand voice. Specific tracking for click-through and conversion per recommendation. The team's quarterly mapping audit calendar. These vary by team.

--- a/skills/quiz-and-assessment-design/references/scoring-algorithm-patterns.md
+++ b/skills/quiz-and-assessment-design/references/scoring-algorithm-patterns.md
@@ -1,0 +1,284 @@
+# Scoring algorithm patterns
+
+Direct mapping, weighted scoring, multi-dimensional, branching. Choice criteria and tradeoffs. The math that turns answers into a segment.
+
+The scoring algorithm is the bridge from question answers to result categorization. The right algorithm produces meaningful segments; the wrong algorithm produces results that do not match audience self-perception.
+
+---
+
+## Pattern A: Direct mapping
+
+Each answer corresponds directly to a segment. The dominant answer choice determines the result.
+
+**How it works.**
+
+- Each question's answer choices map to specific segments.
+- Each answer adds 1 point (or fixed weight) to its corresponding segment.
+- The segment with the most points wins.
+
+**Example.**
+
+Question: "What size is your team?"
+- 1-5 → "Solo" (+1)
+- 6-25 → "Growing" (+1)
+- 26-100 → "Mid-market" (+1)
+- 100+ → "Enterprise" (+1)
+
+After all questions, the segment with the highest count wins.
+
+**Strengths.**
+
+- Simple, transparent, easy to explain.
+- Easy to maintain (changes are obvious in their effect).
+- The scoring logic can be displayed to the audience without confusion.
+
+**Weaknesses.**
+
+- Limited nuance; one answer cannot contribute to multiple segments meaningfully.
+- Risk of ties when multiple segments score equally.
+
+**When to use.** When segments are well-defined and questions clearly distinguish them. The default starting point for many quizzes.
+
+---
+
+## Pattern B: Weighted scoring
+
+Each answer adds points (with weights) to one or more segments. The highest-scoring segment wins.
+
+**How it works.**
+
+- Each question's answer choices add weighted points to one or more segments.
+- An answer might add 3 points to segment A and 1 point to segment B.
+- After all questions, the segment with the highest total score wins.
+
+**Example.**
+
+Question: "What is your sales process maturity?"
+- "Founder-led, no defined process" → "Solo" (+3), "Growing" (+1)
+- "Some defined steps" → "Growing" (+3), "Mid-market" (+1)
+- "Defined sales playbook" → "Mid-market" (+3), "Enterprise" (+1)
+- "Multi-stage enterprise process" → "Enterprise" (+4)
+
+This question is more central to segmentation, so its weights are higher.
+
+**Strengths.**
+
+- Allows nuance; one answer can contribute to multiple segments.
+- Different questions can have different importance through their weights.
+- Reduces tie likelihood by spreading weights.
+
+**Weaknesses.**
+
+- Less transparent (audience cannot easily reverse-engineer the result).
+- More complex to maintain (changes to weights have non-obvious effects).
+- Easy to bias accidentally if weights are not audited.
+
+**When to use.** When segmentation needs nuance, when some questions are more important than others, when the segmentation is multi-attribute.
+
+---
+
+## Pattern C: Multi-dimensional
+
+The quiz produces scores across multiple axes. The result combines the scores into a 2D or 3D segment.
+
+**How it works.**
+
+- The quiz captures scores across 2-3 distinct dimensions (e.g., introvert/extrovert AND analytical/intuitive).
+- The result is determined by the position on each dimension (introvert + analytical = one quadrant; extrovert + intuitive = another).
+- Common in personality assessments, fit-evaluations, and any segmentation that is genuinely multi-axis.
+
+**Example.**
+
+A 2-dimensional quiz might score:
+- Dimension 1: technical depth (low to high)
+- Dimension 2: collaboration preference (solo to team)
+
+Result quadrants:
+- High technical, solo → "Solo specialist"
+- High technical, team → "Team specialist"
+- Low technical, solo → "Solo generalist"
+- Low technical, team → "Team generalist"
+
+**Strengths.**
+
+- Captures genuine multi-dimensional segmentation.
+- Produces results that feel nuanced and accurate.
+- Allows for richer recommendations matched to the dimensional combination.
+
+**Weaknesses.**
+
+- Significantly more complex than single-axis scoring.
+- Larger result-set to design and maintain (4 quadrants from 2 dimensions; 8 from 3 dimensions).
+- Harder for the audience to predict their result before taking.
+
+**When to use.** When segmentation is genuinely multi-axis (personality, fit-evaluation, learning style, decision-making style).
+
+---
+
+## Pattern D: Branching logic
+
+The next question depends on the previous answer. Allows for adaptive questioning.
+
+**How it works.**
+
+- The quiz starts with a few common questions.
+- Based on early answers, the quiz routes to different question sets.
+- Different paths through the quiz produce different results.
+
+**Example.**
+
+Question 1: "Do you currently use a CRM?"
+- Yes → branch A (questions about current CRM, satisfaction, gaps)
+- No → branch B (questions about why not, what would change, current process)
+
+The two branches produce different question sets that map to different segments.
+
+**Strengths.**
+
+- Adaptive; questions feel relevant to the taker.
+- Can produce highly specific segmentation.
+- Reduces irrelevant questions for any one taker.
+
+**Weaknesses.**
+
+- Significantly more complex to build and test.
+- Harder to compare segments because not all takers answered the same questions.
+- Maintenance is harder; changes to one branch can affect overall scoring.
+
+**When to use.** When later questions make sense only in the context of earlier ones, when the audience genuinely needs different questions based on their initial situation.
+
+---
+
+## Choice criteria
+
+Which pattern fits which quiz.
+
+**Use direct mapping when:**
+
+- Segments are well-defined and clearly distinguished.
+- Each question maps cleanly to one segment.
+- Transparency matters (audience benefits from being able to reason about their result).
+
+**Use weighted scoring when:**
+
+- Segmentation needs nuance.
+- Some questions are more central to segmentation than others.
+- Most answers contribute to multiple segments meaningfully.
+
+**Use multi-dimensional when:**
+
+- Segmentation is genuinely multi-axis.
+- The audience expects a richly textured result (personality assessments, learning styles).
+- Each dimension can be measured by a coherent subset of questions.
+
+**Use branching when:**
+
+- Later questions depend on earlier context.
+- The audience genuinely splits into distinct groups that need different question sets.
+- The maintenance complexity is justified by the segmentation value.
+
+The simplest pattern that produces the right segmentation is usually the best choice. Complexity has cost; only spend it where it produces value.
+
+---
+
+## Tie-breaking
+
+What happens when two segments score equally.
+
+**Pattern A: First-tied-segment wins.** The segment that reached the top score first (in the order segments are evaluated) wins. Simple but can introduce bias if the order is not deliberate.
+
+**Pattern B: Tie-breaker question.** A specific question whose answer breaks the tie. Useful when ties are common.
+
+**Pattern C: Combined-segment result.** A result for the tie itself ("You are between segment A and segment B"). Useful when the tie is genuinely meaningful.
+
+**Pattern D: Re-prompt or randomize.** Ask one more clarifying question to break the tie. Adds friction but produces a definitive result.
+
+**The choice.** Depends on how often ties occur and how meaningful the distinction between tied segments is. If ties are rare and the segments are similar, Pattern A is fine. If ties are common and the segments differ significantly, Pattern B or C is warranted.
+
+---
+
+## Edge-case handling
+
+What happens at the boundaries of the scoring.
+
+**The all-segments-zero edge case.** A taker answers in a way that gives zero points to every segment. Rare but possible. Default to the most common segment, or surface a "we could not categorize you" message that prompts re-engagement.
+
+**The very-high-single-segment edge case.** A taker scores extremely high on one segment, far above any other. Often signals strong segmentation; the result is reliable.
+
+**The all-segments-equal edge case.** A taker scores equally across all segments. Often signals the questions did not distinguish; the result is unreliable. May warrant a different question set or a different recommendation flow.
+
+**The contradictory-answers edge case.** A taker's answers contradict each other in ways the scoring did not anticipate. Often surfaces in audit; the question set may need clarification.
+
+---
+
+## Scoring transparency to the user
+
+Whether to show the score during or after the quiz.
+
+**Show the score.** When the dimensions or score are themselves meaningful to the user (personality assessments often benefit from showing dimensional scores).
+
+**Hide the score.** When the score is implementation detail and the segment is the meaningful output (most recommendation quizzes hide the score).
+
+**Hybrid.** Show segment + a brief explanation of how it was determined. "Your result is X. The questions that most influenced this were Y and Z."
+
+The choice depends on whether the score helps the user understand or distract from the result.
+
+---
+
+## Algorithm decay
+
+Scoring algorithms decay along with quizzes.
+
+**What decays.**
+
+- Question weights that no longer reflect the segmentation reality.
+- Segments that have shifted in audience composition.
+- Edge cases that have become more common.
+
+**Maintenance cadence.** Quarterly review of the scoring algorithm. Audit a sample of takers to confirm results match expectations.
+
+**Drift indicators.**
+
+- One segment receiving 70+ percent of takers.
+- Audience comments that the result feels wrong.
+- Sales-team feedback that quiz-sourced leads are misclassified.
+
+---
+
+## Algorithm testing
+
+Test the scoring algorithm before launch and after changes.
+
+**Persona testing.** Create personas representing each intended segment. Take the quiz as each persona; verify each persona reaches the intended segment.
+
+**Edge-case testing.** Try answer combinations that should produce ties, contradictions, or boundary conditions. Verify the algorithm handles them gracefully.
+
+**Volume testing.** Run the quiz with synthetic data simulating expected audience composition. Verify segment distribution matches expectations.
+
+**Production monitoring.** Track segment distribution over time. Sudden shifts may indicate question or scoring issues.
+
+---
+
+## Common scoring failures
+
+**Algorithm too simple for the segmentation.** Direct mapping when weighted scoring is needed; segments end up poorly distinguished.
+
+**Algorithm too complex for the segmentation.** Multi-dimensional when single-axis would have served; complexity without value.
+
+**Hidden bias in weights.** Weights that systematically favor one segment regardless of true audience composition.
+
+**Tie-breaking arbitrary.** Ties resolved in inconsistent or biased ways.
+
+**No production monitoring.** Algorithm drifts unnoticed; segment distribution becomes skewed.
+
+**Scoring not documented.** Future maintainers cannot reason about the algorithm; changes break in unexpected ways.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The four scoring patterns with how-it-works, strengths, weaknesses, and when-to-use guidance. Choice criteria. Tie-breaking patterns. Edge-case handling. Scoring transparency. Algorithm decay and maintenance. Algorithm testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific scoring algorithms for specific quizzes. Specific weights and segment mappings. Specific testing personas. Specific tooling for algorithm implementation and monitoring. These vary by team.


### PR DESCRIPTION
Growth Tooling Tier 1. New audience track in the catalog covering interactive web tooling that turns visitors into leads. 6 skills shipped as a grouped dispatch:

1. lead-magnet-design (parent-frame methodology)
2. calculator-design
3. quiz-and-assessment-design
4. multi-step-form-design
5. chatbot-flow-design
6. funnel-flow-architecture (architecture skill that orchestrates the others)

Each skill includes a 13-14 section SKILL.md (~2800-3000 words) plus 9 reference files, all with the methodology/implementation discipline applied per the codified pattern.

## Catalog growth

- 86 to 92 skills
- 315 to 369 reference files (+54: 9 per skill x 6 skills)
- New growth-tooling category with 6 entries

## Generator extension

scripts/generate_readme_catalog.py extended with growth-tooling in the CATEGORIES list. Category placed after growth and before marketing, with intro paragraph explaining the audience track.

## Quality gates

- Zero em-dashes across all 60 files
- Forbidden phrase check passed (with manual fix-ups for "leverage" and "robust" instances that surfaced in audit)
- Methodology-level / Implementation choices closing section in all 54 reference files
- Lint passed (92 skills, 1 pre-existing warning preserved)
- Generator idempotent

## Tier 2

Tier 2 (6 more growth-tooling skills: onboarding-wizard-design, interactive-product-tour, upgrade-flow-design, scheduler-and-booking-design, comparison-tool-design, product-configurator-design) queued for separate dispatch.