### PR TITLE
feat(skills): add Growth Tooling Tier 2 (6 skills, closes Growth Tooling track at 12 skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-92-blue.svg)](#the-92-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-98-blue.svg)](#the-98-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 92 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 98 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -35,7 +35,7 @@
 - [Quick example](#quick-example)
 - [How they compose](#how-they-compose)
 <!-- COUNT_TOC:START -->
-- [The 92-skill catalog](#the-92-skill-catalog)
+- [The 98-skill catalog](#the-98-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -63,8 +63,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **92 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
-- **369 reference files** (templates, checklists, decision matrices, worked examples)
+- **98 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
+- **423 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -253,11 +253,11 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 92-skill catalog
+## The 98-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 92 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 98 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -389,7 +389,7 @@ End-to-end SEO audit workflows that pull data from the Ahrefs MCP and produce co
 | 67 | [`analytics-strategy`](skills/analytics-strategy/SKILL.md) | Measurement frameworks, dashboard design, event taxonomy |
 | 68 | [`cro-optimization`](skills/cro-optimization/SKILL.md) | Hypothesis-driven testing, conversion optimization |
 
-### Growth tooling (6)
+### Growth tooling (12)
 
 Interactive web tools that turn visitors into leads. Lead magnets, calculators, quizzes, multi-step forms, chatbots, and the cross-tool funnel architecture that orchestrates them.
 
@@ -401,6 +401,12 @@ Interactive web tools that turn visitors into leads. Lead magnets, calculators, 
 | 72 | [`multi-step-form-design`](skills/multi-step-form-design/SKILL.md) | Designing multi-step forms that respect cognitive load while maintaining completion intent. Distinguishes kitchen-sink-single-page (overwhelms) from progress-theater (steps without genuine staging) from genuinely-staged (each step earns its own page) |
 | 73 | [`chatbot-flow-design`](skills/chatbot-flow-design/SKILL.md) | Designing conversational flows for chatbots and AI agents on websites. Distinguishes scripted-bot (rigid trees, fail edge cases) from hallucinating-bot (LLM without structure, makes things up) from structured-guided-conversation (LLM-powered with intent architecture and fallback discipline) |
 | 74 | [`funnel-flow-architecture`](skills/funnel-flow-architecture/SKILL.md) | Architecting cross-tool conversion flows that match audience and stage. Distinguishes silo-funnels (every tool standalone) from kitchen-sink-funnels (every audience squeezed through one path) from matched-funnels (architecture matched to audience-and-stage) |
+| 75 | [`onboarding-wizard-design`](skills/onboarding-wizard-design/SKILL.md) | Designing first-run product onboarding wizards. Distinguishes tutorial-overload (dump everything upfront) from skip-friendly-empty (skipped onboarding leads to abandoned product) from earned-progressive-disclosure (right things at the right moments) |
+| 76 | [`interactive-product-tour`](skills/interactive-product-tour/SKILL.md) | Designing in-product tours and contextual help. Distinguishes tooltip-spam (every button has a tour stop) from one-and-done (tour shows once, never seen again) from contextual-when-needed (surfaces help at the moment friction occurs) |
+| 77 | [`upgrade-flow-design`](skills/upgrade-flow-design/SKILL.md) | Designing free-to-paid conversion flows. Distinguishes paywall-everywhere (gates everything aggressively) from free-forever-trap (no upgrade path surfaces) from value-triggered-upgrade (paywall surfaces at moments of demonstrated value) |
+| 78 | [`scheduler-and-booking-design`](skills/scheduler-and-booking-design/SKILL.md) | Designing schedulers and booking flows. Distinguishes any-time-friction (no qualification, just a booking link) from interrogation-gate (so much qualification it scares users off) from qualified-fast-path (just enough qualification to set up the call well) |
+| 79 | [`comparison-tool-design`](skills/comparison-tool-design/SKILL.md) | Designing comparison tools that help users decide. Distinguishes feature-list-dump (every feature in a row, no decision support) from hidden-recommendation (biased comparison pretending to be neutral) from honest-comparison-with-guidance (genuine comparison plus opinionated recommendation) |
+| 80 | [`product-configurator-design`](skills/product-configurator-design/SKILL.md) | Designing interactive product configurators. Distinguishes infinite-options (decision paralysis from too many options) from canned-bundles-only (no real customization) from guided-configuration (smart defaults plus meaningful constraints plus escape hatches) |
 
 ### Marketing (3)
 
@@ -408,39 +414,39 @@ Paid media discipline: strategy, creative, and performance analytics. Pairs with
 
 | # | Skill | What it does |
 |---|---|---|
-| 75 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
-| 76 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
-| 77 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
+| 81 | [`paid-media-strategy`](skills/paid-media-strategy/SKILL.md) | Hypothesis to spend: channel selection, budget allocation, audience targeting, bid strategy, attribution reality, and the failure modes that burn agency-scale budgets |
+| 82 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
+| 83 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
 
 ### Research (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 78 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
-| 79 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
-| 80 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
-| 81 | [`discovery-research-synthesis`](skills/discovery-research-synthesis/SKILL.md) | Synthesizing customer interviews, research notes, and support tickets into actionable PM decisions. Distinguishes data-dump (no synthesis) from insight-theater (overpolished narrative) from actionable synthesis (decision-grade clarity) |
-| 82 | [`user-feedback-aggregation`](skills/user-feedback-aggregation/SKILL.md) | Collecting and synthesizing user feedback across channels into continuous decision signal. Triage discipline that distinguishes loudest-voice (whoever complains most) from averaged-noise (every signal weighted equally) from triaged-synthesis (weighted by source quality and decision relevance) |
+| 84 | [`ux-research`](skills/ux-research/SKILL.md) | Research planning, user interviews, qualitative synthesis |
+| 85 | [`usability-testing`](skills/usability-testing/SKILL.md) | Test design, moderation, findings reports |
+| 86 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
+| 87 | [`discovery-research-synthesis`](skills/discovery-research-synthesis/SKILL.md) | Synthesizing customer interviews, research notes, and support tickets into actionable PM decisions. Distinguishes data-dump (no synthesis) from insight-theater (overpolished narrative) from actionable synthesis (decision-grade clarity) |
+| 88 | [`user-feedback-aggregation`](skills/user-feedback-aggregation/SKILL.md) | Collecting and synthesizing user feedback across channels into continuous decision signal. Triage discipline that distinguishes loudest-voice (whoever complains most) from averaged-noise (every signal weighted equally) from triaged-synthesis (weighted by source quality and decision relevance) |
 
 ### Cross-cutting workflows (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 83 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
-| 84 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
-| 85 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
-| 86 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
-| 87 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
+| 89 | [`form-strategy`](skills/form-strategy/SKILL.md) | Form design, validation patterns, spam prevention, conversion tuning |
+| 90 | [`content-migration`](skills/content-migration/SKILL.md) | Platform migrations with SEO equity preservation |
+| 91 | [`internationalization`](skills/internationalization/SKILL.md) | Locale strategy, hreflang, translation workflow, RTL design |
+| 92 | [`dependency-management`](skills/dependency-management/SKILL.md) | Package updates, security patches, lockfile hygiene |
+| 93 | [`cost-optimization`](skills/cost-optimization/SKILL.md) | Infrastructure spend audits, rightsizing, contract negotiation |
 
 ### Process and team (5)
 
 | # | Skill | What it does |
 |---|---|---|
-| 88 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
-| 89 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
-| 90 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
-| 91 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
-| 92 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
+| 94 | [`stakeholder-communication`](skills/stakeholder-communication/SKILL.md) | Status updates, exec readouts, project communications |
+| 95 | [`documentation-strategy`](skills/documentation-strategy/SKILL.md) | Documentation systems, what to document, maintenance cadence |
+| 96 | [`vendor-evaluation`](skills/vendor-evaluation/SKILL.md) | Tool and vendor selection using a structured rubric |
+| 97 | [`team-onboarding-playbook`](skills/team-onboarding-playbook/SKILL.md) | 30-60-90 onboarding plans for new hires and contractors |
+| 98 | [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) | The meta-skill: how to write your own custom skills |
 <!-- CATALOG:END -->
 
 ---

--- a/skills/comparison-tool-design/SKILL.md
+++ b/skills/comparison-tool-design/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: comparison-tool-design
+description: "Designing side-by-side comparison tools (plan-compare, product-compare, alternative-compare) that help users decide rather than just listing features. Axis selection, default-comparison logic, recommendation discipline. Honest about feature-list-dump (every feature in a row, no decision support), hidden-recommendation (biased comparison pretending to be neutral), and honest-comparison-with-guidance (genuine comparison plus opinionated recommendation) patterns. Triggers on comparison tool, plan compare, product compare, alternative compare, vs page, decision support tool. Also triggers when conversion through comparison stages is poor, when users are abandoning at the comparison step, or when a comparison tool is being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing comparison tools that help users decide. Distinguishes feature-list-dump (every feature in a row, no decision support) from hidden-recommendation (biased comparison pretending to be neutral) from honest-comparison-with-guidance (genuine comparison plus opinionated recommendation)"
+display_order: 11
+---
+
+# Comparison Tool Design
+
+A senior product marketing director's playbook for designing side-by-side comparison tools that help users decide rather than just listing features. Plan-compare, product-compare, alternative-compare. Axis selection, default-comparison logic, recommendation discipline. The discipline of building a comparison tool that earns the user's trust.
+
+Most comparison tools fail in one of two ways. They dump every feature into a giant grid (4 options × 40 features = 160 cells) and ask the user to weigh everything against everything. The user leaves without choosing. Or they pretend to be neutral comparisons but are actually sales pitches with biased defaults and weighted framing; the user catches the bias and trust collapses.
+
+The comparison tools that work do something different. Genuine like-for-like comparison plus an explicit opinionated recommendation. "For X audience, choose Y." The recommendation is visible, defended, and not the only path; users can override. The tool helps the user decide rather than asking them to decide alone.
+
+The voice is the senior product marketing director who has watched comparison tools double conversion when redesigned with honest recommendations and watched them collapse when feature grids grew without decision support. Practical, opinionated about which axes matter, willing to call out when the comparison is decoration.
+
+When to use this skill: scoping a comparison tool for the first time, auditing a feature-grid comparison that produces no conversion lift, designing recommendation logic that is honest about the recommendation, or deciding which axes earn placement in a comparison tool.
+
+---
+
+## What this skill covers
+
+This skill spans side-by-side comparison tools. The growth-tooling distinctions:
+
+- `calculator-design` is calculators that give a number. This skill is comparing known options.
+- `quiz-and-assessment-design` is quizzes that give a category. This skill is comparing options the user already knows about.
+- **`comparison-tool-design` (this skill)** is axis selection, default-comparison logic, recommendation engine, filter-and-toggle UX.
+- `landing-page-copy` is pricing-page copy; one specific application of comparison tools is the pricing page.
+- `content-strategy` is upstream; what topics warrant comparison content.
+
+The audience: product marketers, growth marketers, content marketers running vs-pages and decision-support tooling, agencies running comparison work for clients.
+
+Out of scope: calculator design (covered by `calculator-design`); quiz design (covered by `quiz-and-assessment-design`); the engineering implementation; specific Webflow/Framer/CMS configurations (those stay implementation-side).
+
+---
+
+## The comparison-tool decision: when comparison tools earn investment
+
+Before designing the tool, decide whether a comparison tool is the right answer.
+
+**Comparison tools earn investment when:**
+
+- The audience is at a decision moment between known options (vs unknown options where a quiz or recommendation tool fits better).
+- The options have meaningful differences that warrant side-by-side analysis.
+- The brand can articulate honest distinctions between options without becoming sales pitch.
+- The audience benefits from decision support, not just feature listing.
+
+**Comparison tools do NOT earn investment when:**
+
+- Options are too similar to compare meaningfully.
+- The brand cannot make honest distinctions without creating sales-pitch dynamics.
+- A simple comparison table or written content would serve.
+- The audience does not actually face this decision (manufactured comparisons).
+
+The decision is not "should we have a comparison tool"; it is "is the comparison tool the right tool for this decision."
+
+Detail in `references/comparison-tool-decision-criteria.md`.
+
+---
+
+## Feature-list-dump vs hidden-recommendation vs honest-comparison-with-guidance
+
+The keystone framing.
+
+**Feature-list-dump.** Every option's every feature in a giant grid. No decision support. The user is asked to weigh 40 cells against each other; most leave without choosing. Cost: design effort wasted on a grid that does not produce decisions; the audience perceives the grid as overwhelming.
+
+**Hidden-recommendation.** "Comparison" tool that is actually a sales pitch. Defaults favor one option; framing weights the answer; the recommendation is invisible but baked in. Trust erodes when users notice the bias. Cost: short-term conversion may look fine; long-term brand damage from "manipulative" reputation.
+
+**Honest-comparison-with-guidance.** Genuine like-for-like comparison plus an explicit opinionated recommendation ("For X audience, choose Y"). The recommendation is visible, defended, and not the only path; users can override. Cost: design effort upfront is significant; conversion typically improves because users feel respected and helped.
+
+The litmus test. Does the tool tell the user what to choose for their specific situation, with reasoning? If yes, honest-comparison-with-guidance. If it dumps features without guidance, feature-list-dump. If it says "the right answer is obviously [our preferred option]" without acknowledgment, hidden-recommendation.
+
+---
+
+## Axis selection: which dimensions matter, which are noise
+
+The single most consequential decision in comparison tool design.
+
+**The principle.** Axes (the rows of the comparison) should be the dimensions that genuinely affect the decision, not every feature available.
+
+**Strong axes.**
+
+- **Decision-relevant capabilities.** Features that materially affect the audience's outcome.
+- **Cost dimensions.** Price, total cost of ownership, hidden costs.
+- **Constraint dimensions.** Capacity, scale, integration support.
+- **Service dimensions.** Support quality, onboarding, SLA.
+- **Risk dimensions.** Vendor stability, security, compliance.
+
+**Weak axes.**
+
+- **Marketing checkboxes.** Features that exist on every option; checkmarks across the row.
+- **Nice-to-haves.** Features the audience does not actually weigh.
+- **Vendor-specific terminology.** Features named differently by each vendor; comparison becomes label confusion.
+- **Decoration features.** Features added to the grid because the brand has them and competitors do not.
+
+**The 8-12 axis rule.** Most production comparison tools work well with 8-12 axes. Beyond that, decision paralysis sets in.
+
+Detail in `references/axis-selection-patterns.md`.
+
+---
+
+## Default-comparison logic
+
+Which options compare by default, and why.
+
+**The principle.** Defaults shape the user's first impression. Honest defaults reflect the audience's likely starting point; biased defaults shape conclusions.
+
+**Default options.**
+
+- Audience-fit defaults. The options the audience most commonly considers.
+- Stage-fit defaults. The options that match the audience's stage of decision.
+- Inferred defaults. Based on referral source, query, or prior interaction.
+
+**Default axes.**
+
+- The axes most relevant to the typical audience.
+- Audience can expand to additional axes if interested.
+
+**Bias-flattering defaults.**
+
+- Defaults set so brand always wins on visible axes.
+- Defaults that hide axes where competitors win.
+- Defaults that frame in brand's terminology.
+
+The discipline. Defaults serve the audience, not the brand. When defaults must reflect brand strength, do so honestly with disclosure.
+
+Detail in `references/default-comparison-logic.md`.
+
+---
+
+## Recommendation engine design
+
+When to recommend, how to defend the recommendation.
+
+**The principle.** Comparison tools that recommend are more useful than tools that just list. The recommendation must be defensible.
+
+**Recommendation patterns.**
+
+- **Single recommendation.** "For [audience], choose [option] because [reasons]." Clear; opinionated.
+- **Multi-segment recommendation.** "If you are [A], choose X. If you are [B], choose Y." Honest about audience-fit.
+- **Conditional recommendation.** "If [factor] matters most, X. If [other factor] matters most, Y." Helps the user decide based on priorities.
+
+**Recommendation defense.**
+
+- The reasoning shown.
+- The audience for the recommendation explicit.
+- The override path visible.
+
+**Anti-pattern: hidden recommendation.** Tool that defaults to one option's victory through axis selection and framing, without explicit recommendation. Users feel manipulated when they catch the pattern.
+
+Detail in `references/recommendation-engine-design.md` and `references/honest-recommendation-discipline.md`.
+
+---
+
+## Filter and toggle UX
+
+What users can adjust, what should stay fixed.
+
+**Filterable elements.**
+
+- Which options to compare (user adds or removes options).
+- Which axes to show (user filters to relevant dimensions).
+- Audience or use case (user signals their context; tool adapts).
+
+**Fixed elements.**
+
+- Methodology disclosure (always visible).
+- Recommendation reasoning (always findable).
+- Source citations (always linkable).
+
+**The filter-fatigue trap.** Too many filters; user paralyzed.
+
+**The under-filtered trap.** Tool too rigid; user cannot match their context.
+
+The discipline. Filters that materially help; not filters for the sake of customization.
+
+Detail in `references/filter-and-toggle-patterns.md`.
+
+---
+
+## Comparison-fatigue patterns
+
+Why most comparisons fail to produce decisions.
+
+**Pattern 1: Too many cells.** 40 features × 5 options = 200 cells; cognitive overload.
+
+**Pattern 2: All-checkmarks rows.** Every option has the feature; the row produces no signal.
+
+**Pattern 3: Inconsistent axis terminology.** Each vendor names features differently; user confused.
+
+**Pattern 4: Hidden costs.** Pricing visible; fees, overage, integrations not surfaced.
+
+**Pattern 5: Apples-to-oranges options.** Comparing genuinely different things; no axis applies cleanly.
+
+**Pattern 6: No recommendation.** Tool lists; user must decide; user does not.
+
+The cumulative effect. The tool produces no decision; users default to the brand they already heard of.
+
+Detail in `references/comparison-fatigue-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-comparison-failures.md`.
+
+- "Tool gets traffic; conversion is unchanged." Likely feature-list-dump; no decision support.
+- "Sales says competitor leads cite our tool as biased." Hidden-recommendation pattern; trust damage.
+- "Mobile users do not engage with the tool." Comparison grids do not work well on mobile; design for it.
+- "Power users criticize axis selection." Audience knows these features; tool may have used easy axes rather than decision-relevant.
+- "Tool was great at launch; conversion declined over time." Features changed; comparison stale.
+- "Audience says 'this is helpful' but does not convert." Recommendation absent or weak; users get information without decision support.
+- "Comparison shows every option as 'good' for something." Dilution; no clear recommendation.
+- "Adding more features to the comparison reduced conversion." Crossed the cell-count threshold; cognitive overload.
+
+---
+
+## The framework: 12 considerations for comparison tool design
+
+When designing or auditing a comparison tool, walk these 12 considerations.
+
+1. **The comparison-tool decision.** Is a tool the right answer, or does written content serve?
+2. **Honest-comparison-with-guidance, not feature-list-dump or hidden-recommendation.** Genuine compare plus opinionated rec.
+3. **Axis selection.** 8-12 decision-relevant axes; cut decoration features.
+4. **Default-comparison logic.** Honest defaults; not bias-flattering.
+5. **Recommendation engine designed.** Visible; defended; not the only path.
+6. **Filter and toggle UX.** Filters that help; not filters for customization theater.
+7. **Methodology disclosed.** Source data, axis weighting, audience definition.
+8. **Mobile parity.** Tool works on the devices the audience uses.
+9. **Maintenance discipline.** Comparison stays current as options change.
+10. **Honest about competitor strengths.** When competitors win on an axis, say so.
+11. **Audience-fit measured.** Per-segment conversion through the tool.
+12. **Conversion as success metric.** Not just engagement; downstream choice and retention.
+
+The output of the framework is a comparison tool that earns the user's trust by helping them decide, with recommendation that is honest and defensible.
+
+---
+
+## Reference files
+
+- [`references/comparison-tool-decision-criteria.md`](references/comparison-tool-decision-criteria.md) - When comparison tools earn the build vs when written content serves.
+- [`references/axis-selection-patterns.md`](references/axis-selection-patterns.md) - Strong axes, weak axes, the 8-12 rule.
+- [`references/default-comparison-logic.md`](references/default-comparison-logic.md) - Honest defaults vs bias-flattering defaults.
+- [`references/recommendation-engine-design.md`](references/recommendation-engine-design.md) - When to recommend, how to defend, override path.
+- [`references/filter-and-toggle-patterns.md`](references/filter-and-toggle-patterns.md) - Filterable vs fixed elements; filter-fatigue trap.
+- [`references/comparison-fatigue-patterns.md`](references/comparison-fatigue-patterns.md) - Why most comparisons fail to produce decisions.
+- [`references/honest-recommendation-discipline.md`](references/honest-recommendation-discipline.md) - The discipline that distinguishes hidden from honest recommendations.
+- [`references/comparison-anti-patterns.md`](references/comparison-anti-patterns.md) - The patterns that look like comparisons but degrade trust.
+- [`references/common-comparison-failures.md`](references/common-comparison-failures.md) - 8+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: comparison tools earn the choice when they earn the user's trust
+
+The comparison tools that work as compounding assets are the ones the audience trusts to help them decide. Not because the tool flatters the brand. Not because the tool dumps features. Because the tool genuinely helps the user pick the option that fits their situation, and is honest about which option that is.
+
+That is the bar. Below the bar are feature-list-dump (no decision support; user leaves without choosing) and hidden-recommendation (biased pretending to be neutral; trust collapses when caught). Above the bar are honest-comparison-with-guidance tools where axis selection, default logic, recommendation engine, and filter UX work together to produce decisions the audience trusts.
+
+The discipline is in the design choices. The decision to build a comparison at all. The axes that earn placement. The defaults that serve the audience. The recommendation that is visible and defended. The filters that help the user match their context. The methodology that is disclosed. The maintenance that keeps the comparison current.

--- a/skills/comparison-tool-design/references/axis-selection-patterns.md
+++ b/skills/comparison-tool-design/references/axis-selection-patterns.md
@@ -1,0 +1,185 @@
+# Axis selection patterns
+
+Strong axes, weak axes, the 8-12 rule.
+
+Axes (the rows of the comparison) should be the dimensions that genuinely affect the decision. Done well, axes produce decisions; done poorly, they produce overwhelm.
+
+---
+
+## The decision-relevance principle
+
+Each axis should affect the audience's decision. Axes that do not are decoration.
+
+**The win.** A comparison tool with 10 axes covering capability, pricing, integration, support quality. Each axis materially affects whether the audience would choose.
+
+**The fail.** Same tool with 35 axes including marketing-checkbox features. User overwhelmed; many cells provide no signal.
+
+The discipline. Axes earn placement through decision relevance.
+
+---
+
+## Strong axes
+
+Patterns that earn placement.
+
+**Decision-relevant capabilities.** The 5-7 capabilities the audience explicitly evaluates.
+
+**Cost dimensions.** Price, total cost of ownership, hidden costs.
+
+**Constraint dimensions.** Capacity, scale ceilings, integrations, geography.
+
+**Service dimensions.** Support quality, onboarding, SLA.
+
+**Risk dimensions.** Vendor stability, security, compliance.
+
+**Time dimensions.** Time to value, implementation timeline.
+
+**The selection discipline.** Each axis answers "will this matter to the audience?" If no, cut.
+
+---
+
+## Weak axes
+
+Patterns that fail.
+
+**Marketing checkboxes.** Features on every option; checkmarks across the row. No signal.
+
+**Nice-to-haves.** Features the audience does not weigh.
+
+**Vendor-specific terminology.** Features named differently by each vendor; label confusion.
+
+**Decoration features.** Added because brand has them.
+
+**Generic checkmarks.** "Customer support: yes/yes/yes." Not differentiating.
+
+---
+
+## The 8-12 axis rule
+
+Most production comparison tools work well with 8-12 axes.
+
+**Why 8-12.**
+
+- Below 8: comparison thin.
+- Above 12: cognitive overload.
+
+**Exceptions.**
+
+- Highly technical audiences may absorb 15-20.
+- Consumer audiences may tolerate 6-8.
+
+**The over-12 trap.** Each axis beyond 12 reduces engagement.
+
+---
+
+## Axis ordering
+
+Within the comparison, order matters.
+
+**Strong order.** Most decision-relevant first.
+
+**Weak order.** Random; alphabetical; feature-category without importance weighting.
+
+**The first-axis discipline.** First axis should be one of the most important; users may skim past later axes.
+
+---
+
+## Axis grouping
+
+When axes group naturally.
+
+**Grouping patterns.** Capability axes together; cost together; service together; risk together.
+
+**Strengths.** Easier to scan.
+
+**Weaknesses.** Group dividers add visual complexity.
+
+**When to use.** When axis count justifies (10+ axes).
+
+---
+
+## Axis content per cell
+
+What each cell shows.
+
+**Beyond checkmarks.** "Yes/no" rarely produces decisions. Numbers, descriptions, comparisons add depth.
+
+**Examples.**
+
+- Cost: "$X/month" not just "Yes" to "has pricing."
+- Capacity: "Up to 1000 users" not just "Yes" to "scales."
+- Support: "24/7 chat plus phone" not just "Yes" to "support."
+
+The cell content discipline. Depth where decisions need it.
+
+---
+
+## Axis defaults
+
+Which axes show by default; which behind toggle.
+
+**Default-shown axes.** The 8-12 most decision-relevant.
+
+**Toggle-shown axes.** Less critical; audience can expand.
+
+**The hide-bias trap.** Hiding axes where brand loses; detection eventual.
+
+**The honest-default principle.** Defaults reflect audience importance; not brand strength.
+
+---
+
+## Axis updates
+
+Axes decay.
+
+**What decays.**
+
+- Axes that lost relevance.
+- Axes that gained relevance.
+- Axis content stale.
+
+**Maintenance cadence.** Quarterly review.
+
+---
+
+## Axis testing
+
+Validate axes with the audience.
+
+**Methods.**
+
+- User research: which axes do they consider?
+- A/B test: different axis sets.
+- Sales-call mining: which axes do prospects ask about?
+
+The validation discipline. Axes are hypotheses; validate.
+
+---
+
+## Common axis failures
+
+**Too many axes.** Cognitive overload.
+
+**Too few axes.** Comparison thin.
+
+**Wrong axes.** Audience does not weigh them.
+
+**Marketing-checkbox axes.** No signal.
+
+**Vendor-specific terminology.** Label confusion.
+
+**Hidden axes where brand loses.** Bias detected.
+
+**Stale axis content.** Pricing or features outdated.
+
+**Axis ordering ignores importance.** First axes are not most critical.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The decision-relevance principle. Strong axes (6 patterns). Weak axes (5 patterns). The 8-12 rule. Axis ordering. Axis grouping. Cell content. Axis defaults. Updates. Testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific axes for specific tools. Specific cell content. Specific tooling. The team's audit calendar. These vary by team.

--- a/skills/comparison-tool-design/references/common-comparison-failures.md
+++ b/skills/comparison-tool-design/references/common-comparison-failures.md
@@ -1,0 +1,179 @@
+# Common comparison failures
+
+8+ failure patterns with diagnoses and cures.
+
+---
+
+## "Tool gets traffic; conversion is unchanged."
+
+**The diagnosis.** Likely feature-list-dump; no decision support.
+
+**The cure.** Add recommendation. Cut decoration axes. Detail in `references/recommendation-engine-design.md`.
+
+---
+
+## "Sales says competitor leads cite our tool as biased."
+
+**The diagnosis.** Hidden-recommendation pattern; trust damage.
+
+**The cure.** Honest recommendation discipline (`references/honest-recommendation-discipline.md`). Acknowledge competitor strengths.
+
+---
+
+## "Mobile users do not engage with the tool."
+
+**The diagnosis.** Comparison grids do not work well on mobile.
+
+**The cure.** Mobile-first design. Stacked layout. Reduced axis count for mobile.
+
+---
+
+## "Power users criticize axis selection."
+
+**The diagnosis.** Audience knows these features; tool may have used easy axes rather than decision-relevant.
+
+**The cure.** Audit axes against real audience decisions. Replace marketing-checkbox axes with decision-relevant ones.
+
+---
+
+## "Tool was great at launch; conversion declined over time."
+
+**The diagnosis.** Features changed; comparison stale.
+
+**The cure.** Quarterly maintenance.
+
+---
+
+## "Audience says 'this is helpful' but does not convert."
+
+**The diagnosis.** Recommendation absent or weak.
+
+**The cure.** Add recommendation with reasoning and clear next-step CTA.
+
+---
+
+## "Comparison shows every option as 'good' for something."
+
+**The diagnosis.** Dilution; no clear recommendation.
+
+**The cure.** Take a stand. Recommendation should be opinionated; tradeoffs acknowledged.
+
+---
+
+## "Adding more features to the comparison reduced conversion."
+
+**The diagnosis.** Crossed the cell-count threshold; cognitive overload.
+
+**The cure.** Cut back. 8-12 axes is the working range.
+
+---
+
+## "Sales says many leads come through the tool but bounce on demo."
+
+**The diagnosis.** Tool's framing oversells; reality on demo does not match.
+
+**The cure.** Honest tool produces honest leads. Audit framing for sales-pitch dynamics.
+
+---
+
+## "Audience-segment recommendations feel stereotyped."
+
+**The diagnosis.** Segment definitions based on assumptions rather than research.
+
+**The cure.** Validate audience segments with research. Refine recommendations based on real needs.
+
+---
+
+## "Specific competitor is missing; users ask why."
+
+**The diagnosis.** Competitor omitted from comparison.
+
+**The cure.** Include relevant competitors. If intentionally excluded, disclose why ("we focus on X category; competitor Y is in different category").
+
+---
+
+## "Tool methodology questioned by analyst or journalist."
+
+**The diagnosis.** Methodology hidden or weakly defended.
+
+**The cure.** Detailed methodology disclosure. Be ready to defend specific axis choices and weights.
+
+---
+
+## "Tool conversion is fine; sales conversion does not match."
+
+**The diagnosis.** Tool optimizes for tool-conversion; downstream not aligned.
+
+**The cure.** Track downstream metrics. Optimize for downstream conversion, not just tool engagement.
+
+---
+
+## "Filter use is low; users see default comparison only."
+
+**The diagnosis.** Filters added but not promoted; users do not realize they exist.
+
+**The cure.** Promote filters; or accept that defaults serve and reduce filter complexity.
+
+---
+
+## "Filters produce empty result combinations."
+
+**The diagnosis.** Filter logic does not constrain combinations to those producing comparable options.
+
+**The cure.** Smart filter logic. When filters would produce empty result, surface alternatives.
+
+---
+
+## "Recommendation fires for one option always."
+
+**The diagnosis.** Hidden-recommendation; bias-flattering logic.
+
+**The cure.** Test the recommendation engine across audience scenarios. Ensure competitors win when fit warrants.
+
+---
+
+## "Audience tells us the comparison feels accurate but the recommendation feels off."
+
+**The diagnosis.** Comparison data accurate; recommendation engine logic does not match audience priorities.
+
+**The cure.** Validate recommendation logic. Audience research on what they weigh vs what the tool weights.
+
+---
+
+## "We A/B tested adding axes; conversion went down."
+
+**The diagnosis.** Crossed the cell-count threshold.
+
+**The cure.** Maintain axis discipline. More is not always better.
+
+---
+
+## "Tool produces good conversion for new visitors; returning visitors do not engage."
+
+**The diagnosis.** Tool optimized for first-time-decision audience; returning visitors have other needs.
+
+**The cure.** Different surfaces for different stages. Returning visitors may want simpler reference rather than full tool.
+
+---
+
+## The pattern across failures
+
+Most comparison tool failures fall into one of three patterns.
+
+**Pattern 1: No decision support.** Feature-list-dump, no-recommendation, dilution. The fix is clear, defensible recommendation.
+
+**Pattern 2: Bias damages trust.** Hidden-recommendation, contradiction, omitted competitors, stereotypes. The fix is honest recommendation discipline.
+
+**Pattern 3: Friction.** Over-filtered, mobile-broken, fatigue patterns. The fix is reducing cognitive load and matching audience use.
+
+The metric pattern: comparison failures often look fine on engagement alone. The signal is in conversion, downstream metrics, audience trust.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (no-decision-support, bias, friction). The principle that engagement alone is insufficient.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered. Specific multi-metric dashboards. Specific cures. The team's audit and retirement processes. These vary by team.

--- a/skills/comparison-tool-design/references/comparison-anti-patterns.md
+++ b/skills/comparison-tool-design/references/comparison-anti-patterns.md
@@ -1,0 +1,218 @@
+# Comparison anti-patterns
+
+The patterns that look like comparisons but degrade trust. Easy to ship; cost shows up in conversion, brand reputation, and audience trust.
+
+---
+
+## The feature-list-dump comparison
+
+The pattern. Every feature × every option. No decision support.
+
+The signal. Users skim; do not choose; tool produces no conversion lift.
+
+The cure. Cut to 8-12 decision-relevant axes. Add recommendation.
+
+---
+
+## The hidden-recommendation comparison
+
+The pattern. Defaults bias toward brand without disclosure.
+
+The signal. Sophisticated audiences notice; trust collapses.
+
+The cost. Long-term brand damage.
+
+The cure. Honest defaults; explicit recommendation; acknowledge competitor strengths.
+
+---
+
+## The all-checkmarks comparison
+
+The pattern. Every option has every feature; checkmarks across the rows.
+
+The signal. Rows produce no signal; users skim.
+
+The cure. Cut generic-checkmark rows. Replace with specifics that differentiate.
+
+---
+
+## The terminology-confused comparison
+
+The pattern. Each vendor's terminology used in their column; user cannot tell if features match.
+
+The signal. Users confused; comparison breaks semantically.
+
+The cure. Normalize terminology. Vendor names in subtext; functional descriptions in main label.
+
+---
+
+## The hidden-cost comparison
+
+The pattern. Headline pricing visible; overage, fees, integrations not surfaced.
+
+The signal. Users compare on visible price; learn about hidden costs later; feel deceived.
+
+The cure. Total cost of ownership surfaced.
+
+---
+
+## The apples-to-oranges comparison
+
+The pattern. Options compared that are genuinely different things.
+
+The signal. Comparison feels strained; axes do not apply cleanly.
+
+The cure. Compare options the audience actually considers together. Separate tools for separate categories if needed.
+
+---
+
+## The no-recommendation comparison
+
+The pattern. Tool lists; user decides alone.
+
+The signal. High abandonment; conversion lift absent.
+
+The cure. Add recommendation with reasoning.
+
+---
+
+## The contradicts-itself comparison
+
+The pattern. Comparison shows competitor winning on most axes; tool recommends brand anyway.
+
+The signal. Users notice the contradiction; trust collapses.
+
+The cure. Recommendation aligns with comparison; or recommendation defends the contradiction explicitly.
+
+---
+
+## The stale comparison
+
+The pattern. Information from 6+ months ago.
+
+The signal. Users notice; trust drops.
+
+The cure. Quarterly maintenance.
+
+---
+
+## The over-filtered comparison
+
+The pattern. 12+ filters; user paralysis at filter step.
+
+The signal. High drop-off before the comparison loads.
+
+The cure. Reduce filter count; default-heavy.
+
+---
+
+## The under-filtered comparison
+
+The pattern. Tool too rigid; one fixed view.
+
+The signal. Specific segments convert poorly.
+
+The cure. Add filters where audiences split.
+
+---
+
+## The mobile-broken comparison
+
+The pattern. Grid designed for desktop; mobile cramped or scroll-required.
+
+The signal. Mobile conversion much lower.
+
+The cure. Mobile-first design.
+
+---
+
+## The methodology-hidden comparison
+
+The pattern. Tool shown without explaining how comparison was built.
+
+The signal. Sophisticated users question the tool.
+
+The cure. Methodology disclosure.
+
+---
+
+## The audience-stereotype comparison
+
+The pattern. Audience-segment recommendations rely on stereotypes ("enterprise = big and slow").
+
+The signal. Users in those segments feel mis-served.
+
+The cure. Audience-segment recommendations based on real needs, not assumptions.
+
+---
+
+## The over-recommend comparison
+
+The pattern. Tool recommends in cases where genuine differentiator does not exist.
+
+The signal. Users notice the recommendation feels arbitrary.
+
+The cure. "We cannot rank these for you" is sometimes the honest answer.
+
+---
+
+## The competitor-omission comparison
+
+The pattern. Important competitor missing from the comparison.
+
+The signal. Users ask "where is X?" or feel comparison is incomplete.
+
+The cure. Include relevant competitors. If a competitor is omitted intentionally, disclose why.
+
+---
+
+## The bias-flattering-axis-selection comparison
+
+The pattern. Axes chosen where brand wins; axes hidden where brand loses.
+
+The signal. Sophisticated audiences notice axis selection.
+
+The cure. Honest axis selection. Detail in `references/axis-selection-patterns.md`.
+
+---
+
+## The marketing-checkbox comparison
+
+The pattern. Every option's marketing checkboxes laid out as comparison.
+
+The signal. Comparison reads like marketing brochures rather than analysis.
+
+The cure. Replace marketing checkboxes with specific functional capabilities.
+
+---
+
+## How to detect anti-patterns
+
+Audit cadence. Quarterly review.
+
+**Audit questions per tool.**
+
+- Is the tool feature-list-dump (anti-pattern check)?
+- Does the recommendation acknowledge competitor strengths (anti-pattern check: hidden-recommendation)?
+- Are rows differentiating (anti-pattern check: all-checkmarks)?
+- Is terminology normalized (anti-pattern check: terminology-confused)?
+- Are total costs surfaced (anti-pattern check: hidden-cost)?
+- Are options apples-to-apples (anti-pattern check: apples-to-oranges)?
+- Is recommendation present (anti-pattern check: no-recommendation)?
+- Does recommendation align with comparison (anti-pattern check: contradicts-itself)?
+- Is information current (anti-pattern check: stale)?
+- Are filters calibrated (anti-pattern check: over-filtered, under-filtered)?
+- Does mobile work (anti-pattern check: mobile-broken)?
+- Is methodology disclosed (anti-pattern check: methodology-hidden)?
+
+**The retire decision.** Tools failing multiple checks warrant redesign or retirement.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing. Cures matched. Audit cadence and questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped and lessons learned. Specific portfolio audit results. The team's audit calendar. These vary by team.

--- a/skills/comparison-tool-design/references/comparison-fatigue-patterns.md
+++ b/skills/comparison-tool-design/references/comparison-fatigue-patterns.md
@@ -1,0 +1,190 @@
+# Comparison-fatigue patterns
+
+Why most comparisons fail to produce decisions.
+
+Most comparison tools accumulate cognitive load until users abandon without choosing. Comparison-fatigue patterns are the failure modes that make this happen.
+
+---
+
+## Pattern 1: Too many cells
+
+The pattern. 40 features × 5 options = 200 cells.
+
+The signal. Users skim; pick the brand they already heard of; tool produces no decision.
+
+The cost. Comparison work is invisible because users cannot process the volume.
+
+The cure. Reduce cells. 8-12 axes × 3-5 options = 24-60 cells. The comparison density is comprehensible.
+
+---
+
+## Pattern 2: All-checkmarks rows
+
+The pattern. Every option has the feature; the row produces checkmarks across.
+
+The signal. Users skim past; row provides no signal.
+
+The cost. Row earns space without earning attention.
+
+The cure. Cut the row, or replace generic checkmarks with specifics that differentiate.
+
+---
+
+## Pattern 3: Inconsistent axis terminology
+
+The pattern. Each vendor names features differently; comparison becomes label confusion.
+
+The signal. User confusion; cannot tell if "Pro Workspace" and "Premium Studio" are the same thing.
+
+The cost. Comparison breaks at semantic level; users cannot weigh.
+
+The cure. Normalize terminology. Use functional descriptions; vendor labels in subtext.
+
+---
+
+## Pattern 4: Hidden costs
+
+The pattern. Pricing visible; fees, overage, integrations not surfaced.
+
+The signal. Users compare on visible price; learn about hidden costs later; feel deceived.
+
+The cost. Trust damage when discovered.
+
+The cure. Surface total cost of ownership. Acknowledge fees, overage, expected add-ons.
+
+---
+
+## Pattern 5: Apples-to-oranges options
+
+The pattern. Comparing genuinely different things; no axis applies cleanly.
+
+The signal. Comparison feels strained; users cannot tell why these options are being compared.
+
+The cost. Tool exists but produces no useful decision support.
+
+The cure. Compare options the audience would actually consider together. If options are too different, separate tools may serve better.
+
+---
+
+## Pattern 6: No recommendation
+
+The pattern. Tool lists; user must decide; user does not.
+
+The signal. High abandonment; conversion rate low.
+
+The cost. The tool's information work does not produce decisions.
+
+The cure. Add explicit recommendation with reasoning. Detail in `references/recommendation-engine-design.md`.
+
+---
+
+## Pattern 7: Stale information
+
+The pattern. Comparison content from 6+ months ago; competitors have updated; brand has updated.
+
+The signal. Users notice the staleness; trust drops.
+
+The cost. Tool produces decisions based on outdated information.
+
+The cure. Quarterly maintenance. Triggered updates when major competitor or brand changes happen.
+
+---
+
+## Pattern 8: Bias-flattering framing
+
+The pattern. Comparison content frames in brand's favor (showing brand's most expensive plan vs competitors' cheap; using brand's terminology for axes).
+
+The signal. Sophisticated users notice; trust collapses.
+
+The cost. Long-term brand damage.
+
+The cure. Honest framing. Acknowledge competitor strengths. Use neutral terminology where possible.
+
+---
+
+## Pattern 9: Decision paralysis at filter step
+
+The pattern. Tool requires extensive filter setup before showing comparison; users abandon at filter step.
+
+The signal. High drop-off before the comparison loads.
+
+The cost. Comparison work is invisible; users never see it.
+
+The cure. Default-heavy. Show comparison immediately; filters available but optional.
+
+---
+
+## Pattern 10: Mobile illegibility
+
+The pattern. Comparison grid designed for desktop; on mobile, cells cramped or scroll-required.
+
+The signal. Mobile conversion much lower than desktop.
+
+The cost. Mobile audience underserved.
+
+The cure. Mobile-first design. Stacked layout for mobile; reduced axis count.
+
+---
+
+## Pattern 11: No methodology disclosure
+
+The pattern. Comparison shown without explaining how it was assembled. Users do not know if it is honest.
+
+The signal. Users question the comparison; sales hears about doubts.
+
+The cost. Trust degrades; comparison's authority unclear.
+
+The cure. Disclose methodology. Where data came from; how axes were chosen; when last updated.
+
+---
+
+## Pattern 12: Recommendation contradicts comparison
+
+The pattern. Comparison shows option B winning on most axes; tool recommends option A.
+
+The signal. Users notice the contradiction; trust collapses.
+
+The cost. Tool internally inconsistent; users cannot rely on it.
+
+The cure. Recommendation aligns with comparison. If recommendation favors A despite axis losses, defend explicitly ("Option A wins despite [losses] because [audience-specific reasoning]").
+
+---
+
+## The cumulative effect
+
+Most comparison tools fail at multiple of these patterns simultaneously. The cumulative effect: tool produces no decisions; users default to the brand they already heard of; comparison work is wasted.
+
+The cure. Audit each pattern. Each pattern fixed reduces cumulative friction.
+
+---
+
+## How to audit comparison fatigue
+
+Quarterly review.
+
+**Audit questions per tool.**
+
+- Cell count: is it under 100?
+- Are any rows all-checkmarks?
+- Is terminology normalized across options?
+- Are total costs surfaced?
+- Are options apples-to-apples?
+- Is recommendation present and visible?
+- Is information current?
+- Is framing honest?
+- Is filter step lightweight?
+- Does mobile work?
+- Is methodology disclosed?
+- Does recommendation match comparison?
+
+**The retire decision.** Tools failing multiple patterns warrant redesign or retirement.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The 12 fatigue patterns. Signal-pattern-cost framing. Cures. The cumulative effect. Audit questions.
+
+## Implementation choices that stay internal
+
+Specific fatigue patterns the team has shipped historically and lessons learned. Specific portfolio audit results. The team's audit calendar. These vary by team.

--- a/skills/comparison-tool-design/references/comparison-tool-decision-criteria.md
+++ b/skills/comparison-tool-design/references/comparison-tool-decision-criteria.md
@@ -1,0 +1,132 @@
+# Comparison-tool decision criteria
+
+When comparison tools earn the build vs when written content serves.
+
+A comparison tool is meaningful work. Axis selection, default logic, recommendation engine, filter UX, ongoing maintenance. The tool earns this investment only when specific conditions are present.
+
+---
+
+## When comparison tools earn the build
+
+Five conditions that, when present, make a comparison tool a strong investment.
+
+**The audience is at a decision moment between known options.** They know the options exist; they need help choosing. Audiences who do not yet know the options need different tools (quizzes, recommendations).
+
+**The options have meaningful differences.** Comparing two options that differ only in branding produces nothing useful.
+
+**The brand can articulate honest distinctions.** Without becoming sales pitch.
+
+**The audience benefits from decision support.** Some audiences want a tool that helps them decide rather than weigh tradeoffs themselves.
+
+**The success metric is defined.** Conversion through the tool, downstream conversion, choice quality.
+
+When all five are present, a comparison tool is strong investment. When two or fewer are present, written content often serves better.
+
+---
+
+## When comparison tools do NOT earn the build
+
+Funnels where comparison tools add cost without lift.
+
+**Options too similar.** Comparing genuinely interchangeable options produces no decision support.
+
+**Options apples-to-oranges.** Comparison axes do not apply across both.
+
+**Brand cannot make honest distinctions.** Tool will become hidden-recommendation; trust suffers.
+
+**A simple table or article would serve.** Static comparison content is cheaper.
+
+**The audience does not face this decision.** Manufactured comparisons feel forced.
+
+---
+
+## Comparison tools vs written vs-pages
+
+Both compare options; differ in interactivity.
+
+**Written vs-pages strengths.** Cheap; SEO-friendly; easy to update.
+
+**Written vs-pages weaknesses.** Static; no recommendation logic.
+
+**Comparison tool strengths.** Adaptive; surfaces recommendations dynamically; lets users explore.
+
+**Comparison tool weaknesses.** Build cost; maintenance burden.
+
+**The combined approach.** Many production teams use both: vs-pages for SEO; tools for decision support.
+
+---
+
+## The opportunity-cost frame
+
+Comparison tools are significant work.
+
+**Build cost.** Axis curation, recommendation logic, filter UX, methodology disclosure, mobile responsiveness. 30-100 engineering hours plus design and content.
+
+**Maintenance cost.** Quarterly updates run 4-8 hours.
+
+**Opportunity cost.** What else could the team have built? Better vs-pages, calculator, quiz. The tool has to clear those alternatives.
+
+The decision frame. Comparison tools earn investment when they produce more decision lift than alternatives.
+
+---
+
+## Decision worked example
+
+A B2B SaaS analytics platform considering a comparison tool against 3 named competitors.
+
+**Conditions check.**
+
+- Decision moment: yes.
+- Meaningful differences: yes; pricing, features, integration vary.
+- Brand can articulate honest distinctions: yes.
+- Audience benefits: yes.
+- Success metric defined: yes.
+
+**Decision.** Build the comparison tool.
+
+**Architecture.** 10 axes; 4 options; honest recommendation per audience segment.
+
+The decision was deliberate.
+
+---
+
+## Decision worked example: when written serves
+
+A consumer-facing financial product considering a comparison tool against generic bank accounts.
+
+**Conditions check.**
+
+- Decision moment: yes.
+- Meaningful differences: somewhat; many banks similar.
+- Brand articulate distinctions: yes for specific competitors.
+- Audience benefits: somewhat.
+- Success metric: signup; harder to attribute.
+
+**Decision.** Written vs-pages plus a brief comparison table. Full tool not warranted.
+
+The decision was right-sized.
+
+---
+
+## When to retire a comparison tool
+
+Tools can become wrong over time.
+
+**Retire when:**
+
+- Conversion declined consistently.
+- Options changed enough that comparison is misleading.
+- Competitors deprecated.
+- A redesigned vs-page produces equivalent results.
+
+The retire-or-redesign discipline frees capacity.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five conditions that warrant comparison tools. The five conditions that argue against. Comparison tools vs written vs-pages. The opportunity-cost frame. Decision worked examples (yes and no). The retire decision.
+
+## Implementation choices that stay internal
+
+Specific tool decisions for specific products. The team's capacity benchmarks. Specific tooling. Specific success-metric baselines. These vary by team and product.

--- a/skills/comparison-tool-design/references/default-comparison-logic.md
+++ b/skills/comparison-tool-design/references/default-comparison-logic.md
@@ -1,0 +1,169 @@
+# Default-comparison logic
+
+Honest defaults vs bias-flattering defaults.
+
+Defaults shape the user's first impression. Honest defaults reflect the audience's likely starting point; bias-flattering defaults shape conclusions in ways that erode trust when caught.
+
+---
+
+## The honest-default principle
+
+Defaults should serve the audience, not the brand. When defaults must reflect brand strength, do so honestly with disclosure.
+
+**The win.** Default comparison shows the brand alongside 2-3 commonly-considered competitors. Default axes are the 8-12 most decision-relevant. Default audience profile (if pre-selected) reflects the visitor's likely segment.
+
+**The fail.** Default comparison shows the brand alongside the 2 weakest competitors. Default axes are the ones where the brand wins. Audience defaults assume the brand's ideal customer.
+
+The discipline. Defaults make the comparison fair as a starting point; users can adjust.
+
+---
+
+## Default options
+
+Which options compare by default.
+
+**Audience-fit defaults.** The options the audience most commonly considers.
+
+How to determine. Sales-call mining (which competitors do prospects mention?), referral analysis, user research.
+
+**Stage-fit defaults.** The options that match the audience's stage.
+
+How. Awareness audiences may compare against generic categories; decision audiences against specific products.
+
+**Inferred defaults.** Based on referral source or query.
+
+How. Visitor from "X vs Y" search query gets X and Y as defaults; visitor from generic landing gets default comparison set.
+
+---
+
+## Default axes
+
+Which axes show by default.
+
+**The most-critical-axes default.** Top 8-12 axes by decision relevance.
+
+**Audience-relevant axes.** Default to axes most relevant to the inferred or stated audience.
+
+**The hide-where-we-lose anti-pattern.** Defaulting to axes where the brand wins; hiding where it loses. Detection by analytical audiences eventual; trust damage permanent.
+
+The cure. Defaults reflect audience importance, not brand strength. Honest about competitor strengths.
+
+---
+
+## Default audience or use case
+
+When the tool asks (or infers) the audience.
+
+**Pattern A: Pre-selected.** Tool selects an audience based on referrer or query.
+
+Strengths. Lower friction; tool seems intelligent.
+
+Weaknesses. Inference can be wrong.
+
+**Pattern B: Asked upfront.** Tool asks "what is your role?" or "what is your team size?"
+
+Strengths. Accurate; user controls.
+
+Weaknesses. Adds friction; some audiences skip.
+
+**Pattern C: No audience selection.** Tool shows comparison; user can filter.
+
+Strengths. Lowest friction; works for all audiences.
+
+Weaknesses. Generic; no per-audience recommendation.
+
+The choice depends on the tool's complexity and the audience's diversity.
+
+---
+
+## Default recommendation
+
+What the tool recommends by default.
+
+**Pattern A: Single default recommendation.** "For most teams, [option] is the best choice."
+
+Strengths. Clear; opinionated.
+
+Weaknesses. May not fit all visitors.
+
+**Pattern B: Audience-conditional default.** Recommendation changes based on audience selection.
+
+Strengths. Fits different audiences.
+
+Weaknesses. More complex.
+
+**Pattern C: No default recommendation.** Tool requires user to specify before recommending.
+
+Strengths. User commits; recommendation is matched.
+
+Weaknesses. Higher friction.
+
+The discipline. Whatever default, the recommendation is honest about who it is for.
+
+---
+
+## Bias-flattering defaults: the failure
+
+Patterns that destroy trust.
+
+**Defaults set for brand victory.** Comparison tool defaults to axes where the brand wins, hides where it loses.
+
+**Defaults that frame in brand's terminology.** Other options compared in vocabulary that favors the brand's positioning.
+
+**Defaults that misrepresent competitor pricing.** Showing competitor's most expensive plan vs brand's mid-tier.
+
+**Defaults that show outdated competitor info.** Listing features competitors have updated.
+
+**The audience reaction.** Sophisticated audiences notice; trust collapses; brand earns "manipulative" reputation.
+
+---
+
+## Honest defaults with disclosure
+
+When the brand legitimately stands out, honest framing matters.
+
+**The pattern.** "Default view shows the comparison most relevant to teams of [size]. Your situation may differ; use filters to adjust."
+
+**Disclosure where defaults are brand-favorable.** "We are highlighting [axis] because we think it matters most for [audience]. Let us know if you weigh things differently."
+
+The honest framing earns trust where bias-flattering loses it.
+
+---
+
+## Default maintenance
+
+Defaults decay.
+
+**What decays.**
+
+- Default options no longer match audience consideration.
+- Default axes no longer the most relevant.
+- Default audiences shifted.
+
+**Maintenance cadence.** Quarterly review. Update as competitive landscape and audience composition shift.
+
+---
+
+## Common default failures
+
+**Hide-where-we-lose.** Bias detected; trust collapses.
+
+**Stale defaults.** Competitor info outdated.
+
+**Wrong default audience.** Inference produces unfit comparison for visitor.
+
+**No default at all.** Tool requires extensive setup before showing comparison.
+
+**Default obscures methodology.** Defaults look like neutral; methodology is biased.
+
+**Default ignores recent competitor changes.** Defaults from 6 months ago.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The honest-default principle. Default options. Default axes. Default audience or use case. Default recommendation. The bias-flattering failure pattern. Honest defaults with disclosure. Default maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific defaults for specific comparison tools. Specific audience inference logic. The team's audit calendar. These vary by team.

--- a/skills/comparison-tool-design/references/filter-and-toggle-patterns.md
+++ b/skills/comparison-tool-design/references/filter-and-toggle-patterns.md
@@ -1,0 +1,225 @@
+# Filter and toggle patterns
+
+What users can adjust, what should stay fixed. The filter-fatigue trap.
+
+Filters and toggles let users adapt the comparison to their context. Done well, filters help users match the tool to their situation; done poorly, filters become customization theater that adds complexity without value.
+
+---
+
+## The help-don't-customize principle
+
+Filters earn placement when they help users match the comparison to their context. Filters for the sake of customization options add complexity without lift.
+
+**The win.** Tool offers 3 filters: audience size, use case, must-have integrations. Each filter materially adapts the recommendation. Users find their context quickly.
+
+**The fail.** Tool offers 15 filters across multiple dimensions. Decision paralysis at the filter step; users abandon before reaching the comparison.
+
+The discipline. Filters that help; not filters for theater.
+
+---
+
+## Filterable elements
+
+What users can adjust.
+
+**Options to compare.** User adds or removes options.
+
+**Axes to show.** User filters to relevant dimensions.
+
+**Audience or use case.** User signals their context; tool adapts.
+
+**Pricing model preference.** User selects monthly vs annual; per-seat vs flat.
+
+**Region or geography.** User selects where they operate; tool adapts to applicable options.
+
+---
+
+## Fixed elements
+
+What should not be filterable.
+
+**Methodology disclosure.** Always visible.
+
+**Recommendation reasoning.** Always findable.
+
+**Source citations.** Always linkable.
+
+**Honest framing.** Tool is honest about its biases regardless of filter state.
+
+---
+
+## Filter UI patterns
+
+How filters appear.
+
+**Pattern A: Top-of-page filters.**
+
+How it works. Filter row at top; user adjusts; comparison below updates.
+
+Strengths. Visible; familiar.
+
+Weaknesses. Takes screen space; mobile-challenging.
+
+**Pattern B: Sidebar filters.**
+
+How it works. Filter panel on the side; comparison main area.
+
+Strengths. Persistent; works on desktop.
+
+Weaknesses. Mobile-broken; takes space.
+
+**Pattern C: Inline filters.**
+
+How it works. Filters appear within the comparison (per-axis filtering, per-option toggling).
+
+Strengths. Contextual.
+
+Weaknesses. Visual complexity.
+
+**Pattern D: Wizard-style.**
+
+How it works. Tool asks 2-3 filter questions; then shows comparison.
+
+Strengths. Less overwhelming.
+
+Weaknesses. Adds friction upfront.
+
+The choice depends on filter complexity and audience preferences.
+
+---
+
+## Filter count
+
+How many filters earn placement.
+
+**3-5 filters.** Sweet spot. Each filter helps; cumulative friction manageable.
+
+**6-8 filters.** Acceptable for complex tools; require strong UX.
+
+**10+ filters.** Almost always too many. Decision paralysis at filter step.
+
+**1-2 filters.** Often too few; tool feels rigid.
+
+---
+
+## Filter defaults
+
+What filters are pre-set.
+
+**Honest defaults.** Reflect typical audience.
+
+**Audience-detected defaults.** Inferred from referral or context.
+
+**No defaults (user must select).** Adds friction but ensures intentionality.
+
+The default discipline. Defaults reflect audience importance; not brand strength.
+
+---
+
+## Filter combinations
+
+When filters interact.
+
+**Independent filters.** Each filter changes one dimension; combinations multiply.
+
+**Conditional filters.** Some filters appear only after others are set.
+
+**Smart filters.** Tool suggests filters based on earlier selections.
+
+The discipline. Combinations should produce meaningful comparisons; not empty cells.
+
+---
+
+## The filter-fatigue trap
+
+Too many filters; user paralyzed.
+
+**The pattern.** Tool offers 12 filters. User feels they need to set them all to get meaningful comparison. User leaves before completing.
+
+**The signal.** Drop-off at the filter step; users do not reach the comparison.
+
+**The cost.** Comparison tool's main value (the comparison) is invisible.
+
+**The cure.** Reduce filter count. Default-heavy. Optional filters behind a "more options" toggle.
+
+---
+
+## The under-filtered trap
+
+Tool too rigid; user cannot match context.
+
+**The pattern.** Tool shows one fixed comparison; no way to adapt.
+
+**The signal.** Users complain the tool does not fit them; specific segments convert poorly.
+
+**The cost.** Tool serves only the audience the default fits.
+
+**The cure.** Add filters where audience genuinely splits.
+
+---
+
+## Filter mobile design
+
+Filters on mobile have specific considerations.
+
+**Mobile-specific patterns.**
+
+- Filters in a collapsible drawer rather than always-visible panel.
+- Reduced filter count on mobile (defer non-critical filters).
+- Touch-friendly toggles.
+
+**Mobile-broken patterns.**
+
+- Sidebar filters cramping the comparison.
+- Top-of-page filters that scroll off and require scrolling back.
+- Filter modals that take over the screen.
+
+The mobile discipline. Filters work on mobile or do not exist there.
+
+---
+
+## Filter analytics
+
+Track filter use.
+
+**Metrics.**
+
+- Per-filter use rate.
+- Filter abandonment (started filtering; left without completing).
+- Filter combinations that produce no results.
+
+**Diagnostic uses.**
+
+- Filter rarely used: it may not earn placement.
+- Filter abandonment high: too many filters or bad defaults.
+- No-result combinations: filter logic may have gaps.
+
+---
+
+## Common filter failures
+
+**Too many filters.** Filter fatigue.
+
+**Too few filters.** Tool too rigid.
+
+**Filters with no value.** Filters that do not change anything meaningful.
+
+**Filters that produce empty results.** Combinations show no options.
+
+**Mobile-broken filters.** Filters work on desktop, fail mobile.
+
+**Filter UX inconsistent.** Mix of patterns; users confused.
+
+**Default filters bias-flattering.** Defaults make brand look better than reality.
+
+**No filter analytics.** Cannot tell which filters earn their place.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The help-don't-customize principle. Filterable vs fixed elements. Filter UI patterns A through D. Filter count. Filter defaults. Filter combinations. The filter-fatigue and under-filtered traps. Filter mobile design. Filter analytics. Common failures.
+
+## Implementation choices that stay internal
+
+Specific filters for specific tools. Specific filter UI implementations. Specific defaults. The team's mobile testing benchmarks. These vary by team.

--- a/skills/comparison-tool-design/references/honest-recommendation-discipline.md
+++ b/skills/comparison-tool-design/references/honest-recommendation-discipline.md
@@ -1,0 +1,201 @@
+# Honest recommendation discipline
+
+The discipline that distinguishes hidden from honest recommendations.
+
+Recommendations are powerful. Honest ones earn trust; hidden ones erode it. The discipline is to know which kind your tool produces.
+
+---
+
+## The litmus test
+
+A sophisticated user from the target audience tests the tool by selecting a clearly wrong-fit scenario for the brand. Does the tool recommend a competitor when fit warrants?
+
+**The win.** Tool recommends competitor X for the wrong-fit scenario, with reasoning. The sophisticated user trusts the tool because it is willing to recommend against the brand.
+
+**The fail.** Tool always recommends the brand regardless of scenario. The sophisticated user catches the pattern; trust collapses.
+
+The discipline. The tool's willingness to recommend competitors when warranted is the trust marker.
+
+---
+
+## What honest recommendation looks like
+
+Five marks of honesty.
+
+**Mark 1: Brand does not always win.** When competitors fit better, tool says so.
+
+**Mark 2: Reasoning is specific and verifiable.** "Option B has X capability that Option A lacks" rather than "B is better."
+
+**Mark 3: Audience-fit is articulated.** "For [audience] with [needs], choose X. For different audience, choose Y."
+
+**Mark 4: Tradeoffs acknowledged.** "Option X wins on capability A but loses on capability B."
+
+**Mark 5: Methodology disclosed.** Users can see how the recommendation was generated.
+
+When all five are present, the recommendation is honest. When any are absent, hidden-recommendation dynamics creep in.
+
+---
+
+## What hidden recommendation looks like
+
+Five marks of hidden bias.
+
+**Mark 1: Brand always wins regardless of scenario.**
+
+**Mark 2: Reasoning is generic ("best in class") without specifics.**
+
+**Mark 3: Audience-fit not articulated; one recommendation for all.**
+
+**Mark 4: Tradeoffs not acknowledged; brand presented as superior on all axes.**
+
+**Mark 5: Methodology hidden or vague.**
+
+When these patterns combine, the tool is hidden-recommendation regardless of whether the team intended bias.
+
+---
+
+## The acknowledge-competitor-strengths principle
+
+Honest recommendation tools acknowledge where competitors are stronger.
+
+**The pattern.** "Competitor X has the strongest [capability]. We win on [different capability]. For audiences prioritizing [first], X. For audiences prioritizing [second], us."
+
+**Why it works.** Acknowledging strengths signals honesty. Audiences trust the recommendation more because the tool is willing to lose on specific axes.
+
+**The reluctant-acknowledgment failure.** Acknowledging competitor strengths only when forced; minimizing them where possible. Detection by sophisticated audiences eventual.
+
+---
+
+## The recommendation-defense quality
+
+How well the tool defends its recommendation.
+
+**Strong defense.**
+
+- Specific to audience.
+- Tied to specific axes where the recommended option wins.
+- Includes tradeoffs.
+- Cites data or sources.
+
+**Example.**
+
+"For mid-market teams (50-200 users): Option B. Reasons: B's pricing scales better at 200+ users, B's [specific feature] is unmatched, B's support response time is fastest. Tradeoff: B's onboarding is longer than Option A's. For under-50-user teams, Option A may serve better."
+
+**Weak defense.**
+
+- "B is the best choice."
+- "Most teams choose B."
+- Generic claims.
+
+The defense earns trust through specificity and acknowledged tradeoffs.
+
+---
+
+## Audience-segment recommendations
+
+Different audiences may warrant different recommendations.
+
+**Patterns.**
+
+- "Solo and small teams: choose A."
+- "Mid-market: choose B."
+- "Enterprise: choose C."
+
+**Why this works.** Audiences self-identify; tool serves each.
+
+**The single-recommendation-fits-all failure.** One recommendation for diverse audiences misses fit.
+
+The discipline. When audiences differ, recommendations differ.
+
+---
+
+## When the recommendation should be no-recommendation
+
+Sometimes "we cannot tell which is best for you" is the honest answer.
+
+**Patterns.**
+
+- "Both options fit teams in your situation; differentiator is [factor] you should weigh personally."
+- "If [criterion] matters most to you, X. If [criterion] matters most, Y. We cannot rank for you."
+
+**Why this works.** Honest about the limits of recommendation; respects user agency.
+
+**The over-recommend failure.** Recommending in cases where genuine differentiator does not exist; trust suffers when users notice.
+
+---
+
+## Recommendation transparency
+
+Users should understand how the recommendation was generated.
+
+**Disclosure patterns.**
+
+- "We weight [axes] heavily because [reasons]."
+- "If you weigh different axes, your recommendation may differ."
+- "Our methodology is described here."
+
+**The audience that questions.** Some users will dig. Methodology should hold up.
+
+---
+
+## The recommendation-audit pattern
+
+Periodically test the tool's honesty.
+
+**Audit method.**
+
+- Test scenarios where competitors should win.
+- Test scenarios where brand should win.
+- Test edge cases.
+
+**Audit findings.**
+
+- Tool always recommends brand: hidden-recommendation; redesign.
+- Tool sometimes recommends competitors: honest; verify the recommendations make sense.
+- Tool refuses to recommend: may be appropriate for genuine ties; should not be default.
+
+The audit catches drift. Honest tools at launch can become hidden-recommendation through small changes over time.
+
+---
+
+## Honest recommendation maintenance
+
+Honest recommendations decay.
+
+**What decays.**
+
+- Reasoning based on outdated capabilities.
+- Audience-segment definitions that no longer fit.
+- Methodology that no longer matches the tool's logic.
+
+**Maintenance cadence.** Quarterly review. Verify reasoning still holds; verify methodology matches implementation.
+
+---
+
+## Common honest-recommendation failures
+
+**Brand always wins.** Hidden-recommendation; trust risk.
+
+**No defense.** Recommendations without reasoning.
+
+**Generic recommendations.** "Best for most teams" without specificity.
+
+**Single recommendation for diverse audiences.** Missed fit.
+
+**Tradeoffs hidden.** Brand presented as superior on all axes.
+
+**Methodology vague.** Users cannot inspect.
+
+**No competitor-strength acknowledgment.** Trust suffers.
+
+**Stale recommendation.** Reasoning based on outdated info.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The litmus test. Five marks of honest recommendation. Five marks of hidden recommendation. The acknowledge-competitor-strengths principle. Recommendation defense quality. Audience-segment recommendations. When no-recommendation is honest. Recommendation transparency. The audit pattern. Maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific recommendation logic for specific tools. Specific audience-segment mappings. Specific methodology copy. The team's audit calendar. These vary by team.

--- a/skills/comparison-tool-design/references/recommendation-engine-design.md
+++ b/skills/comparison-tool-design/references/recommendation-engine-design.md
@@ -1,0 +1,172 @@
+# Recommendation engine design
+
+When to recommend, how to defend, override path.
+
+Comparison tools that recommend are more useful than tools that just list. The recommendation must be defensible, visible, and not the only path.
+
+---
+
+## The visible-defended-overridable principle
+
+Recommendations are most useful when:
+
+- Visible. Users can see what the tool recommends.
+- Defended. Reasoning is explicit.
+- Overridable. Users who weigh things differently can choose otherwise.
+
+**The win.** Tool recommends "Option B for mid-market teams prioritizing scale." Recommendation prominent; reasoning shown; user can switch audience or pick differently.
+
+**The fail.** Tool dumps features; user must decide alone.
+
+The discipline. Recommend with reasoning; respect override.
+
+---
+
+## Recommendation patterns
+
+Common patterns.
+
+**Pattern A: Single recommendation.** "For [audience], choose [option] because [reasons]." Clear; opinionated.
+
+**Pattern B: Multi-segment recommendation.** "If [A], choose X. If [B], choose Y."
+
+**Pattern C: Conditional recommendation.** "If [factor] matters most, X. If [other], Y."
+
+**Pattern D: Recommendation with caveat.** "We think X fits most teams in your situation, with these caveats."
+
+**Pattern E: No recommendation.** Rarely the right choice.
+
+---
+
+## Defending the recommendation
+
+The reasoning shown.
+
+**Strong defense.** Specific reasons tied to recommended option's strengths; audience-fit articulated; tradeoffs acknowledged.
+
+**Example.** "For mid-market teams: Option B. B's pricing scales better at 200+ users (X% vs Y%), B's integration with [tool] is faster, B's support response is shortest in this tier. Tradeoff: B's interface is less polished than Option A; A wins for teams under 50."
+
+**Weak defense.** "B is our recommendation"; "B is best for most teams"; generic claims.
+
+The defense earns trust through specificity.
+
+---
+
+## The override path
+
+How users can choose otherwise.
+
+**Visible alternative paths.**
+
+- Toggle to switch recommended audience.
+- Filter to weight axes differently.
+- Direct selection of different option.
+
+**Friction balance.**
+
+- Override findable in 1-2 clicks.
+- Override does not require restart.
+- Override preserves user context.
+
+The discipline. Override is honest; users who disagree are not punished.
+
+---
+
+## Recommendation framing
+
+How recommendations are worded.
+
+**Strong framing.** Specific to audience; tied to reasoning; acknowledges tradeoffs; inviting override.
+
+**Weak framing.** "Obviously X is best"; "most experts agree X"; "X is the only choice for serious teams."
+
+What works. Specificity, humility, agency for the user.
+
+---
+
+## Audience-fit recommendations
+
+Different audiences may warrant different recommendations.
+
+**The pattern.** Tool detects or asks about audience; recommendation adapts.
+
+**Detection methods.**
+
+- Referrer or query.
+- Stated input.
+- Inferred from context.
+
+The discipline. Audience signals inform recommendation; do not stereotype.
+
+---
+
+## Recommendation transparency
+
+Users should understand how the recommendation was generated.
+
+**Methodology disclosure.**
+
+- "We weight [axes] heavily because [reasons]."
+- "If you weigh [factor] differently, your recommendation may differ."
+
+The audience that questions. Some users will dig; methodology should hold up.
+
+---
+
+## The recommendation-bias risk
+
+Recommendations are powerful; biased ones damage trust.
+
+**Common biases.**
+
+- Recommending brand in all cases.
+- Recommendations always benefit recommender.
+- Hidden weighting toward brand strengths.
+
+**The trust-collapse.** When users catch bias, they stop trusting entirely.
+
+**The cure.** Acknowledge competitor strengths. Recommend competitors when fit warrants. Honest about who is recommending whom.
+
+---
+
+## Recommendation testing
+
+Validate.
+
+**Methods.**
+
+- User research: do recommendations match what audiences would have chosen with full information?
+- Cohort analysis: do recommendation-followers retain better?
+- Sales feedback: do recommended-option leads convert at higher rates?
+
+The discipline. Recommendation is hypothesis until validated.
+
+---
+
+## Common recommendation failures
+
+**No recommendation.** Tool lists; users decide alone.
+
+**Hidden recommendation.** Tool defaults bias toward one option without disclosure.
+
+**Generic recommendation.** "Best for most teams" without specificity.
+
+**Single recommendation for diverse audiences.** Missed fit.
+
+**Recommendation without defense.** Authoritative without reasoning.
+
+**No override path.** Users who disagree have no clear alternative.
+
+**Recommendation always favors brand.** Trust collapses.
+
+**Stale recommendation.** Reasoning based on outdated capabilities.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The visible-defended-overridable principle. Patterns A through E. Defending the recommendation. The override path. Framing. Audience-fit recommendations. Transparency. The bias risk. Testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific recommendation engines for specific tools. Specific audience-segment mappings. Specific reasoning copy. The team's validation processes. These vary by team.

--- a/skills/interactive-product-tour/SKILL.md
+++ b/skills/interactive-product-tour/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: interactive-product-tour
+description: "Designing in-product tours, tooltips, and contextual help that teach product capabilities without becoming friction. Trigger logic, tour architecture, contextual placement, completion tracking. Honest about tooltip-spam (visual noise that users develop blindness to), one-and-done (help invisible at the moment of need), and contextual-when-needed (surfaces help at the moment friction occurs) patterns. Triggers on product tour, in-product tooltip, contextual help, walkthrough, feature tour, hint system, in-app guidance, tour platform. Also triggers when feature adoption is low, when users miss key product capabilities, or when an in-product help system is being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing in-product tours and contextual help. Distinguishes tooltip-spam (every button has a tour stop) from one-and-done (tour shows once, never seen again) from contextual-when-needed (surfaces help at the moment friction occurs)"
+display_order: 8
+---
+
+# Interactive Product Tour
+
+A senior product marketing director's playbook for designing in-product tours, tooltips, and contextual help that teach product capabilities without becoming friction. Trigger logic, tour architecture, contextual placement, completion tracking. The discipline of building help systems that surface at moments of need and disappear when not needed.
+
+Most product tours fail in one of two ways. They paint every button, link, and feature with "click for tour" hints until the visual noise is so great that users develop blindness to the dots. Or they show a single first-login tour the user skips or skims, after which the same help never re-surfaces when the user actually hits a moment of friction. Help that is invisible at the moment of need is help that does not exist.
+
+The tours that work do something different. They trigger when the user is at a moment of friction, not all the time. They surface contextual hints when the user enters a section they have not explored, clicks into a feature requiring setup, or returns after a long absence. The system knows what the user knows and surfaces help at the right moment.
+
+The voice is the senior product marketing director who has watched feature adoption double when tours were redesigned and watched it collapse when more tooltips were piled onto every surface. Practical, opinionated about the trigger logic that distinguishes useful help from visual noise, willing to call out when no in-product tour at all is the right answer.
+
+When to use this skill: scoping an in-product help system for the first time, auditing a tour system that produces engagement metrics with no adoption lift, designing the trigger logic that decides when help surfaces, or deciding which features warrant tours vs documentation.
+
+---
+
+## What this skill covers
+
+This skill spans in-product tours, tooltips, and contextual help. The growth-tooling distinctions:
+
+- `onboarding-wizard-design` is the sequential first-run experience. This skill is contextual help WITHIN the product, surfacing across the lifecycle.
+- `chatbot-flow-design` is conversational help. This skill is non-conversational tour and tooltip help.
+- **`interactive-product-tour` (this skill)** is trigger logic, tour architecture, contextual placement, completion tracking, and the discipline of being absent until needed.
+- `discovery-research-synthesis` is research that informs tour content. Input, not part of.
+- `pm-spec-writing` is the spec for engineers building the tour. This skill is about WHAT to build; pm-spec-writing is about communicating it.
+
+The audience: product marketers, growth marketers, in-house product teams, agencies running activation work for SaaS clients.
+
+Out of scope: first-run wizards (covered by `onboarding-wizard-design`); conversational help (covered by `chatbot-flow-design`); the engineering implementation; specific Userpilot/Pendo/Appcues platform configurations (those stay implementation-side).
+
+---
+
+## The tour decision: when tours earn vs when documentation suffices
+
+Before designing the tour system, decide whether tours are the right tool.
+
+**Tours earn investment when:**
+
+- The product has features users genuinely miss without prompting. Specific functionality buried in menus, advanced workflows that require sequence, integrations users do not know exist.
+- The audience benefits from in-context guidance more than out-of-context documentation. Tours teach in the place the user will use the feature; docs require context-switching.
+- The team can maintain tours as the product evolves. Tour content decays; without maintenance commitment, tours point to deprecated UI.
+- The success metric is defined. Feature adoption, time-to-value for specific capabilities, reduction in support tickets for tour-covered features.
+
+**Tours do NOT earn investment when:**
+
+- The product's feature set is small enough that documentation suffices. A few tooltips on key features may be all that is needed.
+- The audience prefers self-directed discovery. Some audiences resent in-product guidance and prefer to explore.
+- The team cannot maintain tours alongside product changes. Stale tours are worse than no tours.
+- The product changes frequently. Tour maintenance can exceed tour value if the product churns rapidly.
+
+The decision is not "should we have a tour system"; it is "is in-product tour the right tool for this product and audience."
+
+Detail in `references/tour-decision-criteria.md`.
+
+---
+
+## Tooltip-spam vs one-and-done vs contextual-when-needed
+
+The keystone framing.
+
+**Tooltip-spam.** Every button, link, and feature has a "click for tour" hint or pulsing dot. Visual noise. Users develop blindness to the dots; the tour system fails as a teaching surface. Cost: the design effort produces help nobody perceives; the visual clutter degrades the product overall.
+
+**One-and-done.** A single tour shown on first login. Users skip or skim. The same tour never re-surfaces when the user actually hits a moment of friction. Cost: help that is invisible at the moment of need does not help. Feature adoption stays low; support tickets persist for features the tour covered.
+
+**Contextual-when-needed.** Tours and tooltips trigger when the user is at a moment of friction (entered a section they have not explored, clicked into a feature requiring setup, returned after a long absence, hit a feature flag's first activation). The system knows what the user knows and surfaces help at the right moment. Cost: trigger logic is meaningful work; payoff is help that compounds adoption over time.
+
+The litmus test. Watch a user encounter a feature for the first time. Does the help system surface useful guidance at that moment, or did it surface guidance at first-login that the user has long forgotten? If the former, contextual-when-needed. If the latter, one-and-done. If the help is competing with 14 other tooltip dots scattered across the page, tooltip-spam.
+
+---
+
+## Trigger logic: event-based vs time-based vs state-based
+
+The mechanism that decides when help surfaces.
+
+**Event-based triggers.** Help appears in response to a user action. Clicked a feature for the first time, entered a new section, completed a flow.
+
+When to use. Default for most contextual help. The user did something; help responds.
+
+**Time-based triggers.** Help appears after time elapsed. Returned to the product after 30 days of absence; been on this page for 60 seconds without acting.
+
+When to use. Time can signal need (long absence; stuck on a page). Use sparingly; time alone is a noisy signal.
+
+**State-based triggers.** Help appears based on user state. New user vs power user; account size; feature usage history.
+
+When to use. When the help differs by user segment. State-based triggers personalize help.
+
+**Combined triggers.** Most production tour systems combine all three. Event-driven, with time and state modulating frequency and content.
+
+The discipline. The trigger answers "when does this help surface and why." Decorative triggers (showing help when it is not needed) become tooltip-spam.
+
+Detail in `references/trigger-logic-patterns.md`.
+
+---
+
+## Tour architecture: single tour vs branched vs library of micro-tours
+
+How help is organized.
+
+**Single tour.** One linear tour covering the product. Simple; rigid; rarely fits how users actually explore.
+
+**Branched tour.** Tour adapts based on user choices or path through the product. More relevant; more complex.
+
+**Library of micro-tours.** Dozens of small focused tours, each tied to a specific feature or workflow. Triggered contextually. Most flexible; most maintenance.
+
+**The choice.** Most modern systems use the micro-tour library approach. Single tours feel canned; branched tours are hard to maintain at scale; a library of contextual micro-tours matches how users actually explore.
+
+Detail in `references/tour-architecture-patterns.md`.
+
+---
+
+## Contextual placement: where help appears, how it dismisses
+
+The visual design of help.
+
+**Placement patterns.**
+
+- **Tooltip on hover.** Help appears next to the element on hover. Lightweight; familiar.
+- **Spotlight overlay.** Element highlighted, help appears alongside. More prominent; more disruptive.
+- **Sidebar.** Help appears in a side panel. Can persist while the user works.
+- **Inline.** Help appears in the page flow. Non-disruptive; harder to dismiss.
+
+**Dismissal mechanics.**
+
+- **Click X.** Standard close. Always available.
+- **Click outside.** Help dismisses if the user interacts with anything else. Implies non-modal help.
+- **Auto-dismiss.** Help fades after a few seconds. Risky; users may not have read it.
+- **Persistent until acted on.** Help stays until the user takes the suggested action. Powerful for guided flows; intrusive otherwise.
+
+**Non-intrusion principle.** Help should be findable when wanted, ignorable when not. Modal help that blocks the screen is intrusive; help that disappears too easily fails to teach.
+
+Detail in `references/contextual-placement-patterns.md` and `references/dismissal-and-non-intrusion-patterns.md`.
+
+---
+
+## Completion tracking and re-trigger logic
+
+Knowing what each user has seen, deciding when to show again.
+
+**Per-user state tracking.**
+
+- Which tours has the user completed?
+- Which tours has the user dismissed?
+- Which tours has the user seen but not completed?
+- Time since last interaction.
+
+**Re-trigger logic.**
+
+- Completed tours: usually do not re-show.
+- Dismissed tours: respect the dismissal; possibly re-show after a long delay if the feature becomes relevant again.
+- Skipped tours: re-show at moments of relevance.
+- Long-absent users: re-orient with abbreviated help.
+
+**The over-trigger trap.** Showing the same tour to users who have completed it. Trust degrades; users disable tours.
+
+**The under-trigger trap.** Tours never re-surfacing when the user hits the same friction again. Help fails at the moment of need.
+
+Detail in `references/completion-tracking-and-re-trigger.md`.
+
+---
+
+## Power-user vs new-user differentiation
+
+Different users need different help.
+
+**The principle.** Power users do not want tours on features they already use. New users need tours on features they are encountering for the first time. The help system should know the difference.
+
+**Differentiation signals.**
+
+- Feature usage history (has the user used this feature before?).
+- Tenure (how long has the user been on the product?).
+- Engagement frequency (active daily vs returning monthly).
+- Self-reported skill level (rare; usually inferred).
+
+**Differentiation patterns.**
+
+- Power users see help only on new features.
+- New users see help on the features matching their stage of exploration.
+- Returning users see re-orientation help if their last session was long ago.
+
+**The over-helping trap.** Helping power users with features they mastered. Trust degrades.
+
+**The under-helping trap.** Treating all users as power users. New users miss critical help.
+
+Detail in `references/power-user-vs-new-user-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-tour-failures.md`.
+
+- "Tours show but feature adoption does not improve." Help may be visually present but not contextually relevant. Audit trigger logic.
+- "Users disable tours globally." The system is annoying users. Audit frequency, dismissal, and over-triggering.
+- "First-login tour completion is 80 percent; feature adoption is unchanged." One-and-done pattern; tour content not retained at moment of need.
+- "Tooltips appear everywhere; nobody clicks them." Tooltip-spam; rebalance to contextual triggers.
+- "Tour content references features we deprecated 6 months ago." Maintenance lapse.
+- "Power users complain about pop-ups for things they already know." No power-user differentiation.
+- "Tours work on desktop, break on mobile." Mobile UX of help system not tested.
+- "Some teams ship tours; others don't bother. Inconsistent." No tour governance; some teams build, others ignore.
+- "Tours triggered correctly but users do not act on the suggestion." Help content unclear or call-to-action absent.
+
+---
+
+## The framework: 12 considerations for product tour design
+
+When designing or auditing an in-product tour system, walk these 12 considerations.
+
+1. **The tour decision.** Are tours the right tool, or does documentation suffice?
+2. **Contextual-when-needed, not tooltip-spam or one-and-done.** Help surfaces at moments of friction.
+3. **Trigger logic sound.** Event-based primary, with time and state modulation.
+4. **Tour architecture matches usage.** Library of micro-tours preferred for most products.
+5. **Contextual placement non-intrusive.** Help findable when wanted, ignorable when not.
+6. **Dismissal mechanics honest.** Standard close, click-outside dismiss, no auto-dismiss before reading.
+7. **Completion tracking instrumented.** Per-user state, per-tour status.
+8. **Re-trigger logic respectful.** Completed tours do not re-show; dismissed tours respected.
+9. **Power-user vs new-user differentiation.** Help calibrated to user state.
+10. **Mobile parity.** Help works on the devices the audience uses.
+11. **Maintenance discipline.** Tours updated alongside product changes; quarterly audit.
+12. **Adoption as success metric.** Not just tour completion; feature adoption is the metric that matters.
+
+The output of the framework is a tour system that earns the user's attention by being absent until needed, surfaces help at moments of relevance, and produces feature adoption.
+
+---
+
+## Reference files
+
+- [`references/tour-decision-criteria.md`](references/tour-decision-criteria.md) - When tours earn the build vs when documentation suffices.
+- [`references/trigger-logic-patterns.md`](references/trigger-logic-patterns.md) - Event-based, time-based, state-based, combined triggers. The discipline that distinguishes useful triggers from noise.
+- [`references/tour-architecture-patterns.md`](references/tour-architecture-patterns.md) - Single tour vs branched vs library of micro-tours. The architecture that fits how users actually explore.
+- [`references/contextual-placement-patterns.md`](references/contextual-placement-patterns.md) - Tooltip, spotlight, sidebar, inline. Placement and visual design.
+- [`references/completion-tracking-and-re-trigger.md`](references/completion-tracking-and-re-trigger.md) - Per-user state, re-trigger logic, the over-trigger and under-trigger traps.
+- [`references/power-user-vs-new-user-patterns.md`](references/power-user-vs-new-user-patterns.md) - Differentiation signals and patterns. The over-helping and under-helping traps.
+- [`references/dismissal-and-non-intrusion-patterns.md`](references/dismissal-and-non-intrusion-patterns.md) - Dismissal mechanics. The non-intrusion principle.
+- [`references/tour-anti-patterns.md`](references/tour-anti-patterns.md) - The patterns that look like tours but degrade the product.
+- [`references/common-tour-failures.md`](references/common-tour-failures.md) - 9+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: tours earn the user's attention by being absent until needed
+
+The tour systems that work as compounding assets are the ones the user does not perceive as a tour system. Help surfaces at the moment of friction; disappears when the friction passes; never piles up as visual noise. The user encounters a feature for the first time, sees a brief contextual hint, takes the suggested action, and moves on. The system did its job; the user did not have to think about the system.
+
+That is the bar. Below the bar are tooltip-spam (visual noise that users develop blindness to) and one-and-done (help invisible at the moment of need). Above the bar are contextual-when-needed systems where trigger logic, tour architecture, contextual placement, and re-trigger respect work together to make help feel ambient rather than imposed.
+
+The discipline is in the design choices. The decision to build a tour system at all, or rely on documentation. The trigger logic that decides when help surfaces. The architecture that organizes micro-tours by feature and workflow. The placement and dismissal that make help non-intrusive. The completion tracking that prevents re-showing what users already know. The power-user differentiation that respects expertise. The maintenance cadence that keeps tours in sync with the product.

--- a/skills/interactive-product-tour/references/common-tour-failures.md
+++ b/skills/interactive-product-tour/references/common-tour-failures.md
@@ -1,0 +1,171 @@
+# Common tour failures
+
+9+ failure patterns with diagnoses and cures.
+
+---
+
+## "Tours show but feature adoption does not improve."
+
+**The diagnosis.** Help may be visually present but not contextually relevant. Tour content may be unclear or call-to-action absent.
+
+**The cure.** Audit trigger logic (`references/trigger-logic-patterns.md`). Verify tours fire at moments of friction. Audit content; ensure tours have clear CTAs.
+
+---
+
+## "Users disable tours globally."
+
+**The diagnosis.** The system is annoying users. Audit frequency, dismissal, over-triggering.
+
+**The cure.** Frequency caps (`references/dismissal-and-non-intrusion-patterns.md`). Per-user state tracking (`references/completion-tracking-and-re-trigger.md`). Audit cumulative exposure per session.
+
+---
+
+## "First-login tour completion is 80 percent; feature adoption is unchanged."
+
+**The diagnosis.** One-and-done pattern. Tour content not retained at moment of need.
+
+**The cure.** Move from single first-login tour to library of contextual micro-tours. Detail in `references/tour-architecture-patterns.md`.
+
+---
+
+## "Tooltips appear everywhere; nobody clicks them."
+
+**The diagnosis.** Tooltip-spam. Visual blindness has set in.
+
+**The cure.** Audit triggers. Remove tooltips that are not earning their place. Reserve hints for moments of friction.
+
+---
+
+## "Tour content references features we deprecated 6 months ago."
+
+**The diagnosis.** Maintenance lapse.
+
+**The cure.** Quarterly tour audit. Tag tours by feature; deprecate tours when features deprecate.
+
+---
+
+## "Power users complain about pop-ups for things they already know."
+
+**The diagnosis.** No power-user differentiation.
+
+**The cure.** Add feature-usage gating. Detail in `references/power-user-vs-new-user-patterns.md`.
+
+---
+
+## "Tours work on desktop, break on mobile."
+
+**The diagnosis.** Mobile UX of help system not tested.
+
+**The cure.** Mobile-first design and testing. Different placement patterns for mobile.
+
+---
+
+## "Some teams ship tours; others don't bother. Inconsistent."
+
+**The diagnosis.** No tour governance. Some teams build tours, others ignore them.
+
+**The cure.** Tour ownership. Designate who maintains the system. Tour authoring guidelines.
+
+---
+
+## "Tours triggered correctly but users do not act on the suggestion."
+
+**The diagnosis.** Help content unclear or call-to-action absent.
+
+**The cure.** Audit tour content. Each tour should have a clear, actionable CTA matched to the user's likely intent.
+
+---
+
+## "Tour completion looks fine; adoption is mixed by feature."
+
+**The diagnosis.** Some tours work, others do not. Per-tour adoption tracking surfaces which.
+
+**The cure.** Per-tour adoption-lift measurement. Retire or redesign tours that do not produce adoption lift.
+
+---
+
+## "We added more tours; user complaints went up."
+
+**The diagnosis.** Cumulative frequency overload. Each tour reasonable; total exposure too much.
+
+**The cure.** Per-session frequency caps. Audit cumulative exposure.
+
+---
+
+## "Returning users miss new features we shipped during their absence."
+
+**The diagnosis.** No re-orientation help for long-absent users.
+
+**The cure.** Returning-user re-orientation pattern. Detail in `references/power-user-vs-new-user-patterns.md`.
+
+---
+
+## "Tour analytics broke after the last release."
+
+**The diagnosis.** Instrumentation drift.
+
+**The cure.** Verify analytics after every release. Add to deployment smoke test.
+
+---
+
+## "Tour fires but user is mid-task; they abandon."
+
+**The diagnosis.** Trigger logic does not respect ongoing tasks.
+
+**The cure.** Detect mid-task state; defer tour. Trigger at moments of natural pause.
+
+---
+
+## "We A/B tested tour content; adoption did not move."
+
+**The diagnosis.** Content was not the issue. Could be trigger, audience, or feature design.
+
+**The cure.** Test variables that matter. Trigger logic, audience targeting, feature design itself. Sometimes the tour cannot save a bad feature.
+
+---
+
+## "Tours are clear; adoption is good; users still file support tickets."
+
+**The diagnosis.** Tours covered the feature but not the edge cases. Documentation is needed for depth.
+
+**The cure.** Tours plus docs. Tours teach the common case; docs cover edge cases.
+
+---
+
+## "Power users say tours feel patronizing."
+
+**The diagnosis.** Copy tone wrong; or tours fire on features power users have mastered.
+
+**The cure.** Match copy to brand voice (treat users as adults). Add power-user differentiation.
+
+---
+
+## "Tour platform broke after last platform update."
+
+**The diagnosis.** Tour platform changes (Userpilot/Pendo/Appcues SDK updates) can break existing tours.
+
+**The cure.** Test after platform updates. Have a rollback plan.
+
+---
+
+## The pattern across failures
+
+Most tour failures fall into one of three patterns.
+
+**Pattern 1: The tour does not surface at the right moment.** Tooltip-spam, one-and-done, over-trigger, under-trigger. The fix is trigger logic.
+
+**Pattern 2: The tour does not match the audience or device.** No power-user differentiation, mobile-broken, patronizing. The fix is matching to user state.
+
+**Pattern 3: The tour decays.** Stale references, broken triggers, deprecated features still tour-covered. The fix is maintenance.
+
+The metric pattern: tour failures often look fine on completion alone. The signal is in feature adoption, support ticket reduction, user retention. Programs that track only completion keep shipping the same patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (trigger, audience-fit, decay). The principle that completion alone is insufficient.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered and the lessons learned. Specific multi-metric dashboards. Specific cures. The team's audit and retirement processes. These vary by team.

--- a/skills/interactive-product-tour/references/completion-tracking-and-re-trigger.md
+++ b/skills/interactive-product-tour/references/completion-tracking-and-re-trigger.md
@@ -1,0 +1,203 @@
+# Completion tracking and re-trigger
+
+Per-user state, re-trigger logic, the over-trigger and under-trigger traps.
+
+Knowing what each user has seen, deciding when to show again. Done well, tours feel ambient; done poorly, tours either re-show endlessly or fail to re-surface when needed.
+
+---
+
+## The state-aware principle
+
+The tour system should know what each user has seen, completed, dismissed, and ignored. Decisions about whether to show, re-show, or skip a tour should be based on this state.
+
+**The win.** A user who completed the advanced filtering tour does not see it again. A user who skipped it might see it again at a moment of more relevance. A user who dismissed all tours sees nothing.
+
+**The fail.** Users see the same tour every time they log in. Users who dismissed tours globally still get them. Users who would benefit from a re-shown tour at the right moment never see it again.
+
+The discipline. Track state per user per tour; use state to inform re-trigger logic.
+
+---
+
+## Per-user state tracking
+
+What to track.
+
+**Per tour, per user.**
+
+- Has the user seen this tour?
+- Did they complete it?
+- Did they dismiss it without completing?
+- When did they last interact with it?
+- Did they take the suggested action after the tour?
+
+**Globally per user.**
+
+- Are tours globally enabled or disabled?
+- What is their tenure on the product?
+- What user state attributes apply (plan, role, segment)?
+
+**Aggregate.**
+
+- Tour completion rate.
+- Tour dismissal rate.
+- Action-taken-after-tour rate.
+
+The data informs both individual and system decisions.
+
+---
+
+## Re-trigger logic
+
+When to re-show.
+
+**Completed tours.**
+
+- Default: do not re-show. The user got what they needed.
+- Exception: re-show if the feature changed materially. The tour is no longer the same tour.
+
+**Dismissed tours.**
+
+- Respect the dismissal.
+- If the feature becomes relevant again much later (60+ days, significant feature change), consider gentle re-surfacing with respect.
+
+**Skipped tours (saw but did not complete).**
+
+- Re-trigger at moments of more relevance. The user did not commit; help may land better contextually.
+- After 2-3 skip events, treat like dismissed; respect the pattern.
+
+**Ignored tours (saw but did not interact).**
+
+- Treat similarly to skipped.
+- Re-trigger at moments of higher friction.
+
+---
+
+## The over-trigger trap
+
+Showing the same tour to users who have completed it.
+
+**The pattern.** No completion tracking; tours fire on every page load.
+
+**The signal.** Users complain about repeat tours; users disable tours globally; trust drops.
+
+**The cost.** The tour system loses credibility. Users who would have benefited from new tours dismiss them along with the over-triggered repeats.
+
+**The cure.** Track completion. Tours that have been completed do not re-fire (with rare exceptions for material feature changes).
+
+---
+
+## The under-trigger trap
+
+Tours never re-surfacing when the user hits the same friction again.
+
+**The pattern.** First-login tours that show once and never come back.
+
+**The signal.** Users hit the same feature later; have forgotten the tour; ask support; the help failed at the moment of need.
+
+**The cost.** The tour system was decorative; the help did not compound adoption.
+
+**The cure.** Re-trigger logic at moments of need. Even completed tours can re-surface in abbreviated form when the user hits the relevant feature months later.
+
+---
+
+## Re-trigger conditions
+
+Specific conditions that warrant re-triggering.
+
+**Material feature change.** The feature the tour covers has changed enough that the tour content is materially different. Re-show with "this feature has changed; here is what is new."
+
+**Long absence.** User returned after 60+ days; subset of tours can re-surface as re-orientation.
+
+**Plan change.** User upgraded plan; tours for previously-locked features become relevant.
+
+**Role change.** User's role changed (e.g., promoted to admin); admin-relevant tours become applicable.
+
+**Time-based decay.** Some tours benefit from periodic refreshers (rare; use carefully).
+
+The discipline. Each re-trigger condition should be deliberate, not default.
+
+---
+
+## Frequency limits
+
+Even thoughtful re-triggers can over-fire.
+
+**Per-tour frequency.**
+
+- Default: never re-show after completion.
+- Re-trigger conditions: maximum once per condition met.
+
+**Per-session frequency.**
+
+- Maximum tours per session (cumulative across all tours): often 1-3.
+- Beyond that, defer additional tours to next session.
+
+**Per-week frequency.**
+
+- Some users encounter many features in a week; the system should not fire 20 tours.
+- Cap weekly tour exposure to maintain attention.
+
+The discipline. Audit cumulative tour exposure per session and per week. Individual tour decisions are not enough.
+
+---
+
+## Dismiss vs disable distinction
+
+Two different signals.
+
+**Dismiss.** User closed a specific tour. Tells the system "this tour is not for me right now."
+
+**Disable.** User turned off all tours via settings. Tells the system "I do not want any tours."
+
+**Treatment.**
+
+- Dismiss: respect for that tour; consider re-trigger at moments of higher relevance.
+- Disable: respect globally; do not show any tours.
+
+**The disable-respect failure.** Some tour systems override the global disable for "important" tours. This breaks user trust. Disable should mean disable (compliance triggers excepted, with disclosure).
+
+---
+
+## Tour analytics for completion
+
+Track what each tour produces.
+
+**Per-tour metrics.**
+
+- Trigger rate (how often does this tour fire?).
+- Completion rate (of users who saw it, how many completed?).
+- Dismissal rate (how many dismissed without completing?).
+- Action-taken rate (how many took the suggested action after?).
+- Adoption lift (do users who saw the tour adopt the feature at higher rates than those who did not?).
+
+The metrics inform whether the tour is earning its place.
+
+**The adoption-lift question.** If users who saw the tour adopt the feature at the same rate as users who did not, the tour is not adding value. Either redesign or retire.
+
+---
+
+## Common completion-tracking failures
+
+**No tracking.** Tours fire repeatedly; users complain.
+
+**Tracking exists but ignored.** State stored but trigger logic does not use it; over-trigger persists.
+
+**Stale state.** User dismissed tour 6 months ago; product changed; tour does not re-show despite being newly relevant.
+
+**Cross-device gaps.** State tracked per device; user switches device and re-encounters every tour.
+
+**Disable not respected.** Global disable ignored for "important" tours; user trust collapses.
+
+**No adoption-lift measurement.** Tours track completion but not whether they produced adoption; weak tours persist.
+
+**Re-trigger overzealous.** Re-trigger conditions fire too liberally; users see tours they completed re-appear without justification.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The state-aware principle. Per-user state tracking. Re-trigger logic. The over-trigger and under-trigger traps. Re-trigger conditions. Frequency limits. Dismiss vs disable distinction. Tour analytics. Common failures.
+
+## Implementation choices that stay internal
+
+Specific tracking implementations. Specific re-trigger logic per tour. Specific frequency baselines. The team's tooling. These vary by team and product.

--- a/skills/interactive-product-tour/references/contextual-placement-patterns.md
+++ b/skills/interactive-product-tour/references/contextual-placement-patterns.md
@@ -1,0 +1,245 @@
+# Contextual placement patterns
+
+Tooltip, spotlight, sidebar, inline. Placement and visual design.
+
+The placement decides whether help feels ambient or imposed. Done well, help is findable when wanted, ignorable when not. Done poorly, help blocks the user or disappears before they read it.
+
+---
+
+## The non-imposition principle
+
+Help should be findable when wanted, ignorable when not. Help that demands the user's full attention is help that costs trust.
+
+**The win.** A tooltip appears next to a feature, visible but not blocking. The user reads if interested, dismisses or ignores if not. The interaction is brief and respectful.
+
+**The fail.** A modal overlay blocks the entire screen, demanding the user click to dismiss before continuing. The user loses momentum; resents the interruption.
+
+The discipline. Match placement intensity to help importance. Most help should be lightweight.
+
+---
+
+## Pattern A: Tooltip on hover
+
+Help appears next to the element on hover.
+
+**How it works.**
+
+- User hovers over the element.
+- Tooltip appears next to it.
+- Tooltip dismisses when hover ends.
+
+**Strengths.**
+
+- Lightweight.
+- Familiar pattern.
+- Non-intrusive.
+
+**Weaknesses.**
+
+- Mouse-only by default; keyboard users may miss.
+- Limited content (cannot fit much in a tooltip).
+- Dismisses too easily for content the user needs to read.
+
+**When to use.** Brief hints, definitions, quick clarifications. Not for multi-step guidance.
+
+---
+
+## Pattern B: Spotlight overlay
+
+Element highlighted; help appears alongside.
+
+**How it works.**
+
+- The relevant element is highlighted (often via dimmed surrounding area).
+- A help card appears nearby explaining the element.
+- User clicks "Got it" or similar to dismiss.
+
+**Strengths.**
+
+- More prominent; harder to miss.
+- Can fit more content than tooltip.
+- Good for feature-specific tours.
+
+**Weaknesses.**
+
+- More disruptive.
+- Dimming the page can frustrate users who wanted to do something else.
+
+**When to use.** Feature-specific tours, the kind of help that warrants the user's full attention briefly.
+
+---
+
+## Pattern C: Sidebar
+
+Help appears in a side panel.
+
+**How it works.**
+
+- Help opens in a panel (often right side of screen).
+- User can read while the main content remains accessible.
+- Panel persists until dismissed.
+
+**Strengths.**
+
+- Persistent reference; user can refer back.
+- Does not block main content.
+- Can fit substantial content.
+
+**Weaknesses.**
+
+- Takes screen space.
+- May not work on mobile.
+
+**When to use.** When the help is reference material the user may want to consult while working. Multi-step guides where the user is doing the steps in the main content.
+
+---
+
+## Pattern D: Inline
+
+Help appears in the page flow.
+
+**How it works.**
+
+- Help is embedded directly in the page content.
+- Often appears as a banner, inline hint, or contextual section.
+- User scrolls past or interacts with it.
+
+**Strengths.**
+
+- Non-disruptive.
+- Always findable (does not appear and disappear).
+- Works well on mobile.
+
+**Weaknesses.**
+
+- Can be missed entirely.
+- Adds page length.
+
+**When to use.** Empty states, contextual hints that should always be visible, supplementary information that some users want.
+
+---
+
+## Pattern E: Modal overlay
+
+Help blocks the screen until dismissed.
+
+**How it works.**
+
+- A full-screen or large modal appears.
+- User must dismiss to continue.
+
+**Strengths.**
+
+- Highest visibility.
+- Forces attention on critical messages.
+
+**Weaknesses.**
+
+- Most disruptive.
+- Easily abused; produces annoyance.
+- Should be reserved for critical messages.
+
+**When to use.** Compliance-critical messages, terms updates, data-loss warnings. Almost never for routine help.
+
+---
+
+## Placement choice by content type
+
+What pattern fits what content.
+
+**Brief hints (1 sentence):** tooltip on hover.
+
+**Feature explanations (2-3 sentences plus example):** spotlight overlay.
+
+**Multi-step guides (3-5 steps):** spotlight overlay sequence or sidebar.
+
+**Reference material (multiple paragraphs):** sidebar.
+
+**Empty states and contextual hints:** inline.
+
+**Compliance / critical messages:** modal overlay.
+
+The match between content and placement is part of the design discipline.
+
+---
+
+## Visual design discipline
+
+How help looks.
+
+**Visual weight.**
+
+- Tooltips: light, almost invisible until needed.
+- Spotlights: medium; visible but not aggressive.
+- Modals: heavy; demand attention.
+
+**Brand consistency.**
+
+- Help styling matches the product's design system.
+- Tone matches brand voice.
+- Colors should not feel "this is a tour"; they should feel like part of the product.
+
+**Iconography.**
+
+- Help often uses small icons (info, lightbulb) to signal "this is help."
+- Icons should be consistent across help surfaces.
+
+---
+
+## Animation discipline
+
+How help appears and disappears.
+
+**Subtle animation.** Fade in, slight slide. Reinforces transition without distracting.
+
+**Aggressive animation.** Bounce, attention-grabbing motion. Useful sparingly; abused, becomes annoyance.
+
+**No animation.** Instant appear/disappear. Snappy; some users prefer it.
+
+**Prefers-reduced-motion.** Respect user system preferences. No bouncing for users who configured reduced motion.
+
+---
+
+## Mobile placement considerations
+
+Mobile changes everything.
+
+**Tooltips.** Hover does not exist on mobile; tooltips need touch alternative. Often replaced with tap-to-show.
+
+**Spotlights.** Spotlight overlays need to fit mobile screens. Smaller content; fewer steps.
+
+**Sidebars.** Often impossible on mobile; replaced with full-screen modals or omitted.
+
+**Inline.** Works well on mobile. Usually the safest mobile-first pattern.
+
+**Modal overlays.** Take over the screen on mobile; even more disruptive than on desktop.
+
+The mobile discipline. Test help on actual devices. Mobile help should be lighter and more inline-oriented.
+
+---
+
+## Common placement failures
+
+**Wrong pattern for content.** Modal for a brief hint; tooltip for a multi-step guide.
+
+**Visual weight wrong.** Aggressive animation for routine help; invisible animation for critical messages.
+
+**Mobile broken.** Tooltips that do not work on touch; sidebars that take over the mobile screen.
+
+**Brand-inconsistent.** Help styled differently from the rest of the product; feels bolted on.
+
+**Animation distracting.** Bouncing tooltips that draw the eye constantly.
+
+**No reduced-motion respect.** Animations fire regardless of system preferences.
+
+**Help blocks the action it is teaching.** Spotlight overlays the very element the user needs to click.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The non-imposition principle. Patterns A through E. Placement choice by content type. Visual design discipline. Animation discipline. Mobile considerations. Common failures.
+
+## Implementation choices that stay internal
+
+Specific placement designs for specific tours. Specific tooling. Specific brand styles. The team's mobile testing benchmarks. These vary by team and product.

--- a/skills/interactive-product-tour/references/dismissal-and-non-intrusion-patterns.md
+++ b/skills/interactive-product-tour/references/dismissal-and-non-intrusion-patterns.md
@@ -1,0 +1,229 @@
+# Dismissal and non-intrusion patterns
+
+Dismissal mechanics. The non-intrusion principle.
+
+How tours close, how they respect the user's path, how they avoid becoming friction. The discipline that makes tours feel ambient rather than imposed.
+
+---
+
+## The non-intrusion principle
+
+Help should be findable when wanted, ignorable when not. Tours that demand the user's full attention earn user resentment quickly.
+
+**The win.** A tooltip appears next to a feature. The user reads, dismisses, moves on. Two seconds total. The interaction was brief.
+
+**The fail.** A modal blocks the screen. The user has to read or dismiss before continuing. The interruption costs momentum and trust.
+
+The discipline. Match intensity to importance. Most tours should be light.
+
+---
+
+## Dismissal patterns
+
+How tours close.
+
+**Pattern A: Click X.**
+
+How it works. A standard close button (often X or "Close") dismisses the tour.
+
+When to use. Default. Always available; users always know how to dismiss.
+
+**Pattern B: Click outside.**
+
+How it works. Tour dismisses if the user clicks anywhere outside the help element.
+
+When to use. For non-modal tooltips; lightweight help.
+
+**Pattern C: Auto-dismiss.**
+
+How it works. Tour fades after a few seconds of no interaction.
+
+When to use. Sparingly. Risky because users may not have read it. Best for very brief notifications.
+
+**Pattern D: Persistent until acted on.**
+
+How it works. Tour stays until the user takes the suggested action.
+
+When to use. For guided flows where the user is meant to perform the action. Discouraged for routine help (intrusive).
+
+**Pattern E: Dismiss-and-don't-show-again.**
+
+How it works. Dismissing offers an explicit "don't show me this again" option.
+
+When to use. For tours users may want to never see again (low-priority recurring tips).
+
+---
+
+## Dismiss prominence
+
+How visible the dismiss is.
+
+**Equal prominence.** Dismiss and primary action have similar visual weight.
+
+**Primary-prominent.** Primary action ("Got it" or "Try it") is bold; dismiss is secondary.
+
+**Hidden dismiss.** Dismiss requires clicking outside or finding a small X. Discouraged; users feel trapped.
+
+The discipline. Dismiss should be findable in under 2 seconds without searching.
+
+---
+
+## Click-outside dismissal
+
+When the user clicks elsewhere, what happens.
+
+**Pattern: Dismiss fully.** Tour closes; user continues with what they were doing.
+
+**Pattern: Pause and resume.** Tour pauses; if the user comes back, it resumes. Rarely the right choice; introduces unpredictability.
+
+**Pattern: Block click.** Tour stays; click outside is captured but does not pass through. Most intrusive; reserved for compliance.
+
+The discipline. Click-outside should usually dismiss. Users want to continue; let them.
+
+---
+
+## Auto-dismiss design
+
+When help fades automatically.
+
+**Time-based.** Help disappears after N seconds.
+
+- 3-5 seconds: too short for anything but a single sentence.
+- 8-12 seconds: reasonable for short help.
+- 15+ seconds: probably too long; users have moved on.
+
+**Action-based.** Help disappears when the user takes the suggested action.
+
+- Useful for guided steps.
+- Risk: user does something else; help disappears confusingly.
+
+**Hover-based.** Help disappears when hover ends.
+
+- Tooltip default.
+- Brief by nature.
+
+**The auto-dismiss risk.** Users who needed the help may have been reading slowly; auto-dismiss takes the help away before they finish.
+
+The cure. Either give enough time, or let users explicitly dismiss.
+
+---
+
+## Frequency caps for non-intrusion
+
+How many tours can fire in a session.
+
+**Per-session caps.**
+
+- Maximum tours per session: 1-3 typical.
+- Beyond that, additional tours defer to next session.
+
+**Per-page caps.**
+
+- Maximum tours per page load: usually 1.
+- Multiple tooltips on a page can stack; visual noise climbs.
+
+**Per-day caps.**
+
+- For users who use the product all day, daily caps prevent fatigue.
+
+The discipline. Cumulative exposure matters as much as individual tour quality.
+
+---
+
+## Spacing and animation
+
+How tours appear and disappear.
+
+**Subtle entry.** Fade in; slight slide. Reinforces transition without distracting.
+
+**Aggressive entry.** Bounce, pulse, shake. Gets attention; abused, becomes annoyance.
+
+**Subtle exit.** Fade out; quick.
+
+**The animation discipline.** Subtle entries and exits. Save aggressive animation for rare attention-needed moments.
+
+---
+
+## Spatial respect
+
+Where the help appears matters.
+
+**Avoid blocking the action.** Help should not cover the element it is teaching.
+
+**Avoid blocking critical content.** Help should not obscure the user's primary work area.
+
+**Avoid covering navigation.** Help that hides nav prevents the user from leaving.
+
+**Allow scroll.** If the user needs to scroll while help is visible, scroll should still work.
+
+---
+
+## Help dismissal preserves user state
+
+When the user dismisses, what is preserved.
+
+**Form data:** preserved. Dismissing help should not reset form inputs.
+
+**Page state:** preserved. Dismissing help should not navigate away.
+
+**User progress:** preserved. Dismissing help should not undo work.
+
+**The state-loss failure.** Help dismissal that resets the page or loses inputs costs trust catastrophically.
+
+---
+
+## Power-user dismissal patterns
+
+Power users want to dismiss faster.
+
+**Keyboard dismissal.** ESC closes help. Power users use keyboard.
+
+**Click-anywhere-to-dismiss.** Allows fast dismissal without targeting the X.
+
+**Settings to disable globally.** Allows opting out of all tours.
+
+The discipline. Power users should be able to dismiss in under a second.
+
+---
+
+## New-user dismissal patterns
+
+New users may need more time.
+
+**Persistent tooltips for guided flows.** Help stays visible during the flow it is teaching.
+
+**Linked help.** Dismissing help leaves a way to find it again ("Need help? Check our guides").
+
+**Contextual reminders.** Help re-surfaces if the user struggles with the same area later.
+
+The discipline. New users should not lose access to help permanently from a single dismissal.
+
+---
+
+## Common dismissal failures
+
+**Dismiss too prominent.** User dismisses before reading; misses the help.
+
+**Dismiss hidden.** User cannot find the dismiss; feels trapped.
+
+**Auto-dismiss too short.** Help disappears before reading; user does not know what was there.
+
+**Dismiss does not respect.** Tour reappears after dismiss.
+
+**Dismiss loses state.** Form inputs reset; user loses work.
+
+**No keyboard dismiss.** Power users cannot dismiss quickly.
+
+**Modal blocks until dismissed.** User cannot continue without engaging.
+
+**Help blocks the action.** Spotlight covers the very element being taught.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The non-intrusion principle. Patterns A through E for dismissal. Dismiss prominence. Click-outside dismissal. Auto-dismiss design. Frequency caps. Spacing and animation. Spatial respect. State preservation on dismiss. Power-user vs new-user dismissal patterns. Common failures.
+
+## Implementation choices that stay internal
+
+Specific dismissal designs for specific tours. Specific animation timings. Specific frequency baselines. The team's tooling. These vary by team and product.

--- a/skills/interactive-product-tour/references/power-user-vs-new-user-patterns.md
+++ b/skills/interactive-product-tour/references/power-user-vs-new-user-patterns.md
@@ -1,0 +1,204 @@
+# Power-user vs new-user patterns
+
+Differentiation signals and patterns. The over-helping and under-helping traps.
+
+Different users need different help. The discipline is to know which user is which and tailor the help system to their state.
+
+---
+
+## The state-respect principle
+
+Power users do not want tours on features they already use. New users need tours on features they are encountering for the first time. The help system should know the difference and respect both.
+
+**The win.** A power user encounters a newly-shipped feature; sees a brief tour. A new user encounters a feature for the first time; sees the same tour. A power user encounters a feature they have used 50 times; sees nothing.
+
+**The fail.** Both users see the same tour every time. Power users disable tours; new users miss critical help when they need it most.
+
+The discipline. Tour visibility should depend on user state, not user category alone.
+
+---
+
+## Differentiation signals
+
+What lets the system know which user is which.
+
+**Feature usage history.** Has the user used this feature before?
+
+- Most reliable signal.
+- Tracks per-feature, per-user state.
+- Updates in real time as the user uses the feature.
+
+**Tenure on the product.** How long has the user been a customer?
+
+- Approximate signal; new accounts vs old accounts.
+- Useful when feature usage data is missing.
+
+**Engagement frequency.** Daily active vs returning monthly.
+
+- Active users tend to know the product better.
+- Returning users may need re-orientation.
+
+**Plan or role.** Free vs paid; admin vs end-user; user vs viewer.
+
+- Different roles use different feature sets.
+- Plan changes can unlock new features.
+
+**Self-reported skill level.** Rare; usually inferred.
+
+- Some products ask during signup.
+- Useful but unreliable; people self-assess inaccurately.
+
+The discipline. Combine signals. Single signals are noisy.
+
+---
+
+## Differentiation patterns
+
+How to surface different help.
+
+**Pattern A: Feature-usage gating.**
+
+How it works. Each tour has a "show only if user has not used this feature" condition. Power users with usage history skip; new users see.
+
+When to use. Default for feature-specific tours. Most reliable.
+
+**Pattern B: Tenure-based filtering.**
+
+How it works. New users (under 7 days) see all relevant tours. Established users (over 30 days) see tours only for newly-shipped features.
+
+When to use. When feature usage data is incomplete or unavailable.
+
+**Pattern C: Engagement-based modulation.**
+
+How it works. Daily active users see fewer tours; returning monthly users may see re-orientation help.
+
+When to use. When engagement frequency predicts product knowledge.
+
+**Pattern D: Role-based differentiation.**
+
+How it works. Admins see admin-specific tours; end-users see end-user tours.
+
+When to use. When the product has materially different surfaces for different roles.
+
+**Pattern E: Newly-shipped feature highlighting.**
+
+How it works. New feature ships; tour fires for ALL users (power users and new users) because everyone is new to this feature.
+
+When to use. Feature launches. Power users benefit from the tour just as much as new users for this case.
+
+---
+
+## The over-helping trap
+
+Helping power users with features they have mastered.
+
+**The pattern.** Tours fire regardless of user state; power users see tours they do not need.
+
+**The signal.** Power user complaints; tour disable rate climbs; trust degrades.
+
+**The cost.** Power users disable tours globally; the system loses access to them for genuinely new features.
+
+**The cure.** Add feature-usage gating. Respect tenure and engagement signals.
+
+---
+
+## The under-helping trap
+
+Treating all users as power users.
+
+**The pattern.** Tours fire only on first-login or never. New users miss help when they need it.
+
+**The signal.** Feature adoption stays low among new users; support tickets persist for tour-covered features.
+
+**The cost.** New users churn or stay underactivated.
+
+**The cure.** Tours fire when users encounter features for the first time, regardless of how long they have been on the product.
+
+---
+
+## Returning-user re-orientation
+
+Long-absent users may need re-orientation.
+
+**The pattern.** User has not logged in for 60+ days. On return, abbreviated re-orientation help surfaces.
+
+**Design.**
+
+- Brief (2-3 steps max).
+- Highlights what changed in the user's absence.
+- Easy to dismiss for users who do not need it.
+
+**The over-helping risk.** Users returning from a 1-week absence do not need re-orientation. Set the absence threshold appropriately.
+
+---
+
+## Newly-shipped feature handling
+
+When a feature ships, the help system has new content.
+
+**The pattern.** A new tour ships with the feature. Trigger fires for all users (power and new alike) because everyone encounters this feature for the first time.
+
+**Discipline.**
+
+- Tag the tour as "new feature."
+- Fire on first encounter regardless of user tenure.
+- After most users have seen it (e.g., 80 percent of monthly active users), the tour can transition to standard new-user-only logic.
+
+**Power-user respect.** Even new feature tours should be brief. Power users will read what they need; do not slow them with five-step explanations.
+
+---
+
+## Plan or role change handling
+
+User state can change.
+
+**Plan upgrade.** User moves from free to paid; new features become available; relevant tours become applicable.
+
+**Role change.** User promoted to admin; admin tours become applicable.
+
+**The discipline.** Re-evaluate tour eligibility on state change. Plan upgrade triggers a "you have new features available" re-orientation.
+
+---
+
+## Inferred vs asked differentiation
+
+When to ask the user vs when to infer.
+
+**Ask sparingly.** Asking adds friction; users tire of being categorized.
+
+**Infer when possible.** Behavioral signals usually outperform self-report.
+
+**When to ask.**
+
+- Onboarding (use case, role).
+- Major plan changes that affect tour eligibility.
+
+**When not to ask.**
+
+- After onboarding; let behavior speak.
+
+---
+
+## Common power-user vs new-user failures
+
+**No differentiation.** All users see all tours; over-helping power users.
+
+**Differentiation only by tenure.** New accounts vs old; misses that some new accounts have power users (came from competitor) and some old accounts have casual users.
+
+**No re-orientation for returning users.** Users who left 90 days ago re-encounter as if first-time; they remember enough to skip re-orientation; but the help fails when they hit a changed feature.
+
+**Newly-shipped features not flagged.** Tour does not surface for power users who have used adjacent features; they miss the new capability.
+
+**Plan upgrade not triggering re-evaluation.** User upgrades; new features available; tours for those features do not surface.
+
+**Inferring poorly.** Inference logic mistakes user state; help is wrong for the user.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The state-respect principle. Differentiation signals (5 signals). Patterns A through E. The over-helping and under-helping traps. Returning-user re-orientation. Newly-shipped feature handling. Plan or role change handling. Inferred vs asked differentiation. Common failures.
+
+## Implementation choices that stay internal
+
+Specific differentiation rules for specific products. Specific signals weighted by team. The team's plan and role mapping. These vary by team and product.

--- a/skills/interactive-product-tour/references/tour-anti-patterns.md
+++ b/skills/interactive-product-tour/references/tour-anti-patterns.md
@@ -1,0 +1,224 @@
+# Tour anti-patterns
+
+The patterns that look like tours but degrade the product. Easy to ship; the cost shows up in feature adoption, user trust, and brand reputation.
+
+---
+
+## The tooltip-spam tour
+
+The pattern. Every button, link, and feature has a "click for tour" hint or pulsing dot.
+
+The signal. Users develop blindness to the dots; click rates collapse; tour completion rates near zero.
+
+The cost. The visual clutter degrades the product; users learn to ignore all tooltips, including useful ones.
+
+The cure. Audit triggers. Reserve hints for moments of genuine friction. Detail in `references/trigger-logic-patterns.md`.
+
+---
+
+## The one-and-done tour
+
+The pattern. A single first-login tour. Never re-surfaces.
+
+The signal. Users skip or skim; help unavailable at moments of later need.
+
+The cost. Feature adoption suffers; support tickets persist for tour-covered features.
+
+The cure. Library of micro-tours triggered contextually. Detail in `references/tour-architecture-patterns.md`.
+
+---
+
+## The mega-tour
+
+The pattern. A single tour with 25 steps covering the whole product.
+
+The signal. High abandonment mid-tour; high skip rate; activation does not lift.
+
+The cost. Tutorial-overload pattern applied to tours. Users abandon; help fails.
+
+The cure. Break into micro-tours, each tied to a specific feature.
+
+---
+
+## The over-trigger tour
+
+The pattern. Tour fires on every page load; no completion tracking.
+
+The signal. Repeat exposure; user complaints; tours globally disabled.
+
+The cost. Tour system loses credibility.
+
+The cure. Per-user state tracking. Completed tours do not re-fire.
+
+---
+
+## The under-trigger tour
+
+The pattern. Tour fires only on first-login. Users hit the same friction later; help does not return.
+
+The signal. Specific features show low adoption among long-tenured users; help failed at the moment of need.
+
+The cost. The tour system was decorative for everyone after their first session.
+
+The cure. Re-trigger logic at moments of relevance, even for tours seen long ago.
+
+---
+
+## The dismissive-of-disable tour
+
+The pattern. User disabled all tours globally; system fires tours anyway because they are deemed important.
+
+The signal. User trust collapses; explicit complaints.
+
+The cost. The tour system overrode the user's clear preference; trust does not recover quickly.
+
+The cure. Respect the global disable. Use compliance-only triggers for legally required messages, with clear disclosure.
+
+---
+
+## The blocks-the-action tour
+
+The pattern. Spotlight overlay covers the element it is teaching; user cannot click through.
+
+The signal. User confusion; users dismiss and abandon the action they were about to take.
+
+The cost. The tour failed at its job; the user did not learn the feature because the tour blocked the feature.
+
+The cure. Spotlight placement that highlights without blocking. The user should be able to take the action while the help is visible.
+
+---
+
+## The auto-dismiss-too-fast tour
+
+The pattern. Help fades after 3 seconds.
+
+The signal. Users complain about help disappearing before they read it.
+
+The cost. The help is technically present but functionally absent.
+
+The cure. Either longer auto-dismiss (8-12 seconds), or let users dismiss explicitly.
+
+---
+
+## The validation-strict tour
+
+The pattern. Tour requires the user to take a specific action to proceed; the user takes a different valid path.
+
+The signal. Tour gets stuck; user abandons.
+
+The cost. Forced linearity penalizes users who explore.
+
+The cure. Tour either accepts multiple valid paths or dismisses if the user explores elsewhere.
+
+---
+
+## The brand-inconsistent tour
+
+The pattern. Tour styling looks different from the rest of the product. Generic platform styling rather than brand-aligned.
+
+The signal. Users perceive the tour as bolted on; brand consistency suffers.
+
+The cost. The product feels less polished; tours feel like a separate system.
+
+The cure. Custom-styled tours matching the product's design system.
+
+---
+
+## The mobile-broken tour
+
+The pattern. Tour designed for desktop; breaks on mobile.
+
+The signal. Mobile completion rates much lower; mobile-specific complaints.
+
+The cost. Mobile audience underserved.
+
+The cure. Mobile-first design and testing. Detail in `references/contextual-placement-patterns.md` (mobile section).
+
+---
+
+## The unmaintained tour
+
+The pattern. Tour built once; product evolved; tour content references deprecated features.
+
+The signal. Users hit broken steps; references that no longer apply.
+
+The cost. Trust degrades; users ignore tours expecting them to be wrong.
+
+The cure. Quarterly maintenance. Product changes trigger tour updates as part of the change.
+
+---
+
+## The orphan-tour
+
+The pattern. Tour exists for a feature that was deprecated 6 months ago; nobody removed it.
+
+The signal. Tour fires; clicks lead to 404 or to a removed UI; users confused.
+
+The cost. The tour points to nothing; user trust degrades.
+
+The cure. Tour deprecation alongside feature deprecation.
+
+---
+
+## The fake-engagement tour
+
+The pattern. Tour optimizes for click-through rate by making the action button huge and the dismiss tiny.
+
+The signal. Click-through rate looks high; downstream feature adoption does not match.
+
+The cost. Surface metrics look fine; real adoption does not improve.
+
+The cure. Track adoption as the metric; design honestly. Click-through alone is not enough.
+
+---
+
+## The interrupting tour
+
+The pattern. Tour fires while the user is mid-task; takes over the screen.
+
+The signal. User abandonment spikes at the interruption; users complain.
+
+The cost. The tour cost the user a task completion.
+
+The cure. Tour triggers should respect ongoing tasks. Detect mid-task state; defer.
+
+---
+
+## The patronizing-copy tour
+
+The pattern. Tour copy talks down to users. "Welcome! Let me show you around. Here's how to do something simple."
+
+The signal. Power users dismiss; new users feel patronized.
+
+The cost. Tone hurts trust.
+
+The cure. Match copy to brand voice. Treat users as adults.
+
+---
+
+## How to detect anti-patterns in a portfolio
+
+Audit cadence. Quarterly review of every active tour, looking for these anti-patterns.
+
+**Audit questions per tour.**
+
+- Is the tour triggered relevantly (anti-pattern check: tooltip-spam, over-trigger, under-trigger)?
+- Does the tour respect dismissal (anti-pattern check: dismissive-of-disable)?
+- Does the tour block the action it teaches (anti-pattern check: blocks-the-action)?
+- Is auto-dismiss timed appropriately (anti-pattern check: auto-dismiss-too-fast)?
+- Does the tour match the brand's design (anti-pattern check: brand-inconsistent)?
+- Does the tour work on mobile (anti-pattern check: mobile-broken)?
+- Is the tour current (anti-pattern check: unmaintained, orphan)?
+- Is adoption tracked (anti-pattern check: fake-engagement)?
+
+**The retire decision.** Anti-pattern tours often warrant retirement or redesign.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing for each. Cures matched. The audit cadence and questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and the lessons learned. Specific portfolio audit results. Specific retirement decisions. The team's audit calendar. These vary by team.

--- a/skills/interactive-product-tour/references/tour-architecture-patterns.md
+++ b/skills/interactive-product-tour/references/tour-architecture-patterns.md
@@ -1,0 +1,225 @@
+# Tour architecture patterns
+
+Single tour vs branched vs library of micro-tours. The architecture that fits how users actually explore.
+
+The architecture is how help is organized at the system level. Bad architecture produces canned tours that nobody finishes; good architecture matches how users actually explore.
+
+---
+
+## The exploration-fit principle
+
+The architecture should match how users actually move through the product. Linear architecture fits linear products; library architecture fits exploration.
+
+**The win.** A library of focused micro-tours, each tied to a specific feature, triggered contextually as users encounter features. Each tour is small (2-4 steps); each fires only at relevant moments. Users feel helped without feeling herded.
+
+**The fail.** A single linear tour covering 25 features in sequence. Users who care about feature 17 get nothing relevant in the first 16 steps; they skip everything; help fails.
+
+The discipline. Match architecture to exploration patterns; do not impose linearity on non-linear products.
+
+---
+
+## Pattern A: Single tour
+
+One linear tour covering the product.
+
+**How it works.**
+
+- Tour starts at first-login or via a "Take the tour" prompt.
+- Steps cover features in a defined order.
+- User completes or skips entirely.
+
+**Strengths.**
+
+- Simple to design and maintain.
+- Predictable for users.
+
+**Weaknesses.**
+
+- Linear; rarely fits how users explore.
+- Can become tutorial-overload if comprehensive.
+- One-and-done; rarely re-shown.
+
+**When to use.** Very simple products with linear flows. Rarely the right answer for production tour systems.
+
+---
+
+## Pattern B: Branched tour
+
+Tour adapts based on user choices or path.
+
+**How it works.**
+
+- User selects role/use case at start.
+- Subsequent steps adapt based on the selection.
+- Different users effectively complete different tours.
+
+**Strengths.**
+
+- More relevant than single tour.
+- Personalized.
+
+**Weaknesses.**
+
+- Complex to build and maintain.
+- Hard to instrument cleanly.
+- Still linear in execution.
+
+**When to use.** When the audience splits into 2-3 clear segments with different exploration paths. Use sparingly.
+
+---
+
+## Pattern C: Library of micro-tours
+
+Dozens of small focused tours, each tied to a specific feature or workflow. Triggered contextually.
+
+**How it works.**
+
+- Many small tours (2-4 steps each).
+- Each tour is tied to a specific feature, workflow, or moment.
+- Trigger logic decides when each fires.
+- Users see only the tours relevant to their current exploration.
+
+**Strengths.**
+
+- Matches how users actually explore.
+- Each micro-tour is small enough to complete.
+- Re-trigger logic can re-surface as features become relevant.
+- Most flexible.
+
+**Weaknesses.**
+
+- Most maintenance.
+- Trigger logic complexity.
+- Requires per-tour completion tracking.
+
+**When to use.** Default for production tour systems. Most modern products benefit from this approach.
+
+---
+
+## Pattern D: Hybrid
+
+Combining patterns. Often a brief opening tour plus a library of micro-tours for ongoing help.
+
+**How it works.**
+
+- First-login: brief 3-4 step orientation tour (single).
+- Ongoing: library of micro-tours triggered contextually.
+
+**Strengths.**
+
+- Orientation for new users + ongoing help for everyone.
+- Combines the simplicity of single tour for the moment of arrival with the flexibility of library for the ongoing relationship.
+
+**Weaknesses.**
+
+- Two systems to maintain.
+
+**When to use.** When new users genuinely benefit from an opening orientation AND ongoing contextual help is also valuable.
+
+---
+
+## Architecture choice criteria
+
+Which pattern fits which product.
+
+**Use single tour when:**
+
+- Product is genuinely linear.
+- Audience expects guided sequence.
+- Maintenance capacity is limited.
+
+**Use branched tour when:**
+
+- Audience splits into 2-3 distinct segments.
+- Each segment has a different linear path.
+
+**Use library of micro-tours when:**
+
+- Product has many features users explore non-linearly.
+- Audience is segmented in many ways.
+- Maintenance capacity supports many tours.
+
+**Use hybrid when:**
+
+- New-user orientation matters AND ongoing help also matters.
+
+The simplest architecture that fits the product is usually the best choice.
+
+---
+
+## Micro-tour discipline
+
+Each micro-tour should be small.
+
+**Size guideline.** 2-4 steps per micro-tour.
+
+**Why small.**
+
+- Completable in under a minute.
+- Easy to maintain.
+- Targeted to a specific feature or moment.
+- Less likely to be skipped.
+
+**Anti-pattern.** Micro-tours that grow into 8-10 steps lose their micro nature; they become single tours that happen to be triggered contextually. Re-scope.
+
+---
+
+## Tour tagging and organization
+
+When you have a library, organize it.
+
+**Tagging axes.**
+
+- Feature (which feature the tour covers).
+- Workflow (which user workflow the tour fits in).
+- User type (new, power, returning).
+- Plan (free, paid, enterprise).
+
+**Why tagging matters.**
+
+- Trigger logic can use tags to decide which tour fires.
+- Maintenance can find tours by feature when the feature changes.
+- Audit can identify orphan tours not tied to current features.
+
+---
+
+## Tour deprecation
+
+When features change, tours need to retire or update.
+
+**Retire when:**
+
+- Feature was deprecated; tour points to nothing.
+- Feature changed enough that tour content is wrong; redesign instead of patch.
+
+**Update when:**
+
+- Feature changed in details but tour structure still applies.
+
+**The deprecation hygiene.** Quarterly audit of tours against current product. Tours pointing to deprecated features get retired; tours that still apply but need refresh get updated.
+
+---
+
+## Common architecture failures
+
+**Single tour for non-linear product.** Users skip; help fails.
+
+**Branched tour with too many branches.** Maintenance burden; quality degrades per branch.
+
+**Library without tagging.** Tours accumulate; nobody can find them; some are stale.
+
+**Mega-tours.** Micro-tours that grew to 10+ steps; lose their micro nature.
+
+**Orphan tours.** Tours pointing to features that no longer exist; not retired.
+
+**Inconsistent micro-tour quality.** Some tours polished, others slapdash; users notice.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The exploration-fit principle. Patterns A through D. Architecture choice criteria. Micro-tour discipline. Tour tagging and organization. Tour deprecation. Common failures.
+
+## Implementation choices that stay internal
+
+Specific architectures for specific products. Specific tooling for tour authoring and management. The team's tagging conventions. Specific quarterly audit calendars. These vary by team and product.

--- a/skills/interactive-product-tour/references/tour-decision-criteria.md
+++ b/skills/interactive-product-tour/references/tour-decision-criteria.md
@@ -1,0 +1,154 @@
+# Tour decision criteria
+
+When tours earn the build vs when documentation suffices.
+
+A tour system is meaningful work. Trigger logic, tour architecture, contextual placement, completion tracking, ongoing maintenance. Tours earn this investment only when specific conditions are present.
+
+---
+
+## When tours earn the build
+
+Five conditions that, when present, make tours a strong investment.
+
+**The product has features users genuinely miss.** Specific functionality buried in menus, advanced workflows requiring sequence, integrations users do not know exist. Without prompting, users do not find these features.
+
+**The audience benefits from in-context guidance more than documentation.** Tours teach in the place the user will use the feature; docs require context-switching. Some audiences prefer the immediacy of in-context help.
+
+**The team can maintain tours.** Tour content decays as the product evolves. Without maintenance commitment, tours point to deprecated UI; users hit broken steps.
+
+**The success metric is defined.** Feature adoption per tour-covered feature, time-to-value for specific capabilities, reduction in support tickets. Without the metric, evaluation is impossible.
+
+**The product changes at a sustainable pace.** Tours can keep up. Products that change weekly may have tour-maintenance burden exceeding tour value.
+
+When all five are present, tours are a strong investment. When two or fewer are present, documentation often serves better.
+
+---
+
+## When tours do NOT earn the build
+
+Funnels where tours add complexity without value.
+
+**The product's feature set is small enough that documentation suffices.** A few tooltips on key features may be all that is needed. Building a full tour infrastructure is overkill.
+
+**The audience prefers self-directed discovery.** Some audiences resent in-product guidance. Developer tools, professional creative tools, specialist software often have audiences who want to explore on their own.
+
+**The team cannot maintain tours.** Stale tours are worse than no tours. Without commitment, tours decay into liability.
+
+**The product changes too frequently.** A product churning weekly may have tours that go stale within days of being shipped. The maintenance cost exceeds the tour benefit.
+
+**The audience is small enough that direct outreach is more efficient.** Onboarding calls, customer success engagement, and direct help may serve a small audience better than tour infrastructure.
+
+The honest assessment matters. Tours are sometimes the wrong tool even when the team has capacity to build them.
+
+---
+
+## Documentation vs tours: the comparison
+
+Both teach features; they differ in delivery.
+
+**Documentation strengths.**
+
+- Stable; changes don't require tour updates.
+- Searchable; users find what they need.
+- Comprehensive; can cover edge cases.
+- Accessible from outside the product (sharing, linking).
+
+**Documentation weaknesses.**
+
+- Requires context-switching from product to docs.
+- Users may not know to consult docs.
+- Static; cannot react to user state.
+
+**Tour strengths.**
+
+- In-context; help where the user will use the feature.
+- Dynamic; can react to user state and behavior.
+- Non-disruptive when designed well.
+
+**Tour weaknesses.**
+
+- Maintenance burden.
+- Can become tooltip-spam if undisciplined.
+- Less comprehensive than docs.
+
+**The combined approach.** Most production teams use both. Tours for the moments where in-context guidance matters; docs for depth and reference.
+
+---
+
+## The opportunity-cost frame
+
+Tour systems are significant work.
+
+**The build cost.** Trigger logic infrastructure, tour authoring, instrumentation, integration with the product, design and copy. A meaningful tour system often takes 60-200 engineering hours plus design and copy per major tour.
+
+**The maintenance cost.** Quarterly review minimum; product changes trigger tour updates. 4-12 hours per active tour per quarter.
+
+**The opportunity cost.** What else could the team have built? Direct in-product improvements, better empty states, contextual prompts that do not require tour infrastructure. The tour system has to clear the bar of those alternatives.
+
+The decision frame. Tours earn investment when they produce more adoption lift than the alternatives.
+
+---
+
+## Decision worked example
+
+A B2B SaaS analytics platform considering an in-product tour system.
+
+**Conditions check.**
+
+- Features users miss: yes. Advanced analysis modes, custom dashboard creation, integration setup all underused.
+- In-context guidance benefits: yes. Users explore in-product; pulling them to docs breaks flow.
+- Maintenance commitment: yes. Customer success team owns tours.
+- Success metric defined: yes. Feature adoption per tour-covered feature within 30 days of first encounter.
+- Product change pace: moderate. Major features ship monthly; minor changes weekly. Tour updates fit the cadence.
+
+**Decision.** Build the tour system. The conditions warrant it.
+
+**Architecture.** Library of micro-tours, each tied to a specific feature. Triggered contextually when users first encounter the feature.
+
+**Maintenance commitment.** CS team reviews quarterly; major product changes trigger tour updates as part of the change.
+
+The decision was deliberate, not default.
+
+---
+
+## Decision worked example: when to choose differently
+
+A developer-tool company considering in-product tours.
+
+**Conditions check.**
+
+- Features users miss: somewhat. Some advanced features underused, but the audience tends to find them through docs.
+- In-context guidance benefits: weak. Developers strongly prefer docs and prefer not to be interrupted.
+- Maintenance commitment: yes (capacity exists).
+- Success metric: defined.
+- Product change pace: moderate.
+
+**Decision.** Do not build a full tour system. Invest in better docs, smarter empty states, and a few high-value contextual hints. The audience's preference for self-directed discovery argues against tour infrastructure.
+
+The decision was right-sized to the audience.
+
+---
+
+## When to retire a tour system
+
+Tour systems can become wrong over time.
+
+**Retire when:**
+
+- Feature adoption (the tour's success metric) has declined consistently and refinements have not moved it.
+- Users globally disable tours via settings.
+- The product changes have outpaced maintenance; tours are stale.
+- A redesigned product surface (better empty states, better contextual prompts) makes tours redundant.
+- The team can no longer maintain tours.
+
+The retire-or-redesign discipline frees capacity.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five conditions that warrant tours. The five conditions that argue against. Documentation vs tours comparison. The opportunity-cost frame. Decision worked examples (yes and no). The retire decision.
+
+## Implementation choices that stay internal
+
+Specific tour decisions for specific products. The team's capacity benchmarks. Specific tooling. Specific success-metric baselines. These vary by team and product.

--- a/skills/interactive-product-tour/references/trigger-logic-patterns.md
+++ b/skills/interactive-product-tour/references/trigger-logic-patterns.md
@@ -1,0 +1,226 @@
+# Trigger logic patterns
+
+Event-based, time-based, state-based, combined triggers. The discipline that distinguishes useful triggers from noise.
+
+The trigger answers "when does this help surface and why." Decorative triggers (showing help when it is not needed) become tooltip-spam. Useful triggers surface help at moments of friction.
+
+---
+
+## The relevance principle
+
+Trigger help when the user is at a moment of friction or genuine need. Do not trigger help when the user is moving through familiar territory.
+
+**The win.** A user clicks into a feature for the first time. The tour system recognizes this is the user's first encounter and surfaces a brief contextual hint. The user reads, takes the suggested action, moves on.
+
+**The fail.** Same user, same feature. The tour system has no first-encounter detection; it triggers on every page load. The user has dismissed the same tooltip 12 times; develops blindness to all tooltips.
+
+The discipline. Each trigger should answer "why this user, why now."
+
+---
+
+## Pattern A: Event-based triggers
+
+Help appears in response to a user action.
+
+**How it works.**
+
+- The user performs an action (clicks a feature, enters a section, completes a flow).
+- The trigger fires based on the event.
+- Help appears contextually.
+
+**Examples.**
+
+- First click into a new section.
+- Completed a flow for the first time.
+- Hit a state where help would be useful (empty list, no data connected, no teammates invited).
+
+**Strengths.**
+
+- Most relevant; help responds to what the user just did.
+- Naturally contextual.
+
+**Weaknesses.**
+
+- Requires per-event tracking.
+- Can over-trigger if events are too granular.
+
+**When to use.** Default for most contextual help. Events drive the trigger.
+
+---
+
+## Pattern B: Time-based triggers
+
+Help appears after time elapsed.
+
+**How it works.**
+
+- A timer starts when relevant condition is met.
+- After a defined interval, help triggers.
+- Time can be session time, time on page, time since last action, or time since last login.
+
+**Examples.**
+
+- User has been on a page for 60 seconds without acting (signals stuck).
+- User returned after 30 days of absence (signals re-orientation needed).
+- User has been a customer for 90 days (signals capacity for advanced features).
+
+**Strengths.**
+
+- Catches stuck users events alone might miss.
+- Useful for re-engagement of long-absent users.
+
+**Weaknesses.**
+
+- Time alone is a noisy signal.
+- "Stuck" might just be reading.
+- Easy to misuse and produce annoyance.
+
+**When to use.** Sparingly. Time-based triggers should always combine with event or state signals.
+
+---
+
+## Pattern C: State-based triggers
+
+Help appears based on user state.
+
+**How it works.**
+
+- The user has attributes (new vs power; small vs large account; specific role; specific plan).
+- Trigger fires based on attribute match.
+
+**Examples.**
+
+- Power users see help only on newly-shipped features.
+- Enterprise customers see different tour on workspace features than SMB.
+- Users on free plan see different upgrade-related help than paid.
+
+**Strengths.**
+
+- Personalizes help to user segment.
+- Avoids over-helping users who do not need it.
+
+**Weaknesses.**
+
+- Requires user-state infrastructure.
+- State changes (plan upgrade, role change) need to update triggers.
+
+**When to use.** When help differs significantly by user segment. State modulates event triggers.
+
+---
+
+## Pattern D: Combined triggers
+
+Most production tour systems combine event, time, and state.
+
+**Example combined trigger.**
+
+"Show tour for advanced filtering feature when:
+- User clicks the filter icon for the first time (event).
+- User has been on the platform more than 7 days (state, not too new).
+- User is on a paid plan (state, feature is paid-only).
+- User has not dismissed this specific tour before (state, respect prior dismissal)."
+
+The combination produces relevant triggers without false positives.
+
+**The discipline.** Trigger conditions accumulate. Each condition prevents over-triggering.
+
+---
+
+## Trigger frequency limits
+
+Even relevant triggers can over-fire.
+
+**Per-tour limits.**
+
+- Once per user (most tours).
+- Once per quarter (re-orientation tours).
+- Once per session per page (low-priority hints).
+
+**Per-session limits.**
+
+- Cap total tour interruptions per session (e.g., max 2 tours per session).
+- Cap total tooltip appearances per session.
+
+**The cumulative-frequency problem.** Each individual tour may be reasonable; the cumulative count across many tours can become noise.
+
+The discipline. Audit cumulative triggers per session, not just per tour.
+
+---
+
+## Trigger disabling and respect
+
+Users may disable tours globally.
+
+**The pattern.** A settings option lets users disable all tours.
+
+**The discipline.** Respect the disable. No tour should override the global setting (compliance triggers may be exception).
+
+**Re-engaging disabled users.**
+
+- Do not auto-re-enable.
+- Surface specific high-value features as one-time prompts that respect the disable.
+- Trust that users who disabled know what they want.
+
+---
+
+## Trigger logic and accessibility
+
+Triggers must work for users with assistive technology.
+
+**Considerations.**
+
+- Triggers should not assume mouse hover (keyboard users miss them).
+- Triggers should not auto-fire to overwhelm screen readers.
+- Triggers should respect prefers-reduced-motion.
+
+Detail in `accessibility-audit` for deeper accessibility coverage.
+
+---
+
+## Trigger logic testing
+
+Test triggers across user paths.
+
+**Test cases.**
+
+- New user encounters feature: trigger fires.
+- Returning user encounters same feature: trigger does not re-fire (respects history).
+- Power user encounters newly-shipped feature: trigger fires.
+- User who dismissed a tour: dismissed tour does not re-fire.
+- User who disabled tours globally: no tours fire.
+- User on mobile vs desktop: triggers behave consistently.
+
+**Production monitoring.**
+
+- Track trigger fire rate per tour.
+- Track tour completion rate per tour.
+- Track unique users who saw each tour.
+- Anomalies (sudden spike in triggers) often indicate logic issues.
+
+---
+
+## Common trigger logic failures
+
+**Over-triggering.** Triggers fire on every page load; users develop blindness.
+
+**Under-triggering.** Triggers fire only on first-login; users miss help when they need it later.
+
+**No state awareness.** Power users see beginner tours; new users see tours for features they have not unlocked.
+
+**No frequency limits.** Each individual tour is fine; cumulative triggers per session are noise.
+
+**Disabled users not respected.** Tours fire despite global disable.
+
+**Stale triggers.** Triggers reference features deprecated 6 months ago.
+
+**Untested edge cases.** Specific user paths produce broken triggers; nobody noticed.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The relevance principle. Patterns A through D (event, time, state, combined). Trigger frequency limits. Trigger disabling and respect. Accessibility considerations. Trigger testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific trigger configurations for specific tours. Specific tooling for trigger management. The team's testing protocols. Specific frequency baselines. These vary by team and product.

--- a/skills/onboarding-wizard-design/SKILL.md
+++ b/skills/onboarding-wizard-design/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: onboarding-wizard-design
+description: "Designing first-run product onboarding wizards that get users to the ah-ha moment without overwhelming them. Step architecture, progressive disclosure, escape hatches, completion incentives, drop-off measurement. Honest about tutorial-overload (dump everything upfront), skip-friendly-empty (skipped onboarding leads to abandoned product), and earned-progressive-disclosure (right things at the right moments) patterns. Triggers on onboarding wizard, product onboarding, first-run experience, signup flow, activation flow, FRX, time-to-value, ah-ha moment design. Also triggers when activation rates are low, when users skip onboarding and never return, when onboarding flows are being scoped for the first time, or when audience research shows users not finding key features."
+category: growth-tooling
+catalog_summary: "Designing first-run product onboarding wizards. Distinguishes tutorial-overload (dump everything upfront) from skip-friendly-empty (skipped onboarding leads to abandoned product) from earned-progressive-disclosure (right things at the right moments)"
+display_order: 7
+---
+
+# Onboarding Wizard Design
+
+A senior product marketing director's playbook for designing first-run product onboarding wizards that get users to the ah-ha moment without overwhelming them. Step architecture, progressive disclosure, escape hatches, completion incentives, drop-off measurement. The discipline of building an onboarding sequence the user actually completes.
+
+Most product onboarding wizards fail in one of two ways. They cram every feature into a 12-step intro the user has not earned the patience for. Or they offer a "skip onboarding" button so prominent that users skip into an empty product with no context, and then churn the next day because they never found the value. The activation rate is the metric that matters, and most wizards are optimizing for the wrong thing.
+
+The wizards that work do something different. Each step earns the user one step closer to value. The wizard surfaces the right thing at the right moment, not everything upfront. Skip exists but is balanced against staying engaged. The user reaches the ah-ha moment with a sense that the product respected their time.
+
+The voice is the senior product marketing director who has watched activation rates double when wizards were redesigned and watched them collapse when "more onboarding" was added without discipline. Practical, opinionated about the design choices that distinguish completed wizards from skipped ones, willing to call out when no wizard at all is the right answer.
+
+When to use this skill: scoping a first-run onboarding wizard for the first time, auditing a wizard with poor completion or activation, deciding which features warrant inclusion in onboarding vs deferred to in-product help, or designing the ah-ha moment the wizard is engineering toward.
+
+---
+
+## What this skill covers
+
+This skill spans first-run product onboarding wizards. The growth-tooling distinctions:
+
+- `multi-step-form-design` is pre-signup data capture (forms before the user has access). This skill is post-signup product onboarding. Different phase, different audience state.
+- `interactive-product-tour` is contextual help WITHIN the product, surfacing across the lifecycle. This skill is the sequential first-run experience.
+- `chatbot-flow-design` is conversational help. This skill is non-conversational sequential setup.
+- **`onboarding-wizard-design` (this skill)** is the post-signup wizard's structure, ah-ha moment design, progressive disclosure, skip mechanics, drop-off measurement.
+- `pm-spec-writing` is the spec for engineers building the wizard. This skill is about WHAT to build; pm-spec-writing is about communicating it.
+
+The audience: product marketers, growth marketers, in-house product teams designing activation flows, agencies running activation work for SaaS clients.
+
+Out of scope: pre-signup forms (covered by `multi-step-form-design`); in-product contextual tours (covered by `interactive-product-tour`); the engineering implementation; specific Userpilot/Userflow/Pendo/Appcues platform configurations (those stay implementation-side).
+
+---
+
+## The wizard decision: when wizards earn vs when contextual help suffices
+
+Before designing the wizard, decide whether a wizard is the right tool.
+
+**Wizards earn investment when:**
+
+- The product has a meaningful setup step before value emerges. Connect a data source, invite a teammate, configure a workspace. Without setup, the product is empty; the wizard makes setup tractable.
+- The ah-ha moment requires multiple actions in sequence. Single-action ah-ha moments (paste a URL, see a result) often work better with contextual prompts than with wizards.
+- The audience expects guided onboarding. B2B SaaS with technical setup, enterprise software, configurable products. Some audiences (consumer, frictionless tools) reject wizard friction.
+- The team can maintain the wizard. Wizards decay as the product evolves; without maintenance commitment, the wizard becomes a liability.
+
+**Wizards do NOT earn investment when:**
+
+- The product reaches value immediately. Single-input tools, simple consumer products. A wizard adds friction without lift.
+- Contextual help would suffice. Tooltips, in-feature hints, and progressive in-product education sometimes serve better than upfront wizards.
+- The audience expects no friction. Some audiences abandon at any wizard; meet them where they are.
+- The team cannot maintain the wizard alongside product changes. Stale wizards point to deprecated features; users hit broken steps.
+
+The decision is not "should we have an onboarding wizard"; it is "is the wizard the right tool for this specific product and audience."
+
+Detail in `references/wizard-decision-criteria.md`.
+
+---
+
+## Tutorial-overload vs skip-friendly-empty vs earned-progressive-disclosure
+
+The keystone framing.
+
+**Tutorial-overload.** Every feature explained in a 12-step intro before the user has touched the product. Cognitive overload. Users skip if they can; abandon if they cannot. Cost: the wizard's design effort produces a sequence almost nobody completes; activation rate suffers because the user did not reach the value-giving moment.
+
+**Skip-friendly-empty.** "Skip onboarding" button at every step, so prominent that users always take it. Users skip; arrive at an empty product with no context; churn within hours. Cost: activation rate falls off a cliff because users never set up the basics that make the product functional.
+
+**Earned-progressive-disclosure.** Each step earns the user one step closer to value. The wizard surfaces the right thing at the right moment, not everything upfront. Skip exists but is friction-balanced against staying engaged (e.g., skip places the user in a partially-set-up state with clear callouts to complete setup later). Cost: design effort is significant; activation rate often climbs significantly as a result.
+
+The litmus test. Watch a new user complete (or skip) the wizard. Did they reach a moment where the product visibly demonstrated value within their first session? If yes, the wizard is earned-progressive-disclosure. If they completed every step but never reached value, tutorial-overload. If they skipped and never returned, skip-friendly-empty.
+
+---
+
+## Step architecture: what belongs in each step, sequence logic
+
+The structure that makes wizards actually work.
+
+**The principle.** Each step should move the user one step closer to value. Steps that do not should be cut.
+
+**Common step patterns.**
+
+- **Welcome and orientation.** Quick context-setting, often skippable. Sets expectations for what the wizard will do.
+- **Identity and account context.** Who are you, what's your role, what brought you here. Often used to personalize subsequent steps.
+- **Critical setup step.** The one thing the product cannot work without (connect data source, invite teammates, set primary use case). This is often where wizards justify their existence.
+- **First-action step.** Get the user to take a meaningful action that produces visible result. The ah-ha moment lives here or right after.
+- **Configuration deferral.** Surface the things that can be set up later but are commonly needed; let the user defer with a clear path back.
+- **Confirmation and next steps.** Recap what was set up; surface what to do next; route to in-product home.
+
+**Step coherence test.** Each step should answer: did this step move the user closer to value? Steps that exist for completeness or feature-pride should be cut.
+
+Detail in `references/step-architecture-patterns.md`.
+
+---
+
+## The ah-ha moment design
+
+What the wizard is actually trying to engineer.
+
+**The principle.** The ah-ha moment is the moment the user feels "oh, this is what the product does for me." The wizard's structure should engineer toward that moment.
+
+**Identifying the ah-ha moment.**
+
+- It is the visible demonstration of value, not just feature explanation.
+- It is action-tied, not knowledge-tied. The user did something and saw the result.
+- It is single-shot. One clear moment, not a checklist of moments.
+- It is honest. The user genuinely got value; not a contrived demo.
+
+**Design implications.**
+
+- The wizard's path should converge on the ah-ha moment. Steps that do not contribute should be deferred or cut.
+- The ah-ah moment should appear within the user's first session, ideally within 5-10 minutes of signup. Longer time-to-value correlates with churn.
+- The ah-ha moment differs by audience. The B2B admin's ah-ha moment differs from the end-user's. Wizards may need to differentiate.
+
+**Common ah-ha moment patterns.**
+
+- **First successful query/output.** The user ran something against their data and saw a useful result.
+- **First meaningful collaboration moment.** The user shared something with a teammate and saw the response.
+- **First saved configuration.** The user set up something they will return to.
+- **First value-demonstrating insight.** The user saw a metric, recommendation, or pattern that surprised them.
+
+Detail in `references/ah-ha-moment-engineering.md`.
+
+---
+
+## Progressive disclosure patterns
+
+How to surface only what is needed at each step.
+
+**The principle.** Show only the inputs, options, and information the user needs to complete the current step. Defer everything else to in-product help or later configuration.
+
+**Pattern A: Default-heavy.** Each step has smart defaults. The user can accept or override. Most users accept; advanced users override. Reduces cognitive load.
+
+**Pattern B: Required-now, optional-later.** Required fields surface in the wizard; optional configuration surfaces in-product after activation. The wizard stays focused.
+
+**Pattern C: Expand-on-demand.** Sections collapsed by default; the user expands if interested. Rare; works when the user has agency to explore.
+
+**Pattern D: Branching.** Different users see different steps based on earlier answers. Powerful but adds maintenance complexity.
+
+The discipline. Each piece of information shown in the wizard must justify its inclusion. Decorative information adds friction; surface it later.
+
+Detail in `references/progressive-disclosure-patterns.md`.
+
+---
+
+## Skip and resume mechanics
+
+When users skip, where they land. When they resume, what they see.
+
+**The skip principle.** Skip should never produce an empty product. If skipping is offered, the user must land in a state where they can still progress; the wizard's deferred steps must be retrievable.
+
+**Skip patterns.**
+
+- **Soft skip with context.** "Skip for now" deposits the user into a partially-set-up state with clear callouts to complete deferred setup.
+- **Skip-and-defer.** Skipped steps are queued for later in-product prompts.
+- **Skip-with-warning.** "Skipping setup will limit your experience to X. Continue?" Honest about consequences.
+- **No skip.** For wizards that absolutely require completion (compliance forms, paid signups). Use sparingly.
+
+**Resume patterns.**
+
+- **Auto-resume on next login.** The user lands at the step they left.
+- **Manual resume from in-product entry.** A persistent "Complete setup" surface that returns the user to the wizard.
+- **Soft resume.** Wizard fades out as the user completes equivalent actions in-product naturally.
+
+**The skip-friendly-empty failure.** Skip is too prominent and consequence-free; the user lands in an unconfigured product and has no path back. Activation collapses.
+
+**The cure.** Skip is honest about consequences and offers a path back. The user who skips knows what they skipped.
+
+Detail in `references/skip-and-resume-mechanics.md`.
+
+---
+
+## Drop-off measurement and remediation
+
+Where users abandon the wizard, and how to fix it.
+
+**Per-step instrumentation.** Track step start, step completion, step abandonment for every step. The metrics inform every other improvement.
+
+**Common drop-off patterns.**
+
+- **First-step drop-off.** User landed on the wizard, looked at it, left. Often signals the wizard's value proposition is not clear or the audience expected no wizard.
+- **Mid-wizard drop-off.** User abandoned mid-process. Audit the specific step; field count, sensitive info, unclear progress.
+- **Skip-everything drop-off.** User skipped every available step. Either the wizard is not earning its time or the skip is too prominent.
+
+**Remediation patterns.**
+
+- First-step drop-off: clarify the wizard's purpose; reduce upfront fields; consider whether the wizard is needed at all.
+- Mid-wizard drop-off: audit the high-drop step; reduce friction; reconsider whether that step belongs in the wizard.
+- Skip-everything drop-off: rebalance skip prominence; consider whether the wizard should be replaced with contextual prompts.
+
+**The instrumentation requirement.** Without per-step tracking, drop-off remediation is guesswork. Set up tracking before launch.
+
+Detail in `references/drop-off-measurement-templates.md`.
+
+---
+
+## Wizard variations by user type
+
+Different users may need different wizards.
+
+**The admin vs end-user distinction.** Admins set up the workspace; end-users start using it. Wizards aimed at both fail both. Differentiated wizards serve each.
+
+**The technical vs non-technical distinction.** Technical users skip explanations; non-technical users need them. The wizard's tone and depth should match.
+
+**The size-of-team distinction.** Solo founders have different setup needs than 50-person teams. Wizards may branch.
+
+**Differentiation patterns.**
+
+- **Role-based branching.** First step asks role; subsequent steps adapt.
+- **Use-case-based branching.** First step asks use case; wizard tailors.
+- **Size-based branching.** Solo, team, enterprise paths differ.
+
+**The over-differentiated trap.** Too many variants produce unmaintainable wizards. Most wizards work with 2-3 variants at most.
+
+Detail in `references/user-type-variation-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-onboarding-failures.md`.
+
+- "Activation rate is low; completion rate is high." Wizard completed but did not engineer the ah-ha moment. Audit what users did after completing.
+- "Skip rate is over 50 percent." Either the wizard is not earning its time or skip is too prominent. Audit both.
+- "Users complete the wizard then abandon the product within 24 hours." Time-to-value too long; ah-ha moment not in first session.
+- "Wizard works for new users; existing users hit broken steps." Wizard not maintained alongside product; deprecated features still in flow.
+- "Different segments complete at very different rates." Audience-fit varies; consider role-based or use-case-based branching.
+- "Mobile completion is half of desktop." Mobile UX of the wizard broken.
+- "We added more onboarding steps; activation went down." Tutorial-overload pattern; more is not better.
+- "Skip mechanics work but users do not return to complete setup." Skip-and-defer not working; in-product prompts to return are missing or ignored.
+- "Wizard analytics broke after the last release." Instrumentation drift; track and refresh.
+
+---
+
+## The framework: 12 considerations for onboarding wizard design
+
+When designing or auditing an onboarding wizard, walk these 12 considerations.
+
+1. **The wizard decision.** Is a wizard the right tool, or do contextual prompts suffice?
+2. **Earned-progressive-disclosure, not tutorial-overload or skip-friendly-empty.** Each step earns one step closer to value.
+3. **Step architecture sound.** Each step moves the user closer to value; non-contributing steps cut.
+4. **The ah-ha moment engineered.** Single visible value moment, action-tied, in the first session.
+5. **Progressive disclosure applied.** Show only what is needed now; defer the rest.
+6. **Skip mechanics honest.** Skip exists but does not produce an empty product.
+7. **Resume mechanics work.** Skipped users have a path back; instrumented for follow-through.
+8. **Drop-off measurement instrumented.** Per-step tracking from launch.
+9. **User-type variations balanced.** 2-3 variants max; over-differentiation avoided.
+10. **Mobile parity.** Wizard works on the devices the audience uses.
+11. **Activation as success metric.** Not just completion rate; the metric is post-wizard product engagement.
+12. **Maintenance discipline.** Wizard updated alongside product changes; quarterly audit.
+
+The output of the framework is an onboarding wizard that gets users to the ah-ha moment, respects their time, and produces activation rates the team can defend.
+
+---
+
+## Reference files
+
+- [`references/wizard-decision-criteria.md`](references/wizard-decision-criteria.md) - When wizards earn the build vs when contextual help suffices.
+- [`references/step-architecture-patterns.md`](references/step-architecture-patterns.md) - What belongs in each step. Sequence logic. Step coherence test.
+- [`references/ah-ha-moment-engineering.md`](references/ah-ha-moment-engineering.md) - Identifying the ah-ha moment; designing the wizard to converge on it.
+- [`references/progressive-disclosure-patterns.md`](references/progressive-disclosure-patterns.md) - Default-heavy, required-now-optional-later, expand-on-demand, branching patterns.
+- [`references/skip-and-resume-mechanics.md`](references/skip-and-resume-mechanics.md) - Skip patterns and resume patterns. The skip-friendly-empty failure.
+- [`references/drop-off-measurement-templates.md`](references/drop-off-measurement-templates.md) - Per-step instrumentation. Common drop-off patterns and remediation.
+- [`references/user-type-variation-patterns.md`](references/user-type-variation-patterns.md) - Admin vs end-user, technical vs non-technical, size-based branching.
+- [`references/wizard-anti-patterns.md`](references/wizard-anti-patterns.md) - The patterns that look like onboarding but degrade activation.
+- [`references/common-onboarding-failures.md`](references/common-onboarding-failures.md) - 9+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: wizards earn the user's first session
+
+The onboarding wizards that work as compounding assets are the ones that get the user to value within their first session. Not because the wizard had every feature explained. Not because the wizard was skipped quickly. Because the wizard engineered the ah-ha moment, respected the user's time, and surfaced the right thing at the right moment.
+
+That is the bar. Below the bar are tutorial-overload (everything upfront, nobody completes) and skip-friendly-empty (skip too prominent, nobody activates). Above the bar are earned-progressive-disclosure wizards where each step earns the user one step closer to value, skip is honest about consequences, and the activation metric reflects the wizard's actual job.
+
+The discipline is in the design choices. The decision to build a wizard at all, or defer to contextual help. The step architecture that converges on the ah-ha moment. The progressive disclosure that surfaces the right thing at the right moment. The skip mechanics that protect the user from an empty product. The drop-off instrumentation that informs ongoing improvement. The maintenance cadence that keeps the wizard in sync with the product it represents.
+
+When in doubt, ask: did the user reach the ah-ha moment in their first session, and did the wizard help or hinder that? If yes to the first and helped on the second, the wizard earned its build. If no to either, redesign.

--- a/skills/onboarding-wizard-design/references/ah-ha-moment-engineering.md
+++ b/skills/onboarding-wizard-design/references/ah-ha-moment-engineering.md
@@ -1,0 +1,167 @@
+# Ah-ha moment engineering
+
+Identifying the ah-ha moment; designing the wizard to converge on it. The single visible moment when the user feels "oh, this is what the product does for me."
+
+The wizard's job is not completion. It is engineering the ah-ha moment within the user's first session. Without an identifiable ah-ha moment, the wizard has nothing to engineer toward; the result is a sequence that completes without producing activation.
+
+---
+
+## The ah-ha principle
+
+The ah-ha moment is action-tied, single-shot, and visible. The user did something and saw the value the product promised. The wizard's structure should make that moment likely within the first session.
+
+**The win.** A new user finishes the wizard and immediately sees their first dashboard with their actual data, with a number that surprises them in a useful way. They get it.
+
+**The fail.** The user finishes the wizard with a tour of features but never sees the product produce something specifically for them. They completed the wizard; they did not activate.
+
+---
+
+## Identifying the ah-ha moment
+
+The hardest design step is also the most upstream.
+
+**Methods.**
+
+- **Customer research.** Interview activated users (those who returned and engaged) about the moment they felt the product clicked. Patterns emerge.
+- **Usage analysis.** Compare cohorts that activated vs cohorts that churned. What action did the activated cohort take that the churned cohort did not?
+- **Sales-call mining.** Sales conversations often surface the moment prospects say "now I get it." That moment, in-product, is the ah-ha moment.
+
+**Signals of a real ah-ha moment.**
+
+- It is action-tied (the user did something), not knowledge-tied (the user learned something).
+- It is single-shot (one specific moment), not a checklist of moments.
+- It is visible (the user saw the result), not internal (the user felt understanding).
+- It is honest (the user got real value), not contrived (a demo with fake data).
+
+If the team cannot articulate the ah-ha moment, that is the design problem to solve before building the wizard.
+
+---
+
+## Common ah-ha moment patterns
+
+By product type.
+
+**Analytics products.** First successful query against the user's actual data. Not a demo dataset; their data, their result.
+
+**Collaboration products.** First meaningful interaction with a teammate. A shared comment, a delegated task, a thread that produces a decision.
+
+**Content products.** First saved item the user returns to. The content was useful enough to revisit.
+
+**Tooling products.** First completed task that would have taken longer without the tool. The time savings is visible.
+
+**Marketplace products.** First successful match. Buyer found a seller; seller got a lead.
+
+**Configurator products.** First saved configuration. The user committed to a setup they want to see again.
+
+The ah-ha moment varies by product. The discipline (action-tied, single-shot, visible, honest) holds.
+
+---
+
+## Designing the wizard around the ah-ha moment
+
+The wizard's path should converge on the moment.
+
+**Step 1: identify the prerequisites.** What does the user need before the ah-ha moment can happen? Connect data, invite teammate, configure workspace. Those steps are mandatory.
+
+**Step 2: identify the path.** What sequence of actions leads to the moment? The wizard's steps mirror that sequence.
+
+**Step 3: identify the friction.** What can break the path? Missing inputs, ambiguous decisions, validation errors. The wizard should pre-empt or smooth those.
+
+**Step 4: place the ah-ha moment intentionally.** The moment should appear at step 3-5 of the wizard, not after a 10-step setup. Earlier is better; aim for the user's first session, ideally first 5-10 minutes.
+
+---
+
+## Time-to-value as design constraint
+
+The shorter the time to ah-ha, the higher the activation rate.
+
+**The benchmark.** First session ah-ha moment correlates with strong activation. Multi-session ah-ha (user has to come back) correlates with moderate activation. Multi-day ah-ha (user has to wait or work for it) correlates with poor activation.
+
+**The design implication.** If the ah-ha moment naturally takes hours or days (e.g., AI training, audit results), the wizard needs an interim ah-ha, something visible the user can see in their first session that signals the eventual ah-ha is coming.
+
+**Examples.**
+
+- AI product where training takes 24 hours: interim ah-ha is "see how your data looks; we will message you when training is done."
+- Audit product where results take 48 hours: interim ah-ha is "see what we are auditing; preview a partial result."
+
+The user's first session should produce something visible and meaningful, even if the full ah-ha comes later.
+
+---
+
+## The ah-ha moment for different audiences
+
+Different users may need different moments.
+
+**Admin vs end-user.** The admin's ah-ha moment may be configuration-related ("the workspace is set up, the team can use it"). The end-user's ah-ha moment is in-product engagement ("I did the thing I came to do"). Wizards may differentiate.
+
+**Technical vs non-technical.** Technical users often want depth (see the API work, see the integration succeed). Non-technical users want outcome (see the result, no API). Different ah-ha moments.
+
+**Solo vs team.** Solo users often want individual productivity. Team users want collaboration moments. The wizard's path may differ.
+
+The discipline. Identify the ah-ha moment per relevant audience segment. Wizards may branch based on segment.
+
+---
+
+## Anti-patterns in ah-ha moment design
+
+**Tutorial-as-ah-ha.** Treating "learned about the features" as activation. The user knows what the product does but has not seen it do something specifically for them. Knowledge-tied, not action-tied; not real activation.
+
+**Demo-as-ah-ha.** Showing a polished demo that does not use the user's data. The user sees what is possible but not what is true for them. Contrived; activation does not stick.
+
+**Multi-moment ah-ha.** Treating "see all features" as the moment. No single moment lands; the user feels they need to see everything before getting it.
+
+**Delayed ah-ha.** The ah-ha moment lands two sessions in. The user does not return for the second session.
+
+**Theoretical ah-ha.** "When users connect their data and run their first analysis, they will love it." Belief without evidence. Without research validating the moment, the wizard is built on theory.
+
+---
+
+## Measuring ah-ha moment effectiveness
+
+Activation rate is the metric. Completion rate is leading indicator at best.
+
+**Activation as the metric.** Define activation explicitly (e.g., user returned within 7 days and engaged with feature X). Track it.
+
+**Wizard completion as leading indicator.** Useful but insufficient. A high completion rate with low activation rate signals the wizard's ah-ha moment is wrong.
+
+**Time-to-activation.** Hours from signup to activation. Shorter correlates with retention.
+
+**Per-segment activation.** Different segments may have different activation rates. Surfaces audience-fit issues.
+
+---
+
+## Validating the ah-ha moment
+
+Once defined, validate.
+
+**Cohort analysis.** Compare cohorts that hit the moment vs cohorts that did not. Did hitting it correlate with retention? If not, the moment is wrong.
+
+**User research.** Interview users who hit the moment. Did they recognize it as the ah-ha moment, or just another step?
+
+**A/B testing.** Test wizard variations that converge on the moment vs variations that do not. Activation rate difference quantifies the moment's value.
+
+The discipline. The ah-ha moment is a hypothesis until validated. Treat it as such.
+
+---
+
+## Common ah-ha moment failures
+
+**No defined moment.** Wizard built without identifying the moment; result is decorative.
+
+**Wrong moment defined.** Moment defined based on intuition; cohort analysis shows it does not predict retention.
+
+**Moment too late.** Moment lands after multiple sessions; users do not return.
+
+**Moment requires too much work.** Moment is real but the user has to do significant setup; drop-off before the moment.
+
+**Moment varies wildly by segment.** Single-moment design fails for an audience with different needs.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The ah-ha principle. Methods for identifying the moment. Common patterns by product type. Designing the wizard around the moment. Time-to-value as design constraint. Audience-specific moments. Anti-patterns. Measurement. Validation. Common failures.
+
+## Implementation choices that stay internal
+
+Specific ah-ha moments for specific products. Specific cohort definitions. Specific research methodologies. The team's research capacity. These vary by team and product.

--- a/skills/onboarding-wizard-design/references/common-onboarding-failures.md
+++ b/skills/onboarding-wizard-design/references/common-onboarding-failures.md
@@ -1,0 +1,171 @@
+# Common onboarding failures
+
+9+ failure patterns with diagnoses and cures. The patterns that surface as "activation is low" or "users skip the wizard" or "we cannot tell if the wizard works."
+
+---
+
+## "Activation rate is low; completion rate is high."
+
+**The diagnosis.** Wizard completed but did not engineer the ah-ha moment. Audit what users did after completing.
+
+**The cure.** Redesign around the ah-ha moment (`references/ah-ha-moment-engineering.md`). Define activation explicitly; verify the wizard produces it; cut steps that do not contribute.
+
+---
+
+## "Skip rate is over 50 percent."
+
+**The diagnosis.** Either the wizard is not earning its time or skip is too prominent. Audit both.
+
+**The cure.** Audit step value (each step contribute to ah-ha?). Audit skip prominence (skip too easy?). Detail in `references/step-architecture-patterns.md` and `references/skip-and-resume-mechanics.md`.
+
+---
+
+## "Users complete the wizard then abandon the product within 24 hours."
+
+**The diagnosis.** Time-to-value too long; ah-ha moment not in first session.
+
+**The cure.** Move the ah-ha moment earlier. If the moment naturally takes longer, design an interim ah-ha for the first session.
+
+---
+
+## "Wizard works for new users; existing users hit broken steps."
+
+**The diagnosis.** Wizard not maintained alongside product; deprecated features still in flow.
+
+**The cure.** Maintenance discipline. Quarterly audit. Product changes trigger wizard updates as part of the change.
+
+---
+
+## "Different segments complete at very different rates."
+
+**The diagnosis.** Audience-fit varies; consider role-based or use-case-based branching.
+
+**The cure.** Differentiate by segment where the differentiation produces materially different paths. Detail in `references/user-type-variation-patterns.md`.
+
+---
+
+## "Mobile completion is half of desktop."
+
+**The diagnosis.** Mobile UX broken or compromised.
+
+**The cure.** Mobile-first design and testing. Test on actual devices.
+
+---
+
+## "We added more onboarding steps; activation went down."
+
+**The diagnosis.** Tutorial-overload pattern; more is not better.
+
+**The cure.** Cut steps that do not contribute to the ah-ha moment. Defer feature explanations to in-product tours.
+
+---
+
+## "Skip mechanics work but users do not return to complete setup."
+
+**The diagnosis.** Skip-and-defer not working; in-product prompts to return are missing or ignored.
+
+**The cure.** Audit prompt logic. Ensure prompts trigger at moments of relevance, with frequency limits, and route to the right setup flow.
+
+---
+
+## "Wizard analytics broke after the last release."
+
+**The diagnosis.** Instrumentation drift; track and refresh.
+
+**The cure.** Verify analytics after every release. Add a smoke test to the deployment process.
+
+---
+
+## "We A/B tested wizard length; conversion did not change."
+
+**The diagnosis.** Length alone may not be the issue. Could be step content, skip prominence, or the underlying ah-ha definition.
+
+**The cure.** Test variables that matter (skip prominence, ah-ha placement, step coherence). Length is one variable; isolate the right one.
+
+---
+
+## "Activation looks good; retention is poor."
+
+**The diagnosis.** Activation metric may be wrong. Users hit a moment that does not predict retention.
+
+**The cure.** Validate the ah-ha moment with cohort analysis. Did users who hit it actually retain? If not, the moment is wrong.
+
+---
+
+## "We cannot tell which step needs work."
+
+**The diagnosis.** Aggregate completion tracked but not per-step.
+
+**The cure.** Per-step instrumentation (`references/drop-off-measurement-templates.md`).
+
+---
+
+## "Wizard worked great at launch; activation has declined."
+
+**The diagnosis.** Decay. Audience shifted; product evolved; references stale.
+
+**The cure.** Quarterly audit. Update what has decayed.
+
+---
+
+## "Sales says the leads from signup are different than they used to be."
+
+**The diagnosis.** Audience composition shifted; the wizard's segmentation may be obsolete.
+
+**The cure.** Update branching or differentiation. Audit the audiences arriving and what they need.
+
+---
+
+## "We built a wizard; the team thinks the bot would have been better."
+
+**The diagnosis.** Possibly. Different products warrant different activation tools.
+
+**The cure.** Validate. If the bot would serve better, test or migrate. The wizard format is not always the right tool.
+
+---
+
+## "Power users complete the wizard then abandon."
+
+**The diagnosis.** Wizard does not respect power users' speed. They want to skip ahead.
+
+**The cure.** Add power-user paths. Skip should be available; advanced configuration should be findable post-wizard.
+
+---
+
+## "We localized the wizard; activation in some locales dropped."
+
+**The diagnosis.** Translation quality, cultural mismatch, or audience-fit specific to the locale.
+
+**The cure.** Audit translation. Audit cultural assumptions. Verify audience-fit per locale.
+
+---
+
+## "The wizard works on Chrome; it crashes on Safari mobile."
+
+**The diagnosis.** Browser/device-specific bugs.
+
+**The cure.** Cross-browser, cross-device testing.
+
+---
+
+## The pattern across failures
+
+Most onboarding wizard failures fall into one of three patterns.
+
+**Pattern 1: The wizard does not engineer the ah-ha moment.** Tutorial-overload, decoration steps, demo-as-ah-ha, late ah-ha. The fix is to redefine and converge on the moment.
+
+**Pattern 2: The wizard does not match the audience.** Skip-friendly-empty, validation-strict, mobile-broken, segment mismatch. The fix is matching the wizard to where the audience actually is.
+
+**Pattern 3: The wizard decays.** Stale references, broken steps, analytics drift. The fix is maintenance discipline.
+
+The metric pattern: wizard failures often look fine on completion alone. The signal is in activation, retention, drop-off per step. Programs that track only completion keep shipping the same patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (ah-ha, audience-fit, decay). The principle that completion alone is insufficient.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered and the lessons learned. Specific multi-metric dashboards. Specific cures. The team's audit and retirement processes. These vary by team.

--- a/skills/onboarding-wizard-design/references/drop-off-measurement-templates.md
+++ b/skills/onboarding-wizard-design/references/drop-off-measurement-templates.md
@@ -1,0 +1,230 @@
+# Drop-off measurement templates
+
+Per-step instrumentation. Common drop-off patterns and remediation. Without per-step tracking, drop-off remediation is guesswork.
+
+The metrics inform every other improvement. Set up tracking before the wizard launches.
+
+---
+
+## The instrumentation requirement
+
+Track step start, step completion, step abandonment for every step.
+
+**Minimum tracking.**
+
+- Wizard start (user landed on step 1).
+- Step start (user reached step N).
+- Step completion (user finished step N, advanced to step N+1).
+- Step abandonment (user left without completing).
+- Wizard completion (user finished all steps, reached end).
+- Skip events (per step where applicable).
+
+**Derived metrics.**
+
+- Step completion rate (users who reached step / users who completed it).
+- Step skip rate (users who reached step / users who skipped).
+- Funnel completion rate (started wizard / finished).
+- Time per step.
+
+Without this data, every diagnostic is theoretical.
+
+---
+
+## Common drop-off points
+
+Three patterns recur across onboarding wizards.
+
+**First-step drop-off.** User landed on the wizard, looked at it, left.
+
+Common causes.
+- Wizard length visible upfront and intimidating.
+- Value proposition unclear.
+- Audience expected no wizard.
+- Mobile UX broken.
+
+**Mid-wizard drop-off.** User abandoned mid-process.
+
+Common causes.
+- Specific step too demanding (high field count, sensitive question, ambiguous input).
+- Cumulative fatigue (wizard too long).
+- Friction at validation or backend processing.
+- Time pressure (user expected faster).
+
+**Late-step drop-off.** User completed most steps but abandoned near the end.
+
+Common causes.
+- Final step requires information the user does not have.
+- Wizard length felt longer than expected.
+- Submission anxiety (user does not know what happens after).
+
+---
+
+## Remediation patterns
+
+For each drop-off pattern.
+
+**First-step drop-off.**
+
+- Reduce visible upfront length (defer to multi-screen or progressive disclosure).
+- Clarify value ("This 5-step setup connects your data and shows your first insight").
+- Reduce step-1 cognitive load (start with the easiest step).
+- Test mobile experience.
+
+**Mid-wizard drop-off.**
+
+- Audit the high-drop step. Is it too demanding? Sensitive? Ambiguous?
+- Reduce field count or split into multiple smaller steps.
+- Add progress indicator if missing.
+- Add reassurance copy if the step is sensitive.
+- Reword ambiguous fields.
+
+**Late-step drop-off.**
+
+- Reduce final-step requirements (move some fields earlier).
+- Add post-submission preview ("After this, we'll set up your dashboard").
+- Add explicit confirmation step before submission.
+
+---
+
+## Drop-off and skip distinction
+
+Skip is intentional; drop-off is involuntary. Track them separately.
+
+**Skip metrics.**
+
+- Skip rate per step (users who reached step / users who skipped).
+- Resume rate per skip (users who skipped step / users who returned to complete).
+- Activation rate per skip (users who skipped specific steps and still activated).
+
+**Drop-off metrics.**
+
+- Abandonment rate per step (users who reached step / users who left without completing or skipping).
+- Time-to-abandonment.
+- Re-engagement rate (users who came back to retry the wizard).
+
+**The diagnostic value.** Skip suggests the user does not value this step right now. Drop-off suggests the wizard failed to engage the user.
+
+---
+
+## Tracking conditional paths
+
+Wizards with branching logic have multiple paths.
+
+**Per-path tracking.**
+
+- Tag each user's path through the wizard.
+- Measure completion rate per path.
+- Identify paths that drop off disproportionately.
+
+**Path-specific remediation.** A path that drops off at step 4 may need step-4 redesign for users on that path. Other paths may not need attention.
+
+---
+
+## Drop-off and audience segmentation
+
+Different audiences may drop off at different points.
+
+**Segment-level tracking.**
+
+- Tag users by source, device, role, or other relevant segment.
+- Measure drop-off per segment.
+- Identify segment-specific issues.
+
+**Common segment patterns.**
+
+- Mobile users drop off more on long steps.
+- Paid-traffic users drop off earlier than organic.
+- New users drop off more than returning visitors.
+
+**Remediation by segment.** Sometimes the right answer is segment-specific (e.g., shorter wizard variant for mobile).
+
+---
+
+## Time-to-completion tracking
+
+How long the wizard takes.
+
+**Total time distribution.** Plot the time-to-complete distribution. Median, p25, p75, p95.
+
+**Per-step time.** Which steps take longest? Are they earning the time?
+
+**Patterns.**
+
+- Wizards taking more than 10 minutes typically see significant drop-off.
+- Steps taking more than 2 minutes typically see step-level drop-off.
+- Long-tail completers (p95) often signal usability issues.
+
+**Remediation by time.** Wizards or steps taking too long should be split or simplified.
+
+---
+
+## A/B testing wizards
+
+Test changes rigorously.
+
+**Test design.** Hypothesize the cause of drop-off; design a treatment; A/B test treatment vs control; measure both step-level drop-off and overall activation.
+
+**Common test types.**
+
+- Wizard length (shorter vs longer).
+- Step ordering (different sequences).
+- Field count per step.
+- Skip prominence.
+- Help text presence/absence.
+- Default-heavy vs required-now-optional-later.
+
+**Test discipline.** One variable at a time. Long enough to capture activation signal. Measure both wizard metrics and downstream activation.
+
+---
+
+## When drop-off is signal, not failure
+
+Some drop-off is healthy.
+
+**The signal.** Wrong audience self-selecting out. A wizard that filters out audiences who would not activate anyway is doing its job.
+
+**The discipline.** Distinguish drop-off from unfit audience (good) from drop-off from fit audience (bad). The downstream activation metric reveals which.
+
+The decision. Optimize for completed-by-fit-audience, not for raw completion rate.
+
+---
+
+## Wizard analytics dashboard
+
+What to surface.
+
+**Per-step funnel.** Start rate, completion rate, drop-off rate per step.
+
+**Skip rates per step.** Where skip is enabled.
+
+**Time-to-completion distribution.** With percentile breakdown.
+
+**Activation rate per cohort.** Wizard completers vs non-completers; activation by skip pattern.
+
+**Trend over time.** Have the metrics changed since the last release?
+
+---
+
+## Common analytics failures
+
+**No instrumentation.** Wizard launched without tracking; quality is invisible.
+
+**Aggregate-only tracking.** Wizard completion tracked but not per-step; remediation requires guesswork.
+
+**Instrumentation drift.** Tracking implemented at launch; field renames or step changes broke the tracking.
+
+**Skip and drop-off conflated.** Cannot distinguish intentional skip from involuntary drop-off.
+
+**Activation not tracked.** Wizard metrics in isolation; cannot tell if completion correlates with activation.
+
+**No segment-level data.** Aggregate hides segment-specific issues.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The instrumentation requirement. Common drop-off points and causes. Remediation patterns. Drop-off vs skip distinction. Tracking conditional paths. Per-segment analytics. Time-to-completion. A/B testing. When drop-off is signal. Dashboard composition. Common failures.
+
+## Implementation choices that stay internal
+
+Specific dashboards for specific wizards. Specific tooling. Specific A/B test designs. The team's audit calendar. These vary by team and product.

--- a/skills/onboarding-wizard-design/references/progressive-disclosure-patterns.md
+++ b/skills/onboarding-wizard-design/references/progressive-disclosure-patterns.md
@@ -1,0 +1,238 @@
+# Progressive disclosure patterns
+
+Default-heavy, required-now-optional-later, expand-on-demand, branching patterns. How to surface only what is needed at each step.
+
+The principle. Show only the inputs, options, and information the user needs to complete the current step. Defer everything else to in-product help or later configuration.
+
+Wizards that try to show everything become tutorial-overload. Wizards that defer everything become skip-friendly-empty. Progressive disclosure is the discipline that surfaces what matters when it matters.
+
+---
+
+## Pattern A: Default-heavy
+
+Each step has smart defaults; the user can accept or override.
+
+**How it works.**
+
+- Inputs come pre-filled with sensible defaults.
+- The user reviews; accepts most; overrides where their context differs.
+- Most users move through quickly; advanced users find the override controls.
+
+**Strengths.**
+
+- Reduces cognitive load.
+- Faster completion.
+- Users without strong preferences proceed; users with strong preferences customize.
+
+**Weaknesses.**
+
+- Defaults must be honest. Bias-flattering defaults erode trust.
+- Defaults need maintenance as the product evolves.
+
+**When to use.** Default for most wizards. Smart defaults reduce friction without removing customization.
+
+---
+
+## Pattern B: Required-now, optional-later
+
+Required fields surface in the wizard; optional configuration surfaces in-product after activation.
+
+**How it works.**
+
+- Each step has only required fields.
+- Optional configuration appears as in-product prompts after the wizard.
+- The wizard stays focused on minimum-viable activation.
+
+**Strengths.**
+
+- Shortest possible wizard.
+- Optional configuration happens when the user has product context.
+- Activation rate improves; configuration completeness rises.
+
+**Weaknesses.**
+
+- Requires in-product prompt infrastructure for the deferred configuration.
+- Some users may never return to complete deferred setup.
+
+**When to use.** When the wizard has accumulated optional fields that bloat completion time. The strongest pattern for trimming bloated wizards.
+
+---
+
+## Pattern C: Expand-on-demand
+
+Sections collapsed by default; the user expands if interested.
+
+**How it works.**
+
+- Step shows the minimal interface.
+- An "advanced options" or "more details" toggle expands additional fields.
+- Most users skip; advanced users explore.
+
+**Strengths.**
+
+- Surfaces depth without forcing it.
+- Power users get what they need.
+
+**Weaknesses.**
+
+- Risk of hiding important fields the user does not realize they need.
+- Adds visual complexity to the step.
+
+**When to use.** When some users genuinely need depth that most do not. Use sparingly; default-heavy plus required-now-optional-later usually serves better.
+
+---
+
+## Pattern D: Branching
+
+Different users see different steps based on earlier answers.
+
+**How it works.**
+
+- Step 1 asks about role, use case, or context.
+- Subsequent steps adapt based on the answer.
+- Different users effectively complete different wizards.
+
+**Strengths.**
+
+- Each user sees only steps that apply to them.
+- Wizard feels personalized.
+
+**Weaknesses.**
+
+- Significant maintenance complexity.
+- Testing burden grows (more paths).
+- Analytics must accommodate variable paths.
+
+**When to use.** When the audience genuinely splits into segments with materially different needs. 2-3 branches max; more becomes unmaintainable.
+
+---
+
+## Pattern E: Hybrid
+
+Combining patterns. Default-heavy plus required-now-optional-later plus a single branch for major audience split.
+
+**Strengths.**
+
+- Reduces friction at multiple levels.
+- Different users benefit from different mechanisms.
+
+**Weaknesses.**
+
+- Design and maintenance complexity.
+
+**When to use.** When the wizard's audience and content warrant the combination. Most production wizards land in some hybrid configuration.
+
+---
+
+## What to surface vs defer
+
+The decision per field.
+
+**Surface in the wizard.**
+
+- Fields without which the product cannot work for the user.
+- Fields that affect the ah-ha moment.
+- Fields that branch downstream steps.
+- Fields that personalize the immediate experience.
+
+**Defer to in-product.**
+
+- Fields that affect long-term configuration but not immediate value.
+- Fields that benefit from product context (the user understands what they are configuring).
+- Fields that are commonly skipped anyway; surface them at moments of relevance.
+
+**The deferable test.** For each wizard field, ask: would the user be better served setting this up after seeing the product, with relevant context? If yes, defer.
+
+---
+
+## Default discipline
+
+Defaults are powerful. They must be honest.
+
+**Honest defaults.**
+
+- Defaults reflect the typical case for the audience.
+- Defaults are sourced (from cohort data, common practice, or team judgment).
+- Defaults can be overridden visibly.
+
+**Bias-flattering defaults.**
+
+- Defaults set to produce favorable signup metrics (cheap plan pre-selected, opt-in checked) without disclosure.
+- Defaults that misrepresent the user's real choice.
+- Defaults that change over time without user notice.
+
+The discipline. Defaults reduce friction; they should not extract data or commitment the user did not consent to.
+
+---
+
+## Information density per step
+
+How much to show.
+
+**Minimal density.** Just the required fields plus a sentence of context. Shortest, fastest.
+
+**Moderate density.** Required fields plus brief explanation plus optional toggle. Balanced.
+
+**Heavy density.** Multiple sections, expandables, detailed help text. Most cognitive load.
+
+The right density depends on the audience and the step's complexity. Default to minimal; add density only when the step's complexity warrants it.
+
+---
+
+## Help text discipline
+
+When to include explanatory text.
+
+**Strong help patterns.**
+
+- Inline tooltip on non-obvious fields.
+- One-sentence explanation per step ("we use this to tailor your dashboard").
+- Examples for fields where the format is ambiguous.
+
+**Weak help patterns.**
+
+- Long help text on every field.
+- Help text that is marketing rather than explanation.
+- Help text that explains things the user already knows.
+
+The discipline. Help text earns its inclusion when it reduces friction. Help text for the sake of completeness adds clutter.
+
+---
+
+## Mobile considerations
+
+Progressive disclosure on mobile.
+
+**Mobile-first defaults.** Default values matter more on mobile because typing is harder.
+
+**Single question per screen.** Mobile screens are small; multi-field steps cramp.
+
+**Touch-friendly toggles.** Expand/collapse must be touch-targetable.
+
+**Minimal help text.** Mobile users skim; long help text is dismissed.
+
+---
+
+## Common progressive disclosure failures
+
+**No defaults.** Every field blank; the user does work the wizard could have done.
+
+**Bias-flattering defaults.** Defaults extract commitment the user did not consent to.
+
+**Over-disclosed.** Every field surfaced; tutorial-overload.
+
+**Under-disclosed.** Important fields hidden; the user finishes the wizard with a misconfigured product.
+
+**Branching without need.** Branches that do not produce materially different paths add complexity without benefit.
+
+**Help text bloat.** Every field has a paragraph of explanation; cognitive load climbs.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five patterns (default-heavy, required-now-optional-later, expand-on-demand, branching, hybrid). Strengths, weaknesses, when-to-use guidance. What to surface vs defer. Default discipline. Information density. Help text discipline. Mobile considerations. Common failures.
+
+## Implementation choices that stay internal
+
+Specific defaults for specific wizards. Specific help copy in brand voice. Specific tooling for progressive disclosure. The team's audit calendar. These vary by team and product.

--- a/skills/onboarding-wizard-design/references/skip-and-resume-mechanics.md
+++ b/skills/onboarding-wizard-design/references/skip-and-resume-mechanics.md
@@ -1,0 +1,205 @@
+# Skip and resume mechanics
+
+Skip patterns and resume patterns. The skip-friendly-empty failure. Honest skip, honest resume.
+
+When users skip, where they land. When they resume, what they see. Skip mechanics done well let users escape without abandoning; done poorly, they produce skip-friendly-empty wizards where users skip into a useless product and churn.
+
+---
+
+## The skip principle
+
+Skip should never produce an empty product. If skipping is offered, the user must land in a state where they can still progress; the wizard's deferred steps must be retrievable.
+
+**The win.** A user clicks "Skip for now" on a setup step. The product places them in a partially-configured state with a clear callout: "Your workspace needs a connected data source to show insights. Set it up here when you're ready." The user understands; engages later.
+
+**The fail (skip-friendly-empty).** A user clicks "Skip" on every step. The product places them in an empty state with no context; the user does not know what to do; they leave and never return.
+
+The discipline. Skip exists, but skip is consequence-honest and recoverable.
+
+---
+
+## Skip patterns
+
+Common patterns for offering skip.
+
+**Pattern A: Soft skip with context.**
+
+How it works. The skip option is available but explains what gets deferred. "Skip for now; we will remind you to connect your data source later."
+
+When to use. Most wizards. Honest about the consequence; provides a path back.
+
+**Pattern B: Skip-and-defer.**
+
+How it works. Skipped steps are queued for later in-product prompts. The wizard does not require completion; the prompts handle re-engagement.
+
+When to use. When the wizard would otherwise be too long; defer everything that can be deferred.
+
+**Pattern C: Skip-with-warning.**
+
+How it works. Skipping triggers an honest warning. "Skipping setup means you won't see [X] until you complete it. Continue?"
+
+When to use. When skipping has real consequences the user should know about. Use sparingly; warnings on every step desensitize.
+
+**Pattern D: No skip.**
+
+How it works. The step must be completed. No skip option.
+
+When to use. For wizards that absolutely require completion (compliance forms, paid signups, regulatory required steps). Use sparingly; users who cannot skip and cannot complete leave instead.
+
+---
+
+## Skip prominence
+
+How visible the skip option is.
+
+**Equal prominence.** Skip and continue have similar visual weight. Honest about both options. Most common.
+
+**Continue-prominent.** Continue is the visual primary; skip is a secondary link. Encourages completion without forbidding skip.
+
+**Skip-prominent.** Skip is more visible than continue. Almost never the right choice; produces skip-friendly-empty.
+
+**Hidden skip.** Skip exists but is hidden behind a "more options" toggle. Discouraged; users cannot find escape if they need it.
+
+The discipline. Continue-prominent for important steps; equal prominence for most steps; never skip-prominent.
+
+---
+
+## Skip-friendly-empty: the failure mode
+
+The pattern where skip is too prominent and consequence-free.
+
+**The pattern.** Every step has a "Skip" button as prominent as "Continue." Skip is consequence-free; users skip every step.
+
+**The result.** Users land in an empty product; they have no context; they leave.
+
+**The cost.** Activation rate falls off a cliff. The wizard's design effort produces an experience nobody actually completes.
+
+**The cure.** Rebalance skip prominence. Make consequences visible. Add resume mechanics so skipped steps can be completed later.
+
+---
+
+## Resume patterns
+
+Where users land when they return.
+
+**Auto-resume on next login.**
+
+How it works. The user returns; the wizard automatically lands at the step they left.
+
+When to use. When wizard completion is genuinely required for product use.
+
+**Manual resume from in-product entry.**
+
+How it works. A persistent "Complete setup" surface in-product returns the user to the wizard.
+
+When to use. When the wizard is recommended but not required; users can engage with the product partially.
+
+**Soft resume.**
+
+How it works. The wizard fades out as the user completes equivalent actions in-product naturally. No explicit re-entry needed.
+
+When to use. When the in-product experience surfaces equivalent prompts; the wizard becomes redundant.
+
+**No resume.**
+
+How it works. Skipped steps are skipped permanently; the wizard runs once.
+
+When to use. Rarely. Most wizards benefit from some resume mechanism.
+
+---
+
+## Skip-and-defer in-product prompt design
+
+The prompts that bring users back.
+
+**Trigger logic.** Prompts trigger based on user behavior, time elapsed, or context. "You have not connected a data source yet; here is how" appears when the user attempts to use a feature requiring data.
+
+**Frequency limits.** Prompts should not nag. One reminder per session is often enough; some prompts should appear once and dismiss permanently.
+
+**Dismiss mechanics.** "Don't show this again" is honest. Hidden dismiss options are hostile.
+
+**Completion routing.** When the user accepts the prompt, route to the right setup flow (often shorter than the original wizard step).
+
+---
+
+## Skip mechanics by step type
+
+Different steps warrant different skip treatment.
+
+**Critical setup steps (without which the product cannot work).** Skip should be possible but consequence-warned. Resume mechanics aggressive.
+
+**Optional configuration steps.** Skip easy and consequence-free; resume mechanics gentle.
+
+**Identity/personalization steps.** Skip easy; the product can default; resume not necessary.
+
+**Marketing/data-collection steps.** Skip easy; the product does not need this; resume rarely warranted (skip is a clean signal of opt-out).
+
+The discipline. Skip prominence and resume aggressiveness should match the step's importance.
+
+---
+
+## Resume measurement
+
+Track resume effectiveness.
+
+**Skip rate per step.** What percentage of users skip each step?
+
+**Resume rate per step.** What percentage of users who skipped a step later return to complete it?
+
+**Activation rate per skip pattern.** Do users who skipped step X activate at lower rates?
+
+**Diagnostic uses.**
+
+- High skip + low resume: wizard losing users who never come back. Audit consequences.
+- High skip + high resume: skip-and-defer working. The wizard is producing graceful escapes.
+- Low skip overall: wizard is engaging users; check completion and activation as next metrics.
+
+---
+
+## Resume copy discipline
+
+What the resume prompt says.
+
+**Helpful resume copy.**
+
+- "Connect your data source to see insights. It takes 2 minutes."
+- "You skipped inviting teammates earlier. Want to do that now?"
+- "Almost done. Two steps left to finish setup."
+
+**Unhelpful resume copy.**
+
+- "You did not finish onboarding."
+- "Complete setup."
+- "You missed steps."
+
+The voice discipline. Resume copy should be helpful, not scolding. The user did not fail; they deferred.
+
+---
+
+## Common skip-and-resume failures
+
+**Skip too prominent.** Users skip everything; activation collapses.
+
+**No skip option.** Users who need to escape leave entirely.
+
+**Hidden skip.** Users cannot find escape; frustration builds; they leave.
+
+**No resume mechanism.** Skipped users never return to complete; configuration stays incomplete.
+
+**Aggressive resume prompts.** Prompts every session; users dismiss permanently.
+
+**Resume routes to wrong place.** User accepts prompt; lands in unrelated flow.
+
+**Resume copy scolds.** User feels punished for skipping; trust degrades.
+
+**Skip without consequence-disclosure.** Users skip not knowing what they will miss; abandon when they discover.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The skip principle. Skip patterns (4 patterns). Skip prominence guidance. The skip-friendly-empty failure. Resume patterns (4 patterns). Skip-and-defer prompt design. Skip mechanics by step type. Resume measurement. Resume copy discipline. Common failures.
+
+## Implementation choices that stay internal
+
+Specific skip and resume implementations for specific wizards. Specific prompt copy in brand voice. Specific tooling for resume infrastructure. The team's resume measurement baselines. These vary by team and product.

--- a/skills/onboarding-wizard-design/references/step-architecture-patterns.md
+++ b/skills/onboarding-wizard-design/references/step-architecture-patterns.md
@@ -1,0 +1,225 @@
+# Step architecture patterns
+
+What belongs in each step. Sequence logic. The step coherence test.
+
+The architecture is the structure that makes wizards work. Bad architecture produces decorative steps that do not move the user closer to value; good architecture converges on the ah-ha moment with discipline.
+
+---
+
+## The convergence principle
+
+Each step should move the user one step closer to value. Steps that do not should be cut.
+
+**The test.** For each step, ask: did this step move the user toward the ah-ha moment? If no, cut it or defer it to in-product help.
+
+**The discipline.** Wizards accumulate steps over time as teams add "while we have them" requests (collect more data, surface more features, etc.). The discipline is to resist accumulation; the wizard's job is convergence, not feature pride.
+
+---
+
+## Common step patterns
+
+Patterns that recur across product onboarding wizards.
+
+**Welcome and orientation.**
+
+- Purpose: set expectations for what the wizard will do.
+- Skippable: usually yes, low cost.
+- When to include: when the wizard's purpose is not obvious from context.
+- When to skip: when the wizard's purpose is obvious; welcome adds friction without value.
+
+**Identity and account context.**
+
+- Purpose: capture who the user is, what brought them here.
+- Required fields: minimal. Name and role are often enough.
+- When to include: when subsequent steps adapt to identity.
+- When to skip: when subsequent steps do not adapt; identity capture is just data collection.
+
+**Critical setup step.**
+
+- Purpose: the one thing the product cannot work without.
+- Examples: connect data source, invite first teammate, set primary use case.
+- This is often where wizards justify their existence. Without this step, the user lands in an empty product.
+
+**First-action step.**
+
+- Purpose: get the user to take a meaningful action that produces visible result.
+- The ah-ha moment lives here or right after.
+- Should be guided enough that success is likely; honest enough that the success is real.
+
+**Configuration deferral.**
+
+- Purpose: surface things that can be set up later but are commonly needed.
+- Lets the user defer with a clear path back.
+- Reduces wizard length without losing coverage.
+
+**Confirmation and next steps.**
+
+- Purpose: recap what was set up; surface what to do next; route to in-product home.
+- Closes the wizard cleanly.
+- Often skipped in design but useful for orientation.
+
+---
+
+## Step sequencing principles
+
+The order matters as much as the steps themselves.
+
+**Principle 1: Earn the patience.** Open with low-friction steps; the user invests; deeper setup follows. Critical setup demanding effort works better at step 2-3 than step 1.
+
+**Principle 2: Ah-ha moment by step 3-5.** If the wizard runs longer than 5 steps before any visible value, drop-off climbs sharply.
+
+**Principle 3: Deferable last.** Steps that can be deferred should sit late in the wizard, where skip is least costly.
+
+**Principle 4: Confirmation explicit.** Close the wizard with a clear "you are done; here is what's next" step. Without it, users feel dropped.
+
+---
+
+## Step coherence test
+
+For each step, can it be described in one sentence as a unit of work that contributes to the ah-ha moment?
+
+**Coherent steps.**
+
+- Step 1: tell us about your role so we can tailor what comes next.
+- Step 2: connect your data source so we can show you something useful.
+- Step 3: run your first query and see a result.
+- Step 4: save the result so you can return to it.
+- Step 5: optionally invite a teammate; otherwise, you are ready.
+
+Each step has clear purpose tied to value.
+
+**Incoherent steps.**
+
+- Step 1: name and email (already collected at signup; redundant).
+- Step 2: tour of features (does not move toward action).
+- Step 3: branding preferences (irrelevant to ah-ha moment).
+- Step 4: marketing opt-in (data collection, not value).
+
+Steps without clear purpose should be cut or deferred.
+
+---
+
+## Step count discipline
+
+How many steps is too many.
+
+**Sweet spot.** Most effective wizards run 3-7 steps. The user can predict completion time; the convergence is tight.
+
+**Too few.** 1-2 steps usually means the wizard format is overkill; contextual prompts often serve better.
+
+**Too many.** 10+ steps signals tutorial-overload. Drop-off climbs sharply; users skip when they can.
+
+**The deferable test.** For wizards exceeding 7 steps, audit each step. Which can be deferred to in-product? Often half can.
+
+---
+
+## Field count per step
+
+Within each step, how many fields.
+
+**3-5 fields per step.** Sweet spot. Coherent unit; completable in 30-60 seconds.
+
+**1-2 fields per step.** Often signals over-staging. The user wonders why the field needed its own step.
+
+**6+ fields per step.** Recreates the kitchen-sink problem within a step. Audit; usually some fields can be cut or deferred.
+
+---
+
+## Branching and conditional steps
+
+When wizards adapt based on earlier answers.
+
+**The pattern.** First step asks about role or use case; subsequent steps adapt.
+
+**Strengths.** The wizard feels relevant; users see only what applies to them.
+
+**Weaknesses.** Maintenance complexity; testing across paths.
+
+**The discipline.** Branch only when the variability genuinely benefits the user. Decorative branching adds cost without lift.
+
+---
+
+## Step transitions
+
+How the user moves between steps.
+
+**Forward transitions.** Clear "Next" or "Continue" CTA. Validation runs before the transition. Snappy; no loading delays.
+
+**Back transitions.** "Back" or "Previous" available. Returning to earlier steps preserves answers.
+
+**Skip transitions.** Skip available but honest about consequences. Skip lands the user in a partially-set-up state with clear callouts to complete deferred setup.
+
+**Loading state.** When the wizard's step requires backend work (connecting data source, processing input), show progress. Silent loading kills momentum.
+
+---
+
+## Step examples by product type
+
+How architecture varies by product.
+
+**B2B SaaS analytics.**
+
+- Welcome → role/use case → connect data source → first query → first saved view → invite team (deferable) → in-product home.
+
+7 steps; meaningful staging; ah-ha at step 5.
+
+**Project management tool.**
+
+- Welcome → workspace setup → first project → first task → invite team → in-product home.
+
+6 steps; ah-ha around step 4.
+
+**Marketing automation.**
+
+- Welcome → connect site → connect data source → first audience → first campaign → in-product home.
+
+6 steps; ah-ha at first audience visualization.
+
+**Consumer note-taking.**
+
+- Probably no wizard. Empty-state prompts and contextual hints serve better.
+
+The patterns vary. The discipline (each step earns its place; ah-ha moment by step 3-5) holds.
+
+---
+
+## Step architecture maintenance
+
+Steps decay. Product changes mean wizard updates.
+
+**Maintenance triggers.**
+
+- Product feature added that the wizard should reference.
+- Product feature deprecated that the wizard still references.
+- Setup process changed; wizard steps no longer match.
+- Audience composition shifted; old role-branching no longer fits.
+
+**Maintenance cadence.** Quarterly review minimum; product changes trigger updates as part of the change.
+
+---
+
+## Common architecture failures
+
+**Decorative steps.** Steps that do not move toward value.
+
+**Tutorial steps.** Steps explaining features the user has not asked about.
+
+**Front-loaded effort.** High-friction step first; users abandon at step 1.
+
+**Late ah-ha moment.** Wizard runs 10 steps before visible value.
+
+**Mandatory steps that should be deferable.** Forces friction users would have accepted later.
+
+**No confirmation step.** User finishes the wizard, lands somewhere unclear.
+
+**Step transitions sluggish.** Loading delays kill momentum.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The convergence principle. Common step patterns. Sequencing principles. The step coherence test. Step count discipline. Field count per step. Branching considerations. Step transitions. Step examples by product type. Maintenance discipline. Common failures.
+
+## Implementation choices that stay internal
+
+Specific step architectures for specific products. Specific copy and tone. Specific tooling. Specific testing protocols. The team's audit calendar. These vary by team and product.

--- a/skills/onboarding-wizard-design/references/user-type-variation-patterns.md
+++ b/skills/onboarding-wizard-design/references/user-type-variation-patterns.md
@@ -1,0 +1,199 @@
+# User type variation patterns
+
+Admin vs end-user, technical vs non-technical, size-based branching. When one wizard does not serve all users.
+
+Different users may need different wizards. The discipline is to differentiate where the audience genuinely splits, without producing unmaintainable proliferation.
+
+---
+
+## The differentiation principle
+
+Differentiate where the audience genuinely splits into segments with materially different needs, language, or paths. Do not differentiate where one wizard serves all.
+
+**The win.** Admins set up the workspace; end-users start using it. A single wizard tries to serve both and fails both. Differentiated wizards serve each meaningfully.
+
+**The fail.** A team builds 5 wizard variants for 5 imagined personas. Maintenance burden compounds; the variants diverge over time; no variant is excellent.
+
+The discipline. Start with one wizard. Differentiate only when data shows segments with different needs and the differentiation produces meaningfully different paths.
+
+---
+
+## Common differentiation axes
+
+Three axes recur.
+
+**Admin vs end-user.**
+
+- Admins set up the workspace, invite teammates, configure integrations.
+- End-users start using what admins set up.
+- Their first sessions look different; the ah-ha moments differ.
+
+**Technical vs non-technical.**
+
+- Technical users want depth (see the API, see the integration succeed, configure deeply).
+- Non-technical users want outcome (see the result, no API).
+- Tone, content, and step coverage differ.
+
+**Size of team.**
+
+- Solo founders configure for one.
+- Small teams configure for collaboration.
+- Enterprise teams have additional setup (SSO, governance, compliance).
+
+---
+
+## Differentiation patterns
+
+How to implement.
+
+**Pattern A: Role-based branching.**
+
+How it works. First step asks role; subsequent steps adapt.
+
+When to use. When the role split is clear and produces different paths.
+
+**Pattern B: Use-case-based branching.**
+
+How it works. First step asks use case; wizard tailors to that use case.
+
+When to use. When the product serves multiple use cases that warrant different ah-ha moments.
+
+**Pattern C: Size-based branching.**
+
+How it works. First step asks team size; solo, team, enterprise paths differ.
+
+When to use. When the product has materially different setups for different scales.
+
+**Pattern D: Inferred branching.**
+
+How it works. Wizard uses signals (signup source, email domain, prior interaction) to infer the segment without asking.
+
+When to use. When asking would feel intrusive but the inference is reliable.
+
+**Pattern E: No branching.**
+
+How it works. Single wizard for all.
+
+When to use. Most products. Branching adds maintenance; only branch when the value is clear.
+
+---
+
+## Admin vs end-user wizard design
+
+How they differ.
+
+**Admin wizard.**
+
+- Setup-heavy. Connect data, invite team, configure permissions.
+- Ah-ha moment: "the workspace is ready; my team can use it."
+- Often longer; admins accept guided setup.
+
+**End-user wizard.**
+
+- Action-light. Find the feature, take the first action, see the result.
+- Ah-ha moment: "I did the thing I came to do."
+- Often shorter; end-users want to start using.
+
+**Cross-talk.** Admins sometimes also become end-users in single-person teams. The wizard may need to detect and serve both modes.
+
+---
+
+## Technical vs non-technical wizard design
+
+How they differ.
+
+**Technical wizard.**
+
+- API depth visible (configuration shown, integration tested).
+- Tone: precise, terse, references documentation.
+- Ah-ha moment: "the integration works; my data is flowing."
+
+**Non-technical wizard.**
+
+- Outcome visible (result shown, no API exposed).
+- Tone: warm, supportive, hides technical complexity.
+- Ah-ha moment: "I see the result the product promised."
+
+**Cross-talk.** Some users are technical for some products and not for others. The wizard may infer rather than ask.
+
+---
+
+## Size-based wizard design
+
+How they differ.
+
+**Solo founder wizard.**
+
+- Single-user setup.
+- Skip team-related steps.
+- Ah-ha moment: individual productivity.
+
+**Small team wizard.**
+
+- Collaboration setup highlighted.
+- Invite-team step prominent.
+- Ah-ha moment: team coordination.
+
+**Enterprise wizard.**
+
+- SSO, governance, compliance setup.
+- Often involves admin handoff to IT or security.
+- Ah-ha moment: deployment-ready configuration.
+
+---
+
+## When to combine vs separate
+
+Designing the matrix.
+
+**Combine when:**
+
+- The differentiation is small (1-2 different steps).
+- Maintenance burden is the bigger concern.
+- The audiences overlap significantly.
+
+**Separate when:**
+
+- The paths differ in 3+ steps.
+- Tone and language differ significantly.
+- Audience-fit is critical (B2B SaaS where different roles experience the product very differently).
+
+**The 2-3 variants max rule.** More than 3 wizard variants becomes unmaintainable. If 4+ variants seem necessary, reconsider whether the segmentation is too granular or whether different wizards should be different products.
+
+---
+
+## Differentiation testing
+
+Verify the differentiation works.
+
+**Cohort comparison.** Compare activation rates across variants. Did differentiation help?
+
+**Per-segment satisfaction.** Survey users post-wizard. Does each segment feel served?
+
+**Drop-off per variant.** Are some variants dropping off more than others? Which steps?
+
+The data informs whether the differentiation earned its complexity.
+
+---
+
+## Common differentiation failures
+
+**Over-differentiation.** Too many variants; maintenance burden; no variant is excellent.
+
+**Under-differentiation.** One wizard for distinct audiences; everyone feels poorly served.
+
+**Wrong axis.** Differentiated by an axis that does not predict need (e.g., gender when role would have been the right split).
+
+**Inferred wrongly.** Inference logic mistakes audience; users see wrong wizard.
+
+**Stale differentiation.** Audience composition shifted; old branching no longer fits.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The differentiation principle. Common differentiation axes. Patterns A through E. Admin vs end-user design. Technical vs non-technical design. Size-based design. Combine-vs-separate decision. Differentiation testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific wizard variants for specific products. Specific copy per variant in brand voice. Specific inference logic. The team's variant maintenance calendars. These vary by team and product.

--- a/skills/onboarding-wizard-design/references/wizard-anti-patterns.md
+++ b/skills/onboarding-wizard-design/references/wizard-anti-patterns.md
@@ -1,0 +1,212 @@
+# Wizard anti-patterns
+
+The patterns that look like onboarding but degrade activation. Anti-patterns are easy to ship; the cost shows up in activation rate, retention, and brand reputation over time.
+
+---
+
+## The tutorial-overload wizard
+
+The pattern. Every feature explained in a 12-step intro before the user has touched the product.
+
+The signal. High skip rate; users abandon mid-wizard; activation rate poor.
+
+The cost. Design effort produces a sequence almost nobody completes. Users who do complete have not seen value; activation suffers.
+
+The cure. Prune steps to those that contribute to the ah-ha moment. Defer feature explanations to in-product tours and contextual help.
+
+---
+
+## The skip-friendly-empty wizard
+
+The pattern. "Skip onboarding" button at every step, so prominent that users always take it.
+
+The signal. Skip rate near 100 percent; users land in unconfigured product; activation rate falls.
+
+The cost. The product appears empty to users who skipped; they do not know what to do; they leave.
+
+The cure. Rebalance skip prominence. Add consequence-honest skip warnings. Add resume mechanisms so skipped steps come back as in-product prompts.
+
+---
+
+## The decoration-step wizard
+
+The pattern. Steps that exist for completeness or feature pride, not for value.
+
+The signal. Drop-off concentrates on specific steps users perceive as pointless; analytics shows steps users always skip.
+
+The cost. Wizard length without value; user perceives the wizard as bloated.
+
+The cure. Audit each step. Cut steps that do not contribute to the ah-ha moment.
+
+---
+
+## The tutorial-as-ah-ha wizard
+
+The pattern. Treating "learned about features" as activation. Wizard ends; user has seen a tour; team treats this as success.
+
+The signal. High completion rate, low retention. Users completed the wizard but did not engage afterward.
+
+The cost. The wizard's success metric is wrong. Real activation never happens.
+
+The cure. Define the ah-ha moment as action-tied. Redesign the wizard to converge on the moment.
+
+---
+
+## The demo-as-ah-ha wizard
+
+The pattern. The wizard ends with a polished demo using fake data.
+
+The signal. Users see what is possible; do not return because their actual data has not been touched.
+
+The cost. The wizard's value is contrived; activation does not stick because the value was hypothetical.
+
+The cure. Make the ah-ha moment real. Use the user's actual data.
+
+---
+
+## The over-branched wizard
+
+The pattern. 5 wizard variants for 5 imagined personas. Maintenance burden compounds.
+
+The signal. Variants diverge over time; some break; activation per variant is uneven.
+
+The cost. Maintenance overhead high; quality of any one variant degrades.
+
+The cure. Reduce variants to 2-3 max. Combine variants where the differentiation does not produce materially different paths.
+
+---
+
+## The under-branched wizard
+
+The pattern. One wizard for distinct audiences. Admins, end-users, technical, non-technical all see the same flow.
+
+The signal. Some segments activate well; others do not. Per-segment data shows the gap.
+
+The cost. The audiences underserved leave; the wizard's design effort produces good outcomes for one segment and bad for others.
+
+The cure. Differentiate where the audience genuinely splits.
+
+---
+
+## The hidden-skip wizard
+
+The pattern. Skip exists but is hidden behind a "more options" toggle or appears only after the user struggles.
+
+The signal. Users who need to escape leave the product entirely instead of skipping.
+
+The cost. Forced friction loses users who would have engaged later if they had been allowed to defer.
+
+The cure. Make skip findable. Make consequences clear. Add resume.
+
+---
+
+## The validation-strict wizard
+
+The pattern. Validation rejects valid inputs because rules are over-specified.
+
+The signal. Users with valid but unusual inputs cannot proceed; abandon.
+
+The cost. Filter loses real users.
+
+The cure. Audit validation. Email plus-aliases, international phone, non-Latin names should pass.
+
+---
+
+## The mobile-broken wizard
+
+The pattern. Wizard works on desktop; breaks on mobile.
+
+The signal. Mobile completion half of desktop or worse.
+
+The cost. Mobile audience underserved; mobile is often majority of traffic.
+
+The cure. Mobile-first design and testing.
+
+---
+
+## The unmaintained wizard
+
+The pattern. Wizard built once; product evolved; wizard not updated.
+
+The signal. Users hit broken steps; references to deprecated features; analytics drift.
+
+The cost. The wizard becomes liability; current users get worse experience than past users.
+
+The cure. Quarterly maintenance. Product changes trigger wizard updates as part of the change.
+
+---
+
+## The interrogation-disguised-as-wizard
+
+The pattern. Wizard asks 12 fields, of which 5 affect product setup. The other 7 are sales-qualification or marketing data.
+
+The signal. Drop-off climbs at fields that feel like sales forms; users sense the manipulation.
+
+The cost. Filter loses users who would have engaged with a product-focused wizard.
+
+The cure. Audit fields. Remove or defer fields that do not contribute to product setup. Capture sales/marketing data later in the relationship.
+
+---
+
+## The popup-interrupted wizard
+
+The pattern. User is mid-wizard; a popup appears (newsletter, chat, special offer); flow breaks.
+
+The signal. Drop-off spikes at the popup moment; users complain about interruption.
+
+The cost. Wizard's user experience hostile; brand earns annoying reputation.
+
+The cure. Suppress popups during wizard completion. Save promotional content for after.
+
+---
+
+## The reset-on-error wizard
+
+The pattern. User submits; validation fails; wizard resets, losing user inputs.
+
+The signal. Users who hit error do not retry; they leave.
+
+The cost. The wizard treats errors punitively; trust collapses.
+
+The cure. Preserve inputs on error. Show error inline; let the user fix and resubmit.
+
+---
+
+## The wizard-without-activation-metric
+
+The pattern. Wizard tracked by completion rate alone. Activation not measured.
+
+The signal. Completion looks fine; team cannot diagnose whether the wizard is producing engaged users.
+
+The cost. The wizard's success metric is wrong; bad wizards look good in dashboards.
+
+The cure. Define and track activation explicitly. Wizard completion is leading indicator at best.
+
+---
+
+## How to detect anti-patterns in a portfolio
+
+Audit cadence. Quarterly review of every active wizard, looking for these anti-patterns.
+
+**Audit questions per wizard.**
+
+- Does each step contribute to the ah-ha moment (anti-pattern check: tutorial-overload, decoration)?
+- Is skip honest about consequences and recoverable (anti-pattern check: skip-friendly-empty, hidden-skip)?
+- Does the wizard match the product's current state (anti-pattern check: unmaintained)?
+- Is activation tracked (anti-pattern check: completion-only metrics)?
+- Does the wizard work on mobile (anti-pattern check: mobile-broken)?
+- Is validation calibrated to actual requirements (anti-pattern check: validation-strict)?
+- Are inputs preserved on error (anti-pattern check: reset-on-error)?
+- Is the audience segmentation right (anti-pattern check: over-branched, under-branched)?
+
+**The retire decision.** Anti-pattern wizards often warrant redesign or retirement.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing for each. Cures matched. The audit cadence and questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and the lessons learned. Specific portfolio audit results. Specific retirement decisions. The team's audit calendar. These vary by team.

--- a/skills/onboarding-wizard-design/references/wizard-decision-criteria.md
+++ b/skills/onboarding-wizard-design/references/wizard-decision-criteria.md
@@ -1,0 +1,133 @@
+# Wizard decision criteria
+
+When wizards earn the build vs when contextual help suffices. The conditions that warrant the wizard format, and the funnels where a wizard adds friction without lift.
+
+A wizard is meaningful work. Step architecture, ah-ha moment design, progressive disclosure, skip mechanics, drop-off instrumentation, ongoing maintenance. The wizard earns this investment only when specific conditions are present.
+
+---
+
+## When wizards earn the build
+
+Five conditions that, when present, make a wizard a strong investment.
+
+**The product has meaningful setup before value emerges.** Connect a data source, invite a teammate, configure a workspace, choose a use case. Without setup, the product is empty; the wizard makes setup tractable. Products that work immediately on signup do not need this.
+
+**The ah-ha moment requires multiple actions in sequence.** Single-action ah-ah moments (paste a URL, see a result) often work better with contextual prompts. Multi-action ah-ha moments benefit from a guided sequence.
+
+**The audience expects guided onboarding.** B2B SaaS with technical setup, enterprise software, configurable products often work well with wizards. Some audiences (frictionless consumer tools) reject wizard friction regardless of product complexity.
+
+**The team can maintain the wizard.** Wizards decay as the product evolves; deprecated features still in flow break the experience. Without maintenance commitment, the wizard becomes a liability.
+
+**The success metric is defined.** Not just completion rate; activation rate (post-wizard product engagement) and time-to-value. Without the success metric, evaluation is impossible.
+
+When all five are present, the wizard is a strong investment. When two or fewer are present, contextual prompts often serve better.
+
+---
+
+## When wizards do NOT earn the build
+
+Funnels where the wizard adds friction without lift.
+
+**The product reaches value immediately.** Single-input tools, simple consumer products, frictionless utilities. A wizard adds steps where the user could already see value.
+
+**Contextual help would suffice.** Tooltips, in-feature hints, progressive in-product education sometimes serve better than upfront wizards. The user explores naturally; help surfaces when needed.
+
+**The audience expects no friction.** Some audiences abandon at any wizard. Consumer-facing high-volume products, embedded tools, prosumer utilities. Meet the audience where they are.
+
+**The team cannot maintain the wizard.** Stale wizards point to deprecated features; users hit broken steps. Without maintenance capacity, no wizard is better than a stale one.
+
+**The setup work is genuinely better in-product.** Some setup is better done after the user understands the product. Wizards that try to set up something the user does not yet understand produce poor configuration.
+
+The honest assessment matters more than the default. "Should we have an onboarding wizard" is not the question. "Is the wizard the right tool for this product and audience" is.
+
+---
+
+## The opportunity-cost frame
+
+A wizard is significant work. Account for it.
+
+**The build cost.** Step architecture, copy, design, instrumentation, integration with the product, maintenance scaffolding. A meaningful wizard often takes 40-150 engineering hours plus design and copy.
+
+**The maintenance cost.** Quarterly review minimum; product changes trigger wizard updates. 4-12 hours per active wizard per quarter.
+
+**The opportunity cost.** What else could the team have built? Direct in-product improvements, contextual help, documentation, a simpler activation funnel. The wizard's success has to clear the bar of those alternatives.
+
+The decision frame. The wizard earns investment when it produces more activation lift than the alternatives, accounting for build plus maintenance.
+
+---
+
+## The ah-ha-moment precondition
+
+Without an identifiable ah-ha moment, the wizard has nothing to engineer toward.
+
+The check. Can the team articulate the single visible moment when the user feels "oh, this is what the product does for me"?
+
+If yes, the wizard can be designed to converge on that moment. If no, the team has not yet defined what activation means; the wizard cannot be designed coherently until that is settled.
+
+**Defining the ah-ha moment is upstream of wizard design.** Sometimes the right move is to spend time identifying the ah-ha moment first (often through customer research) before scoping the wizard. The wizard built without a defined ah-ha moment is the wizard that produces high completion and low activation.
+
+---
+
+## The decision worked example
+
+A B2B SaaS analytics platform considering an onboarding wizard.
+
+**Conditions check.**
+
+- Meaningful setup before value: yes. Connect at least one data source.
+- Ah-ha moment multi-action: yes. Connect data, run first query, see useful result.
+- Audience expects guided onboarding: yes. Data analysts and data leaders generally accept guided setup.
+- Maintenance commitment: yes. Activation team owns the wizard.
+- Success metric defined: yes. Activation = ran at least one query within 7 days of signup.
+
+**Decision.** Build the wizard. The conditions warrant it.
+
+**Step architecture.** Welcome (skippable) → connect first data source → confirm connection → guided first query → see result (ah-ha moment) → invite teammates (deferable) → in-product home.
+
+**Maintenance commitment.** Activation team reviews quarterly; product changes trigger wizard updates.
+
+The decision was not "should we have a wizard" but "given these conditions, this is the wizard to build."
+
+---
+
+## The decision worked example: when to choose differently
+
+A consumer note-taking app considering an onboarding wizard.
+
+**Conditions check.**
+
+- Meaningful setup: no. The user can start typing immediately.
+- Ah-ha moment multi-action: no. The ah-ha moment is "I can save a note and find it later," reachable without setup.
+- Audience expects guided onboarding: no. Consumer note-taking audiences resist friction.
+- Maintenance commitment: yes (capacity exists).
+- Success metric: defined (returned within 7 days).
+
+**Decision.** Do not build a wizard. Contextual prompts (sample notes, brief tooltip on first save, short empty-state prompts) serve better.
+
+The decision was "is this wizard right for this product" and the answer was no even though the team had capacity.
+
+---
+
+## When to retire a wizard
+
+Wizards can become wrong even after being right initially.
+
+**Retire when:**
+
+- Activation rate has dropped below baseline for two consecutive quarters and refinements have not moved it.
+- The product has changed enough that the wizard guides users toward deprecated paths.
+- Customer research shows users skipping the wizard and activating fine without it.
+- A redesigned in-product activation flow makes the wizard unnecessary.
+- The team can no longer maintain the wizard.
+
+The retiring discipline frees capacity. Stale wizards are worse than no wizards.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five conditions that warrant a wizard. The five conditions that argue against. The opportunity-cost frame. The ah-ha-moment precondition. Decision worked examples (yes and no). The retire decision.
+
+## Implementation choices that stay internal
+
+Specific wizard scope decisions for specific products. The team's capacity benchmarks. Specific tooling for wizard implementation and instrumentation. Specific success-metric baselines. These vary by team and product.

--- a/skills/product-configurator-design/SKILL.md
+++ b/skills/product-configurator-design/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: product-configurator-design
+description: "Designing build-your-own product configurators (Tesla-style, custom-pricing, plan-builders) with constraint logic, real-time pricing, validation, and save-and-share mechanics. Honest about infinite-options (decision paralysis), canned-bundles-only (no real customization), and guided-configuration (smart defaults plus meaningful constraints plus escape hatches) patterns. Triggers on configurator design, build-your-own, custom configuration, plan builder, product customizer, configuration tool. Also triggers when users abandon mid-configuration, when configurator conversion is poor, or when a configurator is being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing interactive product configurators. Distinguishes infinite-options (decision paralysis from too many options) from canned-bundles-only (no real customization) from guided-configuration (smart defaults plus meaningful constraints plus escape hatches)"
+display_order: 12
+---
+
+# Product Configurator Design
+
+A senior product marketing director's playbook for designing build-your-own product configurators. Tesla-style vehicle configurators, custom-pricing builders, plan-builders, product customizers. Constraint logic, real-time pricing, validation, save-and-share mechanics. The discipline of building a configurator that produces configurations users actually commit to.
+
+Most configurators fail in one of two ways. They expose every parameter at full granularity (47 toggles, 12 sliders) and produce decision paralysis; users abandon halfway through. Or they pretend to be configurators but are actually three pre-built bundles labeled "Custom"; the configurator framing was marketing while the product is bundles.
+
+The configurators that work do something different. Smart defaults that produce a sensible starting configuration; meaningful constraints that prevent invalid combinations and surface why; escape hatches into deeper customization for users who want it; real-time pricing that responds to choices. Users feel guided rather than overwhelmed.
+
+The voice is the senior product marketing director who has watched configurators double conversion when redesigned with smart defaults and watched them collapse when "more options" were added without constraint logic. Practical, opinionated about the constraints that protect users from themselves, willing to call out when canned bundles are the right answer.
+
+When to use this skill: scoping a build-your-own configurator for the first time, auditing a configurator with high abandonment, designing the constraint logic that prevents invalid combinations, or deciding which parameters earn exposure vs which should default.
+
+---
+
+## What this skill covers
+
+This skill spans build-your-own product configurators. The growth-tooling distinctions:
+
+- `calculator-design` is calculators that give a number from inputs. This skill builds a product configuration with multiple decisions.
+- `comparison-tool-design` is comparing known options. This skill builds a custom option.
+- `multi-step-form-design` is data capture. This skill is configuration design.
+- **`product-configurator-design` (this skill)** is constraint logic, real-time pricing, validation, save-and-share, and configurator-to-cart handoff.
+- `pm-spec-writing` is the spec for engineers building the configurator.
+
+The audience: product marketers, growth marketers, ecommerce teams, B2B teams shipping configurable products, agencies running configurator work for clients.
+
+Out of scope: calculator design (covered by `calculator-design`); comparison tools (covered by `comparison-tool-design`); the engineering implementation; specific configurator-platform configurations (those stay implementation-side).
+
+---
+
+## The configurator decision: when configurators earn investment vs when bundles suffice
+
+Before designing the configurator, decide whether a configurator is the right answer.
+
+**Configurators earn investment when:**
+
+- The product has genuinely customizable parameters that affect outcome and cost.
+- The audience values customization beyond what bundles offer.
+- The team can support the configuration logic (validation, pricing, fulfillment).
+- The combinatorial space is meaningful but constrained (not literally infinite).
+
+**Configurators do NOT earn investment when:**
+
+- The product is essentially bundles. Calling them "configurations" is marketing, not product.
+- The audience does not value customization. Some audiences want to choose from curated options, not build.
+- The combinatorial space is so large that no audience can navigate it.
+- Customization produces invalid combinations the team cannot prevent.
+- A simpler comparison or selection tool would serve.
+
+The decision is not "should we have a configurator"; it is "is the configurator the right tool for this product and audience."
+
+Detail in `references/configurator-decision-criteria.md`.
+
+---
+
+## Infinite-options vs canned-bundles-only vs guided-configuration
+
+The keystone framing.
+
+**Infinite-options.** Every parameter exposed at full granularity. 47 toggle switches and 12 sliders. Decision paralysis. Users abandon halfway through; few complete a configuration. Cost: design effort produces a configurator nobody completes; conversion suffers.
+
+**Canned-bundles-only.** "Configurator" that is actually three pre-built bundles labeled Basic/Pro/Enterprise. No real customization. The configurator framing was marketing; the product is bundles. Cost: audience that came expecting customization feels deceived; conversion suffers because expectations did not match reality.
+
+**Guided-configuration.** Smart defaults that produce a sensible starting configuration; meaningful constraints that prevent invalid combinations; escape hatches into deeper customization for users who want it; real-time pricing that responds to choices. Cost: design effort upfront is significant; conversion typically improves meaningfully because users complete configurations they commit to.
+
+The litmus test. Hand the configurator to a stranger in the target audience. Do they reach a configuration they would actually buy in under 5 minutes without expert help? If yes, guided-configuration. If they paralyze at the options, infinite-options. If they only see bundles, canned-bundles-only.
+
+---
+
+## Default-configuration design
+
+The starting point.
+
+**The principle.** The configurator opens with a sensible default configuration. The user adjusts from there.
+
+**Default selection.**
+
+- The configuration most audiences would choose.
+- Reflects audience research (sales-call mining, prior configurations).
+- Inferable from referrer, query, or stated preference.
+
+**Default presentation.**
+
+- Default visible immediately; user sees a complete configuration with price.
+- Adjust controls obvious; user knows what is changeable.
+- Reset-to-default available; users who experiment can return.
+
+**The blank-canvas trap.** Configurator opens empty; user must build from scratch. Decision paralysis at the start.
+
+**The cure.** Default-heavy. The user adjusts; never builds from zero.
+
+Detail in `references/default-configuration-design.md`.
+
+---
+
+## Constraint logic
+
+Preventing invalid combinations; surfacing why.
+
+**The principle.** The configurator should not let users build invalid configurations (combinations that cannot ship, cannot be priced, or do not work together). When constraints engage, the configurator surfaces why.
+
+**Constraint patterns.**
+
+- **Hard constraints.** "Option A and Option B are incompatible." Configurator prevents the combination; explains why.
+- **Soft constraints.** "Combining Option A with Option C is unusual but possible." Configurator allows; warns.
+- **Implication constraints.** "Selecting Option A requires Option D." Configurator auto-includes D; explains.
+- **Capacity constraints.** "This configuration exceeds shipping capacity." Configurator caps; explains.
+
+**Constraint communication.**
+
+- Why this constraint engaged.
+- What user can do (different option, contact for custom).
+- No friction-only blocking; always offer a path.
+
+**The over-constrained trap.** Too many constraints; user feels boxed in.
+
+**The under-constrained trap.** User builds configuration that fails at checkout or fulfillment.
+
+Detail in `references/constraint-logic-patterns.md`.
+
+---
+
+## Real-time pricing and impact display
+
+Pricing that responds to choices.
+
+**The principle.** Price updates as the user adjusts. The user sees the cost impact of each choice immediately.
+
+**Strong pricing display.**
+
+- Total price prominent and updated in real time.
+- Per-choice impact visible ("Adds $X" or "Saves $X").
+- Breakdown available ("How is this priced").
+- Currency and locale appropriate.
+
+**Weak pricing display.**
+
+- Price hidden until the end.
+- Per-choice impact invisible; user does not know what each option costs.
+- Breakdown not available; total is opaque.
+
+**The price-shock trap.** User configures heavily; reaches checkout; sees a price they did not expect; abandons.
+
+**The cure.** Price visible throughout. No surprises at checkout.
+
+Detail in `references/real-time-pricing-patterns.md`.
+
+---
+
+## Validation and error patterns
+
+When the configurator catches invalid input.
+
+**The principle.** Validation should be helpful, not punitive.
+
+**Validation patterns.**
+
+- **Inline validation.** Error appears next to the invalid choice.
+- **Pre-emptive validation.** Constraint logic prevents the error from being possible.
+- **Final validation.** Pre-checkout review surfaces any remaining issues.
+
+**Error communication.**
+
+- Specific to the issue.
+- Explains why.
+- Offers a path (alternative option, contact for custom).
+
+**The validation-strict trap.** Validation rejects valid edge-case inputs.
+
+**The validation-loose trap.** Configurator accepts inputs that fail downstream.
+
+Detail in `references/validation-and-error-patterns.md`.
+
+---
+
+## Save-and-share mechanics
+
+Configurations users return to or send to others.
+
+**The principle.** Configurators that serve real decision-making produce configurations users want to save and share.
+
+**Save patterns.**
+
+- **Email-link save.** User enters email; configuration link emailed.
+- **Account-based save.** Logged-in users save automatically.
+- **Anonymous-session save.** Browser-based persistence.
+
+**Share patterns.**
+
+- **Shareable URL.** Configuration encoded in URL; share via any channel.
+- **Embed code.** Configuration embeddable on other sites or in proposals.
+- **Email share.** Direct email-to-recipient with configuration.
+
+**Why save-and-share matters.**
+
+- Multi-decision purchases require deliberation.
+- B2B configurations often need stakeholder review.
+- Returning users continue rather than restart.
+
+Detail in `references/save-and-share-mechanics.md`.
+
+---
+
+## Configurator-to-cart handoff
+
+When the user commits.
+
+**The principle.** Handoff from configurator to cart should preserve the configuration entirely.
+
+**Handoff patterns.**
+
+- Configuration becomes the cart item.
+- Cart shows the configuration summary.
+- Edit-from-cart returns to configurator with state preserved.
+
+**The handoff failure.** Configuration partially preserved; cart shows a generic SKU; user cannot tell if their custom build is reflected.
+
+**The cure.** Handoff loop closed. Configuration visible in cart; price matches; edits possible.
+
+Detail in `references/configurator-to-cart-handoff.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-configurator-failures.md`.
+
+- "Users abandon halfway through configuration." Likely infinite-options pattern; too many decisions.
+- "Configurator generates valid-looking configs that fail at fulfillment." Under-constrained; constraint logic missing.
+- "Users complain about price surprises at checkout." Pricing not real-time or hidden until end.
+- "Sales says many users contact for help configuring." Configurator too complex for audience; defaults wrong.
+- "Users save configurations but do not return." Save mechanism works but follow-up missing.
+- "Configurator works on desktop, breaks on mobile." Mobile UX broken.
+- "Audience completes but conversion to purchase is low." Configurator works; commitment friction at handoff.
+- "We added more options; abandonment climbed." Crossed the cognitive-load threshold.
+- "Constraint engaged but user did not understand why." Communication broken; users feel arbitrarily blocked.
+
+---
+
+## The framework: 12 considerations for configurator design
+
+When designing or auditing a configurator, walk these 12 considerations.
+
+1. **The configurator decision.** Is configurator the right tool, or do bundles serve?
+2. **Guided-configuration, not infinite-options or canned-bundles-only.** Smart defaults plus meaningful constraints plus escape hatches.
+3. **Default configuration sensible.** User adjusts from default; does not build from zero.
+4. **Constraint logic prevents invalid combinations.** Hard, soft, implication, capacity constraints.
+5. **Constraint communication clear.** Why constraint engaged; what user can do.
+6. **Real-time pricing visible.** Price updates with choices; breakdown available.
+7. **Validation helpful.** Inline; specific; offers paths.
+8. **Save-and-share works.** Multi-session; shareable; B2B-friendly.
+9. **Configurator-to-cart handoff preserves state.** Cart shows configuration.
+10. **Mobile parity.** Configurator works on the devices the audience uses.
+11. **Conversion as success metric.** Not just completion rate; downstream purchase.
+12. **Maintenance discipline.** Configurations updated as product changes; quarterly audit.
+
+The output of the framework is a configurator that earns the configuration that ships, with constraint logic, pricing, and handoff working together to produce commitments users keep.
+
+---
+
+## Reference files
+
+- [`references/configurator-decision-criteria.md`](references/configurator-decision-criteria.md) - When configurators earn the build vs when bundles serve.
+- [`references/default-configuration-design.md`](references/default-configuration-design.md) - The starting point. Default selection and presentation.
+- [`references/constraint-logic-patterns.md`](references/constraint-logic-patterns.md) - Hard, soft, implication, capacity constraints. Communication patterns.
+- [`references/real-time-pricing-patterns.md`](references/real-time-pricing-patterns.md) - Price updates with choices. Breakdown and impact display.
+- [`references/validation-and-error-patterns.md`](references/validation-and-error-patterns.md) - Helpful validation. Inline, pre-emptive, final.
+- [`references/save-and-share-mechanics.md`](references/save-and-share-mechanics.md) - Email-link, account, anonymous, shareable URL, embed.
+- [`references/configurator-to-cart-handoff.md`](references/configurator-to-cart-handoff.md) - Handoff that preserves configuration; cart visibility; edit-from-cart.
+- [`references/configurator-anti-patterns.md`](references/configurator-anti-patterns.md) - The patterns that look like configurators but degrade conversion.
+- [`references/common-configurator-failures.md`](references/common-configurator-failures.md) - 9+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: configurators earn investment when they earn the configuration that ships
+
+The configurators that work as compounding assets are the ones that produce configurations users commit to. Not 50-cell decision matrices. Not bundles dressed as configurators. Configurations the user built, priced, validated, saved, and bought.
+
+That is the bar. Below the bar are infinite-options (decision paralysis; users abandon) and canned-bundles-only (configurator framing without real customization; users feel deceived). Above the bar are guided-configuration tools where smart defaults, meaningful constraints, real-time pricing, validation, and save-and-share work together to produce commitments.
+
+The discipline is in the design choices. The decision to build a configurator at all. The default configuration that opens the experience. The constraint logic that protects users from invalid combinations. The pricing that updates with choices. The validation that helps without punishing. The save-and-share that supports multi-decision purchases. The cart handoff that preserves the configuration. The maintenance that keeps the configurator in sync with the product it represents.

--- a/skills/product-configurator-design/references/common-configurator-failures.md
+++ b/skills/product-configurator-design/references/common-configurator-failures.md
@@ -1,0 +1,179 @@
+# Common configurator failures
+
+9+ failure patterns with diagnoses and cures.
+
+---
+
+## "Users abandon halfway through configuration."
+
+**The diagnosis.** Likely infinite-options pattern; too many decisions.
+
+**The cure.** Smart defaults; reduce option count; escape hatches into deeper customization.
+
+---
+
+## "Configurator generates valid-looking configs that fail at fulfillment."
+
+**The diagnosis.** Under-constrained; constraint logic missing.
+
+**The cure.** Add constraint logic. Detail in `references/constraint-logic-patterns.md`.
+
+---
+
+## "Users complain about price surprises at checkout."
+
+**The diagnosis.** Pricing not real-time or hidden until end.
+
+**The cure.** Real-time pricing throughout. Detail in `references/real-time-pricing-patterns.md`.
+
+---
+
+## "Sales says many users contact for help configuring."
+
+**The diagnosis.** Configurator too complex for audience; defaults wrong.
+
+**The cure.** Audit defaults; reduce option exposure; consider canned bundles for simple cases.
+
+---
+
+## "Users save configurations but do not return."
+
+**The diagnosis.** Save mechanism works but follow-up missing.
+
+**The cure.** Reminder email after save; nudge before configuration expires.
+
+---
+
+## "Configurator works on desktop, breaks on mobile."
+
+**The diagnosis.** Mobile UX broken.
+
+**The cure.** Mobile-first design and testing.
+
+---
+
+## "Audience completes but conversion to purchase is low."
+
+**The diagnosis.** Configurator works; commitment friction at handoff.
+
+**The cure.** Audit cart handoff; ensure configuration preserved; reduce checkout friction.
+
+---
+
+## "We added more options; abandonment climbed."
+
+**The diagnosis.** Crossed cognitive-load threshold.
+
+**The cure.** Cut options; surface fewer; defer complexity behind escape hatches.
+
+---
+
+## "Constraint engaged but user did not understand why."
+
+**The diagnosis.** Communication broken.
+
+**The cure.** Constraint copy specific; explains why; offers paths.
+
+---
+
+## "Configurations frequently differ from cart."
+
+**The diagnosis.** Handoff broken.
+
+**The cure.** Test cart handoff. Configuration ID system; single pricing source.
+
+---
+
+## "Sales says enterprise customers want full configurations sales-led."
+
+**The diagnosis.** Enterprise audience wants white-glove; configurator self-serve does not match expectation.
+
+**The cure.** Enterprise path: configurator surfaces "Talk to sales for custom" for above-threshold configurations.
+
+---
+
+## "We A/B tested adding more options; conversion went down."
+
+**The diagnosis.** Crossed the threshold.
+
+**The cure.** More is not always better. Maintain option discipline.
+
+---
+
+## "Returning users see different prices than they saved."
+
+**The diagnosis.** Pricing shifted; configurator silently updated.
+
+**The cure.** Honest about price changes on resume.
+
+---
+
+## "Mobile configuration completion is half of desktop."
+
+**The diagnosis.** Mobile UX significantly worse.
+
+**The cure.** Mobile-first redesign; reduce option exposure on mobile.
+
+---
+
+## "Validation rejects valid international inputs."
+
+**The diagnosis.** Validation too strict.
+
+**The cure.** Audit validation rules; allow international formats.
+
+---
+
+## "Some configurations work; others fail post-checkout."
+
+**The diagnosis.** Constraint logic incomplete; some invalid combinations slip through.
+
+**The cure.** Audit constraints. Add missing rules.
+
+---
+
+## "Configurator's average configuration is more expensive than baseline."
+
+**The diagnosis.** May not be a problem (real customization adds cost) or may be (default biased toward expensive).
+
+**The cure.** Audit defaults. Defaults should reflect typical use, not flatter revenue.
+
+---
+
+## "Sales pipeline shrunk after configurator launch; people self-serve."
+
+**The diagnosis.** Configurator absorbed the audience that would have called.
+
+**The cure.** This may be intentional (cost reduction) or unintentional (loss of complex deals). Decide if the shift is desired.
+
+---
+
+## "Configurator launched; analytics broke."
+
+**The diagnosis.** Instrumentation missed.
+
+**The cure.** Verify analytics post-launch. Per-step instrumentation for diagnostic.
+
+---
+
+## The pattern across failures
+
+Most configurator failures fall into one of three patterns.
+
+**Pattern 1: Cognitive overload.** Infinite-options, too many decisions, no defaults. The fix is guided-configuration.
+
+**Pattern 2: Trust damage.** Hidden pricing, price drift, unclear constraints, lost state. The fix is transparency.
+
+**Pattern 3: Handoff failures.** Cart loses configuration; checkout disappears it. The fix is loop closure.
+
+The metric pattern: configurator failures often look fine on engagement. Signal is in completion rate, conversion to purchase, downstream order accuracy.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (cognitive overload, trust damage, handoff). The principle that engagement alone is insufficient.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered. Specific dashboards. Specific cures. The team's audit and retirement processes. These vary by team.

--- a/skills/product-configurator-design/references/configurator-anti-patterns.md
+++ b/skills/product-configurator-design/references/configurator-anti-patterns.md
@@ -1,0 +1,193 @@
+# Configurator anti-patterns
+
+The patterns that look like configurators but degrade conversion. Easy to ship; the cost shows up in completion rates, downstream conversion, and brand trust.
+
+---
+
+## The infinite-options configurator
+
+The pattern. Every parameter exposed at full granularity.
+
+The signal. Decision paralysis; high abandonment.
+
+The cure. Smart defaults; meaningful constraints; escape hatches into deeper customization.
+
+---
+
+## The canned-bundles-only configurator
+
+The pattern. Three pre-built bundles labeled "Custom."
+
+The signal. Audience expecting customization feels deceived.
+
+The cure. Real configuration logic; or honest bundle framing.
+
+---
+
+## The blank-canvas configurator
+
+The pattern. Configurator opens empty; user must build from scratch.
+
+The signal. First-step abandonment.
+
+The cure. Default-heavy. Open with sensible default.
+
+---
+
+## The hidden-pricing configurator
+
+The pattern. Price not visible until checkout.
+
+The signal. Users abandon at checkout when total surprises.
+
+The cure. Real-time pricing throughout.
+
+---
+
+## The under-constrained configurator
+
+The pattern. User can build invalid configurations that fail downstream.
+
+The signal. Sales gets calls about failed orders.
+
+The cure. Constraint logic. Detail in `references/constraint-logic-patterns.md`.
+
+---
+
+## The over-constrained configurator
+
+The pattern. Too many constraints; user feels boxed in.
+
+The signal. User abandons; sales gets calls for "custom" configurations.
+
+The cure. Reduce constraints to genuine requirements; offer custom path for edge cases.
+
+---
+
+## The unclear-constraint configurator
+
+The pattern. Constraint engages without explanation.
+
+The signal. Users confused; bounce rate climbs.
+
+The cure. Constraint communication. Why constraint engaged; what user can do.
+
+---
+
+## The lose-state-on-error configurator
+
+The pattern. Validation engages; configuration resets.
+
+The signal. Users abandon at first error.
+
+The cure. Preserve state; errors local.
+
+---
+
+## The mobile-broken configurator
+
+The pattern. Configurator works on desktop; breaks on mobile.
+
+The signal. Mobile completion much lower than desktop.
+
+The cure. Mobile-first design.
+
+---
+
+## The lost-on-cart configurator
+
+The pattern. Cart shows generic SKU; configuration not visible.
+
+The signal. Users edit; configurator restarts; abandonment.
+
+The cure. Cart presentation preserves configuration.
+
+---
+
+## The price-drift configurator
+
+The pattern. Configurator shows one price; cart shows another.
+
+The signal. Users feel deceived.
+
+The cure. Single source of truth for pricing.
+
+---
+
+## The save-mechanism-broken configurator
+
+The pattern. User saves; recovery link broken; configuration lost.
+
+The signal. Users complain; abandonment increases on long configurations.
+
+The cure. Test save mechanism end-to-end.
+
+---
+
+## The validation-strict configurator
+
+The pattern. Validation rejects valid edge-case inputs.
+
+The signal. Users with valid inputs cannot proceed.
+
+The cure. Audit validation; allow international, plus-aliased, non-Latin inputs.
+
+---
+
+## The unmaintained configurator
+
+The pattern. Product changed; configurator did not.
+
+The signal. Configurator references deprecated options; pricing wrong.
+
+The cure. Quarterly maintenance; product changes trigger configurator updates.
+
+---
+
+## The aggressive-pricing-anchoring configurator
+
+The pattern. Strikethrough prices that were never charged; "$X for a limited time" perpetually.
+
+The signal. Sophisticated audiences notice; trust collapses.
+
+The cure. Honest anchoring; real discounts only.
+
+---
+
+## The orphan-configuration configurator
+
+The pattern. Configurations save; user returns; configuration valid but pricing changed silently.
+
+The signal. Users surprised at price difference.
+
+The cure. Honest about price changes on resume.
+
+---
+
+## How to detect anti-patterns
+
+Audit cadence. Quarterly review.
+
+**Audit questions per configurator.**
+
+- Is default sensible (anti-pattern check: blank-canvas)?
+- Are constraints calibrated (anti-pattern check: over-constrained, under-constrained, unclear)?
+- Is pricing visible and consistent (anti-pattern check: hidden-pricing, price-drift)?
+- Does state preserve on error (anti-pattern check: lose-state-on-error)?
+- Does mobile work (anti-pattern check: mobile-broken)?
+- Does cart preserve configuration (anti-pattern check: lost-on-cart)?
+- Is validation calibrated (anti-pattern check: validation-strict)?
+- Is configurator current (anti-pattern check: unmaintained)?
+- Are saved configurations honest about price changes (anti-pattern check: orphan-configuration)?
+
+**The retire decision.** Configurators failing multiple checks warrant redesign or retirement.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing. Cures matched. Audit cadence and questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped and lessons learned. Specific portfolio audit results. The team's audit calendar. These vary by team.

--- a/skills/product-configurator-design/references/configurator-decision-criteria.md
+++ b/skills/product-configurator-design/references/configurator-decision-criteria.md
@@ -1,0 +1,129 @@
+# Configurator decision criteria
+
+When configurators earn the build vs when bundles serve.
+
+A configurator is meaningful work. Constraint logic, real-time pricing, validation, save-and-share, cart handoff, ongoing maintenance. The configurator earns this investment only when specific conditions are present.
+
+---
+
+## When configurators earn the build
+
+Five conditions that, when present, make a configurator a strong investment.
+
+**The product has genuinely customizable parameters that affect outcome and cost.** Not just cosmetic options; real parameters that change what the user gets.
+
+**The audience values customization beyond what bundles offer.** Some audiences want choice; others prefer curated bundles.
+
+**The team can support the configuration logic.** Validation, pricing, fulfillment for variable configurations.
+
+**The combinatorial space is meaningful but constrained.** Not literally infinite; not so small that bundles would suffice.
+
+**The success metric is defined.** Configuration completion rate, configuration-to-purchase rate, average configuration price.
+
+When all five are present, a configurator is strong investment. When two or fewer are present, bundles often serve better.
+
+---
+
+## When configurators do NOT earn the build
+
+Funnels where configurators add complexity without lift.
+
+**The product is essentially bundles.** Calling them configurations is marketing.
+
+**The audience prefers curated options.** Some audiences resent customization friction.
+
+**The combinatorial space is too large.** No audience can navigate.
+
+**Customization produces invalid combinations.** Team cannot prevent; users hit failures.
+
+**A simpler tool would serve.** Comparison, calculator, or selection tool.
+
+The honest assessment matters. Configurators are sometimes the wrong tool.
+
+---
+
+## Configurators vs bundles
+
+When each fits.
+
+**Bundles strengths.** Simple; clear; no decision paralysis. Easy to maintain.
+
+**Bundles weaknesses.** Audiences that need customization underserved.
+
+**Configurators strengths.** Match real customer needs; capture revenue from edge cases.
+
+**Configurators weaknesses.** Build cost; complexity.
+
+**The combined approach.** Some products offer bundles AND a configurator for users who want custom.
+
+---
+
+## The opportunity-cost frame
+
+Configurators are significant work.
+
+**Build cost.** Constraint logic, pricing engine, save-and-share, validation, cart integration. 60-200 engineering hours typical.
+
+**Maintenance cost.** Product changes trigger configurator updates. 4-12 hours per quarter.
+
+**Opportunity cost.** Better bundles, comparison tool, calculator. The configurator has to clear those alternatives.
+
+The decision frame. Configurators earn investment when they produce more revenue than bundle-only or alternative formats.
+
+---
+
+## Decision worked example
+
+A B2B SaaS with seat-based + add-on pricing.
+
+**Conditions check.**
+
+- Genuinely customizable: yes (seats, add-ons, integrations).
+- Audience values customization: yes; team size and add-ons vary.
+- Team can support: yes.
+- Combinatorial space: meaningful but constrained.
+- Success metric: defined.
+
+**Decision.** Build the configurator.
+
+The decision was deliberate.
+
+---
+
+## Decision worked example: when bundles serve
+
+A consumer SaaS with three plans.
+
+**Conditions check.**
+
+- Genuinely customizable: no; plans are bundles.
+- Audience values customization: no; users pick plans.
+- Combinatorial space: trivial.
+
+**Decision.** Bundles. No configurator needed.
+
+The decision was right-sized.
+
+---
+
+## When to retire a configurator
+
+Configurators can become wrong over time.
+
+**Retire when:**
+
+- Conversion declined and refinements have not moved it.
+- Most users default-and-purchase; customization unused.
+- Product changed; configurator no longer matches.
+
+The retire-or-redesign discipline frees capacity.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five conditions for configurators. The five against. Configurators vs bundles. Opportunity-cost frame. Decision worked examples. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific configurator decisions for specific products. Capacity benchmarks. Tooling. These vary by team.

--- a/skills/product-configurator-design/references/configurator-to-cart-handoff.md
+++ b/skills/product-configurator-design/references/configurator-to-cart-handoff.md
@@ -1,0 +1,159 @@
+# Configurator-to-cart handoff
+
+Handoff that preserves configuration; cart visibility; edit-from-cart.
+
+When the user commits, the handoff to cart determines whether the commitment sticks. Done well, handoff preserves the configuration; done poorly, the cart shows generic SKUs and the user feels their custom build was lost.
+
+---
+
+## The preserve-the-build principle
+
+The configuration becomes the cart item. The cart shows the configuration. Editing returns to the configurator with state preserved.
+
+**The win.** User finishes configuration; clicks add to cart; cart shows the custom configuration with breakdown and price; user can edit, returning to configurator with all choices preserved.
+
+**The fail.** User finishes; clicks add to cart; cart shows "Custom Product - $X" with no detail. User cannot tell if their build is reflected.
+
+The discipline. Handoff loop closed.
+
+---
+
+## Cart presentation
+
+How the configuration appears in cart.
+
+**Configuration summary.** Key choices listed (not all; not none).
+
+**Price breakdown.** Subtotal matches configurator's price.
+
+**Edit link.** Clear path back to configurator with state preserved.
+
+**Visual.** If configurator shows visual configuration, cart shows it too (or summary image).
+
+---
+
+## Edit-from-cart
+
+When user wants to change.
+
+**Pattern.** Cart includes "Edit configuration" link.
+
+**Behavior.**
+
+- Click; return to configurator.
+- All choices loaded.
+- Adjust; commit; cart updates.
+
+**The lose-state-on-edit failure.** User clicks edit; configurator restarts; previous choices lost.
+
+The cure. State preserved through the handoff loop.
+
+---
+
+## Multi-item handoff
+
+When the user configures multiple items.
+
+**Pattern.** Each configuration becomes a separate cart item with its own summary.
+
+**Edit each independently.** User can edit one without affecting others.
+
+---
+
+## B2B configurator-to-quote
+
+When the configurator generates a quote rather than direct cart.
+
+**Pattern.** Configuration generates a quote; quote can be shared, approved, then converted to order.
+
+**Strengths.** B2B workflows often require approval.
+
+**The discipline.** Quote includes everything the configuration includes; conversion to order preserves.
+
+---
+
+## Handoff to checkout
+
+After cart, checkout.
+
+**The principle.** Configuration details flow through checkout. Confirmation email reflects the configuration.
+
+**The drop-config-at-checkout failure.** Configuration disappears at checkout; user cannot verify.
+
+The cure. Configuration visible throughout the funnel.
+
+---
+
+## Configuration ID
+
+The technical bridge.
+
+**Pattern.** Each configuration gets an ID. Cart, checkout, fulfillment all reference the ID.
+
+**Strengths.** Stable reference.
+
+**Weaknesses.** Requires backend infrastructure.
+
+---
+
+## Pricing consistency
+
+Prices match across configurator, cart, checkout.
+
+**The principle.** No price drift between stages.
+
+**The drift failure.** Configurator shows $X; cart shows $Y; user feels deceived.
+
+**Causes.** Caching, currency conversion, tax estimation, discount expiration.
+
+**The cure.** Single source of truth for pricing; all stages query.
+
+---
+
+## Save-and-share-to-cart
+
+When users return from saved configurations.
+
+**Pattern.** Saved configuration link opens configurator with state; user can add to cart from there.
+
+**The discipline.** Save mechanism integrates with cart workflow.
+
+---
+
+## Mobile cart handoff
+
+On mobile, the handoff transition matters.
+
+**Considerations.**
+
+- Cart visible without horizontal scroll.
+- Edit returns work on mobile.
+- Configuration summary readable.
+
+---
+
+## Common handoff failures
+
+**Cart shows generic SKU.** User cannot verify configuration.
+
+**Edit restarts configurator.** Previous choices lost.
+
+**Pricing drifts between stages.** User confused.
+
+**Configuration disappears at checkout.** Cannot verify.
+
+**Multi-item handoff broken.** Configurations conflict in cart.
+
+**B2B quote misses details.** Quote does not match configuration.
+
+**Confirmation email lacks configuration.** User cannot verify post-purchase.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The preserve-the-build principle. Cart presentation. Edit-from-cart. Multi-item handoff. B2B configurator-to-quote. Handoff to checkout. Configuration ID. Pricing consistency. Save-and-share-to-cart. Mobile considerations. Common failures.
+
+## Implementation choices that stay internal
+
+Specific cart implementations for specific configurators. Specific configuration-ID systems. Specific backend integrations. These vary by team.

--- a/skills/product-configurator-design/references/constraint-logic-patterns.md
+++ b/skills/product-configurator-design/references/constraint-logic-patterns.md
@@ -1,0 +1,173 @@
+# Constraint logic patterns
+
+Hard, soft, implication, capacity constraints. Communication patterns.
+
+Constraints prevent invalid configurations. Done well, they protect users from errors and surface why; done poorly, they feel arbitrary or fail to prevent invalid configurations.
+
+---
+
+## The protect-and-explain principle
+
+Constraints should prevent invalid configurations and explain why when they engage.
+
+**The win.** User selects Option A. System recognizes A is incompatible with currently-selected Option B. Inline message: "Option A and Option B are incompatible. Choose A or B." User adjusts; understands.
+
+**The fail.** User builds configuration. Submits. Backend rejects. User confused; no path forward.
+
+The discipline. Constraints engage at choice-time; explain why; offer paths.
+
+---
+
+## Pattern A: Hard constraints
+
+Combinations that cannot exist.
+
+**How it works.**
+
+- Two options incompatible; configurator prevents both selected.
+- User selects A; B becomes unavailable (greyed; with explanation).
+- Or vice versa.
+
+**Strengths.** Prevents invalid configurations.
+
+**Weaknesses.** Can frustrate users who do not understand the constraint.
+
+**When to use.** Genuinely incompatible options.
+
+---
+
+## Pattern B: Soft constraints
+
+Combinations that are unusual but possible.
+
+**How it works.**
+
+- User selects unusual combination.
+- System warns: "This combination is unusual. Most teams choose [alternative]."
+- User can proceed.
+
+**Strengths.** Respects user agency; provides guidance.
+
+**Weaknesses.** Some users will ignore warning; downstream issues.
+
+**When to use.** Combinations that work but are uncommon.
+
+---
+
+## Pattern C: Implication constraints
+
+When choosing one option requires another.
+
+**How it works.**
+
+- User selects A.
+- System auto-selects required B (or surfaces it for selection).
+- Explains: "Selecting A requires B because [reason]."
+
+**Strengths.** Prevents missing-dependency errors.
+
+**Weaknesses.** Implication chains can grow complex.
+
+**When to use.** When dependencies are clear and predictable.
+
+---
+
+## Pattern D: Capacity constraints
+
+Configuration exceeds product or fulfillment capacity.
+
+**How it works.**
+
+- User configures heavily; reaches capacity ceiling.
+- System caps; explains: "Max [X] supported per configuration."
+- Offers contact for custom.
+
+**Strengths.** Prevents impossible configurations.
+
+**Weaknesses.** Can frustrate enterprise audiences; offer contact for custom.
+
+**When to use.** Hard product limits.
+
+---
+
+## Pattern E: Combinatorial constraints
+
+When multiple choices interact in complex ways.
+
+**How it works.**
+
+- Configurator evaluates the full configuration after each change.
+- Constraints engage based on combinations, not individual options.
+- Surface conflicts as they emerge.
+
+**Strengths.** Handles complex products.
+
+**Weaknesses.** Maintenance complexity.
+
+**When to use.** Products with genuine combinatorial constraints.
+
+---
+
+## Constraint communication
+
+How constraints surface.
+
+**Inline.** Message next to the constrained choice.
+
+**Modal.** Full-screen explanation for major constraints.
+
+**Toast.** Brief notification for minor.
+
+**The discipline.** Match intensity to constraint importance.
+
+---
+
+## Constraint copy
+
+What the message says.
+
+**Strong copy.** "Option A and Option B are incompatible because [specific reason]. Choose A or B."
+
+**Weak copy.** "Invalid configuration."
+
+The discipline. Specific; explanatory; offers paths.
+
+---
+
+## Constraint maintenance
+
+Constraints decay.
+
+**What decays.**
+
+- Constraints from old product variants.
+- Constraints inherited from deprecated options.
+- New options not yet constrained.
+
+**Maintenance cadence.** Quarterly review with product changes.
+
+---
+
+## Common constraint failures
+
+**Over-constrained.** Too many constraints; user feels boxed in.
+
+**Under-constrained.** User builds invalid configuration; fails downstream.
+
+**Constraint without explanation.** User confused by arbitrary blocking.
+
+**Stale constraints.** Inherited from old product.
+
+**Constraint surface inappropriate.** Modal for minor; toast for major.
+
+**No path offered.** Constraint blocks; user has no alternative.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The protect-and-explain principle. Patterns A through E. Constraint communication. Constraint copy. Maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific constraints for specific configurators. Specific copy. Specific tooling. These vary by team.

--- a/skills/product-configurator-design/references/default-configuration-design.md
+++ b/skills/product-configurator-design/references/default-configuration-design.md
@@ -1,0 +1,109 @@
+# Default-configuration design
+
+The starting point. Default selection and presentation.
+
+The configurator opens with a default configuration. Done well, the default makes the user feel guided rather than overwhelmed; done poorly, the user faces a blank canvas and abandons.
+
+---
+
+## The default-heavy principle
+
+Configurators should open with a sensible default, not a blank canvas.
+
+**The win.** User opens the configurator; sees a complete configuration with price; can adjust from there.
+
+**The fail.** User opens the configurator; sees empty fields and 0 fields completed. Decision paralysis.
+
+The discipline. Default-heavy; user adjusts from default; never builds from zero.
+
+---
+
+## Default selection
+
+Which configuration is the default.
+
+**Common-case default.** The configuration most audiences would choose. Reflects audience research.
+
+**Inferred default.** Based on referrer, query, or stated preference.
+
+**Audience-segment default.** Different defaults for different segments (small vs enterprise).
+
+**The most-popular default.** Use what most users actually pick.
+
+---
+
+## Default presentation
+
+How the default appears.
+
+**Visible immediately.** User sees a complete configuration with price.
+
+**Adjust controls obvious.** User knows what is changeable.
+
+**Reset-to-default available.** Users who experiment can return to default.
+
+**Summary-and-detail.** Default shown as summary with expandable detail.
+
+---
+
+## The blank-canvas trap
+
+When configurators open empty.
+
+**The pattern.** Empty fields; user must build from scratch.
+
+**The signal.** High first-step abandonment.
+
+**The cost.** Users abandon before reaching ah-ha moment of seeing a configuration.
+
+**The cure.** Default-heavy. Open with a complete configuration.
+
+---
+
+## Default updating
+
+Defaults decay.
+
+**What decays.**
+
+- Most-popular configuration shifts.
+- Audience composition changes.
+- Product changes invalidate defaults.
+
+**Maintenance cadence.** Quarterly review.
+
+---
+
+## Default-by-segment
+
+Different audiences may warrant different defaults.
+
+**Pattern.** Detect or ask about audience; default adapts.
+
+**Detection.** Referrer, query, stated input, or inferred from context.
+
+The discipline. Audience-fit defaults serve better than one-size-fits-all.
+
+---
+
+## Common default failures
+
+**Blank canvas.** No default; user paralyzes.
+
+**Wrong default.** Most users adjust away; default does not match audience.
+
+**Stale default.** Reflects old product or pricing.
+
+**Default obscures customization.** User does not realize options exist.
+
+**Default biased toward expensive.** Default flatters revenue, not user fit.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The default-heavy principle. Default selection. Default presentation. The blank-canvas trap. Default updating. Default-by-segment. Common failures.
+
+## Implementation choices that stay internal
+
+Specific defaults for specific configurators. Specific detection logic. Specific tooling. These vary by team.

--- a/skills/product-configurator-design/references/real-time-pricing-patterns.md
+++ b/skills/product-configurator-design/references/real-time-pricing-patterns.md
@@ -1,0 +1,157 @@
+# Real-time pricing patterns
+
+Price updates with choices. Breakdown and impact display.
+
+Pricing that responds to choices. Done well, users see cost impact immediately; done poorly, price-shock at checkout drives abandonment.
+
+---
+
+## The no-surprises principle
+
+Price visible throughout the configuration. No surprises at checkout.
+
+**The win.** Total price visible at top of configurator. Updates as user adjusts. Per-choice impact visible ("Adds $X"). Breakdown available.
+
+**The fail.** Price hidden until checkout. User configures heavily. Sees price; abandons.
+
+The discipline. Price visible; breakdown available; surprises eliminated.
+
+---
+
+## Total price display
+
+How the total appears.
+
+**Prominent placement.** Top or top-right of configurator.
+
+**Real-time updates.** Updates immediately as user changes choices.
+
+**Currency and locale.** Match the user's locale.
+
+**Period.** Per-month, per-year, one-time. Match the product's pricing model.
+
+---
+
+## Per-choice impact
+
+Showing what each option costs.
+
+**Inline impact.** "+$X/month" next to the option.
+
+**Strikethrough for upgrades.** Old price strikethrough; new price highlighted.
+
+**Free options labeled.** "Free" or "Included" explicit.
+
+The discipline. User can see the cost of each choice without computing.
+
+---
+
+## Pricing breakdown
+
+How the total breaks down.
+
+**Expandable breakdown.** "How is this priced" toggle reveals detail.
+
+**Categorized breakdown.** Base + add-ons + fees.
+
+**Subscription vs one-time.** Recurring vs one-time costs distinguished.
+
+The discipline. Breakdown available on demand; not forced.
+
+---
+
+## Annual vs monthly
+
+Subscription periods.
+
+**Toggle visible.** User can switch between annual and monthly.
+
+**Discount disclosed.** "Save X% with annual billing."
+
+**Both totals shown.** Annual total and monthly equivalent.
+
+---
+
+## Hidden cost surfacing
+
+Costs that often hide.
+
+**Setup fees.** Disclosed at configuration; not at checkout.
+
+**Implementation costs.** If applicable, visible.
+
+**Per-user vs flat.** Mode disclosed.
+
+**Overage pricing.** What happens beyond capacity, disclosed.
+
+The hidden-cost trap. Costs surfaced only at checkout; user feels deceived.
+
+---
+
+## Tax and shipping
+
+Where applicable.
+
+**Tax estimate.** Approximate tax visible if jurisdiction can be inferred.
+
+**Shipping estimate.** Approximate shipping visible if applicable.
+
+**Final calculation at checkout.** Estimate at configurator; final at checkout.
+
+The discipline. Estimates clearly labeled; final disclosed.
+
+---
+
+## Price comparison anchoring
+
+Showing alternative configurations.
+
+**Comparison anchoring.** "If you upgrade to X, the price increases to Y."
+
+**Bundle anchoring.** "Equivalent bundle is Z."
+
+**Use carefully.** Anchoring can manipulate; honesty matters.
+
+---
+
+## Pricing maintenance
+
+Pricing decays.
+
+**What decays.**
+
+- Pricing levels from old pricing models.
+- Currency conversions stale.
+- Discount terms expired.
+
+**Maintenance cadence.** When pricing changes, configurator pricing updates as part of the change.
+
+---
+
+## Common pricing failures
+
+**Hidden pricing.** Total not visible until checkout.
+
+**Per-choice impact hidden.** User does not know what each choice costs.
+
+**Surprise fees.** Setup, implementation costs hidden until checkout.
+
+**Stale pricing.** Reflects old prices.
+
+**Tax surprise.** Tax not estimated; user surprised at checkout.
+
+**Currency wrong.** Local user sees wrong currency.
+
+**No annual-vs-monthly toggle.** User locked into one period.
+
+**False discount anchoring.** Strikethrough prices that were never charged.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The no-surprises principle. Total price display. Per-choice impact. Pricing breakdown. Annual vs monthly. Hidden cost surfacing. Tax and shipping. Price comparison anchoring. Pricing maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific pricing displays for specific configurators. Specific currency and tax logic. Specific tooling. These vary by team.

--- a/skills/product-configurator-design/references/save-and-share-mechanics.md
+++ b/skills/product-configurator-design/references/save-and-share-mechanics.md
@@ -1,0 +1,218 @@
+# Save-and-share mechanics
+
+Email-link, account, anonymous, shareable URL, embed.
+
+Configurations users return to or send to others. Multi-decision purchases require deliberation; B2B configurations often need stakeholder review. Save-and-share supports these workflows.
+
+---
+
+## The deliberation-friendly principle
+
+Configurators that serve real decision-making produce configurations users want to save and share.
+
+**The win.** User configures complex purchase. Saves via email-link. Shares with stakeholders. Returns days later. Configuration intact; price unchanged; ready to buy.
+
+**The fail.** User configures; cannot save; loses work between sessions; abandons.
+
+The discipline. Save mechanisms support multi-session and multi-stakeholder workflows.
+
+---
+
+## Pattern A: Email-link save
+
+User enters email; link emailed.
+
+**How it works.**
+
+- "Save and resume later" CTA.
+- User enters email.
+- Link emailed; user clicks to return.
+
+**Strengths.** No account required; cross-device.
+
+**Weaknesses.** Email deliverability; link expiration.
+
+**When to use.** Default for non-authenticated configurators.
+
+---
+
+## Pattern B: Account-based save
+
+Logged-in users save automatically.
+
+**How it works.**
+
+- User logs in.
+- Configurations save to account.
+- User returns; finds saved configurations.
+
+**Strengths.** Multi-configuration management.
+
+**Weaknesses.** Account creation friction.
+
+**When to use.** When configurator is part of a logged-in product.
+
+---
+
+## Pattern C: Anonymous-session save
+
+Browser-based persistence.
+
+**How it works.**
+
+- Configuration saved to browser local storage.
+- User returns same browser; configuration restored.
+
+**Strengths.** Lowest friction.
+
+**Weaknesses.** Lost on browser change; limited persistence.
+
+**When to use.** As supplement to other patterns.
+
+---
+
+## Pattern D: Shareable URL
+
+Configuration encoded in URL.
+
+**How it works.**
+
+- Configurator encodes the configuration in URL parameters.
+- User shares URL; recipient opens; sees same configuration.
+
+**Strengths.** Easy sharing across channels.
+
+**Weaknesses.** URL length; pricing may shift over time.
+
+**When to use.** Shareable configurations; B2B stakeholder review.
+
+---
+
+## Pattern E: Embed code
+
+Configuration embeddable on other sites.
+
+**How it works.**
+
+- Configurator generates embed code.
+- User pastes into other sites or proposals.
+
+**Strengths.** Used in B2B proposals.
+
+**Weaknesses.** Cross-site complexity.
+
+**When to use.** B2B sales contexts.
+
+---
+
+## Pattern F: Hybrid
+
+Combining patterns. Common for production configurators.
+
+**Common combination.** Email-link save + shareable URL + anonymous-session backup.
+
+**Strengths.** Multiple paths.
+
+**Weaknesses.** Complexity.
+
+---
+
+## Save trust communication
+
+Users hesitate to save partial sensitive configurations.
+
+**What to communicate.**
+
+- What is saved.
+- How long it persists.
+- Who can access it.
+- How to delete.
+
+The discipline. Trust communication explicit; not buried in privacy policy.
+
+---
+
+## Resume experience
+
+When user returns.
+
+**The principle.** Resume should be uninterrupted.
+
+**The pattern.**
+
+- User clicks recovery link or logs in.
+- Lands at the configuration; rest preserved.
+- Continues without re-doing.
+
+**Resume failures.**
+
+- Configuration partially preserved; values lost.
+- Pricing changed; user surprised.
+- Constraint logic shifted; configuration now invalid.
+
+The discipline. Resume preserves; communicate any changes (e.g., "Pricing has updated since you last visited").
+
+---
+
+## Pricing on resume
+
+When prices change between save and resume.
+
+**Honest pattern.** Show the saved configuration with original price; surface "Pricing has changed; updated price is X" with explanation.
+
+**Dishonest pattern.** Silently update price; user does not notice.
+
+The discipline. Honesty about price changes.
+
+---
+
+## Sharing privacy
+
+Shared configurations may include sensitive info.
+
+**Considerations.**
+
+- What is in the URL/embed.
+- Who can see it.
+- How long links are valid.
+
+The discipline. Sharing respects user privacy; sensitive details may need account-based sharing rather than URL.
+
+---
+
+## Save-and-share analytics
+
+Track usage.
+
+**Metrics.**
+
+- Save rate.
+- Resume rate per saved configuration.
+- Share rate.
+- Configurations completed via save-and-share path.
+
+---
+
+## Common save-and-share failures
+
+**No save mechanism.** Users lose work; abandon.
+
+**Save mechanism brittle.** Links expire; account access broken.
+
+**Resume loses state.** User lands at start; loses work.
+
+**Pricing surprise on resume.** Silent price update.
+
+**Sharing exposes sensitive info.** Embedded URLs share more than intended.
+
+**Save trust missing.** Users do not save because they distrust persistence.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The deliberation-friendly principle. Patterns A through F. Save trust communication. Resume experience. Pricing on resume. Sharing privacy. Analytics. Common failures.
+
+## Implementation choices that stay internal
+
+Specific save mechanisms for specific configurators. Specific tooling for URL encoding and embed generation. Privacy review processes. These vary by team.

--- a/skills/product-configurator-design/references/validation-and-error-patterns.md
+++ b/skills/product-configurator-design/references/validation-and-error-patterns.md
@@ -1,0 +1,191 @@
+# Validation and error patterns
+
+Helpful validation. Inline, pre-emptive, final.
+
+Validation catches invalid input. Done well, validation is helpful and inline; done poorly, validation is punitive or arrives only at submission.
+
+---
+
+## The catch-helpful principle
+
+Validation should catch errors at the point where helping the user is most efficient.
+
+**The win.** User selects an option that requires another. Inline validation surfaces immediately; explains; auto-corrects or guides.
+
+**The fail.** User configures complete configuration. Submits. Validation runs at backend. User sees error; loses momentum.
+
+The discipline. Validation timing matters; specific, helpful messages matter; preserve user inputs on error.
+
+---
+
+## Pattern A: Inline validation
+
+Validation runs as the user makes choices.
+
+**How it works.**
+
+- User selects an option.
+- System validates against the rest of the configuration.
+- If invalid, message appears next to the choice.
+
+**Strengths.** Errors caught at point of input.
+
+**Weaknesses.** Real-time validation can lag; intrusive if too aggressive.
+
+**When to use.** Default for most configurators.
+
+---
+
+## Pattern B: Pre-emptive validation
+
+Constraints prevent invalid choices from being selectable.
+
+**How it works.**
+
+- Options that would create conflicts are disabled with explanation.
+- User cannot select the invalid option.
+
+**Strengths.** Errors prevented; user does not encounter them.
+
+**Weaknesses.** Some users want to see the option even if disabled.
+
+**When to use.** When the constraint is hard and explanation is clear.
+
+---
+
+## Pattern C: Final validation
+
+Validation runs at submission.
+
+**How it works.**
+
+- User completes configuration.
+- Submit; system runs full validation.
+- Errors surfaced at this stage.
+
+**Strengths.** Catches errors that span multiple fields.
+
+**Weaknesses.** Late; user invested in completing.
+
+**When to use.** As supplement to inline validation; not primary.
+
+---
+
+## Pattern D: Hybrid
+
+Combining patterns.
+
+**Common combination.** Pre-emptive for hard constraints; inline for soft validation; final as backup.
+
+**Strengths.** Multiple safety nets.
+
+**Weaknesses.** Complexity.
+
+**When to use.** Production configurators with multiple constraint types.
+
+---
+
+## Validation message discipline
+
+What the message says.
+
+**Strong messages.**
+
+- Specific to the issue.
+- Explains why.
+- Offers a path (alternative option, contact for custom).
+
+**Examples.**
+
+- "Option A requires Option B; we have selected B for you."
+- "Option C is incompatible with Option D. Choose one or contact us for custom."
+- "Quantity exceeds 1000; for larger quantities contact our team."
+
+**Weak messages.**
+
+- "Invalid configuration."
+- "Error."
+- "Please correct the issues."
+
+The discipline. Specific, helpful, offers paths.
+
+---
+
+## Validation strictness
+
+How aggressively to validate.
+
+**Too strict.** Rejects valid inputs at edge cases. Frustrates users.
+
+**Too loose.** Accepts invalid inputs that fail downstream.
+
+**The right strictness.** Validation matches actual product constraints.
+
+---
+
+## Preserve inputs on error
+
+What happens when validation engages.
+
+**The principle.** Errors should not lose user inputs.
+
+**The pattern.** Error appears; rest of configuration preserved; user adjusts the specific issue.
+
+**The reset-on-error failure.** Form resets entirely on error. User loses all work; abandons.
+
+The cure. Errors are local; configuration state preserved.
+
+---
+
+## Mobile validation
+
+Validation on mobile.
+
+**Mobile considerations.**
+
+- Inline messages must fit mobile screens.
+- Auto-correct should work with touch.
+- Error states must be visible without zoom.
+
+The mobile discipline. Test validation on actual devices.
+
+---
+
+## Validation testing
+
+Test validation across cases.
+
+**Test cases.**
+
+- Valid configurations: pass through.
+- Invalid configurations (each constraint type): caught with helpful message.
+- Edge cases (boundary values, unusual combinations): handled.
+- Mobile: works on touch.
+
+---
+
+## Common validation failures
+
+**Late validation.** Errors caught only at submission.
+
+**Generic error messages.** No guidance.
+
+**Strict validation rejects valid inputs.** Edge cases lost.
+
+**Loose validation accepts invalid.** Fails downstream.
+
+**Reset-on-error.** User loses work.
+
+**Validation interrupts typing.** Real-time validation too eager.
+
+**Mobile-broken validation.** Errors invisible or off-screen.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catch-helpful principle. Patterns A through D. Validation message discipline. Validation strictness. Preserve inputs on error. Mobile validation. Validation testing. Common failures.
+
+## Implementation choices that stay internal
+
+Specific validation rules for specific configurators. Specific copy. Specific tooling. These vary by team.

--- a/skills/scheduler-and-booking-design/SKILL.md
+++ b/skills/scheduler-and-booking-design/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: scheduler-and-booking-design
+description: "Designing meeting schedulers and booking experiences that qualify leads, set up calls well, and convert at higher rates than a generic Calendly link. Availability logic, qualification gating, prep automation, follow-up sequencing. Honest about any-time-friction (no qualification, just a booking link), interrogation-gate (so much qualification it scares users off), and qualified-fast-path (just enough qualification to set up the call well) patterns. Triggers on scheduler design, meeting booking, demo scheduling, sales call scheduling, calendar tool, booking page, qualification flow. Also triggers when sales team complains about cold demos, when booking conversion is poor, or when scheduler is being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing schedulers and booking flows. Distinguishes any-time-friction (no qualification, just a booking link) from interrogation-gate (so much qualification it scares users off) from qualified-fast-path (just enough qualification to set up the call well)"
+display_order: 10
+---
+
+# Scheduler and Booking Design
+
+A senior growth practitioner's playbook for designing meeting schedulers and booking experiences that qualify leads, set up calls well, and convert at higher rates than a generic booking link. Availability logic, qualification gating, prep automation, follow-up sequencing. The discipline of building a scheduler that earns the booking by earning a better call.
+
+Most schedulers fail in one of two ways. Generic booking links produce cold demos where reps know nothing about the person they are about to talk to. Conversion stays at the rate of unqualified raw demos. Or qualification forms with 12 fields scare users off before they can book; drop-off at the form approaches 90 percent; only the leads who happen to survive the form actually convert.
+
+The schedulers that work do something different. Just enough qualification to set up the call well (3-5 strategic fields), context-aware availability (high-fit leads see senior reps; low-fit leads route differently), prep automation that briefs the rep before the call. The booking is honest about who the audience is; the call is set up to succeed.
+
+The voice is the senior growth practitioner who has watched schedulers double demo conversion when redesigned and watched them collapse when more qualification was added. Practical, opinionated about which fields earn their place, willing to call out when the booking flow is the wrong tool.
+
+When to use this skill: scoping a scheduler for the first time, auditing a booking flow with poor conversion or poor downstream call quality, designing the qualification gate that produces context without producing friction, or deciding routing logic that matches leads to the right reps.
+
+---
+
+## What this skill covers
+
+This skill spans meeting schedulers and booking experiences across acquisition and sales contexts. The growth-tooling distinctions:
+
+- `multi-step-form-design` is pre-signup data capture (forms before the user has access to anything). This skill is meeting-booking specifically; qualification fields exist but the goal is the call, not the data.
+- `funnel-flow-architecture` is broader funnel architecture. This skill is the scheduler specifically.
+- `lead-magnet-design` is different commitment level. Magnets earn an email; bookings earn time.
+- **`scheduler-and-booking-design` (this skill)** is the qualification, availability, routing, prep automation, and follow-up sequencing for meetings.
+- `pm-spec-writing` is the spec for engineers building the scheduler.
+
+The audience: growth marketers, product marketers, marketing operations leads, sales operations leads, agencies running booking optimization for SaaS clients.
+
+Out of scope: pre-signup forms (covered by `multi-step-form-design`); broader funnel orchestration (covered by `funnel-flow-architecture`); the engineering implementation; specific Calendly/Cal.com/Chili Piper/SavvyCal platform configurations (those stay implementation-side).
+
+---
+
+## The booking-flow decision: scheduler vs forms vs sales-pipeline tools
+
+Before designing the scheduler, decide whether a scheduler is the right tool.
+
+**Schedulers earn investment when:**
+
+- The conversion goal is a meeting (demo, sales call, consultation). Email-only conversions do not need a scheduler.
+- The audience is willing to commit time. Schedulers ask for a calendar slot; not all audiences are ready for that.
+- The team has enough sales or success capacity to handle scheduled meetings. Without capacity, scheduled meetings produce wait times that erode conversion.
+- The team can support qualification logic and routing. Without these, a generic booking link is the result.
+
+**Schedulers do NOT earn investment when:**
+
+- The conversion goal is a download or signup. Use forms or magnet flows.
+- The audience volume is too low for routing logic. A handful of bookings per month does not need infrastructure.
+- The team's capacity is variable and routing cannot reflect that. Scheduling without capacity awareness produces no-shows on both sides.
+- A simpler contact form would serve the same purpose.
+
+The decision is not "should we have a scheduler"; it is "is the scheduler the right next investment for this audience and goal."
+
+Detail in `references/scheduler-decision-criteria.md`.
+
+---
+
+## Any-time-friction vs interrogation-gate vs qualified-fast-path
+
+The keystone framing.
+
+**Any-time-friction.** Generic booking link with no qualification, no context capture. Reps show up to calls cold; they spend the first 10 minutes asking the same qualification questions the form should have captured. Conversion stays at the rate of unqualified raw demos. Cost: sales capacity used inefficiently; high-fit leads get the same experience as low-fit leads; downstream conversion suffers.
+
+**Interrogation-gate.** Qualification form with 12 fields before the user can book. Drop-off at the form approaches 90 percent. The qualification works for the leads who survive but the system loses everyone else. Cost: high-fit leads who would have converted abandon at the form; conversion rate is poor even though the post-form leads are well-qualified.
+
+**Qualified-fast-path.** Just enough qualification to set up the call well (3-5 strategic fields), context-aware availability (high-fit leads see senior reps; low-fit leads see SDRs or are routed to async), prep automation that briefs the rep before the call. Cost: design effort upfront is significant; conversion plus downstream call quality both improve meaningfully.
+
+The litmus test. Does the rep arrive at the call already knowing the prospect's situation? Did the prospect feel respected by the booking experience? If yes to both, qualified-fast-path. If the rep starts cold, any-time-friction. If the prospect dropped at the form, interrogation-gate.
+
+---
+
+## Qualification field design
+
+Which fields earn their place; which create friction.
+
+**The principle.** Each qualification field should serve one of two purposes: route the booking to the right rep, or give the rep enough context to skip the qualification phase of the call. Fields serving neither purpose are friction.
+
+**Strong qualification fields.**
+
+- **Company size or team size.** Routes to the right rep tier; enables enterprise vs SMB tracking.
+- **Use case or primary goal.** Lets the rep prepare for the conversation that matches.
+- **Current solution or stack.** Tells the rep where the prospect is starting.
+- **Timeline or urgency.** Routes to active-pipeline vs nurture.
+- **Role or job function.** Lets the rep tailor framing.
+
+**Weak qualification fields.**
+
+- **Phone number** (often unnecessary if email and meeting time are captured).
+- **Generic comments box** (free-text; rarely informs prep).
+- **Marketing data not used in the call** (industry codes, lead-source detail).
+- **Demographic data unrelated to the call** (gender, age).
+
+**The five-field rule.** Most production schedulers work well with 3-5 qualification fields. More than 5 starts producing interrogation-gate dynamics. Less than 3 does not give the rep useful prep context.
+
+Detail in `references/qualification-field-design.md`.
+
+---
+
+## Availability logic
+
+Round-robin, weighted by fit, calendar integration.
+
+**Pattern A: Pure round-robin.** Bookings cycle through available reps in order.
+
+When to use. Simple distribution; small teams.
+
+Strengths. Even distribution; simple logic.
+
+Weaknesses. Does not match high-fit leads to senior reps; does not load-balance based on capacity.
+
+**Pattern B: Weighted round-robin.** Bookings cycle but weighted by rep performance, capacity, or specialty.
+
+When to use. Teams with rep specialization; teams where capacity differs.
+
+**Pattern C: Fit-based routing.** High-fit leads (large company, high urgency) route to senior reps; lower-fit leads route to SDRs or async resources.
+
+When to use. Teams with multi-tier sales motion; clear fit signals captured.
+
+**Pattern D: Hybrid.** Combines patterns. Fit-based routing for top tier; round-robin within tier.
+
+When to use. Most production teams.
+
+**The match-to-rep discipline.** The qualification fields feed routing logic. Routing fails if qualification does not capture routing-relevant data.
+
+Detail in `references/availability-logic-patterns.md`.
+
+---
+
+## Routing patterns
+
+Different reps for different lead types.
+
+**By company size.** SMB to SDRs, mid-market to AEs, enterprise to senior AEs.
+
+**By use case.** Different specialists for different product use cases.
+
+**By geography.** Different reps for different time zones or regions.
+
+**By language.** Native-language reps for non-English-primary leads.
+
+**By account ownership (B2B).** If the lead's company is already a customer or prospect of an AE, route to that AE.
+
+**The unrouted lead.** Some leads do not fit obvious routing. Default rule needed: round-robin or specific catchall.
+
+Detail in `references/routing-patterns.md`.
+
+---
+
+## Prep automation
+
+Briefing the rep before the call.
+
+**The principle.** The qualification data should reach the rep in a useful form before the call. Without prep automation, the data sits unused.
+
+**Prep automation patterns.**
+
+- **CRM enrichment.** Qualification data populates the CRM record; rep sees it in their pre-call review.
+- **Calendar invite enrichment.** Qualification data appears in the meeting invite description; rep sees it on their calendar.
+- **Slack or email brief.** Pre-call brief sent to the rep with synthesized prospect info.
+- **Account research.** Qualification data triggers automated research (company size verification, recent news).
+
+**Strong prep automation.** The rep arrives at the call already knowing: who the prospect is, what they are trying to accomplish, what they are using today, when they need a solution.
+
+**Weak prep automation.** The rep has the qualification data but it is buried in a CRM field nobody opens. The rep starts the call cold despite the data.
+
+Detail in `references/prep-automation-patterns.md`.
+
+---
+
+## Confirmation and reminder sequences
+
+The communications around the booking.
+
+**Booking confirmation.** Sent immediately after booking. Confirms time; restates context; sets expectations.
+
+**Pre-meeting reminder.** Sent 24 hours and/or 1 hour before. Reduces no-shows.
+
+**Post-meeting follow-up.** Sent within hours of the call. Recap; next steps; resources.
+
+**Reschedule and no-show flows.** Different flows for different outcomes.
+
+**The reminder discipline.** Reminders are useful; over-reminding is friction. Two reminders (24-hour and 1-hour) is typical.
+
+Detail in `references/reminder-sequence-patterns.md`.
+
+---
+
+## Reschedule and no-show handling
+
+What happens when meetings do not go to plan.
+
+**Reschedule patterns.**
+
+- Easy self-serve reschedule (no friction).
+- Reschedule preserves qualification data.
+- Reschedule notifies the rep proactively.
+
+**No-show patterns.**
+
+- Auto-detect (rep reports no-show; or system detects unattended meeting).
+- Follow-up to the prospect (gentle; not punitive).
+- Re-engagement sequence (one or two attempts to rebook).
+- Eventual deactivation (do not pursue forever).
+
+**The respect-the-no principle.** Prospects who no-show twice often do not want the meeting. Multiple aggressive reschedule attempts feel like pressure.
+
+Detail in `references/reschedule-and-no-show-handling.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-scheduler-failures.md`.
+
+- "Booking conversion is high; demo conversion to sale is low." Qualification too thin; cold demos do not convert.
+- "Booking conversion is low; demo conversion to sale is high." Interrogation-gate; qualification scares off would-be buyers.
+- "Sales says many bookings come from wrong-fit leads." Routing logic not connecting qualification to rep tier.
+- "No-show rate is over 30 percent." Reminder sequence broken; or commitment friction at booking too low.
+- "Reps complain they get no context before calls." Prep automation broken; data captured but not delivered to rep.
+- "Calendar integration breaks every few weeks." Brittle integration; or rep calendar permissions changing.
+- "Mobile booking conversion is half of desktop." Mobile UX issue.
+- "Booking link gets shared by reps; routing logic bypassed." Generic link in use alongside structured flow; bypass undermines routing.
+- "Round-robin produces uneven workload." Reps with different capacity treated equally.
+
+---
+
+## The framework: 12 considerations for scheduler and booking design
+
+When designing or auditing a scheduler, walk these 12 considerations.
+
+1. **The booking-flow decision.** Is a scheduler the right tool, or a form / sales-pipeline tool?
+2. **Qualified-fast-path, not any-time-friction or interrogation-gate.** Just enough qualification to set up the call well.
+3. **Qualification fields earn their place.** 3-5 fields; each routes or preps.
+4. **Availability logic matches team structure.** Round-robin, weighted, fit-based, or hybrid.
+5. **Routing connects qualification to rep tier.** High-fit leads to senior reps.
+6. **Prep automation delivers data to reps.** CRM enrichment, calendar invite, Slack brief.
+7. **Confirmation and reminders reduce no-shows.** 24-hour and 1-hour typical.
+8. **Reschedule is friction-low.** Self-serve; preserves data.
+9. **No-show flow honest.** Re-engagement attempts limited; respect non-response.
+10. **Mobile parity.** Booking works on the devices the audience uses.
+11. **Conversion to sale as success metric.** Not just booking rate; downstream call-to-sale conversion.
+12. **Maintenance discipline.** Routing rules updated as team changes; quarterly audit.
+
+The output of the framework is a scheduler that earns the booking by earning a better call, with conversion that compounds because the calls themselves are better.
+
+---
+
+## Reference files
+
+- [`references/scheduler-decision-criteria.md`](references/scheduler-decision-criteria.md) - When schedulers earn the build vs when forms or sales-pipeline tools serve.
+- [`references/qualification-field-design.md`](references/qualification-field-design.md) - Strong and weak qualification fields. The five-field rule.
+- [`references/availability-logic-patterns.md`](references/availability-logic-patterns.md) - Round-robin, weighted, fit-based, hybrid. Match-to-rep discipline.
+- [`references/routing-patterns.md`](references/routing-patterns.md) - By size, use case, geography, language, account ownership. Unrouted-lead default.
+- [`references/prep-automation-patterns.md`](references/prep-automation-patterns.md) - CRM enrichment, calendar invite, Slack brief, account research.
+- [`references/reminder-sequence-patterns.md`](references/reminder-sequence-patterns.md) - Confirmation, 24-hour, 1-hour, post-meeting. Frequency discipline.
+- [`references/reschedule-and-no-show-handling.md`](references/reschedule-and-no-show-handling.md) - Reschedule patterns, no-show patterns, respect-the-no principle.
+- [`references/scheduler-anti-patterns.md`](references/scheduler-anti-patterns.md) - The patterns that look like schedulers but degrade conversion.
+- [`references/common-scheduler-failures.md`](references/common-scheduler-failures.md) - 9+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: schedulers earn the booking when they earn the better call
+
+The schedulers that work as compounding assets are the ones that produce better calls. Not just more bookings. Calls where the rep arrives prepared; the prospect feels respected; the conversation moves faster because qualification was already done. Conversion compounds because the calls themselves convert better.
+
+That is the bar. Below the bar are any-time-friction (cold demos, conversion suffers) and interrogation-gate (90 percent abandon at the form). Above the bar are qualified-fast-path schedulers where qualification, availability, routing, prep automation, and follow-up sequencing combine into a system that earns the booking and the call.
+
+The discipline is in the design choices. The decision to use a scheduler at all. The qualification fields that earn their place. The availability logic that matches lead to rep. The routing that respects rep tier and capacity. The prep automation that delivers context to reps before the call. The reminder cadence that reduces no-shows without becoming spam. The reschedule and no-show handling that respects the prospect.

--- a/skills/scheduler-and-booking-design/references/availability-logic-patterns.md
+++ b/skills/scheduler-and-booking-design/references/availability-logic-patterns.md
@@ -1,0 +1,272 @@
+# Availability logic patterns
+
+Round-robin, weighted, fit-based, hybrid. Match-to-rep discipline.
+
+How the scheduler decides which rep gets which booking. Done well, availability logic distributes load while matching high-fit leads to senior reps; done poorly, leads land on the wrong reps and conversion suffers.
+
+---
+
+## The match-to-rep principle
+
+The qualification fields feed routing logic. Routing fails if qualification does not capture routing-relevant data.
+
+**The win.** A high-fit enterprise lead (large company, urgent timeline) sees availability for senior AEs. Low-fit lead (small team, exploring) sees availability for SDRs. Each lead gets the right call.
+
+**The fail.** Same scheduler with pure round-robin. Enterprise lead lands on an SDR; SDR is unprepared; conversion drops.
+
+The discipline. Routing is not separate from qualification; the two are coupled.
+
+---
+
+## Pattern A: Pure round-robin
+
+Bookings cycle through available reps in order.
+
+**How it works.**
+
+- Available reps in the queue.
+- Each booking goes to the next rep.
+- Cycle continues.
+
+**Strengths.**
+
+- Even distribution.
+- Simple logic.
+- Easy to explain to the team.
+
+**Weaknesses.**
+
+- Does not match high-fit leads to senior reps.
+- Does not load-balance based on capacity.
+- Does not account for rep specialization.
+
+**When to use.** Small teams; reps are interchangeable; volume is low.
+
+---
+
+## Pattern B: Weighted round-robin
+
+Bookings cycle but weighted by rep performance, capacity, or specialty.
+
+**How it works.**
+
+- Each rep has a weight (performance score, capacity, etc.).
+- Distribution skews toward higher-weighted reps.
+- Still distributes; just unevenly.
+
+**Strengths.**
+
+- Higher-performing reps get more bookings.
+- Capacity differences accommodated.
+
+**Weaknesses.**
+
+- Lower-performing reps get fewer learning opportunities.
+- Weighting must be maintained.
+
+**When to use.** Teams with significant rep performance differences; teams where capacity differs.
+
+---
+
+## Pattern C: Fit-based routing
+
+High-fit leads route to senior reps; lower-fit leads route to SDRs or async resources.
+
+**How it works.**
+
+- Qualification fields determine fit score.
+- High-fit leads see availability for senior reps only.
+- Lower-fit leads see availability for SDRs.
+
+**Strengths.**
+
+- Senior reps focus on high-value conversations.
+- SDRs handle qualification and nurture.
+- Resource allocation matches lead value.
+
+**Weaknesses.**
+
+- Requires clear fit signals from qualification.
+- May produce uneven workload (senior reps light, SDRs heavy).
+
+**When to use.** Teams with multi-tier sales motion; clear fit signals captured.
+
+---
+
+## Pattern D: Specialty-based routing
+
+Bookings route to reps with specific expertise.
+
+**How it works.**
+
+- Qualification captures use case or industry.
+- Bookings route to the rep with matching specialty.
+
+**Strengths.**
+
+- Rep is genuinely prepared for the specific conversation.
+- Higher conversion when specialty matches.
+
+**Weaknesses.**
+
+- Specialist reps can become bottlenecks.
+- Requires per-rep specialty tagging.
+
+**When to use.** Products with multiple distinct use cases or verticals.
+
+---
+
+## Pattern E: Account-ownership routing (B2B)
+
+If the lead's company is already in pipeline or a customer, route to the owning AE.
+
+**How it works.**
+
+- Qualification or domain matching detects existing-account leads.
+- Bookings route to the AE who owns the account.
+- Override default routing.
+
+**Strengths.**
+
+- Account owner has context.
+- Avoids confusion of multiple reps on the same account.
+
+**Weaknesses.**
+
+- Requires CRM integration to detect ownership.
+- Account ownership must be current.
+
+**When to use.** B2B teams with account-ownership models.
+
+---
+
+## Pattern F: Hybrid
+
+Combining patterns. Most production teams use hybrid.
+
+**Common combinations.**
+
+- Account-ownership routing first (existing accounts to AEs).
+- Then fit-based routing (high-fit new leads to senior AEs).
+- Then specialty-based routing within tier.
+- Then round-robin within remaining pool.
+
+**Strengths.**
+
+- Handles common cases.
+- Routes lead to best-matched rep.
+
+**Weaknesses.**
+
+- More complex to maintain.
+- More edge cases to handle.
+
+**When to use.** Mature production teams with multi-tier sales motion.
+
+---
+
+## Calendar integration
+
+How availability connects to actual calendars.
+
+**Direct calendar integration.** Scheduler reads rep calendars; shows actual availability.
+
+Strengths. No double-booking; reflects reality.
+
+Weaknesses. Requires calendar permissions; integration brittle.
+
+**Office hours definition.** Reps define availability windows; scheduler shows those.
+
+Strengths. Simpler integration; no calendar permissions needed.
+
+Weaknesses. Manual maintenance; reps may forget to update.
+
+**Hybrid.** Scheduler uses office hours plus calendar busy/free for fine-grain.
+
+Strengths. Resilient to integration issues.
+
+Weaknesses. More complex.
+
+---
+
+## Buffer time
+
+Time between meetings.
+
+**Why it matters.** Back-to-back meetings produce rushed reps and late starts. Buffer protects rep effectiveness.
+
+**Common buffers.** 10-15 minutes between meetings.
+
+**The discipline.** Buffer should be in the calendar logic, not optional.
+
+---
+
+## Capacity caps
+
+How many meetings per day per rep.
+
+**Why caps matter.** Reps booked solid produce poor calls; quality drops; conversion suffers.
+
+**Common caps.** 3-5 demos per day per rep typical for B2B SaaS.
+
+**The discipline.** Caps respect rep effectiveness, not just calendar availability.
+
+---
+
+## Time zone handling
+
+The scheduler shows availability in the prospect's time zone.
+
+**The principle.** Display in prospect's time zone; reps see in their own.
+
+**Common patterns.**
+
+- Auto-detect from browser; show prospect that detection.
+- Allow manual override.
+- Display rep's time zone for clarity ("PT" badge).
+
+**Anti-pattern.** Showing all times in rep's time zone; prospect has to convert mentally.
+
+---
+
+## Out-of-office and holiday handling
+
+Real life intervenes.
+
+**Patterns.**
+
+- Calendar integration handles vacation as busy time.
+- Manual office-hours updates handle planned absences.
+- Holiday calendars block company-wide closures.
+
+**The discipline.** Out-of-office should be respected automatically; otherwise no-shows happen.
+
+---
+
+## Common availability failures
+
+**Pure round-robin for tiered teams.** High-fit leads land on junior reps.
+
+**No capacity caps.** Reps overbooked; quality drops.
+
+**No buffer.** Meetings run late; reps are stressed.
+
+**Time zone confusion.** Prospect sees rep's time zone; bookings happen at wrong times.
+
+**Stale rep weights.** Weighted round-robin uses last-quarter performance; recent changes ignored.
+
+**Specialty routing without specialty data.** Specialty-based routing requires per-rep tagging; missing tags route incorrectly.
+
+**Account-ownership not detected.** Existing-account lead bounces around between reps.
+
+**Calendar integration broken.** Double-bookings happen; trust degrades.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The match-to-rep principle. Patterns A through F (round-robin, weighted, fit-based, specialty, account-ownership, hybrid). Calendar integration. Buffer time. Capacity caps. Time zone handling. Out-of-office and holiday handling. Common failures.
+
+## Implementation choices that stay internal
+
+Specific routing logic for specific teams. Specific weights and caps. Specific tooling. The team's audit calendar. These vary by team.

--- a/skills/scheduler-and-booking-design/references/common-scheduler-failures.md
+++ b/skills/scheduler-and-booking-design/references/common-scheduler-failures.md
@@ -1,0 +1,179 @@
+# Common scheduler failures
+
+9+ failure patterns with diagnoses and cures.
+
+---
+
+## "Booking conversion is high; demo conversion to sale is low."
+
+**The diagnosis.** Qualification too thin; cold demos do not convert.
+
+**The cure.** Add 3-5 strategic qualification fields. Detail in `references/qualification-field-design.md`.
+
+---
+
+## "Booking conversion is low; demo conversion to sale is high."
+
+**The diagnosis.** Interrogation-gate; qualification scares off would-be buyers.
+
+**The cure.** Cut qualification to 3-5 fields. Defer non-essential questions to in-call.
+
+---
+
+## "Sales says many bookings come from wrong-fit leads."
+
+**The diagnosis.** Routing logic not connecting qualification to rep tier.
+
+**The cure.** Add fit-based routing. Detail in `references/routing-patterns.md`.
+
+---
+
+## "No-show rate is over 30 percent."
+
+**The diagnosis.** Reminder sequence broken; or commitment friction at booking too low.
+
+**The cure.** Audit reminder cadence. Strengthen pre-meeting communications. Detail in `references/reminder-sequence-patterns.md`.
+
+---
+
+## "Reps complain they get no context before calls."
+
+**The diagnosis.** Prep automation broken; data captured but not delivered.
+
+**The cure.** CRM enrichment, calendar invite enrichment, Slack brief. Detail in `references/prep-automation-patterns.md`.
+
+---
+
+## "Calendar integration breaks every few weeks."
+
+**The diagnosis.** Brittle integration; or rep calendar permissions changing.
+
+**The cure.** Monitor integration; fix permissions; have a manual fallback for downtime.
+
+---
+
+## "Mobile booking conversion is half of desktop."
+
+**The diagnosis.** Mobile UX issue.
+
+**The cure.** Mobile-first design and testing.
+
+---
+
+## "Booking link gets shared by reps; routing logic bypassed."
+
+**The diagnosis.** Generic link in use alongside structured flow.
+
+**The cure.** Disable generic links. Train reps; provide rep-specific structured links if needed.
+
+---
+
+## "Round-robin produces uneven workload."
+
+**The diagnosis.** Reps with different capacity treated equally.
+
+**The cure.** Weighted round-robin or capacity-aware routing.
+
+---
+
+## "Time zone errors cause no-shows."
+
+**The diagnosis.** Time zone display unclear or auto-detection wrong.
+
+**The cure.** Display time zone clearly at booking and in invites. Auto-detect prospect time zone; allow override.
+
+---
+
+## "Reps reschedule manually frequently."
+
+**The diagnosis.** Routing produces wrong-fit bookings; reps fix manually.
+
+**The cure.** Audit routing logic; fix the source of the wrong-fit bookings.
+
+---
+
+## "Conversion was strong; quality dropped after sales team change."
+
+**The diagnosis.** New rep tier or specialization mix; routing not updated.
+
+**The cure.** Routing rules updated as team changes. Quarterly review.
+
+---
+
+## "We added more qualification fields; conversion dropped."
+
+**The diagnosis.** Crossed the five-field threshold.
+
+**The cure.** Cut back. Five-field rule from `references/qualification-field-design.md`.
+
+---
+
+## "Some segments convert; others do not."
+
+**The diagnosis.** Single scheduler treats all segments the same.
+
+**The cure.** Per-segment qualification or routing. Different segments may need different schedulers.
+
+---
+
+## "Schedulers work for direct traffic; partner-sourced leads convert poorly."
+
+**The diagnosis.** Partner-sourced leads have different fit profile; routing or qualification not adapted.
+
+**The cure.** Source-based routing. Partner leads may need different rep tier or different prep.
+
+---
+
+## "We tried different reminder cadences; no-shows did not move."
+
+**The diagnosis.** No-show may not be reminder-driven. Could be commitment friction at booking, time zone errors, or audience mismatch.
+
+**The cure.** Test other variables. Audit booking commitment level, time zone clarity, audience-fit.
+
+---
+
+## "Sales says enterprise prospects skip the scheduler and email instead."
+
+**The diagnosis.** Enterprise audiences sometimes want personal contact rather than self-serve booking.
+
+**The cure.** Offer a "talk to sales" alternative for enterprise leads. Hybrid approach.
+
+---
+
+## "Conversion dropped after we updated the booking flow."
+
+**The diagnosis.** Specific change introduced friction.
+
+**The cure.** Compare metrics pre- and post-change. Roll back if necessary; isolate the issue.
+
+---
+
+## "Reschedule flow loses qualification data."
+
+**The diagnosis.** Reschedule treated as new booking; data not preserved.
+
+**The cure.** Reschedule preserves qualification. Detail in `references/reschedule-and-no-show-handling.md`.
+
+---
+
+## The pattern across failures
+
+Most scheduler failures fall into one of three patterns.
+
+**Pattern 1: Qualification miscalibrated.** Any-time-friction, interrogation-gate, or wrong fields. The fix is calibrating qualification to the team's needs.
+
+**Pattern 2: Routing or prep miscalibrated.** Wrong-rep-tier, no-prep-automation, broken integrations. The fix is connecting qualification to rep workflow.
+
+**Pattern 3: Communication miscalibrated.** Aggressive reminders, brittle no-show flows, missing reschedule paths. The fix is gentle, useful communication.
+
+The metric pattern: scheduler failures often look fine on booking conversion alone. The signal is in demo-to-sale conversion, no-show rates, rep prep quality. Programs that track only booking rate keep shipping the same patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (qualification, routing/prep, communication). The principle that booking rate alone is insufficient.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered. Specific multi-metric dashboards. Specific cures. The team's audit and retirement processes. These vary by team.

--- a/skills/scheduler-and-booking-design/references/prep-automation-patterns.md
+++ b/skills/scheduler-and-booking-design/references/prep-automation-patterns.md
@@ -1,0 +1,247 @@
+# Prep automation patterns
+
+CRM enrichment, calendar invite, Slack brief, account research.
+
+The qualification data should reach the rep in a useful form before the call. Without prep automation, the data sits unused and the rep starts the call cold despite the data being captured.
+
+---
+
+## The data-reaches-rep principle
+
+Prep automation closes the loop between qualification capture and rep readiness.
+
+**The win.** Prospect books; qualification data populates the CRM record, appears in the calendar invite, and triggers a brief Slack message to the rep with synthesized prep notes. The rep arrives at the call already knowing the prospect's situation.
+
+**The fail.** Qualification data captured; sits in a database; rep does not see it until they search for it. Most reps do not search; they start the call cold.
+
+The discipline. Capture qualification AND deliver it to the rep where they will see it.
+
+---
+
+## Pattern A: CRM enrichment
+
+Qualification data populates the CRM record.
+
+**How it works.**
+
+- Booking submission writes to CRM (Salesforce, HubSpot, etc.).
+- Fields populate the lead/contact record.
+- Rep sees the data when they review the lead.
+
+**Strengths.**
+
+- Single source of truth.
+- Fits existing rep workflow (reps already check CRM).
+
+**Weaknesses.**
+
+- Reps may not check CRM before every call.
+- CRM custom fields require setup.
+
+**When to use.** Default; baseline for any prep automation.
+
+---
+
+## Pattern B: Calendar invite enrichment
+
+Qualification data appears in the meeting invite description.
+
+**How it works.**
+
+- When the meeting is created, the invite description includes the qualification data.
+- Rep sees it on their calendar; visible at-a-glance.
+
+**Strengths.**
+
+- Rep cannot miss it; calendar is the moment of action.
+- Works regardless of CRM access.
+
+**Weaknesses.**
+
+- Calendar invite descriptions can be long; reps may not read fully.
+- Updates after booking do not appear in the invite.
+
+**When to use.** Strong complement to CRM enrichment.
+
+---
+
+## Pattern C: Slack or email brief
+
+Pre-call brief sent to the rep with synthesized prospect info.
+
+**How it works.**
+
+- Booking triggers a Slack message or email to the rep.
+- Brief includes qualification data plus context (account history, company info, prior interactions).
+- Often delivered hours or a day before the call.
+
+**Strengths.**
+
+- Active delivery; rep receives it without searching.
+- Can include synthesized context (CRM history, news, prior touches).
+
+**Weaknesses.**
+
+- Slack noise can dilute brief; reps may scroll past.
+- Email may sit unread.
+
+**When to use.** When the team's workflow includes Slack or email-driven prep.
+
+---
+
+## Pattern D: Account research
+
+Qualification data triggers automated research.
+
+**How it works.**
+
+- Booking triggers automated lookup (company size verification via Clearbit/ZoomInfo, recent news search, social media check).
+- Research results appended to CRM or prep brief.
+
+**Strengths.**
+
+- Rep gets richer context than qualification alone provides.
+- Catches data prospects did not provide.
+
+**Weaknesses.**
+
+- Research tools cost.
+- Can miss for small companies or international.
+
+**When to use.** Enterprise sales motion; high-value calls warrant research investment.
+
+---
+
+## Pattern E: Hybrid
+
+Combining patterns. Most production teams use multiple.
+
+**Common combination.**
+
+- CRM enrichment as baseline.
+- Calendar invite enrichment for at-a-glance visibility.
+- Slack brief 24 hours before the call for richer prep.
+- Account research for high-fit leads.
+
+The hybrid produces multiple touchpoints; rep sees prep data wherever they happen to look first.
+
+---
+
+## What to include in prep automation
+
+The fields that matter to the rep.
+
+**Standard inclusions.**
+
+- Prospect name and role.
+- Company name and size.
+- Use case or primary goal.
+- Current solution.
+- Timeline or urgency.
+- Source (paid, organic, referral).
+
+**Sometimes useful.**
+
+- Company industry and recent news.
+- Prior interactions with the brand.
+- LinkedIn profile link.
+- Account history (existing customer, prior trial).
+
+**Avoid in prep.**
+
+- Free-text fields the prospect filled with noise.
+- Marketing data not relevant to the call (UTM details, lead source granularity).
+- Personal data not needed for the call.
+
+---
+
+## Prep timing
+
+When the brief reaches the rep.
+
+**At-booking.** Brief delivered immediately after booking. Rep can prepare any time.
+
+**Day-before.** Brief delivered 24 hours before. Forces prep into the rep's workflow.
+
+**Hour-before.** Brief delivered 1 hour before. Last-minute prep; useful for back-to-back calls.
+
+**The combined approach.** Most teams use at-booking (CRM record) plus day-before (Slack) plus calendar visibility throughout.
+
+---
+
+## Prep brief copy
+
+What the brief says.
+
+**Strong brief copy.**
+
+- "Sarah Lee, Director of Marketing at [Company], 200-500 employees, evaluating analytics tools to replace [current solution] within 60 days."
+
+What works. Specific; structured; gives rep enough to prepare.
+
+**Weak brief copy.**
+
+- "New booking from Sarah Lee."
+
+What fails. No context; rep starts cold despite the data being captured upstream.
+
+The discipline. Brief should be specific enough that the rep arrives ready.
+
+---
+
+## Prep automation testing
+
+Verify the loop works.
+
+**Test cases.**
+
+- Booking happens; CRM record created; data populates.
+- Booking happens; calendar invite shows the qualification data.
+- Booking happens; Slack brief arrives at the right time.
+- Edge case: prospect updates booking; prep updates accordingly.
+
+**Production monitoring.** If reps consistently arrive at calls cold, prep automation is broken somewhere.
+
+---
+
+## Privacy and consent
+
+Prep automation involves handling user data.
+
+**The principle.** Data captured at booking flows to internal systems for prep. The prospect has implicitly consented to internal use through the booking.
+
+**Limits.**
+
+- Data should not flow to systems unrelated to the booking purpose.
+- Account research should respect privacy norms.
+- GDPR and other regulations apply.
+
+---
+
+## Common prep automation failures
+
+**No automation.** Data captured; reps do not see it.
+
+**CRM enrichment without rep CRM use.** Data is in CRM; reps do not check CRM before calls.
+
+**Slack brief lost in noise.** Prep brief among 50 other Slack messages; rep misses.
+
+**Calendar invite truncated.** Invite description too long; reps see only opening.
+
+**Stale account research.** Research data from months ago.
+
+**Brief copy generic.** Brief contains data but not synthesized context.
+
+**Updates after booking not propagated.** Prospect updates info; prep stays old.
+
+**No testing.** Prep loop broken; nobody noticed.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The data-reaches-rep principle. Patterns A through E (CRM, calendar, Slack, research, hybrid). What to include in prep. Prep timing. Prep brief copy discipline. Prep automation testing. Privacy and consent. Common failures.
+
+## Implementation choices that stay internal
+
+Specific prep configurations for specific teams. Specific Slack templates and CRM custom fields. Specific research tooling. The team's privacy review processes. These vary by team.

--- a/skills/scheduler-and-booking-design/references/qualification-field-design.md
+++ b/skills/scheduler-and-booking-design/references/qualification-field-design.md
@@ -1,0 +1,221 @@
+# Qualification field design
+
+Strong and weak qualification fields. The five-field rule.
+
+The fields decide the booking flow's friction and the call's quality. Done well, qualification produces context for the call without scaring off prospects; done poorly, it produces interrogation-gate dynamics.
+
+---
+
+## The earns-its-place principle
+
+Each qualification field should serve one of two purposes: route the booking to the right rep, or give the rep enough context to skip the qualification phase of the call. Fields serving neither purpose are friction.
+
+**The win.** Four fields: company size, role, primary use case, timeline. Each routes or preps. Conversion is high; rep prep is concrete.
+
+**The fail.** Twelve fields including industry code, employee count range, marketing source, lead-source detail, gender. Most do not affect routing or prep; conversion drops 70 percent.
+
+The discipline. Audit each field. Cut fields that do not earn placement.
+
+---
+
+## Strong qualification fields
+
+Patterns that earn placement.
+
+**Company size or team size.**
+
+Why it works. Routes to the right rep tier (SMB vs mid-market vs enterprise); enables segment tracking; concrete signal of fit.
+
+Format. Dropdown with bands ("1-10," "11-50," "51-200," "201-1000," "1000+").
+
+**Use case or primary goal.**
+
+Why it works. Lets the rep prepare for the conversation that matches.
+
+Format. Dropdown with 5-7 use cases; or short open text if use cases are not enumerable.
+
+**Current solution or stack.**
+
+Why it works. Tells the rep where the prospect is starting; informs migration vs greenfield framing.
+
+Format. Dropdown of common alternatives plus "other" with text field.
+
+**Timeline or urgency.**
+
+Why it works. Routes to active-pipeline vs nurture; signals urgency to the rep.
+
+Format. Dropdown ("Within 30 days," "1-3 months," "3-6 months," "Just exploring").
+
+**Role or job function.**
+
+Why it works. Lets the rep tailor framing; routes to specialist reps if role-aligned.
+
+Format. Dropdown of common roles; "Other" field for unusual cases.
+
+---
+
+## Weak qualification fields
+
+Patterns that fail.
+
+**Phone number.**
+
+Why it fails. Often unnecessary if email and meeting time are captured. Reps can request phone in the call. Phone field adds friction without value for the booking itself.
+
+When to include. If the call is by phone (not video), phone is necessary.
+
+**Generic comments box.**
+
+Why it fails. Free-text rarely informs prep. Most prospects skip; some over-share; few provide useful context.
+
+When to include. Sparingly; if structured fields cannot capture the necessary context.
+
+**Marketing data not used in the call.**
+
+Why it fails. Industry codes, lead-source detail, etc. add friction without affecting the call's quality.
+
+When to include. Capture later (post-meeting follow-up form, CRM enrichment) rather than at the booking.
+
+**Demographic data unrelated to the call.**
+
+Why it fails. Gender, age, etc. rarely inform a B2B sales conversation.
+
+When to include. Almost never. Only if regulatory or product-specific reasons require.
+
+---
+
+## The five-field rule
+
+Most production schedulers work well with 3-5 qualification fields.
+
+**Why 3-5.**
+
+- 3 fields is the minimum for useful qualification.
+- 5 fields is the threshold beyond which drop-off climbs.
+- Production data across many SaaS products supports this range.
+
+**Exceptions.**
+
+- Some enterprise sales contexts warrant 5-7 fields because the audience expects qualification.
+- Some highly specialized products warrant fewer fields (1-2) because conversion volume matters more.
+
+**The over-five trap.** Each additional field beyond 5 reduces conversion meaningfully. The marginal value of field 6 rarely justifies the conversion cost.
+
+---
+
+## Field ordering
+
+Within the form, the order matters.
+
+**Open with low-friction.** Identity fields (name, email) first. Familiar; easy.
+
+**Build to value.** Use-case or goal fields next. The prospect engages with what the call will be about.
+
+**Save commitment for later.** Timeline or budget fields late. The prospect has invested; harder ask is acceptable.
+
+**End with optional.** Comments or "anything else?" at the end if included. The prospect can leave or skip.
+
+---
+
+## Field formats
+
+How each field captures input.
+
+**Dropdowns.** Best for categorical fields. Constrains responses; easy to route on.
+
+**Text fields.** For free-form fields (name, email, sometimes use case).
+
+**Sliders.** Rarely useful in qualification.
+
+**Yes/No toggles.** For binary qualifying questions (e.g., "Do you currently use a CRM?").
+
+**Conditional fields.** Some fields appear based on earlier answers. Use sparingly; complexity adds maintenance.
+
+---
+
+## Field validation
+
+What to validate.
+
+**Email format.** Standard validation; respect plus-aliases and international domains.
+
+**Required vs optional.** Mark explicitly.
+
+**Length and character.** Don't reject international names or non-Latin characters.
+
+**The validation-strict failure.** Validation that rejects valid inputs (international phone formats, plus-sign emails) loses real prospects.
+
+---
+
+## Inferred vs asked fields
+
+What to ask vs what to infer.
+
+**Ask sparingly.** Each field is friction.
+
+**Infer when possible.**
+
+- Lead source: from URL parameters or referrer.
+- Company info: from email domain.
+- Geography: from IP or browser.
+- Timezone: from browser.
+
+**The discipline.** If the system can infer a value reliably, do not ask.
+
+---
+
+## Field-level analytics
+
+Track per-field drop-off.
+
+**Per-field completion rate.** Where in the form do prospects abandon?
+
+**Diagnostic uses.**
+
+- Specific field with high abandonment: friction at that field.
+- Field rarely completed even by survivors: often signals the field can be cut.
+- Specific segment abandons specific fields: segment-specific friction.
+
+The data informs which fields earn their place over time.
+
+---
+
+## Field maintenance
+
+Fields decay.
+
+**What decays.**
+
+- Dropdowns with options that no longer match audience.
+- Fields the rep team stopped using for prep.
+- Fields whose routing logic changed without update.
+
+**Maintenance cadence.** Quarterly review of each field. Are reps using the data? Is routing connecting field-to-tier?
+
+---
+
+## Common field failures
+
+**Too many fields.** Drop-off at the form.
+
+**Fields not used.** Captured but reps do not prep with them.
+
+**Wrong field types.** Free text where dropdown would route better.
+
+**Validation too strict.** Loses valid prospects.
+
+**No analytics.** Cannot tell which fields are working.
+
+**Stale field options.** Dropdowns no longer match audience.
+
+**Fields asked that could be inferred.** Friction without need.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The earns-its-place principle. Strong qualification fields (5 patterns). Weak qualification fields (4 patterns). The five-field rule. Field ordering. Field formats. Field validation. Inferred vs asked. Field-level analytics. Field maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific fields for specific schedulers. Specific dropdown options. Specific tooling for inference. The team's audit calendar. These vary by team and product.

--- a/skills/scheduler-and-booking-design/references/reminder-sequence-patterns.md
+++ b/skills/scheduler-and-booking-design/references/reminder-sequence-patterns.md
@@ -1,0 +1,256 @@
+# Reminder sequence patterns
+
+Confirmation, 24-hour, 1-hour, post-meeting. Frequency discipline.
+
+The communications around the booking. Done well, reminders reduce no-shows without becoming spam; done poorly, reminders are either insufficient (no-shows climb) or excessive (prospect resents).
+
+---
+
+## The reduce-no-shows-without-spam principle
+
+Reminders matter; their volume should be calibrated.
+
+**The win.** Confirmation immediately after booking; one reminder 24 hours before; one reminder 1 hour before. Three communications total. No-show rate drops; prospects feel reminded but not nagged.
+
+**The fail.** Confirmation; 5-day reminder; 2-day reminder; 1-day reminder; 1-hour reminder; 15-minute reminder. Six communications. Prospects mute the channel; no-shows persist for users who muted.
+
+The discipline. Reminders earn their place; cumulative volume should be capped.
+
+---
+
+## Pattern A: Booking confirmation
+
+Sent immediately after booking.
+
+**What it includes.**
+
+- Confirmed time and meeting type.
+- Calendar invite attached.
+- Brief restate of expectations (e.g., "Looking forward to learning about your X").
+- Reschedule and cancel links.
+
+**Strengths.**
+
+- Immediate; reduces buyer's remorse.
+- Sets expectations.
+- Provides reschedule path.
+
+**Weaknesses.**
+
+- One-touch communication.
+
+**When to use.** Always.
+
+---
+
+## Pattern B: Pre-meeting reminder
+
+Sent 24 hours and/or 1 hour before.
+
+**24-hour reminder.**
+
+- Useful for users who book days in advance.
+- Lets them prepare or reschedule with notice.
+
+**1-hour reminder.**
+
+- Useful for last-minute prep.
+- Catches calendar drift.
+
+**Both useful or one only?**
+
+- Most production teams use both.
+- For very short booking windows (same-day), 1-hour is enough.
+- For longer-lead bookings, 24-hour matters.
+
+---
+
+## Pattern C: Post-meeting follow-up
+
+Sent within hours of the call.
+
+**What it includes.**
+
+- Brief recap.
+- Action items (rep's commitments).
+- Resources mentioned in the call.
+- Next-step CTA (next meeting, document, trial).
+
+**Strengths.**
+
+- Captures momentum from the call.
+- Documents commitments.
+
+**Weaknesses.**
+
+- Requires rep to populate after the call (or rep-side tooling to auto-generate).
+
+**When to use.** Sales conversations where next steps matter.
+
+---
+
+## Pattern D: Reschedule prompts
+
+When the prospect cannot make the meeting.
+
+**What it includes.**
+
+- Easy reschedule link.
+- Brief check-in copy ("Need to reschedule? No problem.").
+
+**Strengths.**
+
+- Reduces no-shows; users reschedule rather than ghost.
+
+**Weaknesses.**
+
+- Some users use this to reschedule indefinitely.
+
+**When to use.** Always available; not aggressive.
+
+---
+
+## Pattern E: No-show follow-up
+
+When the prospect does not attend.
+
+**What it includes.**
+
+- Acknowledgment of missed meeting.
+- Reschedule link.
+- Brief context-restatement.
+
+**Tone.** Gentle, not punitive. The prospect may have had a real reason.
+
+**The respect-the-no-show principle.** After 1-2 reschedule attempts, accept that the prospect is not engaging.
+
+---
+
+## Reminder timing
+
+When each communication fires.
+
+**Common cadence.**
+
+- T+0: Confirmation immediately after booking.
+- T-24h: Reminder 24 hours before.
+- T-1h: Reminder 1 hour before.
+- T+15m: Late-arrival check (sometimes).
+- T+24h: Post-meeting follow-up.
+
+The discipline. Each communication earns its place. Drop the ones that do not.
+
+---
+
+## Channel choice
+
+Which channels to use.
+
+**Email.** Default. Reliable; familiar.
+
+**SMS.** Higher attention; more friction. Use selectively for high-value bookings.
+
+**In-app notification.** If the booking is for a logged-in user, in-app reminders work.
+
+**Slack or Teams.** For B2B internal-team meetings.
+
+**The cumulative discipline.** Multiple channels for the same reminder is excessive. Pick one channel per reminder.
+
+---
+
+## Reminder copy
+
+What the reminders say.
+
+**Strong reminder copy.**
+
+- "Looking forward to our call tomorrow at 2 PM PT. Here's what we'll cover: [agenda]."
+- "Reminder: 1 hour until our call. Join here: [link]."
+- "Thanks for the call today. Here's what we discussed: [recap]."
+
+What works. Specific; useful; brief.
+
+**Weak reminder copy.**
+
+- "Don't forget your meeting!"
+- "Your meeting is in 1 hour."
+- "Did you know..."
+
+What fails. Generic; no value-add; just a notification.
+
+---
+
+## Reminder personalization
+
+How much to personalize.
+
+**Default personalization.** Name; meeting time; rep name.
+
+**Strong personalization.** Brief context tied to qualification ("Looking forward to discussing your [use case] situation").
+
+**Over-personalization.** Long personalized paragraphs that read as marketing.
+
+The discipline. Personalize where it adds value; do not pad with personalization for its own sake.
+
+---
+
+## Reminder analytics
+
+Track effectiveness.
+
+**Metrics.**
+
+- Open rate per reminder.
+- Reschedule rate per reminder.
+- No-show rate (cumulative across cadence).
+- Cancellation rate.
+
+**Diagnostic uses.**
+
+- Low open rate: subject line weak or channel wrong.
+- High reschedule rate after specific reminder: that reminder triggers reconsideration.
+- High no-show despite reminders: friction at the meeting itself, not the reminder.
+
+---
+
+## Reminder maintenance
+
+Reminders decay.
+
+**What decays.**
+
+- Templates with stale rep names or roles.
+- Calendar links that broke after platform changes.
+- Channel preferences that no longer fit audience.
+
+**Maintenance cadence.** Quarterly review of reminder templates and channels.
+
+---
+
+## Common reminder failures
+
+**Too many reminders.** Cumulative volume is spam; users mute.
+
+**Too few reminders.** No-show rate climbs.
+
+**Generic copy.** No value; users dismiss.
+
+**Wrong channel.** SMS for an audience that prefers email.
+
+**Stale templates.** Rep names from former employees; broken calendar links.
+
+**No post-meeting follow-up.** Conversation momentum lost.
+
+**Aggressive no-show follow-up.** Multiple reminder attempts after a no-show; respect non-response.
+
+**Personalization padding.** Long personalized text that reads as marketing.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The reduce-no-shows-without-spam principle. Patterns A through E (confirmation, pre-meeting, post-meeting, reschedule, no-show). Reminder timing. Channel choice. Reminder copy discipline. Reminder personalization. Reminder analytics. Reminder maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific reminder cadences for specific teams. Specific copy in brand voice. Specific channel choices. The team's no-show baselines. These vary by team.

--- a/skills/scheduler-and-booking-design/references/reschedule-and-no-show-handling.md
+++ b/skills/scheduler-and-booking-design/references/reschedule-and-no-show-handling.md
@@ -1,0 +1,241 @@
+# Reschedule and no-show handling
+
+Reschedule patterns, no-show patterns, respect-the-no principle.
+
+What happens when meetings do not go to plan. Done well, reschedule and no-show handling protect the relationship and capture re-engagement; done poorly, they punish the prospect for ordinary life events.
+
+---
+
+## The respect-the-no principle
+
+Prospects who reschedule or no-show often have real reasons. Handling should be gentle, not punitive.
+
+**The win.** Prospect no-shows; gentle follow-up offers easy reschedule. Prospect reschedules once; offered again at a new convenient time. After two no-shows, the system stops aggressive pursuit and routes to nurture.
+
+**The fail.** Prospect no-shows; system fires three reminder emails over two days; phone call follows; prospect feels harassed.
+
+The discipline. Acknowledge that life intervenes; offer a path back; do not pressure.
+
+---
+
+## Reschedule patterns
+
+When prospects need to change the meeting.
+
+**Pattern A: Self-serve reschedule.**
+
+How it works. The booking confirmation includes a reschedule link. Prospect clicks; sees new availability; selects new slot.
+
+Strengths. No friction; respect for the prospect's time.
+
+Weaknesses. Some abuse possible (repeated reschedules).
+
+When to use. Default for most schedulers.
+
+**Pattern B: Reschedule preserves qualification data.**
+
+How it works. Reschedule keeps all the qualification info; rep does not lose context.
+
+Strengths. Reschedule does not cost prep work.
+
+Weaknesses. None significant.
+
+When to use. Always.
+
+**Pattern C: Reschedule notifies the rep.**
+
+How it works. When prospect reschedules, rep gets notified. Original calendar slot freed up.
+
+Strengths. Rep can use the freed slot.
+
+Weaknesses. None.
+
+When to use. Always.
+
+**Pattern D: Reschedule limits.**
+
+How it works. After N reschedules, the system flags the booking for review or routes to nurture.
+
+Strengths. Prevents abuse.
+
+Weaknesses. Risks alienating prospects with legitimate scheduling difficulty.
+
+When to use. Sparingly; usually 3+ reschedules before flagging.
+
+---
+
+## No-show patterns
+
+When prospects do not attend.
+
+**Detection.**
+
+- Rep reports no-show after the meeting time.
+- System detects unattended meeting (if integrated with video platform).
+- Manual reports from CS or sales ops.
+
+**Pattern A: Single follow-up.**
+
+How it works. Within 4-24 hours of the no-show, send a single gentle email offering reschedule.
+
+Strengths. Catches genuine forgetfulness.
+
+Weaknesses. Single touch may not catch users on vacation.
+
+When to use. Default.
+
+**Pattern B: Two-touch follow-up.**
+
+How it works. First email immediate. Second email 3-5 days later if no response.
+
+Strengths. Catches prospects who were genuinely busy.
+
+Weaknesses. Risks feeling persistent.
+
+When to use. Higher-value bookings where multi-touch is justified.
+
+**Pattern C: Sales-led recovery.**
+
+How it works. For high-value no-shows, sales rep reaches out personally.
+
+Strengths. Most engaging; can recover the relationship.
+
+Weaknesses. Expensive; only viable for high-value accounts.
+
+When to use. Enterprise no-shows or accounts with strategic value.
+
+**Pattern D: Async route.**
+
+How it works. Send the no-show prospect resources or content rather than another booking attempt. Re-engagement deferred.
+
+Strengths. Respects the no-show as a signal.
+
+Weaknesses. May lose prospects who would have rebooked.
+
+When to use. After 1-2 unsuccessful reschedule attempts.
+
+---
+
+## Reschedule cadence
+
+How often to retry.
+
+**Single reschedule attempt:** offer once; respect non-response.
+
+**Multiple attempts:** at most 2 attempts spaced 3-7 days apart. Stop after that.
+
+**No reschedule attempts:** for bookings flagged as low-fit; route to nurture.
+
+The discipline. Each reschedule attempt earns its place. Cumulative attempts become harassment.
+
+---
+
+## When to abandon reschedule
+
+Some no-shows should be respected as final.
+
+**Signals to stop.**
+
+- Prospect explicitly asked to stop contact.
+- Multiple no-shows from same prospect.
+- No response to 2 reschedule attempts.
+- Email bounced or unsubscribed.
+
+**The respect-the-pattern principle.** Multiple no-shows often signal the prospect's needs changed. Continuing pursuit damages the brand.
+
+---
+
+## No-show flow design
+
+The full sequence.
+
+**T+0 (no-show happens).**
+
+- Rep marks no-show in CRM.
+- Free the calendar slot.
+
+**T+4-24h (first follow-up).**
+
+- Email: "Sorry we missed you. Want to reschedule? [Link]."
+
+**T+3-5d (second follow-up if needed).**
+
+- Email: "We're still interested in connecting if your schedule changed. Here's the reschedule link."
+
+**T+10d (final attempt or async route).**
+
+- Send relevant content; surface re-engagement option without pressure.
+
+**T+30d+.**
+
+- Treat as nurture; pursue through other channels (email newsletter, content).
+
+The cadence respects multiple touchpoints without becoming aggressive.
+
+---
+
+## No-show analytics
+
+Track patterns.
+
+**Per-segment no-show rate.**
+
+- Different sources, sizes, or use cases may no-show at different rates.
+
+**Per-rep no-show rate.**
+
+- Some reps may correlate with higher no-shows (timing, time zone, prep gaps).
+
+**Reschedule conversion rate.**
+
+- Of rescheduled bookings, what percentage attend.
+
+**Diagnostic uses.**
+
+- High overall no-show: reminder sequence weak or commitment friction at booking too low.
+- Specific segment no-shows more: that segment may need different cadence.
+- Specific rep no-shows more: their availability or prep may be off.
+
+---
+
+## Time zone and travel mistakes
+
+Common reasons for no-shows that are not the prospect's fault.
+
+**Prevention.**
+
+- Display time zone clearly at booking.
+- Calendar invites include time zone.
+- Reminders include time zone.
+
+**The cure for time zone mistakes.** Quick reschedule; do not penalize.
+
+---
+
+## Common reschedule and no-show failures
+
+**Aggressive recovery.** Multiple touches over short periods; harassment.
+
+**Reschedule limits too tight.** Genuine prospects flagged after 2 reschedules; lost.
+
+**Reschedule loses qualification data.** Rep loses context on reschedule.
+
+**No reschedule path.** Prospect cannot reschedule; ghosts instead.
+
+**No-show no follow-up.** Prospect's missed meeting is just lost; could have rebooked.
+
+**Punitive copy.** No-show follow-up shames the prospect.
+
+**Time zone confusion.** Prospect missed because of time zone error; system blames the prospect.
+
+**Stale reschedule links.** Link works at booking; broken later.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The respect-the-no principle. Reschedule patterns A through D. No-show patterns A through D. Reschedule cadence. When to abandon. No-show flow design. No-show analytics. Time zone considerations. Common failures.
+
+## Implementation choices that stay internal
+
+Specific reschedule limits for specific teams. Specific follow-up cadences. Specific copy in brand voice. The team's audit calendar. These vary by team.

--- a/skills/scheduler-and-booking-design/references/routing-patterns.md
+++ b/skills/scheduler-and-booking-design/references/routing-patterns.md
@@ -1,0 +1,235 @@
+# Routing patterns
+
+By size, use case, geography, language, account ownership. Unrouted-lead default.
+
+The specific routing rules that translate qualification answers into rep assignments. Done well, routing matches lead to rep cleanly; done poorly, leads bounce around or land on wrong reps.
+
+---
+
+## Routing-by-company-size
+
+The most common routing axis.
+
+**Pattern.**
+
+- 1-50 employees: SDR or self-serve.
+- 51-500 employees: AE.
+- 501-2000 employees: senior AE.
+- 2000+ employees: enterprise AE.
+
+**Why it works.** Different sizes have different sales motions; rep tier should match.
+
+**Failure modes.**
+
+- Size bands set years ago; team scaled; bands no longer right.
+- Size data missing or stale.
+- Solo founders with backed companies appear "small" but warrant senior treatment.
+
+---
+
+## Routing-by-use-case
+
+Different specialists for different product use cases.
+
+**Pattern.**
+
+- Use case A: rep with A specialty.
+- Use case B: rep with B specialty.
+- General use case: any AE.
+
+**Why it works.** Specialists arrive with deeper context; conversion higher.
+
+**Failure modes.**
+
+- Specialist becomes bottleneck.
+- New use cases without assigned specialist.
+- Use case overlap; multiple specialists could fit.
+
+---
+
+## Routing-by-geography
+
+Different reps for different regions or time zones.
+
+**Pattern.**
+
+- Americas: US-based AEs.
+- EMEA: European AEs.
+- APAC: APAC AEs.
+
+**Why it works.** Time zone alignment; cultural fit; language fit.
+
+**Failure modes.**
+
+- Insufficient coverage in some regions.
+- Cross-region accounts confuse routing.
+- Geography data missing or wrong.
+
+---
+
+## Routing-by-language
+
+Native-language reps for non-English-primary leads.
+
+**Pattern.**
+
+- English-primary: US/UK AEs.
+- Spanish-primary: Spanish-speaking AEs.
+- Etc.
+
+**Why it works.** Native-language conversation produces better calls.
+
+**Failure modes.**
+
+- Incomplete language coverage.
+- Multi-language leads bounce.
+- Language inferred wrong from email or location.
+
+---
+
+## Routing-by-account-ownership
+
+If the lead's company is already in pipeline or a customer, route to the owning AE.
+
+**Pattern.**
+
+- Detect domain match against CRM.
+- If match, route to AE who owns the account.
+- If no match, default routing.
+
+**Why it works.** Account owner has context; avoids confusion.
+
+**Failure modes.**
+
+- Domain detection misses subsidiaries or aliases.
+- Account ownership stale (former AE).
+- New lead from existing account but for unrelated use case.
+
+---
+
+## Routing-by-source
+
+Different reps for different lead sources (paid, organic, partner, referral).
+
+**Pattern.**
+
+- Partner-sourced leads: partner-channel AE.
+- Paid-sourced leads: marketing-aligned AEs.
+- Organic-sourced: general AEs.
+
+**Why it works.** Different sources signal different commitment; specialists handle differently.
+
+**Failure modes.**
+
+- Source data missing or attribution wrong.
+- Paid traffic includes high-fit leads who would have come organically.
+
+---
+
+## Routing-by-tier
+
+Combining size, use case, and other signals into a tier score.
+
+**Pattern.**
+
+- Lead score 80-100: senior AE.
+- Lead score 50-79: AE.
+- Lead score 0-49: SDR or async.
+
+**Why it works.** Single score combines multiple signals.
+
+**Failure modes.**
+
+- Score model out of date.
+- Score thresholds wrong for current capacity.
+- Score data incomplete; defaults dominate.
+
+---
+
+## The unrouted-lead default
+
+Some leads do not fit obvious routing.
+
+**Patterns for default.**
+
+- **Round-robin among all available reps.** Simple.
+- **Catchall AE.** One rep gets all unrouted leads.
+- **Async or self-serve.** Lead goes to a self-serve resource if no obvious rep.
+
+**The discipline.** Default rule should be explicit. Unrouted leads should not silently fail or bounce.
+
+---
+
+## Routing transparency
+
+Prospect-side vs rep-side visibility.
+
+**Prospect-side.** Generally, prospects do not see routing logic. They see a calendar with available times.
+
+**Rep-side.** Reps should see why they were assigned (lead score, fit signals). Helps with prep.
+
+**Anti-pattern.** Routing happens silently; rep does not know what made this lead route to them.
+
+---
+
+## Routing changes and team transitions
+
+When the team changes, routing must follow.
+
+**Common transitions.**
+
+- Rep leaves; their accounts and routing reassign.
+- New rep hires; routing weights adjust.
+- Tier restructure (rep promoted from SDR to AE).
+- Specialty changes.
+
+**The maintenance discipline.** Routing rules update as team changes. Stale routing can route leads to absent reps.
+
+---
+
+## Routing analytics
+
+Track routing effectiveness.
+
+**Metrics.**
+
+- Per-rep booking volume.
+- Per-rep conversion (booking-to-sale).
+- Per-route conversion (route x → sale rate).
+- Routing override rate (manual reassignments).
+
+**Diagnostic uses.**
+
+- Per-rep volume uneven without reason: routing logic skewing.
+- Per-route conversion uneven: routing matching wrong.
+- High override rate: routing logic not capturing real fit.
+
+---
+
+## Common routing failures
+
+**Routing data missing.** Qualification did not capture; routing defaults dominate.
+
+**Stale routing rules.** Team changed; rules did not.
+
+**Stale rep weights.** Performance scores from quarters ago.
+
+**Account-ownership detection wrong.** Subsidiary leads route to unfit AE.
+
+**Specialty routing without specialty data.** Specialty-based routing requires tagging; tags miss.
+
+**Default rule unclear.** Unrouted leads silently fail.
+
+**Routing override frequent.** Reps reassign manually; routing logic does not match reality.
+
+**Round-robin for tiered team.** High-fit leads land on junior reps.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+Routing patterns by size, use case, geography, language, account ownership, source, tier. The unrouted-lead default. Routing transparency. Team transitions. Routing analytics. Common failures.
+
+## Implementation choices that stay internal
+
+Specific routing rules for specific teams. Specific size bands and tier thresholds. Specific tooling. The team's audit calendar. These vary by team.

--- a/skills/scheduler-and-booking-design/references/scheduler-anti-patterns.md
+++ b/skills/scheduler-and-booking-design/references/scheduler-anti-patterns.md
@@ -1,0 +1,209 @@
+# Scheduler anti-patterns
+
+The patterns that look like schedulers but degrade conversion. Anti-patterns are easy to ship; the cost shows up in booking conversion, downstream call quality, and brand reputation.
+
+---
+
+## The any-time-friction scheduler
+
+The pattern. Generic booking link with no qualification.
+
+The signal. Reps show up cold; downstream demo-to-sale conversion poor.
+
+The cost. Sales capacity used inefficiently; call quality suffers.
+
+The cure. Add 3-5 qualification fields; route to right rep tier; deliver prep to reps.
+
+---
+
+## The interrogation-gate scheduler
+
+The pattern. 12-field qualification form before booking.
+
+The signal. 90 percent drop-off at the form.
+
+The cost. Lose conversions from would-be buyers; only the most committed survive the form.
+
+The cure. Cut to 3-5 fields; defer additional questions to in-call or post-meeting.
+
+---
+
+## The wrong-rep-tier scheduler
+
+The pattern. Round-robin routing for tiered team.
+
+The signal. Enterprise leads land on SDRs; SDRs unprepared; conversion drops.
+
+The cost. High-value leads get junior reps; senior reps underutilized.
+
+The cure. Fit-based routing tied to qualification.
+
+---
+
+## The no-prep-automation scheduler
+
+The pattern. Qualification captured but not delivered to reps.
+
+The signal. Reps start calls cold despite qualification data existing.
+
+The cost. Qualification work wasted; cold-call dynamics return.
+
+The cure. CRM enrichment, calendar invite enrichment, Slack briefs.
+
+---
+
+## The no-buffer scheduler
+
+The pattern. Back-to-back meetings without buffer time.
+
+The signal. Reps run late; calls feel rushed; quality drops.
+
+The cost. Reps stressed; calls poorer; conversion suffers.
+
+The cure. 10-15 minute buffer between meetings.
+
+---
+
+## The no-capacity-cap scheduler
+
+The pattern. Reps booked solid all day every day.
+
+The signal. Quality drops; rep burnout.
+
+The cost. Calls that book are lower quality; reps eventually leave.
+
+The cure. Cap meetings per day per rep (3-5 typical).
+
+---
+
+## The time-zone-confused scheduler
+
+The pattern. Times shown in rep's time zone; prospect has to convert mentally.
+
+The signal. Wrong-time bookings; no-shows from time zone errors.
+
+The cost. Prospects miss meetings; assume their fault.
+
+The cure. Auto-detect prospect time zone; display explicitly.
+
+---
+
+## The aggressive-reminder scheduler
+
+The pattern. Multiple reminders per booking (5+ touchpoints).
+
+The signal. Prospects mute or unsubscribe; reminder effectiveness drops.
+
+The cost. Reminders trained to be ignored; no-shows persist.
+
+The cure. Two reminders typical (24-hour, 1-hour). Cap cumulative volume.
+
+---
+
+## The aggressive-no-show-recovery scheduler
+
+The pattern. Multiple reschedule attempts over short period.
+
+The signal. Brand earns harassment reputation; recovery rate drops.
+
+The cure. One-to-two reschedule attempts max; respect non-response.
+
+---
+
+## The aggressive-cancellation-prevention scheduler
+
+The pattern. Cancellation requires multi-step or contact with sales.
+
+The signal. Public complaints; trust damage.
+
+The cost. Reputation harm; sometimes regulatory issues.
+
+The cure. Self-serve cancellation; one click.
+
+---
+
+## The unmaintained scheduler
+
+The pattern. Routing rules from years ago; team changed; rules did not.
+
+The signal. Leads route to absent reps; bookings sit unread.
+
+The cure. Quarterly maintenance. Team transitions trigger routing updates.
+
+---
+
+## The mobile-broken scheduler
+
+The pattern. Booking flow works on desktop; breaks on mobile.
+
+The signal. Mobile conversion half of desktop.
+
+The cost. Mobile audience underserved.
+
+The cure. Mobile-first design and testing.
+
+---
+
+## The double-booking scheduler
+
+The pattern. Calendar integration broken; multiple bookings for same time.
+
+The signal. Reps and prospects both arrive; one waits or leaves.
+
+The cost. Rep frustration; prospect confusion; brand damage.
+
+The cure. Calendar integration tested. Buffer time. Conflict detection.
+
+---
+
+## The shared-link bypass scheduler
+
+The pattern. Reps share generic booking links alongside structured flow.
+
+The signal. Routing logic bypassed; cold demos return.
+
+The cost. Investment in qualification and routing partially undone.
+
+The cure. Disable generic links. Train reps to use structured links.
+
+---
+
+## The integration-brittle scheduler
+
+The pattern. Calendar, CRM, or video integration breaks frequently.
+
+The signal. Reps complain about manual workarounds.
+
+The cost. Operational friction; data inconsistency.
+
+The cure. Stable integrations; monitoring; rollback plans.
+
+---
+
+## How to detect anti-patterns
+
+Audit cadence. Quarterly review of scheduler portfolio.
+
+**Audit questions.**
+
+- Is qualification calibrated (anti-pattern check: any-time-friction, interrogation-gate)?
+- Does routing match team tier (anti-pattern check: wrong-rep-tier)?
+- Does prep automation deliver (anti-pattern check: no-prep-automation)?
+- Is calendar logic sound (anti-pattern check: no-buffer, no-capacity-cap, double-booking)?
+- Are reminders calibrated (anti-pattern check: aggressive-reminder)?
+- Is no-show recovery respectful (anti-pattern check: aggressive-no-show-recovery)?
+- Is cancellation easy (anti-pattern check: aggressive-cancellation-prevention)?
+- Does the system work on mobile (anti-pattern check: mobile-broken)?
+- Are integrations stable (anti-pattern check: integration-brittle)?
+
+**The retire decision.** Anti-pattern schedulers warrant redesign or retirement.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing. Cures matched. Audit cadence and questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and lessons learned. Specific portfolio audit results. The team's audit calendar. These vary by team.

--- a/skills/scheduler-and-booking-design/references/scheduler-decision-criteria.md
+++ b/skills/scheduler-and-booking-design/references/scheduler-decision-criteria.md
@@ -1,0 +1,175 @@
+# Scheduler decision criteria
+
+When schedulers earn the build vs when forms or sales-pipeline tools serve.
+
+A scheduler is meaningful work. Qualification logic, availability rules, routing, prep automation, follow-up sequences, ongoing maintenance. The scheduler earns this investment only when specific conditions are present.
+
+---
+
+## When schedulers earn the build
+
+Five conditions that, when present, make a scheduler a strong investment.
+
+**The conversion goal is a meeting.** Demo, sales call, consultation. Email-only or trial-signup conversions do not need a scheduler.
+
+**The audience is willing to commit time.** Schedulers ask for a calendar slot; not all audiences are ready for that. Top-of-funnel awareness audiences are usually not ready; consideration-stage audiences often are.
+
+**The team has enough capacity to handle scheduled meetings.** Without capacity, scheduled meetings produce wait times that erode conversion. Reps booked solid for two weeks lose conversions to faster competitors.
+
+**The team can support qualification logic and routing.** Without these, a generic booking link is the result. Generic booking links produce cold demos.
+
+**The success metric is defined.** Booking conversion, demo-to-sale conversion, no-show rate, call quality (often measured via rep self-reports). Without the success metric, evaluation is impossible.
+
+When all five are present, a scheduler is strong investment. When two or fewer are present, simpler tools (contact forms, sales pipeline outreach) often serve better.
+
+---
+
+## When schedulers do NOT earn the build
+
+Funnels where the scheduler is the wrong tool.
+
+**The conversion goal is a download or signup.** Use forms (covered by `multi-step-form-design`) or magnet flows (covered by `lead-magnet-design`).
+
+**The audience volume is too low.** A handful of bookings per month does not need routing infrastructure; a contact form may serve better.
+
+**The team's capacity is variable and routing cannot reflect it.** Scheduling without capacity awareness produces booked-too-tight or booked-too-loose patterns; both fail.
+
+**A simpler contact form would serve.** Inbound leads where sales does outbound contact may not need a scheduler; the prospect just provides info; the rep reaches out.
+
+**The audience prefers async communication.** Some audiences (technical buyers, asynchronous teams) prefer email or document exchange to scheduled calls.
+
+The honest assessment matters. Schedulers are sometimes the wrong tool even when the team has capacity to build them.
+
+---
+
+## Schedulers vs forms
+
+Both capture lead info; they differ in commitment.
+
+**Form strengths.**
+
+- Lower commitment from the prospect.
+- Higher top-of-funnel volume.
+- Suitable for any conversion type (download, demo request, contact).
+
+**Form weaknesses.**
+
+- No automatic time commitment.
+- Requires sales follow-up to schedule.
+- Wait time between form submission and meeting.
+
+**Scheduler strengths.**
+
+- Time committed at booking; no scheduling delay.
+- Higher prospect commitment signal.
+- Direct conversion to a calendar slot.
+
+**Scheduler weaknesses.**
+
+- Higher friction; not all prospects ready.
+- Requires capacity to handle bookings.
+- Routing complexity.
+
+**The choice.** When the conversion is a meeting and the audience is consideration-stage, scheduler. When the conversion is more open or the audience is awareness-stage, form.
+
+---
+
+## Schedulers vs sales-pipeline tools
+
+For B2B sales, alternatives exist.
+
+**Sales pipeline strengths.**
+
+- Sales-led; rep makes contact on their schedule.
+- Can prioritize based on fit before reaching out.
+
+**Sales pipeline weaknesses.**
+
+- Slower response.
+- Higher acquisition cost per booking.
+
+**Scheduler advantages.**
+
+- Self-serve; faster response.
+- Lower acquisition cost.
+
+**The combined approach.** Many production teams use both: scheduler for self-serve high-intent leads; sales pipeline for outbound and complex deals.
+
+---
+
+## The opportunity-cost frame
+
+A scheduler is significant work. Account for it.
+
+**The build cost.** Qualification logic, availability rules, routing, prep automation, reminder sequences, integration with CRM and calendar, mobile responsiveness. A meaningful scheduler often takes 40-150 engineering hours plus operational setup.
+
+**The maintenance cost.** Routing rules update as team changes; integrations need maintenance. Quarterly review and updates run 4-8 hours.
+
+**The opportunity cost.** What else could the team have built? A simpler contact form, a better sales-led process, direct outreach. The scheduler has to clear the bar of those alternatives.
+
+The decision frame. Scheduler earns investment when it produces more meeting volume at acceptable quality than alternatives.
+
+---
+
+## Decision worked example
+
+A B2B SaaS with 50 demo requests per week.
+
+**Conditions check.**
+
+- Conversion goal is a meeting: yes.
+- Audience willing to commit time: yes (mid-market audience).
+- Team capacity: yes; 4 reps with capacity for 12-15 demos per week each.
+- Qualification and routing supported: yes; reps differ by industry vertical.
+- Success metric defined: booking conversion, demo-to-trial within 14 days.
+
+**Decision.** Build the scheduler. The conditions warrant it.
+
+**Architecture.** 4-field qualification (size, role, use case, timeline); fit-based routing (enterprise to senior AE, mid-market to AE, SMB to SDR); CRM enrichment and Slack brief for prep automation.
+
+**Maintenance commitment.** Quarterly review; team-change updates as part of onboarding.
+
+The decision was deliberate, not default.
+
+---
+
+## Decision worked example: when to choose differently
+
+A consumer-facing financial advisory company with 5 inbound consultations per week.
+
+**Conditions check.**
+
+- Conversion goal is a meeting: yes.
+- Audience willing to commit time: yes.
+- Team capacity: yes (3 advisors).
+- Qualification and routing supported: not really; advisors are interchangeable.
+- Volume justifies scheduler infrastructure: low.
+
+**Decision.** Do not build a custom scheduler. Use a generic booking link with a brief 2-field qualification form. The volume does not justify routing infrastructure; the simplicity is fine.
+
+The decision was right-sized.
+
+---
+
+## When to retire a scheduler
+
+Schedulers can become wrong over time.
+
+**Retire-or-redesign when:**
+
+- Conversion has dropped below baseline consistently and refinements have not moved it.
+- Team structure changed; routing logic no longer fits.
+- Volume changed; infrastructure no longer matches need.
+- Integration with CRM or calendar has broken repeatedly.
+
+The retire-or-redesign discipline frees capacity.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The five conditions that warrant schedulers. The five conditions that argue against. Schedulers vs forms. Schedulers vs sales-pipeline tools. The opportunity-cost frame. Decision worked examples (yes and no). The retire decision.
+
+## Implementation choices that stay internal
+
+Specific scheduler decisions for specific teams. The team's capacity benchmarks. Specific tooling. Specific success-metric baselines. These vary by team and product.

--- a/skills/upgrade-flow-design/SKILL.md
+++ b/skills/upgrade-flow-design/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: upgrade-flow-design
+description: "Designing free-to-paid conversion flows for SaaS products. Trigger moments, paywall design, value demonstration, upsell vs downsell, win-back flows, churn prevention. Honest about paywall-everywhere (gates everything aggressively), free-forever-trap (no upgrade path surfaces), and value-triggered-upgrade (paywall surfaces at moments of demonstrated value) patterns. Triggers on upgrade flow, paywall, free-to-paid, freemium conversion, trial conversion, plan upgrade, subscription upgrade, win-back flow, churn prevention. Also triggers when free-to-paid conversion is low, when paywalls are blocking the wrong moments, or when upgrade flows are being scoped for the first time."
+category: growth-tooling
+catalog_summary: "Designing free-to-paid conversion flows. Distinguishes paywall-everywhere (gates everything aggressively) from free-forever-trap (no upgrade path surfaces) from value-triggered-upgrade (paywall surfaces at moments of demonstrated value)"
+display_order: 9
+---
+
+# Upgrade Flow Design
+
+A senior product marketing director's playbook for designing free-to-paid conversion flows in SaaS products. Trigger moments, paywall design, value demonstration, upsell vs downsell, win-back flows, churn prevention. The discipline of asking for the upgrade at the moment the user has a reason to say yes.
+
+Most upgrade flows fail in one of two ways. They block meaningful product use behind paywalls so aggressively that users churn before reaching the moment that would justify paying. Or they offer a generous free tier with no upgrade path that ever surfaces; users get everything they need; conversion stays at single-digit percentages indefinitely.
+
+The upgrade flows that work do something different. They surface paywalls at moments where the user has demonstrably gotten value. The user has hit a usage threshold, completed a flow, or otherwise demonstrated they are getting the product's promise. The upgrade ask is honest about what they get next; the user is positioned to say yes because the value is fresh.
+
+The voice is the senior product marketing director who has watched conversion rates double when paywalls were re-timed and watched them collapse when more aggressive paywalls were added. Practical, opinionated about the moments that earn the upgrade ask, willing to call out when the product's free tier is too generous to convert.
+
+When to use this skill: scoping a free-to-paid conversion flow for the first time, auditing paywalls that block conversion or never surface, designing the trigger moments that earn upgrade asks, or deciding plan structure that supports upgrades over time.
+
+---
+
+## What this skill covers
+
+This skill spans free-to-paid conversion flows in SaaS products. The growth-tooling distinctions:
+
+- `lead-magnet-design` is top-of-funnel email capture. This skill is free-to-paid conversion in-product.
+- `funnel-flow-architecture` is the cross-tool funnel architecture. This skill is the upgrade flow specifically.
+- **`upgrade-flow-design` (this skill)** is trigger-moment design, paywall presentation, plan structure, win-back, churn prevention.
+- `landing-page-copy` is pricing-page copy; lives downstream of this skill's plan-structure decisions.
+- `pm-spec-writing` is the spec for engineers building the upgrade flow.
+
+The audience: product marketers, growth marketers, in-house product teams, agencies running SaaS conversion work for clients.
+
+Out of scope: cross-funnel architecture (covered by `funnel-flow-architecture`); pricing-page copy (covered by `landing-page-copy`); the engineering implementation; specific Stripe/Chargebee/Recurly/Paddle billing-platform configurations (those stay implementation-side).
+
+---
+
+## The free-tier decision: freemium vs free-trial vs no-free
+
+Before designing the upgrade flow, decide the free-tier structure.
+
+**Freemium (free-forever tier).**
+
+- Users use the product indefinitely without paying.
+- Paid tier offers more value (capacity, features, support).
+- Conversion typically 2-5 percent; volume compensates.
+
+When it works: products with strong network effects, or where free users provide product value (data, content, virality).
+
+**Free-trial (time-limited).**
+
+- Users get full or near-full product for a defined period.
+- After trial, must pay to continue.
+- Conversion typically 10-25 percent of trial signups.
+
+When it works: products where the value is clear quickly; audiences willing to commit time before paying.
+
+**Reverse trial.**
+
+- Users start on paid plan; auto-downgrade to free after period.
+- Less common; mixes signals; can produce surprise churn.
+
+**No-free (paid-only).**
+
+- No free tier; users pay to start.
+- Conversion is from prospects rather than free users.
+- Conversion rates depend on sales motion, not in-product upgrade flows.
+
+When it works: enterprise products, high-touch sales, products where free would dilute brand or capacity.
+
+The decision is upstream of upgrade flow design. Different free-tier structures warrant different upgrade flows.
+
+Detail in `references/free-tier-decision-criteria.md`.
+
+---
+
+## Paywall-everywhere vs free-forever-trap vs value-triggered-upgrade
+
+The keystone framing.
+
+**Paywall-everywhere.** Paywall blocks meaningful product use. Free tier exists but is too constrained to demonstrate value. Users churn before reaching the moment that would justify paying. Cost: users who would have paid after seeing value never reach that moment; conversion suffers despite aggressive paywalling.
+
+**Free-forever-trap.** Generous free tier with no upgrade path that ever surfaces. Users get everything they need; never see why they would pay. Conversion rate stays at single-digit percentages indefinitely. Cost: the team has built a product users like for free; revenue does not follow because the upgrade ask never lands.
+
+**Value-triggered-upgrade.** Paywall surfaces at moments where the user has demonstrably gotten value. The user has hit a usage threshold, completed a flow, or otherwise demonstrated they are getting the product's promise. The upgrade ask is honest about what they get next. Cost: design effort upfront is significant; conversion typically meaningfully higher than either alternative.
+
+The litmus test. After a user encounters the upgrade flow, can they articulate why they should pay? "Because I just hit my limit on this feature I have used 200 times" is value-triggered. "Because the product told me to pay before letting me use it" is paywall-everywhere. "I have not seen an upgrade ask" is free-forever-trap.
+
+---
+
+## Trigger-moment design: where paywalls earn their interruption
+
+The single most consequential decision in upgrade flow design.
+
+**The principle.** Paywalls surface at moments where the user has demonstrated they are getting the product's value. The interruption is justified because the user has a reason to say yes.
+
+**Strong trigger moments.**
+
+- **Usage threshold reached.** User has used a feature N times; further use requires paid plan. Honest because they are clearly getting value.
+- **Capacity limit hit.** User has reached free-tier capacity; upgrade unlocks more. Predictable; expected.
+- **Advanced feature attempted.** User clicked into a feature that requires paid plan. Interest is fresh.
+- **Workflow completed successfully.** User has seen value through a completed action; upgrade ask connects that value to recurring access.
+- **Team-collaboration moment.** User wants to invite teammates; team capabilities require paid plan.
+- **Time-trial ending.** Trial-based products surface upgrade as trial nears end.
+
+**Weak trigger moments.**
+
+- **First-login.** User has not yet seen value; upgrade ask is premature.
+- **Random in-product placement.** Paywall on the dashboard with no specific trigger; users dismiss.
+- **Every-page banner.** Persistent upgrade banner across all surfaces; users develop blindness.
+
+**The discipline.** Each paywall should answer: what value did the user just demonstrate, and how does the paid plan extend that value?
+
+Detail in `references/trigger-moment-design.md`.
+
+---
+
+## Paywall presentation: modal vs banner vs inline
+
+How the paywall surfaces.
+
+**Pattern A: Modal paywall.** Full-screen overlay blocks the action; user must upgrade or dismiss.
+
+When to use. Capacity limits, feature gates the user has hit. The interruption is warranted by the trigger.
+
+**Pattern B: Banner paywall.** Persistent banner at top of page suggesting upgrade.
+
+When to use. Soft prompts; awareness without interruption. Risk of becoming visual noise.
+
+**Pattern C: Inline paywall.** Upgrade ask embedded in the surface where the trigger occurred.
+
+When to use. Contextual prompts that integrate with the workflow.
+
+**Pattern D: Toast or notification.** Brief paywall surfaced as a notification.
+
+When to use. Soft prompts; low-priority upgrade asks.
+
+**Choice criteria.**
+
+- The trigger's strength determines the presentation's intensity.
+- Strong triggers (capacity hit, feature gate) warrant modal.
+- Soft triggers (general awareness) warrant inline or toast.
+
+**Copy and value-prop discipline.**
+
+- The paywall copy should connect to what the user just did.
+- "You have used [feature] 50 times. Upgrade to remove the limit and unlock [related capabilities]." matches the trigger.
+- "Upgrade for more features" is generic and weak.
+
+Detail in `references/paywall-presentation-patterns.md`.
+
+---
+
+## Upsell vs downsell logic
+
+When the user does not accept the primary upgrade.
+
+**Upsell.** User is on basic plan; ask them to upgrade to higher tier.
+
+**Cross-sell.** User is paying; offer add-ons or related products.
+
+**Downsell.** User declined the higher tier; offer a smaller commitment (smaller plan, monthly vs annual, basic vs full feature set).
+
+**The downsell discipline.** Some users will not upgrade to the proposed tier but will upgrade to something. Downsell captures revenue otherwise lost.
+
+**Examples.**
+
+- User declined Pro upgrade; offer Starter plan as a path to begin paying.
+- User declined annual plan; offer monthly with explicit cost difference disclosed.
+- User declined full team plan; offer single-seat upgrade.
+
+**Anti-pattern.** Aggressive downsell that makes the user feel manipulated. Honest framing: "If Pro is more than you need, here is something that fits."
+
+Detail in `references/upsell-vs-downsell-logic.md`.
+
+---
+
+## Win-back flow design
+
+Lapsed users, downgrades, partial-churn.
+
+**Win-back triggers.**
+
+- User has not logged in for 30/60/90 days.
+- User downgraded plan.
+- User canceled but did not delete account.
+- User churned and signed up again later.
+
+**Win-back patterns.**
+
+- **Email-based.** Outreach with renewed value-prop, sometimes with discount or trial extension.
+- **In-product upon return.** When the lapsed user returns, surface re-engagement help and (if appropriate) an upgrade-back ask.
+- **Personal outreach.** For high-value lapsed users, sales or customer success conversation.
+
+**Discount discipline.**
+
+- Discounts to win back can create reverse-incentive (user churns to get discount).
+- Discount sparingly; emphasize new value first.
+
+Detail in `references/win-back-flow-patterns.md`.
+
+---
+
+## Churn prevention upstream of upgrade
+
+The best upgrade flow is the one the user does not need because they did not churn.
+
+**Upstream churn signals.**
+
+- Declining engagement; sessions per week dropping.
+- Last login distant.
+- Support ticket pattern (frustration signals).
+- Plan downgrade interest signals.
+
+**Prevention patterns.**
+
+- **Engagement re-orientation.** Surface help when engagement drops.
+- **Outreach.** Customer success contact for high-value accounts at risk.
+- **Friction reduction.** Audit the reasons users disengage; fix the friction.
+
+**The prevention-vs-recovery economics.** Preventing churn is much cheaper than winning back churned users. Invest upstream.
+
+Detail in `references/churn-prevention-upstream.md`.
+
+---
+
+## Plan structure: tier count, feature gating, pricing-page design
+
+The plans that the upgrade flow leads to.
+
+**Tier count.**
+
+- 2-tier (Free + Paid): simple; clear upgrade path; works for many products.
+- 3-tier (Starter + Pro + Enterprise): broader audience; harder to design.
+- 4+ tier: rarely better; complexity confuses users.
+
+**Feature gating.**
+
+- **Capacity-based.** Free tier limited by use volume; paid unlocks more.
+- **Feature-based.** Free tier missing specific features; paid unlocks them.
+- **Hybrid.** Both capacity and features differ.
+
+**Discipline.** Each tier should have a clear "this is for [X audience] because of [Y]." Tiers without clear audience-fit produce weak conversions.
+
+**Pricing-page design.** The pricing page is downstream of plan structure but lives close to upgrade flow. Detail in `landing-page-copy` for pricing-page copy specifically.
+
+Detail in `references/plan-structure-patterns.md`.
+
+---
+
+## Common failure modes
+
+Rapid-fire. Diagnoses in `references/common-upgrade-failures.md`.
+
+- "Conversion rate is low; users churn before reaching upgrade." Paywall-everywhere; gates blocking value demonstration.
+- "Conversion rate is single-digit; free users use the product for years." Free-forever-trap; no upgrade path surfaces.
+- "Paywall fires; users dismiss; conversion does not lift." Trigger moments wrong; paywall not connected to demonstrated value.
+- "Users hit paywall and churn." Wrong moment; paywall blocks before value is fresh.
+- "Upgrade rate looks fine; downgrade rate is high." Plan structure wrong; users upgrade then realize they did not need the higher tier.
+- "Win-back attempts have low conversion." Re-engagement timing wrong, or value-prop unchanged from what failed initially.
+- "Annual plans not converting; monthly plans dominate." Annual value-prop weak; or commitment friction too high.
+- "Sales says many leads come from churned users coming back." Win-back working but the previous churn was avoidable; audit upstream.
+- "Conversion did not change after we redesigned the paywall." Paywall design was not the problem; trigger or plan structure may be.
+
+---
+
+## The framework: 12 considerations for upgrade flow design
+
+When designing or auditing an upgrade flow, walk these 12 considerations.
+
+1. **The free-tier decision.** Freemium, free-trial, reverse trial, or no-free.
+2. **Value-triggered-upgrade, not paywall-everywhere or free-forever-trap.** Paywalls at moments of demonstrated value.
+3. **Trigger-moment design sound.** Paywalls connect to specific user-demonstrated value.
+4. **Paywall presentation matches trigger intensity.** Strong triggers warrant modal; soft triggers inline.
+5. **Copy connects to the trigger.** Specific value-prop tied to what the user just did.
+6. **Upsell, cross-sell, downsell logic.** When primary upgrade is declined, secondary paths exist.
+7. **Win-back flows designed.** Lapsed users have a clear re-engagement path.
+8. **Churn prevention upstream.** Upstream signals trigger prevention; downstream upgrade flow is one of multiple defenses.
+9. **Plan structure clear.** Tier count appropriate; each tier has clear audience-fit.
+10. **Pricing-page coordinates with upgrade flow.** Plan structure decisions reflected on the pricing page.
+11. **Conversion as success metric.** Not just paywall display; downstream conversion to paid.
+12. **Maintenance discipline.** Plans, paywalls, win-back flows updated alongside product and pricing changes.
+
+The output of the framework is an upgrade flow that earns the user's "yes" by asking at the moment the user has a reason to say yes, with plan structure that fits the audience the product serves.
+
+---
+
+## Reference files
+
+- [`references/free-tier-decision-criteria.md`](references/free-tier-decision-criteria.md) - Freemium, free-trial, reverse trial, no-free. Choice criteria.
+- [`references/trigger-moment-design.md`](references/trigger-moment-design.md) - Where paywalls earn their interruption. Strong vs weak trigger moments.
+- [`references/paywall-presentation-patterns.md`](references/paywall-presentation-patterns.md) - Modal, banner, inline, toast. Copy and value-prop discipline.
+- [`references/upsell-vs-downsell-logic.md`](references/upsell-vs-downsell-logic.md) - When primary upgrade is declined, secondary paths.
+- [`references/win-back-flow-patterns.md`](references/win-back-flow-patterns.md) - Lapsed users, downgrades, partial-churn re-engagement.
+- [`references/churn-prevention-upstream.md`](references/churn-prevention-upstream.md) - Preventing churn before the upgrade flow is needed.
+- [`references/plan-structure-patterns.md`](references/plan-structure-patterns.md) - Tier count, feature gating, audience-fit per tier.
+- [`references/upgrade-flow-anti-patterns.md`](references/upgrade-flow-anti-patterns.md) - The patterns that look like upgrade flows but degrade trust.
+- [`references/common-upgrade-failures.md`](references/common-upgrade-failures.md) - 9+ failure patterns with diagnoses and cures.
+
+---
+
+## Closing: upgrade flows earn revenue when they earn the user's yes
+
+The upgrade flows that compound revenue are the ones that ask at the moment the user has a reason to say yes. Not because the paywall blocked them. Not because the upgrade prompt happened to appear. Because the user just did something that demonstrated value, and the upgrade ask connected that value to continued or expanded access.
+
+That is the bar. Below the bar are paywall-everywhere (gates before value, conversion suffers) and free-forever-trap (no upgrade path, conversion never starts). Above the bar are value-triggered-upgrade flows where trigger-moment design, paywall presentation, plan structure, win-back, and churn prevention work together to convert the right users at the right moments.
+
+The discipline is in the design choices. The free-tier decision (freemium, trial, paid-only) sets the funnel shape. Trigger-moment design decides when paywalls earn their interruption. Paywall presentation decides how the ask lands. Plan structure decides what the user is upgrading to. Win-back and churn prevention catch the cases that escaped the primary upgrade flow.

--- a/skills/upgrade-flow-design/references/churn-prevention-upstream.md
+++ b/skills/upgrade-flow-design/references/churn-prevention-upstream.md
@@ -1,0 +1,250 @@
+# Churn prevention upstream
+
+Preventing churn before the upgrade flow is needed.
+
+The best upgrade flow is the one the user does not need because they did not churn. Investing upstream of churn produces more revenue than recovering churned users.
+
+---
+
+## The prevention-vs-recovery economics
+
+Preventing churn is much cheaper than winning back churned users.
+
+**The math.** Cost of preventing one churn (engagement program, support intervention, friction reduction): X. Cost of winning back one churned user (outreach, discount, re-acquisition): often 3-10X.
+
+**The implication.** Programs that detect churn risk early and intervene save more revenue than win-back programs that activate only after churn.
+
+The discipline. Build upstream signals; intervene before churn happens.
+
+---
+
+## Upstream churn signals
+
+What predicts churn.
+
+**Engagement decline.**
+
+- Sessions per week dropping over 4-week period.
+- Time-in-product per session declining.
+- Feature usage breadth narrowing.
+
+**Engagement gap.**
+
+- Last login distant.
+- Specific feature stopped being used.
+- Days since last meaningful action.
+
+**Support pattern.**
+
+- Support tickets indicating frustration.
+- Multiple unresolved issues.
+- Tone shift in support conversations.
+
+**Plan-related signals.**
+
+- Asked about cancellation.
+- Researched competitors (sometimes detectable through partner data).
+- Downgrade interest.
+
+**Team-level signals (B2B).**
+
+- Champion left the company.
+- Team reduced seats internally.
+- Decision-maker became unresponsive.
+
+The signals combine. Single signals are noisy; combinations predict more reliably.
+
+---
+
+## Detection systems
+
+How to know which users are at risk.
+
+**Engagement scoring.** Composite score based on usage signals; threshold for at-risk classification.
+
+**Health scores.** Often used by customer success teams; combines product engagement, support pattern, contract data.
+
+**Predictive models.** Statistical or ML models that predict churn probability per user.
+
+**Manual flags.** Account managers flag accounts they sense are at risk.
+
+The discipline. Detection should be operationalized; signals should fire alerts to teams who can act.
+
+---
+
+## Intervention patterns
+
+What to do when at-risk users surface.
+
+**Pattern A: Engagement re-orientation.**
+
+How it works. In-product help surfaces when engagement drops. Re-orients the user to value.
+
+When to use. Soft signals; users who may have forgotten what the product does for them.
+
+**Pattern B: Outreach.**
+
+How it works. Customer success or sales reaches out to at-risk accounts.
+
+When to use. High-value accounts; B2B contexts where personal touch matters.
+
+**Pattern C: Friction reduction.**
+
+How it works. Audit reasons users disengage; fix the friction. Often product changes rather than outreach.
+
+When to use. When patterns of disengagement reveal product issues.
+
+**Pattern D: Educational re-engagement.**
+
+How it works. Send the user content (case study, advanced feature explanation) that re-anchors value.
+
+When to use. Soft re-engagement; cheap to scale.
+
+**Pattern E: Plan adjustment.**
+
+How it works. If usage shows the user is over-paying, suggest a downgrade. Counterintuitive but builds trust.
+
+When to use. When the user is genuinely on the wrong plan; saves the relationship.
+
+---
+
+## The engagement-re-orientation pattern
+
+In-product help that surfaces when engagement drops.
+
+**Implementation.**
+
+- Trigger fires when engagement signal drops below threshold.
+- In-product surface shows: "It looks like you have not used [specific feature] in a while. Here is how others use it."
+- Optional brief tour or case study.
+
+**Strengths.**
+
+- Cheap.
+- Scalable.
+- Often catches users who simply forgot.
+
+**Weaknesses.**
+
+- May feel intrusive.
+- Cannot address all reasons for disengagement.
+
+---
+
+## The customer success outreach pattern
+
+Personal contact for high-value accounts.
+
+**Implementation.**
+
+- Health score crosses at-risk threshold.
+- Account manager or CS lead reaches out.
+- Conversation: what is happening, what would help, can we address.
+
+**Strengths.**
+
+- Highest engagement potential.
+- Surfaces real reasons.
+- Builds relationship.
+
+**Weaknesses.**
+
+- Expensive.
+- Only viable for accounts above revenue threshold.
+
+---
+
+## The friction-reduction pattern
+
+Fixing the underlying reason rather than just intervening per user.
+
+**Implementation.**
+
+- Audit common reasons for disengagement.
+- Identify product changes that would address.
+- Ship the changes.
+
+**Strengths.**
+
+- Compounds across all users.
+- Often the highest-impact intervention.
+
+**Weaknesses.**
+
+- Slower; requires product team prioritization.
+- Some friction reasons cannot be product-fixed (audience-fit issues).
+
+---
+
+## The educational-re-engagement pattern
+
+Send content that re-anchors value.
+
+**Implementation.**
+
+- Email or in-product content showing case studies, advanced features, or use cases.
+- Targeted to the user's profile.
+
+**Strengths.**
+
+- Cheap and scalable.
+- Educates without demanding immediate action.
+
+**Weaknesses.**
+
+- Lower engagement than personal outreach.
+- May feel like marketing.
+
+---
+
+## When intervention has limits
+
+Not all churn can be prevented.
+
+**Genuinely unfit users.** Some users signed up but are not the right audience. Their churn is appropriate.
+
+**Genuinely changed needs.** User changed jobs; product no longer relevant. Cannot be retained.
+
+**Genuinely better alternatives.** Competitor genuinely better fit. Recovery may not be appropriate.
+
+**The honest assessment.** Recognizing unpreventable churn is part of the discipline. Intervention should focus on preventable churn.
+
+---
+
+## Churn prevention vs upgrade flow
+
+Different problems; complementary disciplines.
+
+**Churn prevention.** Keeps users engaged; avoids churn.
+
+**Upgrade flow.** Converts engaged users to paid (or higher paid).
+
+**The interaction.** Strong churn prevention produces engaged users; engaged users are the audience for upgrade flow. Programs running both produce more revenue than either alone.
+
+---
+
+## Common prevention failures
+
+**No detection.** Churn happens; nobody flagged it; recovery is the only option.
+
+**Detection without intervention.** Signals fire but nobody acts.
+
+**Intervention timing wrong.** Action too late; user already disengaged emotionally.
+
+**Generic intervention.** Same outreach to all at-risk users; no segmentation.
+
+**Discount-led intervention.** Lead with discount instead of value; trains discount-seeking behavior.
+
+**Prevention misses fixable friction.** Patterns of disengagement reveal product issues; team focuses on per-user intervention instead.
+
+**No measurement.** Cannot tell if prevention reduces churn rate.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The prevention-vs-recovery economics. Upstream churn signals (5 categories). Detection systems. Intervention patterns A through E. When intervention has limits. Churn prevention vs upgrade flow interaction. Common failures.
+
+## Implementation choices that stay internal
+
+Specific signals and thresholds for specific products. Specific health-score formulas. Specific intervention copy and protocols. The team's CS staffing model. These vary by team and product.

--- a/skills/upgrade-flow-design/references/common-upgrade-failures.md
+++ b/skills/upgrade-flow-design/references/common-upgrade-failures.md
@@ -1,0 +1,179 @@
+# Common upgrade failures
+
+9+ failure patterns with diagnoses and cures.
+
+---
+
+## "Conversion rate is low; users churn before reaching upgrade."
+
+**The diagnosis.** Paywall-everywhere; gates blocking value demonstration.
+
+**The cure.** Loosen free tier. Surface paywalls at moments of demonstrated value. Detail in `references/trigger-moment-design.md`.
+
+---
+
+## "Conversion rate is single-digit; free users use the product for years."
+
+**The diagnosis.** Free-forever-trap; no upgrade path surfaces.
+
+**The cure.** Add value-triggered paywalls. Connect upgrade asks to demonstrated value.
+
+---
+
+## "Paywall fires; users dismiss; conversion does not lift."
+
+**The diagnosis.** Trigger moments wrong; paywall not connected to demonstrated value.
+
+**The cure.** Audit trigger logic. Each paywall should answer "what value did the user just demonstrate?"
+
+---
+
+## "Users hit paywall and churn."
+
+**The diagnosis.** Wrong moment; paywall blocks before value is fresh.
+
+**The cure.** Move paywalls to moments of demonstrated value, not pre-value moments.
+
+---
+
+## "Upgrade rate looks fine; downgrade rate is high."
+
+**The diagnosis.** Plan structure wrong; users upgrade then realize they did not need the higher tier.
+
+**The cure.** Clarify tier audiences. Each plan should have specific audience-fit. Detail in `references/plan-structure-patterns.md`.
+
+---
+
+## "Win-back attempts have low conversion."
+
+**The diagnosis.** Re-engagement timing wrong, or value-prop unchanged from what failed initially.
+
+**The cure.** Lead with value-prop change. Avoid discount-only win-back. Detail in `references/win-back-flow-patterns.md`.
+
+---
+
+## "Annual plans not converting; monthly plans dominate."
+
+**The diagnosis.** Annual value-prop weak; or commitment friction too high.
+
+**The cure.** Strengthen annual value (better discount, additional features). Reduce commitment friction (easier mid-year cancellation, prorated refunds).
+
+---
+
+## "Sales says many leads come from churned users coming back."
+
+**The diagnosis.** Win-back working but the previous churn was avoidable; audit upstream.
+
+**The cure.** Invest in churn prevention upstream. Detail in `references/churn-prevention-upstream.md`.
+
+---
+
+## "Conversion did not change after we redesigned the paywall."
+
+**The diagnosis.** Paywall design was not the problem; trigger or plan structure may be.
+
+**The cure.** Test variables that matter. Trigger moment, plan structure, value-prop copy. Paywall presentation alone often does not move the needle.
+
+---
+
+## "Upgrade flow works for new users; existing users do not upgrade."
+
+**The diagnosis.** Triggers designed for new-user behavior; existing users do not hit them.
+
+**The cure.** Segment trigger logic. Existing users may need different triggers (feature-launch upgrades, capacity-growth upgrades).
+
+---
+
+## "Conversion increased but new customer churn climbed."
+
+**The diagnosis.** Paywall too aggressive; converting users who do not see value.
+
+**The cure.** Audit conversion-to-retention correlation. Aggressive conversion may produce buyer's remorse.
+
+---
+
+## "Users complain about hidden charges after upgrade."
+
+**The diagnosis.** Pricing not transparent; users surprised by total cost.
+
+**The cure.** Surface all costs upfront. Annual price, monthly price, taxes if applicable. Hidden costs damage trust.
+
+---
+
+## "Cancellation rate spikes 3 months after upgrade."
+
+**The diagnosis.** Upgrade was made but value did not materialize; users gave it 3 months and left.
+
+**The cure.** Post-upgrade welcome and onboarding. Surface paid features; help users access value of paid plan.
+
+---
+
+## "Different audience segments convert at different rates; we cannot tell why."
+
+**The diagnosis.** Per-segment data not tracked.
+
+**The cure.** Per-segment conversion analytics. Different segments may need different upgrade flows.
+
+---
+
+## "Win-back outreach has unsubscribe rate climbing."
+
+**The diagnosis.** Outreach too frequent or generic.
+
+**The cure.** Segment outreach. Respect non-response. Reduce frequency.
+
+---
+
+## "We A/B tested annual vs monthly default; result was wash."
+
+**The diagnosis.** Default may not have been the issue; price-anchoring or commitment friction may be.
+
+**The cure.** Test different variables. Price level, discount magnitude, presentation order.
+
+---
+
+## "Sales-led upgrades convert at higher rate than self-serve."
+
+**The diagnosis.** Self-serve flow misses something that sales touches address.
+
+**The cure.** Audit what sales does that the flow does not. Often: clarifies value, addresses objections, customizes recommendation.
+
+---
+
+## "We added more upsell prompts; existing customer churn went up."
+
+**The diagnosis.** Prompt fatigue. Existing customers feel squeezed.
+
+**The cure.** Frequency limits on upsell. Less is often more.
+
+---
+
+## "Conversion drops at the credit-card-entry step."
+
+**The diagnosis.** Form friction or trust signals missing.
+
+**The cure.** Optimize the credit-card form. Add trust signals (security badges, refund policy). Reduce required fields.
+
+---
+
+## The pattern across failures
+
+Most upgrade flow failures fall into one of three patterns.
+
+**Pattern 1: Paywalls at wrong moments.** Paywall-everywhere, premature, unconnected, free-forever-trap. The fix is to align paywalls with demonstrated value.
+
+**Pattern 2: Plan structure misaligned.** Plan-paralysis, plan-mismatch, post-upgrade-empty. The fix is clearer tier audiences and post-upgrade experience.
+
+**Pattern 3: Trust damage.** Bait-and-switch, hidden-price, aggressive-downsell, hard-to-cancel. The fix is transparency and respect for the user.
+
+The metric pattern: upgrade flow failures often look fine on conversion alone. The signal is in retention post-upgrade, churn rate, win-back conversion. Programs that track only conversion keep shipping the same patterns.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of failure patterns with diagnoses and cures. The pattern across failures (paywall timing, plan structure, trust). The principle that conversion alone is insufficient.
+
+## Implementation choices that stay internal
+
+Specific failure cases the team has encountered. Specific multi-metric dashboards. Specific cures. The team's audit and retirement processes. These vary by team.

--- a/skills/upgrade-flow-design/references/free-tier-decision-criteria.md
+++ b/skills/upgrade-flow-design/references/free-tier-decision-criteria.md
@@ -1,0 +1,253 @@
+# Free-tier decision criteria
+
+Freemium, free-trial, reverse trial, no-free. Choice criteria.
+
+The free-tier decision is upstream of upgrade flow design. The structure determines what the upgrade flow looks like, which trigger moments matter, and what conversion rates are achievable.
+
+---
+
+## The free-tier decision matters
+
+Different free-tier structures warrant different upgrade flows.
+
+**The win.** A SaaS product chooses freemium because users provide product value (data, virality, network). Upgrade flow surfaces capacity-based paywalls. Conversion is 3 percent but volume produces meaningful revenue.
+
+**The fail.** Same product chooses free-trial without realizing user value matters more than time-bound trial. Trial ends; users churn rather than convert; the product loses the network effect users were providing for free.
+
+The decision is strategic; downstream design choices follow from it.
+
+---
+
+## Pattern A: Freemium (free-forever tier)
+
+Users use the product indefinitely without paying.
+
+**How it works.**
+
+- Free tier offers core value with constraints (capacity limits, feature limits).
+- Paid tier removes constraints or unlocks more.
+- Users may stay free forever; conversion happens when they hit constraints they value enough to pay around.
+
+**Conversion baseline.** 2-5 percent typical for B2B SaaS; varies widely.
+
+**Strengths.**
+
+- Volume.
+- Network effects from free users.
+- Users provide product value (data, content, virality).
+- Lower acquisition cost.
+
+**Weaknesses.**
+
+- Most users do not convert.
+- Free-tier capacity costs.
+- Plan-design pressure to gate the right things.
+
+**When to use.** Products with strong network effects, or where free users genuinely contribute to product value.
+
+---
+
+## Pattern B: Free-trial (time-limited)
+
+Users get full or near-full product for a defined period.
+
+**How it works.**
+
+- Trial period (7-30 days typical).
+- After trial, must pay to continue.
+- Often credit-card-required at start (with auto-charge) or credit-card-not-required (with explicit conversion at end).
+
+**Conversion baseline.** 10-25 percent of trial signups; higher with credit-card-required.
+
+**Strengths.**
+
+- Strong commitment from users who start.
+- Clear conversion deadline.
+- Revenue arrives quickly post-trial.
+
+**Weaknesses.**
+
+- Friction at signup if credit card required.
+- Users churn if trial ends before they reach value.
+- Trial extension dynamics can become a negotiation.
+
+**When to use.** Products where value is clear within the trial period; audiences willing to commit time before paying.
+
+---
+
+## Pattern C: Reverse trial
+
+Users start on paid plan; auto-downgrade to free after period.
+
+**How it works.**
+
+- Signup grants paid features for a defined period.
+- After period, auto-downgrades to free tier.
+- Users who want continued paid features upgrade.
+
+**Conversion baseline.** Moderate; mixes signals.
+
+**Strengths.**
+
+- Users see paid features; familiarity may drive conversion.
+- Easier to start than credit-card-required trial.
+
+**Weaknesses.**
+
+- Surprise when downgrade hits.
+- Some users dislike the loss-aversion framing.
+- Less common; users may not know what to expect.
+
+**When to use.** When the team has tested both freemium and free-trial and reverse-trial outperforms; specific product-audience fits.
+
+---
+
+## Pattern D: No-free (paid-only)
+
+No free tier; users pay to start.
+
+**How it works.**
+
+- Sales conversation or demo; user signs contract or starts subscription.
+- No self-serve free path.
+
+**Strengths.**
+
+- Higher revenue per signup.
+- Clearer signal of intent.
+- No free-tier capacity costs.
+
+**Weaknesses.**
+
+- Lower top-of-funnel volume.
+- Higher acquisition cost.
+- Sales-motion dependent.
+
+**When to use.** Enterprise products, high-touch sales, products where free would dilute brand or capacity.
+
+---
+
+## Pattern E: Hybrid
+
+Combining patterns. Most production products mix.
+
+**Common combinations.**
+
+- Freemium with free-trial of paid tier (free forever; trial of higher tier for free users).
+- Free-trial with credit-card-not-required for self-serve, plus paid-only for enterprise.
+- Reverse-trial for new users, freemium for users who downgrade at end of reverse-trial.
+
+**The hybrid challenge.** More complexity; more paths to maintain. Justify complexity with conversion data.
+
+---
+
+## Choice criteria
+
+How to decide.
+
+**Use freemium when:**
+
+- Network effects matter; free users contribute value.
+- Audience expects free; paid-only would limit reach.
+- Conversion rate at scale produces meaningful revenue.
+
+**Use free-trial when:**
+
+- Value is clear within a trial period.
+- Audience willing to commit time before paying.
+- Conversion economics favor higher rate over higher volume.
+
+**Use reverse-trial when:**
+
+- Both freemium and free-trial have been tested and reverse-trial outperforms.
+- Audience signal-strength is high (paid features get used).
+
+**Use no-free when:**
+
+- Audience is enterprise or high-touch.
+- Product capacity costs prohibit freemium.
+- Sales motion is the dominant funnel.
+
+**Use hybrid when:**
+
+- Different audience segments warrant different free structures.
+- Data justifies the complexity.
+
+---
+
+## Free-tier capacity design
+
+For freemium, the capacity decision.
+
+**The principle.** Free tier offers enough capacity to demonstrate value; not enough to replace paid tier.
+
+**Capacity dimensions.**
+
+- **Use volume.** Number of items, queries, exports per month.
+- **Capacity.** Storage, seats, integrations.
+- **Feature set.** Specific features paid only.
+- **Support level.** Self-serve only on free; live support on paid.
+- **Branding.** Free tier shows brand; paid removes.
+
+**Design discipline.** Free tier should let users hit the ah-ha moment; paid tier should be necessary for sustained or scaled use. Too generous: users do not convert. Too constrained: users do not reach ah-ha.
+
+---
+
+## Trial period length
+
+For free-trial, how long.
+
+**Common periods.**
+
+- **7 days.** Aggressive; works when ah-ha moment is clear and quick.
+- **14 days.** Common B2B; balances time-to-value with urgency.
+- **30 days.** Generous; works for products with longer evaluation cycles.
+- **60+ days.** Rare; usually reflects enterprise sales cycles.
+
+**Decision factors.**
+
+- Time-to-value of the product.
+- Audience evaluation cycle.
+- Conversion rate by trial length (test if uncertain).
+
+---
+
+## Free-tier maintenance
+
+Free-tier structures decay.
+
+**What decays.**
+
+- Capacity limits set years ago no longer match current product capability.
+- Features moved between tiers without comprehensive update.
+- Audience composition shifted; old free-tier no longer fits.
+
+**Maintenance cadence.** Quarterly review of free-tier structure alongside pricing review.
+
+**The decay-driven redesign.** When refinements have not moved conversion, the free-tier structure may need redesign.
+
+---
+
+## Common free-tier failures
+
+**Free-tier too generous.** Users get everything they need; conversion never starts.
+
+**Free-tier too constrained.** Users do not reach value; churn before conversion.
+
+**Trial too short.** Users do not reach ah-ha moment; trial ends with low conversion.
+
+**Trial too long.** Conversion incentive weak; users defer decision.
+
+**Wrong free-tier structure for audience.** Freemium chosen for enterprise audience that wanted no-free; adoption suffers.
+
+**No maintenance.** Free-tier static; conversion declines as product evolves.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The free-tier decision matters principle. Patterns A through E. Choice criteria. Free-tier capacity design. Trial period length. Maintenance considerations. Common failures.
+
+## Implementation choices that stay internal
+
+Specific free-tier structures for specific products. Specific capacity limits. Specific trial lengths. The team's pricing review calendar. These vary by team and product.

--- a/skills/upgrade-flow-design/references/paywall-presentation-patterns.md
+++ b/skills/upgrade-flow-design/references/paywall-presentation-patterns.md
@@ -1,0 +1,293 @@
+# Paywall presentation patterns
+
+Modal, banner, inline, toast. Copy and value-prop discipline.
+
+How the paywall surfaces. Done well, the presentation matches the trigger's intensity; done poorly, presentation fights the trigger and conversion suffers.
+
+---
+
+## The presentation-matches-trigger principle
+
+Strong triggers warrant prominent presentation; soft triggers warrant subtle presentation.
+
+**The win.** A user hits a capacity limit; a modal surfaces explaining the limit and offering upgrade. The modal is justified because the trigger is hard (the user cannot continue without resolving). The user accepts the interruption.
+
+**The fail.** Same user, soft trigger (general awareness moment). A modal surfaces the same way. The interruption is not justified by the trigger; user resents.
+
+The discipline. Match presentation intensity to trigger strength.
+
+---
+
+## Pattern A: Modal paywall
+
+Full-screen overlay blocks the action.
+
+**How it works.**
+
+- Modal overlay appears.
+- User must engage (upgrade) or dismiss to continue.
+- Often blocks the action that triggered it.
+
+**Strengths.**
+
+- Highest visibility.
+- Clear demand for attention.
+- Works for hard triggers (capacity hit, feature gate).
+
+**Weaknesses.**
+
+- Most disruptive.
+- Easily abused; produces annoyance.
+
+**When to use.** Hard triggers where the user cannot proceed without resolution.
+
+---
+
+## Pattern B: Banner paywall
+
+Persistent banner at top of page.
+
+**How it works.**
+
+- Banner remains visible across pages.
+- Often dismissable for the session.
+- Soft prompt; does not block action.
+
+**Strengths.**
+
+- Persistent awareness without blocking.
+- Reaches users who have not hit hard triggers.
+
+**Weaknesses.**
+
+- Visual noise; users develop blindness.
+- Cumulative exposure can feel like spam.
+
+**When to use.** Awareness campaigns. Use sparingly; persistent banners abused become noise.
+
+---
+
+## Pattern C: Inline paywall
+
+Upgrade ask embedded in the surface where the trigger occurred.
+
+**How it works.**
+
+- Paywall content appears within the workflow.
+- User reads in context; can act or scroll past.
+- No overlay; no modal.
+
+**Strengths.**
+
+- Contextual; integrated with the workflow.
+- Non-disruptive.
+- Respectful of user momentum.
+
+**Weaknesses.**
+
+- Easier to miss.
+- May not produce conversion if too easy to ignore.
+
+**When to use.** Soft triggers; awareness without interruption.
+
+---
+
+## Pattern D: Toast or notification
+
+Brief paywall surfaced as a notification.
+
+**How it works.**
+
+- Small notification appears (often corner of screen).
+- Auto-dismisses after time or on click.
+- Brief content.
+
+**Strengths.**
+
+- Lightest weight.
+- Easy to dismiss.
+
+**Weaknesses.**
+
+- Easy to miss entirely.
+- Limited content.
+
+**When to use.** Soft prompts; low-priority awareness.
+
+---
+
+## Pattern E: Hybrid
+
+Combining patterns.
+
+**Common combinations.**
+
+- Modal for hard triggers + inline for soft triggers.
+- Banner for awareness + modal at hard trigger moments.
+- Inline for in-feature prompts + modal at capacity limits.
+
+**The hybrid discipline.** Each presentation has a clear role; users do not see overlapping or competing paywalls.
+
+---
+
+## Choice criteria
+
+Which presentation fits which trigger.
+
+**Use modal when:**
+
+- Trigger is hard (cannot proceed without resolution).
+- Capacity limit reached.
+- Feature gate hit.
+
+**Use inline when:**
+
+- Trigger is contextual but soft.
+- User can continue without resolving.
+- Workflow integration is the priority.
+
+**Use banner when:**
+
+- Awareness campaign across pages.
+- Soft prompt for users who have not hit hard triggers.
+
+**Use toast when:**
+
+- Low-priority awareness.
+- Brief acknowledgment.
+
+The simplest pattern that matches the trigger is usually right. Most upgrade flows benefit from inline + occasional modal.
+
+---
+
+## Copy and value-prop discipline
+
+What the paywall says.
+
+**The principle.** Paywall copy should connect to what the user just did and what they get next.
+
+**Strong copy patterns.**
+
+- "You have used [feature] 50 times this month. Upgrade to remove the limit and unlock [advanced capabilities]."
+- "You have hit your free tier's [capacity]. Upgrade to expand to [paid capacity]."
+- "Inviting teammates requires our [team plan]. Upgrade to invite up to [number] teammates."
+
+What works: specific connection to user action; specific value of upgrade.
+
+**Weak copy patterns.**
+
+- "Upgrade for more features." (Generic; no connection.)
+- "Get the full experience." (Vague; no specifics.)
+- "Don't miss out." (FOMO without value.)
+
+What fails: no connection to user behavior; no specific value-prop.
+
+---
+
+## Plan presentation in paywalls
+
+Showing the upgrade options.
+
+**Single-plan paywall.** One upgrade option presented. Simple; clear.
+
+When to use. When the upgrade is unambiguous (capacity hit; one obvious path).
+
+**Multi-plan paywall.** Two or three upgrade options presented (e.g., Pro vs Enterprise).
+
+When to use. When multiple plans could fit; let the user choose.
+
+**Presentation discipline.**
+
+- Highlight the recommended plan.
+- Make pricing clear.
+- Make value differences clear.
+
+**Anti-pattern.** Showing 5 plans in a paywall. Decision paralysis; user does not choose.
+
+---
+
+## Pricing presentation
+
+How prices appear.
+
+**Per-month vs per-year.** Default to the user's likely commitment level; offer the alternative.
+
+**Price anchoring.** Show what the upgrade saves vs equivalent value (use carefully; can feel manipulative).
+
+**Currency and locale.** Match the user's locale.
+
+**Discounts.** Surface honest discounts (annual discount, promotion). Avoid fake urgency.
+
+---
+
+## Action design
+
+The buttons and CTAs.
+
+**Primary CTA.** "Upgrade to Pro" with specific plan name. Bold; visible.
+
+**Secondary CTA.** "Maybe later" or "See plans." Allows decline without forcing.
+
+**No third option.** Two paths (upgrade or decline) preferred. Three or more paths confuse.
+
+**The decline-respect principle.** "Maybe later" should respect the decline. The same paywall should not re-fire immediately.
+
+---
+
+## Paywall as opportunity to communicate value
+
+Even when the user declines, the paywall is a touchpoint.
+
+**The principle.** Paywall copy explains what paid offers in concrete terms. Even users who decline understand more about the paid plan than they did before.
+
+**Why this matters.** Future trigger moments find users with more context. The decline today may convert next month because the value is now understood.
+
+---
+
+## Paywall analytics
+
+Track the paywall's performance.
+
+**Metrics.**
+
+- Display rate (how often does it surface?).
+- Click rate (how many engage with upgrade button?).
+- Conversion rate (of clicks, how many complete upgrade?).
+- Decline rate (how many dismiss?).
+- Re-show rate per declined paywall.
+
+**Diagnostic uses.**
+
+- High display, low click: copy or value-prop weak.
+- High click, low conversion: friction in upgrade flow downstream.
+- High decline rate: trigger may be wrong, or copy unclear.
+
+---
+
+## Common presentation failures
+
+**Wrong presentation for trigger.** Modal on soft trigger; inline on hard trigger.
+
+**Generic copy.** Paywall does not connect to user behavior.
+
+**Plan paralysis.** Too many options in the paywall.
+
+**Hidden price.** User has to dig to find the cost.
+
+**Decline ignored.** Same paywall re-fires immediately after dismiss.
+
+**Cumulative exposure.** User sees too many paywalls per session.
+
+**Mobile-broken paywall.** Modal on mobile blocks all interaction.
+
+**Loading delay.** Paywall takes time to appear; user has moved on.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The presentation-matches-trigger principle. Patterns A through E. Choice criteria. Copy and value-prop discipline. Plan presentation. Pricing presentation. Action design. Paywall as value communication. Paywall analytics. Common failures.
+
+## Implementation choices that stay internal
+
+Specific paywall designs for specific products. Specific copy in brand voice. Specific tooling. The team's analytics dashboards. These vary by team and product.

--- a/skills/upgrade-flow-design/references/plan-structure-patterns.md
+++ b/skills/upgrade-flow-design/references/plan-structure-patterns.md
@@ -1,0 +1,240 @@
+# Plan structure patterns
+
+Tier count, feature gating, audience-fit per tier.
+
+The plans the upgrade flow leads to. Done well, plan structure makes upgrade decisions clear; done poorly, plan structure produces decision paralysis or upgrade-then-downgrade churn.
+
+---
+
+## The clear-tier-fit principle
+
+Each tier should have a clear "this is for [audience] because of [reason]." Tiers without clear audience-fit produce weak conversions.
+
+**The win.** A SaaS analytics product has 3 tiers. Starter ("solo analysts and small teams"), Growth ("10-50 person analytics teams"), Enterprise ("complex analytics needs at scale"). Each tier maps to a specific audience; users self-select by recognizing themselves.
+
+**The fail.** Same product has 3 tiers labeled Bronze, Silver, Gold with feature checkmarks. Audiences cannot tell which is for them; many pick the wrong tier; downgrade rates climb.
+
+The discipline. Each tier has clear audience-fit articulated.
+
+---
+
+## Tier count
+
+How many tiers.
+
+**2-tier (Free + Paid).**
+
+How it works. Free for some users, paid for everyone else.
+
+Strengths. Simple; clear upgrade path.
+
+Weaknesses. Cannot capture enterprise-tier revenue; cannot serve segmented audiences differently.
+
+When to use. Single-audience products; products with limited feature differentiation.
+
+**3-tier (Starter + Pro + Enterprise).**
+
+How it works. Three plans serving three audiences.
+
+Strengths. Captures entry-level, mid-market, and enterprise. Industry-standard.
+
+Weaknesses. Requires clear audience differentiation; can create decision paralysis if audiences are not clear.
+
+When to use. Most B2B SaaS products. Default for products with diverse audiences.
+
+**4+ tier.**
+
+How it works. Four or more plans.
+
+Strengths. Highly granular; serves many audiences.
+
+Weaknesses. Decision paralysis; users cannot tell which tier fits.
+
+When to use. Rarely. Most products do better with 3 tiers and add-ons rather than 4+ tiers.
+
+The simplest tier count that fits the audience is usually best.
+
+---
+
+## Feature gating patterns
+
+How features differ between tiers.
+
+**Pattern A: Capacity-based gating.**
+
+How it works. All tiers have most features; tiers differ in volume (seats, queries, storage).
+
+Strengths. Clear upgrade trigger when capacity hit. Easy to understand.
+
+Weaknesses. Encourages users to optimize against limits.
+
+When to use. Products where capacity is the key cost driver.
+
+**Pattern B: Feature-based gating.**
+
+How it works. Lower tiers missing specific features; higher tiers unlock them.
+
+Strengths. Clear value differentiation between tiers.
+
+Weaknesses. Feature gating can feel arbitrary; users may want one paid feature but not the rest.
+
+When to use. Products with clearly tiered feature sets (basic vs advanced vs enterprise).
+
+**Pattern C: Hybrid gating.**
+
+How it works. Both capacity and features differ between tiers.
+
+Strengths. Most flexibility; serves diverse audiences.
+
+Weaknesses. More complex to communicate; feature comparison tables get long.
+
+When to use. Default for production B2B SaaS; most products benefit from hybrid.
+
+**Pattern D: Service-based gating.**
+
+How it works. Tiers differ in service level (support, onboarding, SLA).
+
+Strengths. Aligns with enterprise expectations.
+
+Weaknesses. Service costs scale with tier.
+
+When to use. Often for top tier (Enterprise); rarely the only differentiation.
+
+---
+
+## Plan naming
+
+What to call the plans.
+
+**Audience-named plans.** "For solo creators," "For growing teams," "For enterprise."
+
+Strengths. Self-selecting; users know which fits.
+
+Weaknesses. Audience names age; "for startups" can feel limiting.
+
+**Tier-named plans.** "Starter," "Pro," "Enterprise" or "Basic," "Pro," "Premium."
+
+Strengths. Industry-standard; users recognize.
+
+Weaknesses. Generic; does not differentiate from competitors.
+
+**Outcome-named plans.** "Build," "Grow," "Scale."
+
+Strengths. Aspirational; aligns with user goals.
+
+Weaknesses. Vague; users may not know which outcome describes them.
+
+The discipline. Names should be specific enough that users self-select correctly.
+
+---
+
+## Pricing structure
+
+How prices map to tiers.
+
+**Per-seat.** Cost scales with team size.
+
+When to use. Team collaboration products.
+
+**Per-feature.** Cost scales with feature set.
+
+When to use. Modular products.
+
+**Per-usage.** Cost scales with use volume.
+
+When to use. Capacity-driven products.
+
+**Flat per-tier.** Each tier has fixed price regardless of usage.
+
+When to use. Predictable-budget audiences (often enterprise).
+
+**Hybrid pricing.** Combinations of the above.
+
+When to use. Most production products use hybrid (per-seat with usage caps; flat tier with feature differences).
+
+---
+
+## Annual vs monthly
+
+Commitment options.
+
+**Monthly.** Lower commitment; higher friction at cancellation; users can leave easily.
+
+**Annual.** Higher commitment; usually discounted; reduces churn but requires upfront payment.
+
+**Both offered.** Most products offer both; annual discount incentivizes commitment.
+
+**Discipline.** Discount on annual should reflect real value to the company (lower churn, predictable revenue) rather than arbitrary marketing percent-off.
+
+---
+
+## Plan transition design
+
+How users move between plans.
+
+**Free to paid.** First commitment. Smooth experience matters most.
+
+**Tier upgrade (within paid).** From Pro to Enterprise. Often involves billing transition.
+
+**Downgrade (within paid).** From Enterprise to Pro. Should be friction-low to maintain trust; aggressive downgrade prevention damages trust.
+
+**Cancellation to free.** Some products auto-downgrade on cancellation; others fully cancel. Each has tradeoffs.
+
+The transitions should be smooth. Friction at transition damages trust.
+
+---
+
+## Pricing-page coordination
+
+Plan structure decisions reflect on the pricing page.
+
+**The principle.** Plan structure decisions made for the upgrade flow appear on the pricing page. Users should see consistent information.
+
+**The integration.** Pricing-page copy (covered by `landing-page-copy`) implements the plan structure decisions made here. The two skills coordinate.
+
+---
+
+## Plan maintenance
+
+Plans decay.
+
+**What decays.**
+
+- Capacity limits set years ago no longer match product capability.
+- Features moved between tiers over time without comprehensive update.
+- Pricing levels no longer match market.
+- Tier audiences shifted.
+
+**Maintenance cadence.** Annual review at minimum; major product or market changes trigger more frequent.
+
+**The decay-driven redesign.** When plan structure no longer reflects reality, redesign rather than patch.
+
+---
+
+## Common plan structure failures
+
+**Too many tiers.** Decision paralysis; users pick wrong tier.
+
+**Tiers without clear audience-fit.** Generic names without differentiation.
+
+**Misaligned pricing.** Prices that do not reflect value differences between tiers.
+
+**Feature gating arbitrary.** Features gated based on what is easy rather than what audiences need.
+
+**No annual discount.** Users default to monthly; cumulative revenue lower.
+
+**Aggressive downgrade prevention.** Users want to downgrade; friction damages trust.
+
+**Plans not updated.** Pricing or tiers from years ago no longer fit current product or market.
+
+**Pricing-page mismatched.** Plans on the page differ from plans in the upgrade flow.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The clear-tier-fit principle. Tier count guidance. Feature gating patterns A through D. Plan naming patterns. Pricing structure patterns. Annual vs monthly. Plan transition design. Pricing-page coordination. Plan maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific plans for specific products. Specific feature gating decisions. Specific pricing levels. Specific naming conventions. The team's pricing review calendar. These vary by team and product.

--- a/skills/upgrade-flow-design/references/trigger-moment-design.md
+++ b/skills/upgrade-flow-design/references/trigger-moment-design.md
@@ -1,0 +1,217 @@
+# Trigger-moment design
+
+Where paywalls earn their interruption. Strong vs weak trigger moments.
+
+The single most consequential decision in upgrade flow design. Paywalls surface at moments where the user has demonstrated they are getting value. Get this wrong and conversion suffers regardless of paywall design quality.
+
+---
+
+## The earned-interruption principle
+
+Each paywall should answer: what value did the user just demonstrate, and how does the paid plan extend that value?
+
+**The win.** User has used a feature 50 times. Hits the 50th-use limit. Paywall surfaces: "You have used [feature] 50 times this month. Upgrade to remove the limit and unlock [related advanced capabilities]." The trigger is fresh; the value is demonstrated; the user is positioned to say yes.
+
+**The fail.** Same user. Paywall surfaces on first login: "Upgrade for more features." User has not yet demonstrated value; the upgrade ask is premature; user dismisses.
+
+The discipline. Paywalls earn their interruption by connecting to recent demonstrated value.
+
+---
+
+## Strong trigger moments
+
+Patterns that recur across products.
+
+**Usage threshold reached.**
+
+How it works. User has used a feature N times in a period. Further use requires paid plan.
+
+Why it works. The user clearly values the feature. The threshold is predictable; the paywall is honest about the constraint.
+
+**Capacity limit hit.**
+
+How it works. User reached free-tier capacity (storage, seats, queries). Upgrade unlocks more.
+
+Why it works. User encountered an unambiguous block. The block is part of the free-tier promise; the upgrade is the resolution.
+
+**Advanced feature attempted.**
+
+How it works. User clicked into a feature that requires paid plan.
+
+Why it works. Interest is fresh; the user wanted this specific feature. Upgrade ask connects to the specific interest.
+
+**Workflow completed successfully.**
+
+How it works. User completed an action that produced visible value (saved view, exported result, completed flow). Upgrade ask connects continuing or expanding that value to paid plan.
+
+Why it works. Value is fresh; user just experienced what the product does. Upgrade frames continuation.
+
+**Team-collaboration moment.**
+
+How it works. User wants to invite teammates; team capabilities require paid plan.
+
+Why it works. The collaboration intent is concrete; team capabilities are a clear value extension.
+
+**Time-trial ending.**
+
+How it works. Trial-based products surface upgrade as trial nears end.
+
+Why it works. Predictable; user expected it; the conversion conversation is timely.
+
+**Multi-session usage.**
+
+How it works. User has returned multiple times; engagement signal strong; soft upgrade prompt.
+
+Why it works. The user has demonstrated commitment through return; soft prompt fits.
+
+---
+
+## Weak trigger moments
+
+Patterns that fail.
+
+**First-login paywall.**
+
+The pattern. Upgrade ask on first login.
+
+Why it fails. User has not yet seen value; the ask is premature.
+
+**Random in-product placement.**
+
+The pattern. Persistent paywall on the dashboard with no specific trigger.
+
+Why it fails. Not connected to user behavior; users develop blindness.
+
+**Every-page banner.**
+
+The pattern. Persistent upgrade banner across all surfaces.
+
+Why it fails. Visual noise; users learn to ignore.
+
+**Paywall on the action the user expected free.**
+
+The pattern. User believed a feature was free (because of marketing or onboarding); paywall surfaces when they try to use it.
+
+Why it fails. Trust damage. The user feels deceived.
+
+**Paywall on irrelevant moments.**
+
+The pattern. Paywall surfaces during user actions unrelated to the paid feature.
+
+Why it fails. Confusing; user does not connect the ask to anything.
+
+**Paywall right after an error.**
+
+The pattern. User just had a bad experience; immediately gets an upgrade ask.
+
+Why it fails. Tone-deaf; trust degrades.
+
+---
+
+## Trigger moment design discipline
+
+Designing each trigger.
+
+**Step 1: Identify the demonstrated value.** What did the user just do that demonstrates value?
+
+**Step 2: Identify the connection to paid.** How does the paid plan extend or continue that value?
+
+**Step 3: Time the ask.** When in the user's flow does the ask land cleanly without breaking momentum?
+
+**Step 4: Match presentation to importance.** Strong triggers warrant modal; soft triggers inline.
+
+**Step 5: Plan the response paths.** What if user accepts? Declines? Asks for info? Each path designed.
+
+The output is a trigger moment that the user perceives as fair.
+
+---
+
+## Trigger frequency
+
+How often paywalls fire.
+
+**Per-trigger.** A specific trigger should not fire repeatedly. Once it has fired and been declined, give space before re-asking.
+
+**Cumulative session frequency.** Total paywall exposures per session capped (often 1-2). Beyond that, additional triggers defer.
+
+**Per-week.** For users who use the product frequently, weekly cap prevents fatigue.
+
+**The over-trigger trap.** Each individual trigger looks reasonable; cumulative exposure is annoying.
+
+---
+
+## Personalized trigger logic
+
+Different users may warrant different triggers.
+
+**Power-user vs new-user.** Power users may have different trigger thresholds; new users may need more time.
+
+**Plan tier.** Free users see free-to-paid triggers; paid users see paid-to-higher-paid triggers.
+
+**Engagement frequency.** Daily active vs returning monthly may warrant different timing.
+
+**The discipline.** Personalize where data justifies; do not over-segment.
+
+---
+
+## Trigger testing
+
+Test triggers before launching.
+
+**Test cases.**
+
+- New user encounters trigger: appropriate timing?
+- Returning user encounters trigger: re-fire respect?
+- Power user encounters trigger: relevant?
+- User who declined trigger encounters again: respectful?
+
+**Production monitoring.**
+
+- Per-trigger fire rate.
+- Per-trigger conversion rate.
+- Decline rate per trigger.
+- Cumulative session exposure.
+
+The data informs which triggers earn their place and which should be retired.
+
+---
+
+## Trigger maintenance
+
+Triggers decay.
+
+**What decays.**
+
+- Thresholds set years ago no longer match current usage patterns.
+- Features the trigger references have changed or been deprecated.
+- Audience composition shifted; old triggers no longer fit.
+
+**Maintenance cadence.** Quarterly review. Triggers that fire too often, too rarely, or with low conversion warrant attention.
+
+---
+
+## Common trigger-moment failures
+
+**Premature triggers.** Asking before value is demonstrated.
+
+**Unconnected triggers.** Paywall not tied to the user's recent action.
+
+**Over-frequent triggers.** Cumulative exposure becomes noise.
+
+**Stale triggers.** Threshold values set long ago no longer match usage.
+
+**Mistimed triggers.** Right concept, wrong moment in the user's flow.
+
+**Triggers right after errors.** Tone-deaf placement after frustration.
+
+**Triggers that violate free-tier promise.** Asking the user to pay for something they were told was free.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The earned-interruption principle. Strong trigger moments (7 patterns). Weak trigger moments (6 patterns). Trigger moment design discipline. Trigger frequency. Personalized trigger logic. Trigger testing. Maintenance. Common failures.
+
+## Implementation choices that stay internal
+
+Specific triggers for specific products. Specific thresholds. Specific tooling. The team's audit calendar. These vary by team and product.

--- a/skills/upgrade-flow-design/references/upgrade-flow-anti-patterns.md
+++ b/skills/upgrade-flow-design/references/upgrade-flow-anti-patterns.md
@@ -1,0 +1,212 @@
+# Upgrade flow anti-patterns
+
+The patterns that look like upgrade flows but degrade trust. Easy to ship; the cost shows up in conversion, retention, and brand reputation.
+
+---
+
+## The paywall-everywhere flow
+
+The pattern. Paywall blocks meaningful product use; free tier too constrained.
+
+The signal. Users churn before reaching value; conversion stays low despite aggressive paywalling.
+
+The cost. Users who would have paid after seeing value never reach it.
+
+The cure. Loosen the free tier; surface paywalls at moments of demonstrated value.
+
+---
+
+## The free-forever-trap flow
+
+The pattern. Generous free tier; no upgrade path surfaces.
+
+The signal. Conversion stays at single-digit indefinitely.
+
+The cost. Product is loved free; revenue does not follow.
+
+The cure. Add value-triggered paywalls. Connect upgrade to demonstrated value.
+
+---
+
+## The premature-paywall flow
+
+The pattern. Paywall on first login or before value is demonstrated.
+
+The signal. High dismiss rate; conversion does not lift.
+
+The cost. Users associate the brand with hard-sell early; some leave entirely.
+
+The cure. Move paywalls to moments of demonstrated value.
+
+---
+
+## The unconnected-paywall flow
+
+The pattern. Paywall not connected to user behavior; appears at random or on every page.
+
+The signal. Visual noise; users develop blindness.
+
+The cost. Cumulative exposure becomes spam; trust degrades.
+
+The cure. Tie each paywall to specific user-demonstrated value.
+
+---
+
+## The plan-paralysis flow
+
+The pattern. 5+ tiers presented in upgrade flow; users cannot decide.
+
+The signal. Click rate on plans is even across tiers; conversion does not match interest.
+
+The cost. Decision paralysis prevents conversion.
+
+The cure. Reduce tier count to 3. Recommend a default plan based on user signals.
+
+---
+
+## The hidden-price flow
+
+The pattern. Prices buried; users have to dig to find them.
+
+The signal. Users abandon at the price-discovery step.
+
+The cost. Friction at the moment of decision; users leave.
+
+The cure. Surface prices clearly. Hidden pricing damages trust.
+
+---
+
+## The decline-ignored flow
+
+The pattern. User dismisses paywall; same paywall fires immediately.
+
+The signal. Users disable tours globally; complain about persistent paywalls.
+
+The cost. Trust degrades; users may churn from the friction itself.
+
+The cure. Respect declines. Wait substantial time before re-asking.
+
+---
+
+## The aggressive-downsell flow
+
+The pattern. User declines primary; multiple decline-and-counter rounds; user feels pressured.
+
+The signal. Users associate the brand with manipulation.
+
+The cost. Even users who eventually convert leave with negative impressions.
+
+The cure. One downsell at most. Respect the second decline.
+
+---
+
+## The bait-and-switch flow
+
+The pattern. User believed feature was free (because of marketing); paywall surfaces when they try to use it.
+
+The signal. Users complain about deception; trust collapses.
+
+The cost. Long-term brand damage.
+
+The cure. Marketing and product align on what is free. No surprise paywalls on advertised-as-free features.
+
+---
+
+## The discount-led-win-back flow
+
+The pattern. Win-back discount-only; no value-prop change.
+
+The signal. Re-engaged users churn again; users learn to lapse for discounts.
+
+The cost. Reverse incentive; lapse rate rises strategically.
+
+The cure. Lead with value-prop change; discount sparingly.
+
+---
+
+## The aggressive-cancellation-prevention flow
+
+The pattern. User wants to cancel; flow makes cancellation hard (multi-step, hidden, support-only).
+
+The signal. Users complain publicly; brand earns "hard to cancel" reputation.
+
+The cost. Long-term trust damage; sometimes regulatory issue.
+
+The cure. Cancellation should be as easy as signup. Friction at exit damages reputation.
+
+---
+
+## The plan-mismatch flow
+
+The pattern. Tier audiences not clearly differentiated; users pick wrong plan.
+
+The signal. Upgrade rate looks fine; downgrade rate climbs as users realize they picked wrong.
+
+The cost. Churn through dissatisfaction.
+
+The cure. Clarify tier audiences. Each plan should have specific audience-fit visible.
+
+---
+
+## The post-upgrade-empty flow
+
+The pattern. User upgrades; nothing changes immediately. New features unlocked but not surfaced.
+
+The signal. Upgraded users do not engage with paid features they paid for.
+
+The cost. Buyer's remorse; downgrade rate climbs.
+
+The cure. Post-upgrade welcome; surface what changed; help users access new features immediately.
+
+---
+
+## The aggressive-upsell flow
+
+The pattern. Customers paying already; upsell asks fire constantly.
+
+The signal. Customer fatigue; cross-sell rate drops over time.
+
+The cost. Existing customer relationship damaged.
+
+The cure. Frequency limits on upsell. Cross-sell at moments of relevance, not constantly.
+
+---
+
+## The win-back-spam flow
+
+The pattern. Lapsed users get win-back outreach repeatedly without segmentation.
+
+The signal. Unsubscribe rate climbs; brand earns spammy reputation.
+
+The cost. Loses users who might have returned with better outreach.
+
+The cure. Segment win-back; respect non-response; abandon after reasonable attempts.
+
+---
+
+## How to detect anti-patterns
+
+Audit cadence. Quarterly review of upgrade flows.
+
+**Audit questions per flow.**
+
+- Are paywalls connected to demonstrated value (anti-pattern check: paywall-everywhere, premature, unconnected)?
+- Is decline respected (anti-pattern check: decline-ignored, aggressive-downsell)?
+- Is plan structure clear (anti-pattern check: plan-paralysis, plan-mismatch)?
+- Is pricing visible (anti-pattern check: hidden-price)?
+- Is cancellation easy (anti-pattern check: aggressive-cancellation-prevention)?
+- Does post-upgrade experience deliver (anti-pattern check: post-upgrade-empty)?
+- Is win-back honest (anti-pattern check: discount-led, win-back-spam)?
+- Is marketing-product alignment maintained (anti-pattern check: bait-and-switch)?
+
+**The retire decision.** Anti-pattern flows often warrant redesign or retirement.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The catalog of anti-patterns. Signal-pattern-cost framing for each. Cures matched. The audit cadence and questions. The retire decision.
+
+## Implementation choices that stay internal
+
+Specific anti-patterns the team has shipped historically and the lessons learned. Specific portfolio audit results. Specific retirement decisions. The team's audit calendar. These vary by team.

--- a/skills/upgrade-flow-design/references/upsell-vs-downsell-logic.md
+++ b/skills/upgrade-flow-design/references/upsell-vs-downsell-logic.md
@@ -1,0 +1,214 @@
+# Upsell vs downsell logic
+
+When the user does not accept the primary upgrade. Secondary paths.
+
+Not every user accepts the proposed upgrade. The discipline is to capture revenue from users who would pay something but not the proposed amount, while respecting users who genuinely do not want to upgrade.
+
+---
+
+## The secondary-path principle
+
+When the primary upgrade is declined, secondary options may capture revenue otherwise lost.
+
+**The win.** User is offered Pro plan ($X/month). Declines. System offers Starter plan ($X/3/month). User accepts Starter. Some revenue beats no revenue.
+
+**The fail.** User declines Pro; sees no other path; remains free; revenue is zero.
+
+The discipline. Design secondary paths thoughtfully; do not aggressive-downsell into manipulation.
+
+---
+
+## Pattern A: Upsell
+
+User on basic plan; ask them to upgrade to higher tier.
+
+**How it works.**
+
+- Trigger fires when user demonstrates value of higher-tier features.
+- Upgrade flow surfaces with the higher plan.
+
+**Strengths.**
+
+- Higher revenue per converted user.
+- Aligned with demonstrated value.
+
+**Weaknesses.**
+
+- User may not need the higher tier; conversion can be poor.
+
+**When to use.** When the user has hit limits or used features that the higher tier addresses.
+
+---
+
+## Pattern B: Cross-sell
+
+User is paying; offer add-ons or related products.
+
+**How it works.**
+
+- Trigger fires when user shows interest in adjacent capabilities.
+- Cross-sell surfaces complementary product or add-on.
+
+**Strengths.**
+
+- Expands revenue from existing customer.
+- Often easier than acquiring new customers.
+
+**Weaknesses.**
+
+- Risks fatigue if cross-sells are too frequent.
+- Users may feel they are being squeezed.
+
+**When to use.** When add-ons or related products genuinely fit the customer's profile.
+
+---
+
+## Pattern C: Downsell
+
+User declined the higher tier; offer a smaller commitment.
+
+**How it works.**
+
+- User dismisses upgrade.
+- Secondary paywall offers a lower-tier plan, monthly instead of annual, or smaller seat count.
+
+**Strengths.**
+
+- Captures revenue from users not ready for the primary plan.
+- Establishes paying relationship that may upgrade later.
+
+**Weaknesses.**
+
+- Aggressive downsell feels manipulative.
+- Users may downgrade to the lowest option even when they would have paid more.
+
+**When to use.** When the primary plan is decline-prone; downsell catches users who would pay something.
+
+---
+
+## Pattern D: Annual-vs-monthly downsell
+
+User declined annual; offer monthly.
+
+**How it works.**
+
+- Annual plan offered first (with discount).
+- Decline; monthly offered as backup.
+
+**Strengths.**
+
+- Some users avoid annual commitment but accept monthly.
+- Captures revenue from commitment-averse users.
+
+**Weaknesses.**
+
+- Cumulative revenue lower.
+- Can train users to expect monthly when annual was the goal.
+
+**When to use.** When annual is the desired commitment but conversion suffers from upfront cost.
+
+---
+
+## Pattern E: Seat-count downsell
+
+User declined full team plan; offer single-seat upgrade.
+
+**How it works.**
+
+- Team plan offered first.
+- Decline; single-seat upgrade offered.
+
+**When to use.** When the user's situation suggests they would value paid features for themselves but cannot commit team-wide yet.
+
+---
+
+## Downsell discipline
+
+When downsell crosses into manipulation.
+
+**Honest framing.** "If Pro is more than you need, here is something that fits your team size."
+
+**Manipulative framing.** Aggressive flow that pressures the user. Multiple decline-and-counter rounds. Hidden costs. Switching plan terms after acceptance.
+
+**The discipline.** Downsell respects the decline; offers an alternative; does not pressure.
+
+---
+
+## When NOT to downsell
+
+Some declines should be respected.
+
+**The user explicitly does not want any plan.** Continued upgrade asks become harassment.
+
+**The user has signaled disengagement.** Aggressive downsell on a disengaged user accelerates churn.
+
+**The user is on a free tier that fits.** Forcing an upgrade where the user is happy on free degrades trust.
+
+**The user is in a bad moment.** After an error, support ticket, or negative experience, downsell is tone-deaf.
+
+---
+
+## Sequencing upsell, cross-sell, downsell
+
+In a typical flow.
+
+**Step 1: Primary upgrade ask** (matched to trigger).
+**Step 2 (if declined): Downsell** (smaller commitment alternative).
+**Step 3 (if declined): Soft acknowledgment** ("No problem; here is the link to plans whenever you are ready.").
+**Step 4 (later): Cross-sell** (when the user has continued use signals).
+
+The flow respects each decline before re-engaging at a later moment.
+
+---
+
+## Frequency limits across upsell/downsell
+
+How often these surface.
+
+**Within session.** Once primary + once downsell + soft acknowledgment. No more.
+
+**Across sessions.** Wait days or weeks before re-ask. The user's circumstances may have changed.
+
+**Per quarter.** Major upgrade pushes per quarter at most.
+
+---
+
+## Conversion economics of upsell vs downsell
+
+Different patterns have different revenue dynamics.
+
+**Upsell.** Higher revenue per converted user. Lower conversion rate.
+
+**Cross-sell.** Adds revenue per existing customer. Conversion depends on fit.
+
+**Downsell.** Lower revenue per converted user. Higher conversion rate. Captures users who would otherwise stay free.
+
+**The math question.** Total revenue = (upsell rate × upsell revenue) + (downsell rate × downsell revenue) + (free-to-paid rate × paid revenue). Optimize the sum.
+
+---
+
+## Common upsell/downsell failures
+
+**Aggressive downsell rounds.** Multiple decline-and-counter loops; user feels manipulated.
+
+**Downsell that breaks the upsell.** Users learn to decline upsell to get downsell discount.
+
+**No downsell.** Users decline primary; revenue is zero.
+
+**Cross-sell fatigue.** Customers see too many cross-sells; resent.
+
+**Wrong sequencing.** Cross-sell before user has paid first plan.
+
+**No frequency limits.** Cumulative upgrade asks become spam.
+
+**Tone-deaf timing.** Downsell after a customer support escalation.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The secondary-path principle. Patterns A through E (upsell, cross-sell, downsell, annual-vs-monthly, seat-count). Downsell discipline. When NOT to downsell. Sequencing logic. Frequency limits. Conversion economics. Common failures.
+
+## Implementation choices that stay internal
+
+Specific upsell, cross-sell, downsell flows for specific products. Specific copy. Specific tooling. The team's revenue economics modeling. These vary by team and product.

--- a/skills/upgrade-flow-design/references/win-back-flow-patterns.md
+++ b/skills/upgrade-flow-design/references/win-back-flow-patterns.md
@@ -1,0 +1,240 @@
+# Win-back flow patterns
+
+Lapsed users, downgrades, partial-churn re-engagement.
+
+When users disengage, downgrade, or churn, win-back flows attempt to bring them back. Done well, win-back captures revenue from users who left due to specific (often fixable) reasons; done poorly, win-back becomes spam that confirms the user's decision to leave.
+
+---
+
+## The respect-the-decline principle
+
+Users who left often left for reasons. Win-back should be honest about the reasons and offer something genuinely changed, not just a discount.
+
+**The win.** A user lapsed 60 days ago. Win-back email surfaces with: "Since you last logged in, we shipped [specific feature you mentioned wanting]. Want to try it?" The user returns; the value-prop is fresh.
+
+**The fail.** Same user. Win-back email surfaces with: "We miss you! Come back for 20 percent off." The user dismisses; the discount feels like manipulation; the previous problems remain.
+
+The discipline. Win-back is most effective when something has changed (new feature, fixed problem) the user would value.
+
+---
+
+## Win-back triggers
+
+When to fire.
+
+**User has not logged in for 30 days.** Soft trigger; light re-engagement.
+
+**User has not logged in for 60-90 days.** Moderate trigger; more substantive re-engagement.
+
+**User has not logged in for 6+ months.** Aggressive trigger; usually the last attempt before treating as fully churned.
+
+**User downgraded plan.** Trigger surfaces post-downgrade; win-back attempts to retain the higher tier.
+
+**User canceled but did not delete account.** Soft trigger; re-engage before full churn.
+
+**User churned and signed up again.** Different trigger; usually treat as new signup with prior context.
+
+The triggers vary by product and audience.
+
+---
+
+## Pattern A: Email-based win-back
+
+Outreach with renewed value-prop.
+
+**How it works.**
+
+- Email sent to lapsed user.
+- Content focuses on what has changed since they left.
+- May include discount or trial extension.
+
+**Email design discipline.**
+
+- Subject line concrete; not generic "we miss you."
+- Body specific to what has changed.
+- One clear CTA back to product.
+- Easy unsubscribe; respect users who do not want re-engagement.
+
+**Strengths.**
+
+- Cheap; can scale.
+- Reaches users outside the product.
+
+**Weaknesses.**
+
+- Easy to feel like spam.
+- Email deliverability for lapsed users is harder.
+
+**When to use.** Default for lapsed-user re-engagement.
+
+---
+
+## Pattern B: In-product upon return
+
+When a lapsed user returns, surface re-engagement help.
+
+**How it works.**
+
+- User logs in after long absence.
+- In-product surfaces re-orientation and (if appropriate) upgrade-back ask.
+
+**Design.**
+
+- Welcome-back banner with what has changed.
+- Brief tour of new features added during absence.
+- Soft upgrade-back if user downgraded.
+
+**Strengths.**
+
+- The user has already returned; engagement is fresh.
+- Can be specific to the user's prior usage.
+
+**Weaknesses.**
+
+- Misses users who do not return on their own.
+
+**When to use.** When email or other re-engagement has produced a return.
+
+---
+
+## Pattern C: Personal outreach
+
+For high-value lapsed users, sales or customer success conversation.
+
+**How it works.**
+
+- Customer success or sales reach out directly.
+- Often via email or call.
+- Conversation about what changed for the user; what would bring them back.
+
+**Strengths.**
+
+- Highest engagement potential.
+- Surfaces real reasons; can address them.
+
+**Weaknesses.**
+
+- Expensive; only viable for high-value accounts.
+- Risk of harassment if not done well.
+
+**When to use.** Enterprise lapsed accounts, high-revenue lapsed customers, accounts with strategic value.
+
+---
+
+## Pattern D: Offer-based win-back
+
+Discount or trial extension as primary motivator.
+
+**How it works.**
+
+- Offer (e.g., 30 percent off, 3 months free, extended trial) presented to lapsed user.
+- Limited time; explicit terms.
+
+**Strengths.**
+
+- Can move users who left for cost reasons.
+- Easy to implement.
+
+**Weaknesses.**
+
+- Can train users to lapse intentionally to get discounts.
+- Discount alone does not address why they left.
+
+**When to use.** Sparingly. Combine with value-prop changes; do not lead with discount alone.
+
+The discount-as-only-strategy failure. Discounts to win back can create reverse incentives. If users learn that lapsing gets them discounts, lapse rate climbs strategically.
+
+---
+
+## Win-back sequence design
+
+A multi-touch win-back rather than single email.
+
+**Typical sequence.**
+
+- Day 30: light re-engagement (what's new).
+- Day 60: more substantive (specific feature; case study).
+- Day 90: explicit win-back offer (if appropriate).
+- Day 120: final outreach; respect non-response.
+- Beyond Day 120: treat as fully churned.
+
+The sequence respects the user's silence; multiple touches at different intensities.
+
+---
+
+## When to abandon win-back
+
+Some users genuinely do not want to come back. Respect that.
+
+**Signals to stop.**
+
+- User unsubscribed from emails.
+- User explicitly stated they do not want contact.
+- Multiple win-back attempts produced no response.
+- User left for reasons unfixable by the product (changed jobs, changed needs).
+
+**The respect-the-no principle.** Continuing win-back after clear no signals is harassment.
+
+---
+
+## Discount discipline in win-back
+
+When discounts make sense.
+
+**Use discount when:**
+
+- The user explicitly stated cost was a factor.
+- The product's price has not changed but the user's situation has.
+- A time-limited promotion is genuinely available.
+
+**Avoid discount when:**
+
+- The user left for non-cost reasons (poor experience, missing features).
+- The discount would train lapse-for-discount behavior.
+- The discount cannibalizes existing customer revenue.
+
+---
+
+## Win-back analytics
+
+Track effectiveness.
+
+**Metrics.**
+
+- Re-engagement rate (lapsed users who returned after win-back outreach).
+- Conversion rate (returned users who paid or upgraded back).
+- Retention of returned users (do they stay or lapse again?).
+
+**Diagnostic uses.**
+
+- Low re-engagement: outreach not relevant or not delivered.
+- High re-engagement, low conversion: returns happen but value-prop weak.
+- Returns lapse again quickly: underlying issue not fixed.
+
+---
+
+## Common win-back failures
+
+**Generic outreach.** "We miss you" with no specifics; user dismisses.
+
+**Discount-only strategy.** Discount without value-prop change; trains lapse-for-discount.
+
+**Frequency overload.** Too many win-back attempts; harassment.
+
+**No segmentation.** Same outreach to all lapsed users regardless of why they left.
+
+**Ignoring unsubscribes.** Outreach continues despite explicit no.
+
+**No measurement.** Cannot tell if win-back works.
+
+**Returns-lapse-again.** Win-back succeeds short-term; underlying issue persists; user lapses again.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The respect-the-decline principle. Win-back triggers. Patterns A through D (email, in-product, personal, offer-based). Win-back sequence design. When to abandon. Discount discipline. Win-back analytics. Common failures.
+
+## Implementation choices that stay internal
+
+Specific win-back sequences for specific products. Specific outreach copy in brand voice. Specific discount levels. The team's segment-specific approaches. These vary by team and product.


### PR DESCRIPTION
Growth Tooling Tier 2. 6 skills covering activation, conversion, and decision-support tooling.

## What ships

- onboarding-wizard-design (activation cluster)
- interactive-product-tour (activation cluster)
- upgrade-flow-design (conversion cluster)
- scheduler-and-booking-design (conversion cluster)
- comparison-tool-design (decision-support cluster)
- product-configurator-design (decision-support cluster)

Each skill: 12-13 section SKILL.md (~2800-3000 words) plus 9 reference files with methodology/implementation discipline closing.

## Catalog growth

- 92 to 98 skills
- 369 to 423 reference files (+54: 9 per skill x 6 skills)
- Growth-tooling category 6 to 12 entries

## Closes Growth Tooling track

Track now at 12 skills total: 6 Tier 1 (lead-capture, activation surfaces, orchestration) + 6 Tier 2 (activation flows, conversion, decision-support).

## Quality gates

- Zero em-dashes (3 fix-ups for em-dashes that surfaced in audit)
- Forbidden phrases caught and replaced (3 instances of robust/leverage; 2 instances of seamless/leveraged caught pre-commit)
- All 54 new reference files include Methodology-level / Implementation choices closing
- Lint: 98 skills validated, 1 pre-existing warning preserved
- Generator idempotent

## Notes

Two outage incidents during writing (Opus 4.7 unavailable briefly); 3 reference files had to be regenerated. All skills shipped clean.