### PR TITLE
chore: community feedback (typo fix, cross-linking pass, accessibility-audit ARIA reference)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ your-skill-name/
     example.md
 ```
 
-Your `SKILL.md` must include this section order, in this exact order:
+Your `SKILL.md` must include these sections, in this exact order:
 
 1. YAML frontmatter (`name`, `description`)
 2. One-paragraph purpose statement

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
 - **98 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
-- **423 reference files** (templates, checklists, decision matrices, worked examples)
+- **424 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.

--- a/scripts/crosslink_pass.py
+++ b/scripts/crosslink_pass.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+r"""One-shot script for the cross-linking pass.
+
+Convert plain-text mentions of ``references/X.md`` and ``SKILL.md`` into
+markdown links so readers can navigate between SKILL.md and reference
+files in rendered markdown (GitHub web view, README catalog).
+
+Patterns handled:
+
+1. In every ``skills/*/SKILL.md``, replace inline-code mentions
+   ``\`references/X.md\`` that are NOT already part of a markdown link
+   with ``[\`references/X.md\`](references/X.md)``.
+
+2. In every ``skills/*/references/*.md``, replace plain-text mentions
+   of ``SKILL.md`` that are NOT already part of a markdown link with
+   ``[SKILL.md](../SKILL.md)``.
+
+The ``skill-template.md`` template file is skipped for the SKILL.md
+substitution because its mentions are templating instructions, not
+references to a sibling SKILL.md.
+
+Run from the repo root: ``python scripts/crosslink_pass.py``.
+
+Idempotent: running twice produces the same result as running once.
+Reports counts so the result can be diffed.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+
+# Files to skip for the SKILL.md -> [SKILL.md](../SKILL.md) substitution.
+# The template file's mentions are templating instructions, not references.
+SKIP_SKILL_LINK_FILES = {
+    SKILLS_DIR / "skill-creation-walkthrough" / "references" / "skill-template.md",
+}
+
+# Pattern 1: ``\`references/X.md\`` that's NOT already preceded by ``[`` (which
+# would mean it's the link text inside ``[\`references/X.md\`](references/X.md)``).
+REF_INLINE_CODE_RE = re.compile(
+    r"(?<!\[)`(references/[a-z][a-z0-9-]*\.md)`"
+)
+
+# Pattern 2: bare ``SKILL.md`` (not inline code, not a link target). Match a
+# word-boundary before so we don't catch ``MYSKILL.md``. Skip mentions inside
+# inline code spans (between backticks) and existing links.
+SKILL_BARE_RE = re.compile(
+    r"(?<![`/\[\w-])SKILL\.md(?!\)|`)"
+)
+
+
+def link_references_in_skill_md(text: str) -> tuple[str, int]:
+    """Replace inline-code reference paths with markdown links."""
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        path = match.group(1)
+        count += 1
+        return f"[`{path}`]({path})"
+
+    return REF_INLINE_CODE_RE.sub(replace, text), count
+
+
+def link_skill_md_in_reference(text: str) -> tuple[str, int]:
+    """Replace bare SKILL.md mentions with markdown links."""
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        count += 1
+        return "[SKILL.md](../SKILL.md)"
+
+    return SKILL_BARE_RE.sub(replace, text), count
+
+
+def main() -> int:
+    if not SKILLS_DIR.exists():
+        print(f"ERROR: {SKILLS_DIR} not found", file=sys.stderr)
+        return 1
+
+    skill_md_changes = 0
+    skill_md_files_touched = 0
+    skill_md_total = 0
+    ref_changes = 0
+    ref_files_touched = 0
+    ref_total = 0
+
+    for skill_dir in sorted(SKILLS_DIR.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+
+        # Pattern 1: SKILL.md
+        skill_md_path = skill_dir / "SKILL.md"
+        if skill_md_path.exists():
+            skill_md_total += 1
+            text = skill_md_path.read_text(encoding="utf-8")
+            new_text, count = link_references_in_skill_md(text)
+            if new_text != text:
+                skill_md_path.write_text(new_text, encoding="utf-8")
+                skill_md_files_touched += 1
+                skill_md_changes += count
+
+        # Pattern 2: references/*.md
+        ref_dir = skill_dir / "references"
+        if ref_dir.exists():
+            for ref_path in sorted(ref_dir.iterdir()):
+                if not ref_path.is_file() or ref_path.suffix != ".md":
+                    continue
+                ref_total += 1
+                if ref_path in SKIP_SKILL_LINK_FILES:
+                    continue
+                text = ref_path.read_text(encoding="utf-8")
+                new_text, count = link_skill_md_in_reference(text)
+                if new_text != text:
+                    ref_path.write_text(new_text, encoding="utf-8")
+                    ref_files_touched += 1
+                    ref_changes += count
+
+    print(
+        f"SKILL.md pass: {skill_md_changes} replacements across "
+        f"{skill_md_files_touched} of {skill_md_total} files"
+    )
+    print(
+        f"references pass: {ref_changes} replacements across "
+        f"{ref_files_touched} of {ref_total} files"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/accessibility-audit/SKILL.md
+++ b/skills/accessibility-audit/SKILL.md
@@ -172,7 +172,7 @@ Often overlooked. Critical for inclusive products.
 6. **Cognitive checks.** Reading level, error handling, time limits.
 7. **Score against WCAG.** Per success criterion (level A, AA, AAA).
 8. **Prioritize findings.** Critical (blocks users), Important (degrades experience), Minor (polish).
-9. **Write the report.** Use the template in `references/audit-report-template.md`.
+9. **Write the report.** Use the template in [`references/audit-report-template.md`](references/audit-report-template.md).
 10. **Build a remediation plan.** Sequenced fixes with effort and impact estimates.
 
 ---
@@ -234,5 +234,5 @@ Plus a remediation tracking spreadsheet with one row per finding.
 
 ## Reference files
 
-- `references/audit-report-template.md` - Full audit report template.
-- `references/wcag-quick-reference.md` - Condensed WCAG 2.1 AA criteria with audit checks.
+- [`references/audit-report-template.md`](references/audit-report-template.md) - Full audit report template.
+- [`references/wcag-quick-reference.md`](references/wcag-quick-reference.md) - Condensed WCAG 2.1 AA criteria with audit checks.

--- a/skills/accessibility-audit/SKILL.md
+++ b/skills/accessibility-audit/SKILL.md
@@ -236,3 +236,4 @@ Plus a remediation tracking spreadsheet with one row per finding.
 
 - [`references/audit-report-template.md`](references/audit-report-template.md) - Full audit report template.
 - [`references/wcag-quick-reference.md`](references/wcag-quick-reference.md) - Condensed WCAG 2.1 AA criteria with audit checks.
+- [`references/aria-patterns.md`](references/aria-patterns.md) - Decision-grade ARIA patterns. Semantic-HTML-first principle, common interactive widgets (accordion, tabs, modal, toggle, disclosure, navigation), live regions, hiding patterns, labeling, state indicators, anti-patterns.

--- a/skills/accessibility-audit/references/aria-patterns.md
+++ b/skills/accessibility-audit/references/aria-patterns.md
@@ -1,0 +1,471 @@
+# ARIA patterns reference
+
+Decision-grade ARIA patterns for the audit. Covers when to use ARIA, when to skip it, and the common patterns that recur across web products.
+
+ARIA is powerful and easy to misuse. The most common mistake is reaching for ARIA when semantic HTML would have done the job already. The second most common mistake is applying ARIA without the supporting JavaScript that makes the attribute true (e.g., `aria-expanded="false"` on a button that does not actually toggle anything).
+
+This file expands the audit checks in [SKILL.md](../SKILL.md) with the specific patterns auditors should verify and the anti-patterns to flag.
+
+---
+
+## The semantic-HTML-first principle
+
+Before reaching for ARIA, check whether semantic HTML already does what is needed.
+
+**The principle.** ARIA exists to fill gaps in HTML. When semantic HTML provides the same semantics natively, the semantic element is the right answer. Adding ARIA on top of semantic HTML is usually redundant and sometimes broken.
+
+**Examples of redundant ARIA.**
+
+- `<button role="button">` is redundant; the element is already a button.
+- `<nav role="navigation">` is redundant; `<nav>` already has the role.
+- `<a href="..." role="link">` is redundant; the element is already a link.
+- `<input type="checkbox" role="checkbox">` is redundant.
+
+**Examples of correct ARIA.**
+
+- A `<div>` styled to behave like a button needs `role="button"`. A real `<button>` does not.
+- A custom dropdown built on `<div>`s needs `role="combobox"` plus full keyboard handling. A `<select>` does not.
+- A live status region needs `role="status"` or `aria-live`. A static element does not.
+
+**The audit check.** For every ARIA attribute on a page, ask: would this element have the same semantics without ARIA? If yes, the ARIA is redundant; flag it.
+
+**The first ARIA rule.** No ARIA is better than bad ARIA. Bad ARIA actively confuses assistive technology; missing ARIA at most leaves a feature inaccessible (which is bad, but recoverable). Bad ARIA misrepresents the UI to the user, which is worse.
+
+---
+
+## Interactive widget patterns
+
+Patterns that recur across products.
+
+### Accordion (expandable disclosure section)
+
+**Required ARIA.**
+
+- Trigger button: `aria-expanded="true"` or `aria-expanded="false"` reflecting state.
+- Trigger button: `aria-controls="<id-of-panel>"` pointing to the controlled region.
+- Panel: `id="<the-id>"` matching `aria-controls`.
+
+**Required behavior.**
+
+- Trigger is a `<button>` (not a `<div>` or `<a>`).
+- Trigger toggles `aria-expanded` when activated.
+- Click and keyboard (Enter, Space) both work.
+
+**Audit checks.**
+
+- `aria-expanded` reflects current state, not a stale value.
+- `aria-controls` ID exists in the DOM.
+- Multiple accordions on a page: focus stays on trigger after toggle (does not jump unexpectedly).
+
+### Tabs
+
+**Required ARIA.**
+
+- Tab list: `role="tablist"`.
+- Each tab: `role="tab"`, `aria-selected="true"` or `aria-selected="false"`, `aria-controls="<panel-id>"`.
+- Each panel: `role="tabpanel"`, `id="<panel-id>"`, `aria-labelledby="<tab-id>"`.
+
+**Required behavior.**
+
+- Arrow keys move between tabs.
+- Tab key moves into and out of the tablist (not between tabs).
+- Selected tab has `tabindex="0"`; non-selected tabs have `tabindex="-1"` (roving tabindex).
+- Activating a tab updates `aria-selected` and shows the corresponding panel.
+
+**Audit checks.**
+
+- All tabs reachable via arrow keys.
+- Tab key escapes the tablist after one press.
+- Only one tab has `aria-selected="true"` at a time.
+
+### Modal / dialog
+
+**Required ARIA.**
+
+- Container: `role="dialog"` (or `role="alertdialog"` for confirmations).
+- Container: `aria-modal="true"` when modal.
+- Container: `aria-labelledby="<heading-id>"` pointing to the dialog's heading, or `aria-label="<purpose>"`.
+- Optional: `aria-describedby="<description-id>"` pointing to descriptive content.
+
+**Required behavior.**
+
+- Focus moves into the modal when opened (typically to the first focusable element or the dialog itself).
+- Focus is trapped within the modal while open (Tab cycles within; cannot escape).
+- Escape closes the modal.
+- Focus returns to the triggering element when the modal closes.
+- Background content has `inert` attribute or `aria-hidden="true"` (and is not focusable).
+
+**Audit checks.**
+
+- Focus management on open and close (the most common modal failure).
+- Tab does not escape into background content.
+- Screen reader does not read background content while modal is open.
+
+### Toggle button (button that holds state)
+
+**Required ARIA.**
+
+- `aria-pressed="true"` or `aria-pressed="false"` reflecting state.
+
+**Examples.** Mute button, favorite button, bold/italic in a text editor.
+
+**Audit checks.**
+
+- `aria-pressed` reflects state, not a stale value.
+- Toggling produces an audible state change (some screen readers announce the new pressed state).
+- Use of toggle button is appropriate (the button is genuinely a toggle, not a momentary action).
+
+### Disclosure widget (show/hide additional content)
+
+**Required ARIA.**
+
+- Trigger: `<button>` with `aria-expanded="true"` or `aria-expanded="false"`.
+- Optional: `aria-controls="<region-id>"` if the controlled region is not adjacent.
+
+**Examples.** "Show more" buttons, "Read more" expansions.
+
+**Difference from accordion.** Accordions are typically grouped (multiple panels in a related set, often only one open at a time); disclosure widgets are standalone reveals. The ARIA is similar; the surrounding pattern differs.
+
+### Navigation
+
+**Required ARIA.**
+
+- `<nav>` element (semantic; no `role="navigation"` needed).
+- For multiple navs on a page: each `<nav>` should have `aria-label` or `aria-labelledby` to distinguish them ("Primary", "Footer", "Breadcrumb").
+- Current page link: `aria-current="page"`.
+
+**Audit checks.**
+
+- Multiple navs are distinguishable to screen readers.
+- The current page is identified.
+- Skip link is present and works (typically "Skip to main content").
+
+---
+
+## Live region patterns
+
+Regions that announce dynamically.
+
+### aria-live
+
+**Values.**
+
+- `aria-live="polite"`: announces when the user is idle. Most common.
+- `aria-live="assertive"`: announces immediately, interrupting the user. Use sparingly.
+- `aria-live="off"`: do not announce. Default; rarely set explicitly.
+
+**The polite-vs-assertive choice.**
+
+- Polite for status updates that can wait (form save confirmation, content updates).
+- Assertive for urgent messages (errors that block submission, session timeout warnings, security alerts).
+
+**Anti-pattern.** Assertive on routine updates. The screen reader interrupts whatever the user was doing; trust degrades quickly.
+
+### aria-atomic
+
+`aria-atomic="true"` tells screen readers to announce the entire region when any part changes, not just the changed part.
+
+**When to use.** When the announcement only makes sense in context (e.g., "5 of 10 items processed" should announce as a whole, not just "5").
+
+**When not to use.** For long regions where atomic announcements would be repetitive.
+
+### role="status"
+
+Implicit `aria-live="polite"`. Use for non-urgent status messages.
+
+**Examples.** "Item added to cart," "Form saved," "Loading complete."
+
+### role="alert"
+
+Implicit `aria-live="assertive"` and `aria-atomic="true"`. Use for urgent messages.
+
+**Examples.** Form submission errors, session timeout warnings, security alerts.
+
+**Audit checks.**
+
+- Status and alert regions exist where needed (audit dynamic flows).
+- They announce when content changes (test with screen reader).
+- The region is not assertive when polite would do.
+- The region is not used for static content (status/alert are for dynamic announcements).
+
+---
+
+## Hiding from screen reader patterns
+
+When and how to hide content.
+
+### aria-hidden
+
+`aria-hidden="true"` removes the element and its children from the accessibility tree.
+
+**When to use.**
+
+- Decorative icons that have an adjacent text label (the icon is redundant; hide it).
+- Background visual elements that have no semantic meaning.
+- Modal closed state (when not using `inert`).
+
+**When NOT to use.**
+
+- On focusable elements. A focusable element with `aria-hidden="true"` produces a confusing experience: keyboard users can focus it, but screen readers will not announce it.
+- On meaningful content. If the content is meaningful enough to render visually, it is meaningful enough to announce.
+- On entire interactive widgets. The keyboard user can still tab into them; the screen reader cannot announce them.
+
+**Audit check.** For every `aria-hidden="true"`, verify the element is not focusable and contains no focusable descendants. The combination is the most common ARIA bug.
+
+### Visually-hidden CSS class
+
+A CSS pattern that hides content visually but keeps it in the accessibility tree.
+
+**Common implementation.**
+
+```css
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+**When to use.**
+
+- Skip links that should be invisible until focused.
+- Form labels that the design hides but accessibility requires.
+- Additional context for screen reader users (e.g., "Item 3 of 10 in shopping cart").
+
+**Anti-pattern.** Using `display: none` or `visibility: hidden` for content that should remain in the accessibility tree. Both remove from the tree; visually-hidden does not.
+
+---
+
+## Description and labeling patterns
+
+How to give elements accessible names and descriptions.
+
+### aria-label
+
+Provides an accessible name when no visible label exists.
+
+**When to use.**
+
+- Icon-only buttons (`<button aria-label="Close">`).
+- Generic links that need context (`<a aria-label="Read more about pricing" href="...">Read more</a>`).
+- Form inputs without visible labels (rare; usually a visible label is better).
+
+**When not to use.**
+
+- When a visible `<label>` exists. The visible label is the accessible name.
+- For decorative content. Use `aria-hidden` instead.
+
+### aria-labelledby
+
+Points to one or more existing elements whose text becomes the accessible name.
+
+**When to use.**
+
+- When the visible label is in another element (e.g., a `<legend>` for a fieldset).
+- When the accessible name comes from multiple elements (e.g., "Add to cart" combined with the product name).
+- For dialogs labeled by their heading.
+
+**Syntax.** `aria-labelledby="id1 id2"` (space-separated IDs; the names concatenate).
+
+### aria-describedby
+
+Points to one or more existing elements whose text becomes the accessible description (announced after the name and role).
+
+**When to use.**
+
+- Form fields with help text that should announce after the label.
+- Buttons with secondary explanation.
+- Errors associated with form inputs (`aria-describedby="error-id"`).
+
+**Syntax.** Same as `aria-labelledby`.
+
+**The labeling priority.** Browsers compute the accessible name in this priority order: `aria-labelledby` > `aria-label` > `<label>` > placeholder/title (last-resort and unreliable). The accessible description follows: `aria-describedby` > `title`.
+
+---
+
+## State indicator patterns
+
+ARIA attributes for component state.
+
+### aria-busy
+
+`aria-busy="true"` tells assistive tech that the element is in a transitional state (e.g., loading).
+
+**When to use.**
+
+- Sections being updated dynamically.
+- Long-running operations where partial content would be confusing.
+
+**Audit check.** `aria-busy` is removed when the operation completes.
+
+### aria-disabled
+
+`aria-disabled="true"` indicates an element is disabled.
+
+**When to use vs `disabled` attribute.**
+
+- Native HTML `disabled` removes the element from the tab order and prevents interaction.
+- `aria-disabled="true"` keeps the element focusable but indicates disabled state. Useful when you want users to focus and read why the element is disabled, but cannot activate it.
+
+**Audit check.** When using `aria-disabled`, the element should still appear disabled visually and click handlers should be suppressed.
+
+### aria-invalid
+
+`aria-invalid="true"` indicates a form input has a validation error.
+
+**When to use.**
+
+- After validation finds an error.
+- Combined with `aria-describedby` pointing to the error message.
+
+**Audit check.** `aria-invalid` is set/cleared as validation state changes; not a stale attribute.
+
+---
+
+## Common ARIA anti-patterns
+
+Patterns to flag in the audit.
+
+### Overusing roles on semantic elements
+
+**Pattern.** `<button role="button">`, `<nav role="navigation">`, `<a role="link">`.
+
+**Why it fails.** Redundant; clutters markup; sometimes overrides correct semantics.
+
+**Cure.** Remove the redundant role.
+
+### ARIA without supporting behavior
+
+**Pattern.** `aria-expanded="false"` on a button that has no JavaScript to toggle it.
+
+**Why it fails.** The attribute lies; assistive tech reports state that does not match reality.
+
+**Cure.** Either implement the behavior or remove the attribute.
+
+### Focusable element with aria-hidden
+
+**Pattern.** A `<button>` or `<a>` with `aria-hidden="true"`.
+
+**Why it fails.** Keyboard users can focus it; screen readers ignore it. The user encounters a focused element with no announcement.
+
+**Cure.** Either remove `aria-hidden` (if the element is meaningful) or remove from tab order with `tabindex="-1"` and disable interaction.
+
+### Modal without focus management
+
+**Pattern.** `role="dialog"` opens; focus stays on the triggering element behind the modal.
+
+**Why it fails.** Screen reader users do not realize a modal opened. Keyboard users can tab into background content.
+
+**Cure.** Move focus into the modal on open. Trap focus while open. Return focus to trigger on close.
+
+### Live region without dynamic updates
+
+**Pattern.** Static `<div role="status">Loading complete</div>` rendered in initial HTML.
+
+**Why it fails.** Live regions only announce when their content changes after page load. Static content in a live region announces nothing.
+
+**Cure.** Either remove the role (if the content is static) or update the content dynamically.
+
+### Assertive live region for routine updates
+
+**Pattern.** `role="alert"` on every form-save confirmation.
+
+**Why it fails.** Each confirmation interrupts whatever the user was doing. Trust degrades quickly.
+
+**Cure.** Use `role="status"` (polite) for non-urgent updates; reserve `role="alert"` for urgent messages.
+
+### Form input without accessible name
+
+**Pattern.** `<input type="text">` with placeholder but no label.
+
+**Why it fails.** Screen reader announces "edit" or similar generic; user does not know what the input is for. Placeholder disappears when typing, removing context.
+
+**Cure.** Add a visible `<label>` (preferred) or `aria-label`. Placeholder is not a label.
+
+### Error message not associated with input
+
+**Pattern.** Error text appears near a form input but no programmatic association.
+
+**Why it fails.** Screen reader users do not hear the error when focused on the input.
+
+**Cure.** Use `aria-describedby="error-id"` on the input, with the error message in an element with that ID. Optionally add `aria-invalid="true"`.
+
+### Tab order broken by tabindex
+
+**Pattern.** Positive `tabindex` values (`tabindex="1"`, `tabindex="2"`) used to control order.
+
+**Why it fails.** Positive tabindex creates a separate tab order that often conflicts with DOM order; very brittle; almost always wrong.
+
+**Cure.** Use `tabindex="0"` to add to natural order, `tabindex="-1"` to remove from natural order. Avoid positive values.
+
+---
+
+## ARIA in audit reports
+
+What to flag in audit findings.
+
+**Per finding, document:**
+
+- The element (URL plus selector or screenshot).
+- The current ARIA (or its absence).
+- The behavior observed.
+- The behavior expected.
+- The fix.
+
+**Severity calibration.**
+
+- Modal without focus management: P0 (blocks assistive-tech users).
+- Form input without accessible name: P0.
+- Live region using assertive for routine updates: P1.
+- Redundant `role="button"` on a `<button>`: P3 (cosmetic, but trims technical debt).
+
+The severity tracks user impact, not specification adherence per se. A redundant role does not block users; a missing label does.
+
+---
+
+## ARIA testing approach
+
+How auditors verify ARIA.
+
+**Tooling.**
+
+- Browser DevTools accessibility tree (Chrome, Firefox, Safari) shows what assistive tech sees.
+- axe DevTools flags many ARIA misuses.
+- Screen reader testing is the ultimate verification.
+
+**Common verification steps.**
+
+- Inspect the accessibility tree for each interactive component.
+- Verify dynamic ARIA attributes change when state changes.
+- Verify focus management on open/close patterns (modals, menus, popovers).
+- Test with at least one screen reader to hear what users hear.
+
+The accessibility tree (DevTools) often reveals issues invisible to automated scanners. Make it part of the audit.
+
+---
+
+## ARIA references
+
+Beyond this file.
+
+- W3C ARIA Authoring Practices Guide (APG): https://www.w3.org/WAI/ARIA/apg/. Patterns and examples.
+- WAI-ARIA 1.2 specification: https://www.w3.org/TR/wai-aria-1.2/. Canonical reference.
+- The W3C ARIA Roles, States, and Properties listing: https://www.w3.org/TR/wai-aria-1.2/#role_definitions. Searchable.
+
+The APG is the most practical resource. Most patterns in this file are simplified summaries of APG patterns; for production implementation, consult the APG examples.
+
+---
+
+## Methodology-level choices that stay in the public skill
+
+The semantic-HTML-first principle. Required ARIA and behavior for common interactive patterns (accordion, tabs, modal, toggle button, disclosure, navigation). Live region patterns (aria-live, aria-atomic, role="status", role="alert"). Hiding patterns (aria-hidden, visually-hidden CSS). Description and labeling patterns (aria-label, aria-labelledby, aria-describedby). State indicators (aria-busy, aria-disabled, aria-invalid). Common anti-patterns. ARIA in audit reports. ARIA testing approach. References.
+
+## Implementation choices that stay internal
+
+Specific component implementations in the team's framework. Specific JavaScript and class-name conventions for live regions, focus management, and ARIA toggling. Specific design-system patterns for dialogs, tabs, and accordions. The team's ARIA testing protocols and tooling configurations. These vary by team and stack.

--- a/skills/ads-creative-development/SKILL.md
+++ b/skills/ads-creative-development/SKILL.md
@@ -42,7 +42,7 @@ A worked example. A premium coffee brand running a 60-second YouTube awareness a
 
 The biggest lever in performance creative. If the hook fails, no amount of body copy or CTA can recover the impression. A user who scrolled past the first second has already decided. The hook is the whole game until the body justifies why the user kept watching.
 
-Twelve hook patterns work consistently. Detail in `references/hook-pattern-library.md`.
+Twelve hook patterns work consistently. Detail in [`references/hook-pattern-library.md`](references/hook-pattern-library.md).
 
 1. **Problem-agitate-solve.** Open with the problem the audience feels. Agitate by naming the consequence. Solve with the offer. Works when the audience recognizes the pain.
 2. **Direct callout to audience.** "If you are a B2B founder running paid ads..." Triggers self-identification. Works when the audience is narrow and self-aware.
@@ -72,7 +72,7 @@ Different formats fit different combinations of audience, platform, and offer.
 - **Stories or Reels (vertical 9:16).** Best for TikTok, Instagram, and Snap. Native to the platform's primary surface. Skipping anything not vertical here is leaving performance on the table.
 - **Spark Ads (boosted organic).** Best for TikTok. Promotes an existing organic post as an ad. Retains organic engagement signals; consistently outperforms pure paid creative on TikTok.
 
-The decision rule. Match format to platform native style and to audience consumption pattern. Detail in `references/format-decision-matrix.md`.
+The decision rule. Match format to platform native style and to audience consumption pattern. Detail in [`references/format-decision-matrix.md`](references/format-decision-matrix.md).
 
 ---
 
@@ -106,7 +106,7 @@ The decomposition. A creative is a hook plus a body plus a CTA in a format. Trea
 
 Naming convention. Use a structured naming system so the analyst can join performance data back to creative components. Example: `launch2026_meta-reel_hookA_bodyB_ctaC_v1`. The analyst pulls the report, joins on the naming components, and identifies which hook is winning across body and CTA combinations.
 
-Worked example in `references/creative-variation-templates.md`. A half-day production session produces 40 variations from one core concept by using the matrix. Without the matrix, the same 40 variations require five days of authoring overhead.
+Worked example in [`references/creative-variation-templates.md`](references/creative-variation-templates.md). A half-day production session produces 40 variations from one core concept by using the matrix. Without the matrix, the same 40 variations require five days of authoring overhead.
 
 ---
 
@@ -122,7 +122,7 @@ The waterfall. Most teams test everything at once and lose the signal. Sequentia
 
 The common mistake. Testing all variables at once. Variance compounds; the team cannot tell whether the hook, the body, the CTA, or the format made the difference. Sequential is slower but produces real learnings the team can apply to the next campaign.
 
-Detail in `references/testing-cadence-playbook.md`.
+Detail in [`references/testing-cadence-playbook.md`](references/testing-cadence-playbook.md).
 
 ---
 
@@ -138,7 +138,7 @@ Fatigue is real. The same audience seeing the same creative six times a week tun
 
 Refresh cadence. Weekly for high-spend campaigns ($50K+/month). Biweekly for medium spend. Monthly for low spend. The economics: producing a fresh variant is cheaper than running tired creative for one extra week.
 
-The decision tree. If a top performer's metrics are still strong but frequency is climbing, ship variants of the same concept (same hook structure, different copy and visuals). If the metrics are dropping, retire the concept and ship a new one. Detail in `references/fatigue-detection-checklist.md`.
+The decision tree. If a top performer's metrics are still strong but frequency is climbing, ship variants of the same concept (same hook structure, different copy and visuals). If the metrics are dropping, retire the concept and ship a new one. Detail in [`references/fatigue-detection-checklist.md`](references/fatigue-detection-checklist.md).
 
 ---
 
@@ -154,7 +154,7 @@ The hierarchy. Brand voice in every frame; performance discipline in the structu
 
 A worked example. A brand whose voice is "warm and direct, slightly contrarian, plain-language" runs three creatives. The 60-second YouTube awareness piece has the founder talking to camera, plain language, contrarian framing of the category. The 15-second Meta performance ad has fast cuts, plain language captions on screen, contrarian hook ("Stop overpaying for project management software"), specific value prop, CTA. The static carousel has 6 cards, plain language, contrarian opening card, value prop progression, CTA on the last card. Same voice. Different structure. None feels off-brand to a customer who has seen all three.
 
-Detail in `references/brand-voice-performance-balance.md`.
+Detail in [`references/brand-voice-performance-balance.md`](references/brand-voice-performance-balance.md).
 
 ---
 
@@ -172,7 +172,7 @@ Each platform has native norms. Violating them tanks performance. The fix is pro
 
 **Google Display and YouTube.** Depends on placement. YouTube allows longer narrative (15s to 6m); Display is fast banner-style. Skippable YouTube ads need to earn the next second of attention; non-skippable annoys.
 
-Detail in `references/platform-creative-norms.md`.
+Detail in [`references/platform-creative-norms.md`](references/platform-creative-norms.md).
 
 ---
 

--- a/skills/ads-performance-analytics/SKILL.md
+++ b/skills/ads-performance-analytics/SKILL.md
@@ -56,7 +56,7 @@ Every platform's dashboard is optimized to make the platform look effective. Thi
 
 **Self-attribution bias.** Every platform's pixel fires on conversion and the platform claims credit. If you ran Meta, Google, and TikTok in the same week, all three platforms report your conversions as theirs. Sum-of-platforms is always greater than 100% of actual conversions.
 
-The discipline. Never report platform-reported numbers as fact in board decks. Always reconcile against the single source of truth (warehouse, GA4, or unified analytics platform). Detail in `references/platform-reporting-quirks.md`.
+The discipline. Never report platform-reported numbers as fact in board decks. Always reconcile against the single source of truth (warehouse, GA4, or unified analytics platform). Detail in [`references/platform-reporting-quirks.md`](references/platform-reporting-quirks.md).
 
 ---
 
@@ -86,7 +86,7 @@ Practical guidance.
 - Mid-stage. Data-driven attribution from Google plus GA4, with explicit awareness vs closing channel labeling.
 - Mature. MMM as the canonical incremental reference. MTA for in-flight optimization. Last-click for channel-level decisions where ambiguity is acceptable.
 
-Detail and a decision matrix in `references/attribution-model-comparison.md`.
+Detail and a decision matrix in [`references/attribution-model-comparison.md`](references/attribution-model-comparison.md).
 
 ---
 
@@ -103,7 +103,7 @@ The reconciliation pattern.
 - Never trust platform sums.
 - Compute blended CAC as (total ad spend across platforms) divided by (total new customers from warehouse). Not from platform reports.
 
-The board-deck pattern. Report warehouse-attributed conversion counts, never platform-summed. Report blended CAC, not channel-by-channel CAC unless explicitly noted as platform-self-attributed. Detail and templates in `references/dashboard-reconciliation-patterns.md`.
+The board-deck pattern. Report warehouse-attributed conversion counts, never platform-summed. Report blended CAC, not channel-by-channel CAC unless explicitly noted as platform-self-attributed. Detail and templates in [`references/dashboard-reconciliation-patterns.md`](references/dashboard-reconciliation-patterns.md).
 
 ---
 
@@ -137,7 +137,7 @@ Three cohort cuts that matter for paid media.
 
 **By acquisition campaign.** Campaign-level cohort signals. Useful for diagnosing why a campaign that "works" in week 1 produces no recurring revenue.
 
-The signal to act on. Declining cohort LTV over two consecutive months is the alarm. Pause the channel or campaign before the daily metrics force you to. Detail in `references/cohort-analysis-templates.md`.
+The signal to act on. Declining cohort LTV over two consecutive months is the alarm. Pause the channel or campaign before the daily metrics force you to. Detail in [`references/cohort-analysis-templates.md`](references/cohort-analysis-templates.md).
 
 ---
 
@@ -174,7 +174,7 @@ Four methods.
 
 **PSA tests.** Serve some users a public service announcement instead of your ad. Compare conversion rates. Useful for legacy brands with deep budget.
 
-Incremental rate ranges by channel type are in `references/incrementality-testing-playbook.md`. The discipline is to run incrementality tests at least quarterly on the highest-spend channels. Without them, you are optimizing against platform-reported attribution that systematically overcounts.
+Incremental rate ranges by channel type are in [`references/incrementality-testing-playbook.md`](references/incrementality-testing-playbook.md). The discipline is to run incrementality tests at least quarterly on the highest-spend channels. Without them, you are optimizing against platform-reported attribution that systematically overcounts.
 
 ---
 
@@ -214,7 +214,7 @@ A worked example. A retargeting campaign in Meta showed 3.5x ROAS for six months
 
 ## Common interpretation failures
 
-Twelve patterns recur in paid media reporting work. Detail in `references/common-interpretation-failures.md`.
+Twelve patterns recur in paid media reporting work. Detail in [`references/common-interpretation-failures.md`](references/common-interpretation-failures.md).
 
 - "ROAS dropped 20% week over week, kill the campaign." Could be noise. Pre-commit a test window before acting on weekly variance.
 - "Meta says 500 conversions, my warehouse says 200, who is right?" Both are wrong; warehouse is closer to truth, Meta self-attributes. Reconcile, do not pick a winner.

--- a/skills/after-action-report/SKILL.md
+++ b/skills/after-action-report/SKILL.md
@@ -279,4 +279,4 @@ Structure:
 
 ## Reference files
 
-- `references/aar-template.md` - Fillable AAR template covering incidents, launches, and projects.
+- [`references/aar-template.md`](references/aar-template.md) - Fillable AAR template covering incidents, launches, and projects.

--- a/skills/ai-content-collaboration/SKILL.md
+++ b/skills/ai-content-collaboration/SKILL.md
@@ -73,7 +73,7 @@ A non-exhaustive list of stages where AI in the loop is fine and often improves 
 
 In each case, AI accelerates work the human still owns. The acceleration is real; the ownership stays unchanged.
 
-Detail in `references/ai-participation-boundaries.md`.
+Detail in [`references/ai-participation-boundaries.md`](references/ai-participation-boundaries.md).
 
 ---
 
@@ -111,7 +111,7 @@ Five patterns that work, with tradeoffs.
 
 The pattern that fits depends on volume, voice sensitivity, team skill, and time budget. No pattern is "the right one"; pattern selection is a real decision that should match the production context.
 
-Detail in `references/hybrid-workflow-patterns.md`.
+Detail in [`references/hybrid-workflow-patterns.md`](references/hybrid-workflow-patterns.md).
 
 ---
 
@@ -127,7 +127,7 @@ Voice is the dominant casualty of careless AI workflows. The patterns that prese
 
 The honest framing. Voice is the hardest thing to preserve in AI-assisted work and the easiest thing to lose. Programs that do not actively preserve voice end up with content that is technically correct, semantically generic, and indistinguishable from competitors using the same tools.
 
-Detail in `references/voice-ownership-preservation.md`.
+Detail in [`references/voice-ownership-preservation.md`](references/voice-ownership-preservation.md).
 
 ---
 
@@ -153,7 +153,7 @@ AI slop is the term of art for AI-generated content that is technically function
 
 The reader-detection problem. Readers can often sense AI-flavored content even when they cannot articulate why. Generic openings, predictable structures, "perfect" grammar that is emotionally flat. Slop loses reader trust over time even when individual pieces are not penalized.
 
-Detail in `references/ai-slop-detection-and-avoidance.md` and cross-reference editorial-qa's audit patterns.
+Detail in [`references/ai-slop-detection-and-avoidance.md`](references/ai-slop-detection-and-avoidance.md) and cross-reference editorial-qa's audit patterns.
 
 ---
 
@@ -178,7 +178,7 @@ The principle. Disclose when the reader's understanding of the content's origin 
 
 Industry-specific norms vary. Major journalism organizations have published explicit AI usage standards. Content marketing has weaker norms but is moving toward disclosure for high-trust pieces.
 
-Detail in `references/disclosure-and-transparency-patterns.md`.
+Detail in [`references/disclosure-and-transparency-patterns.md`](references/disclosure-and-transparency-patterns.md).
 
 ---
 
@@ -196,7 +196,7 @@ Inconsistent AI usage across a team produces inconsistent output. The discipline
 
 The pathology. AI usage emerges informally, every writer develops their own patterns, output drifts, editors cannot pinpoint why pieces feel off. The discipline is making AI usage explicit, calibrated, and documented.
 
-Detail in `references/team-training-and-calibration.md`.
+Detail in [`references/team-training-and-calibration.md`](references/team-training-and-calibration.md).
 
 ---
 
@@ -215,13 +215,13 @@ The principles.
 
 The intellectual-honesty frame supersedes any specific policy debate. Teams that treat AI usage with intellectual honesty produce content readers can trust over time. Teams that hide, deny, or rationalize lose trust eventually.
 
-Detail in `references/ethics-and-intellectual-honesty.md`.
+Detail in [`references/ethics-and-intellectual-honesty.md`](references/ethics-and-intellectual-honesty.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-collaboration-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-collaboration-failures.md`](references/common-collaboration-failures.md).
 
 - "We used AI and the content feels generic." Voice not preserved; not enough human rewriting.
 - "Hallucinated facts made it to publish." Fact-verification gate skipped or rushed.

--- a/skills/analytics-strategy/SKILL.md
+++ b/skills/analytics-strategy/SKILL.md
@@ -227,4 +227,4 @@ Tracking plan structure:
 
 ## Reference files
 
-- `references/event-taxonomy-template.md` - Starter event catalog with patterns for common product types.
+- [`references/event-taxonomy-template.md`](references/event-taxonomy-template.md) - Starter event catalog with patterns for common product types.

--- a/skills/art-direction/SKILL.md
+++ b/skills/art-direction/SKILL.md
@@ -193,6 +193,6 @@ Plus a separate moodboard or visual reference doc with images.
 
 ## Reference files
 
-- `references/creative-brief-template.md` - Generic art direction brief template covering any production type (photo, illustration, video, animation, mixed).
-- `references/photo-shoot-brief.md` - Detailed brief template for photography commissions.
-- `references/illustration-brief.md` - Brief template for illustration commissions.
+- [`references/creative-brief-template.md`](references/creative-brief-template.md) - Generic art direction brief template covering any production type (photo, illustration, video, animation, mixed).
+- [`references/photo-shoot-brief.md`](references/photo-shoot-brief.md) - Detailed brief template for photography commissions.
+- [`references/illustration-brief.md`](references/illustration-brief.md) - Brief template for illustration commissions.

--- a/skills/backup-and-disaster-recovery/SKILL.md
+++ b/skills/backup-and-disaster-recovery/SKILL.md
@@ -265,4 +265,4 @@ A DR plan document includes:
 
 ## Reference files
 
-- `references/restore-runbook-template.md`: Fillable template for a restore runbook, covering detection, authorization, steps, verification, and rollback.
+- [`references/restore-runbook-template.md`](references/restore-runbook-template.md): Fillable template for a restore runbook, covering detection, authorization, steps, verification, and rollback.

--- a/skills/beta-program-management/SKILL.md
+++ b/skills/beta-program-management/SKILL.md
@@ -81,7 +81,7 @@ Several axes of beta-type choice. The right combination depends on the launch co
 
 The combination decision. A typical structured beta might be closed + beta + external + 6-week time-bounded. A design partner program might be closed + alpha + external + open-ended. An open early access might be open + beta + external + time-bounded. The combination should match the kind of signal the team needs.
 
-Detail in `references/beta-type-decisions.md`.
+Detail in [`references/beta-type-decisions.md`](references/beta-type-decisions.md).
 
 ---
 
@@ -104,7 +104,7 @@ The discipline that makes calibrated cohorts possible.
 
 **The cohort size question.** Calibrated cohorts are usually 20-200 participants for closed external betas. Smaller (5-20) for design partner programs. Larger (200-2,000) for open early access. Beyond 2,000 the program is a soft-launch with beta branding.
 
-Detail in `references/participant-selection-criteria.md`.
+Detail in [`references/participant-selection-criteria.md`](references/participant-selection-criteria.md).
 
 ---
 
@@ -127,7 +127,7 @@ How big is enough; when does signal saturate.
 
 **The "beta size matches signal need" principle.** Cohort size follows from what the team needs to learn. Larger is not always better; calibrated is.
 
-Detail in `references/cohort-sizing-patterns.md`.
+Detail in [`references/cohort-sizing-patterns.md`](references/cohort-sizing-patterns.md).
 
 ---
 
@@ -155,7 +155,7 @@ How participants enter the beta and what they know going in.
 - Missing support path. Participants hit issues, do not know who to contact, churn out of the beta.
 - No incentive clarity. Participants feel underrecognized; engagement decays.
 
-Detail in `references/beta-onboarding-templates.md`.
+Detail in [`references/beta-onboarding-templates.md`](references/beta-onboarding-templates.md).
 
 ---
 
@@ -179,7 +179,7 @@ Structured channels that produce signal rather than noise.
 
 **Channel mix discipline.** Most structured betas use 3-5 channels. Each channel surfaces different kinds of signal. The team synthesizes across channels.
 
-Detail in `references/feedback-collection-patterns.md`.
+Detail in [`references/feedback-collection-patterns.md`](references/feedback-collection-patterns.md).
 
 ---
 
@@ -204,7 +204,7 @@ How the team responds to feedback during the beta.
 
 **The communication discipline.** Participants are kept informed: "We received your feedback on X; we are addressing it in next week's beta update." Silence makes participants feel ignored; over-communication signals overhead. Calibrate.
 
-Detail in `references/mid-beta-triage-and-iteration.md`.
+Detail in [`references/mid-beta-triage-and-iteration.md`](references/mid-beta-triage-and-iteration.md).
 
 ---
 
@@ -225,7 +225,7 @@ Graduation gates that distinguish "ready" from "tired of running the beta."
 
 **The "perpetual beta" anti-pattern.** Beta runs indefinitely because no firm graduation criteria were set. The team avoids the GA commitment by keeping the feature in beta. Force the graduation decision; if the feature is not ready for GA, identify what would make it ready or reconsider whether to ship at all.
 
-Detail in `references/beta-to-ga-graduation-criteria.md`.
+Detail in [`references/beta-to-ga-graduation-criteria.md`](references/beta-to-ga-graduation-criteria.md).
 
 ---
 
@@ -245,13 +245,13 @@ How the beta ends.
 
 **The postmortem.** Internal review of what the beta produced. What was learned, what changed in the GA launch, what would be done differently in future betas. This feeds the team's beta program practice.
 
-Detail in `references/beta-wind-down-communication.md`.
+Detail in [`references/beta-wind-down-communication.md`](references/beta-wind-down-communication.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-beta-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-beta-failures.md`](references/common-beta-failures.md).
 
 - "Our beta produced no signal." Soft-launch pattern; no structured selection or feedback collection.
 - "Our beta has 5,000 users and we cannot synthesize feedback." Kitchen-sink; cohort too large for the structured signal the team needs.

--- a/skills/brand-discovery/SKILL.md
+++ b/skills/brand-discovery/SKILL.md
@@ -152,7 +152,7 @@ This is not yet "the positioning." Discovery surfaces possible territories. `bra
 4. **Competitor mapping.** 3 to 8 competitors deep, including indirect and status-quo competitors.
 5. **Category mapping.** Conventions, shifts, vocabulary, moats.
 6. **Territory generation.** 3 to 5 plausible positioning territories.
-7. **Write the discovery report.** Use the template in `references/discovery-report-template.md`.
+7. **Write the discovery report.** Use the template in [`references/discovery-report-template.md`](references/discovery-report-template.md).
 8. **Hand off to next phase.** Discovery feeds into `creative-brief`, `brand-ideation`, or `content-strategy` depending on where the project goes next.
 
 ---
@@ -191,5 +191,5 @@ Appendices:
 
 ## Reference files
 
-- `references/discovery-report-template.md` - Full discovery report template.
-- `references/interview-guide.md` - Audience interview guide with question prompts.
+- [`references/discovery-report-template.md`](references/discovery-report-template.md) - Full discovery report template.
+- [`references/interview-guide.md`](references/interview-guide.md) - Audience interview guide with question prompts.

--- a/skills/brand-ideation/SKILL.md
+++ b/skills/brand-ideation/SKILL.md
@@ -139,7 +139,7 @@ For each candidate narrative:
 5. **Stage 3: Generate 2 to 4 mood directions.** Each must be distinguishable enough to brief a designer.
 6. **Stage 4: Generate 2 to 3 narrative shapes.** Pick the one that fits the founders, the audience, and the proof points.
 7. **Converge.** Present the user with: 1 positioning, 8 to 12 naming finalists, 2 to 4 mood directions, 2 to 3 narrative shapes. Help them pick.
-8. **Output.** Use the template in `references/ideation-output-template.md`.
+8. **Output.** Use the template in [`references/ideation-output-template.md`](references/ideation-output-template.md).
 
 ---
 
@@ -171,5 +171,5 @@ Optional: a separate `naming-explorations.md` with the full list of 30 to 50 can
 
 ## Reference files
 
-- `references/ideation-output-template.md` - Fillable template for the ideation deliverable.
-- `references/naming-evaluation-rubric.md` - The 6-criteria filter applied with examples.
+- [`references/ideation-output-template.md`](references/ideation-output-template.md) - Fillable template for the ideation deliverable.
+- [`references/naming-evaluation-rubric.md`](references/naming-evaluation-rubric.md) - The 6-criteria filter applied with examples.

--- a/skills/brand-identity/SKILL.md
+++ b/skills/brand-identity/SKILL.md
@@ -199,5 +199,5 @@ These feed directly into `brand-style-guide`.
 
 ## Reference files
 
-- `references/identity-system-spec.md` - Detailed spec template for documenting each element.
-- `references/contrast-and-accessibility.md` - Accessibility checks for color and type, with the math.
+- [`references/identity-system-spec.md`](references/identity-system-spec.md) - Detailed spec template for documenting each element.
+- [`references/contrast-and-accessibility.md`](references/contrast-and-accessibility.md) - Accessibility checks for color and type, with the math.

--- a/skills/brand-style-guide/SKILL.md
+++ b/skills/brand-style-guide/SKILL.md
@@ -142,7 +142,7 @@ The dos and don'ts section is what people actually reference in practice. Make i
 
 1. **Inventory the inputs.** What identity work is finished? What voice work is finished? What is missing?
 2. **Confirm the format.** Is this a PDF, a web page, a Notion doc, a printed book, or all of the above? Different formats have different production requirements.
-3. **Section by section, draft.** Use the template in `references/style-guide-template.md`.
+3. **Section by section, draft.** Use the template in [`references/style-guide-template.md`](references/style-guide-template.md).
 4. **Stress-test with real examples.** For every rule, find a real application example. Rules without examples get ignored.
 5. **Get review from the people who will use it.** Designers, developers, marketers. They will surface gaps.
 6. **Version control.** Style guides evolve. Date the doc. Note what changed in each version.
@@ -198,5 +198,5 @@ For consumer-facing presentation, build a web page version that imports from the
 
 ## Reference files
 
-- `references/style-guide-template.md` - Fillable section-by-section template.
-- `references/maintenance-playbook.md` - How to keep the guide current after launch.
+- [`references/style-guide-template.md`](references/style-guide-template.md) - Fillable section-by-section template.
+- [`references/maintenance-playbook.md`](references/maintenance-playbook.md) - How to keep the guide current after launch.

--- a/skills/brand-voice/SKILL.md
+++ b/skills/brand-voice/SKILL.md
@@ -154,7 +154,7 @@ Aim for 15 to 25 paired examples. This is the most-used part of the voice doc in
 4. **Layer 3: Vocabulary and grammar.** Define preferences. Skip default rules unless they actually distinguish the brand.
 5. **Layer 4: Examples.** Build the paired-example library. 15 to 25 minimum.
 6. **Stress-test.** Pick a fresh writing brief and apply the voice doc. Does it produce on-voice copy? If not, the doc is incomplete.
-7. **Document.** Use the template in `references/voice-document-template.md`.
+7. **Document.** Use the template in [`references/voice-document-template.md`](references/voice-document-template.md).
 8. **Distribute.** Voice docs only work if they get used. Make the doc easy to reference inline (link to it from CMS templates, brief templates, AI assistant prompts).
 
 ---
@@ -189,5 +189,5 @@ This doc can stand alone or feed into `brand-style-guide`.
 
 ## Reference files
 
-- `references/voice-document-template.md` - Fillable template.
-- `references/voice-frameworks.md` - Detailed walkthrough of the Nielsen Norman 4 dimensions, Jung archetypes, and the "we are X not Y" approach.
+- [`references/voice-document-template.md`](references/voice-document-template.md) - Fillable template.
+- [`references/voice-frameworks.md`](references/voice-frameworks.md) - Detailed walkthrough of the Nielsen Norman 4 dimensions, Jung archetypes, and the "we are X not Y" approach.

--- a/skills/calculator-design/SKILL.md
+++ b/skills/calculator-design/SKILL.md
@@ -58,7 +58,7 @@ Before designing the calculator, decide whether a calculator is the right tool f
 
 The decision is not "should we have a calculator"; it is "is the calculator the right next investment for this specific audience and goal."
 
-Detail in `references/calculator-investment-criteria.md`.
+Detail in [`references/calculator-investment-criteria.md`](references/calculator-investment-criteria.md).
 
 ---
 
@@ -96,7 +96,7 @@ The calculator's inputs are the audience's first interaction. Bad input design l
 - Toggle (feature on/off, scenario A vs B). Good for binary choices.
 - Free text (only when the value is genuinely user-specific and cannot be calculated). Use sparingly; free text is friction.
 
-Detail in `references/input-design-patterns.md`.
+Detail in [`references/input-design-patterns.md`](references/input-design-patterns.md).
 
 ---
 
@@ -117,7 +117,7 @@ The defensibility of the result is the calculator's credibility currency.
 
 **The transparent-tool win.** Assumptions visible, sources cited, formulas inspectable. The audience uses the tool, gets a number, and can defend it. The brand is in the conversation because the audience cites the calculator as their source.
 
-Detail in `references/calculation-logic-transparency.md`.
+Detail in [`references/calculation-logic-transparency.md`](references/calculation-logic-transparency.md).
 
 ---
 
@@ -146,7 +146,7 @@ The result is the calculator's product. Bad result presentation wastes the calcu
 - Result followed by 5 paragraphs of marketing. The result is what the user came for; marketing belongs after, not before.
 - Result that requires re-entering all inputs to view. Persist inputs and results within the session.
 
-Detail in `references/result-presentation-patterns.md`.
+Detail in [`references/result-presentation-patterns.md`](references/result-presentation-patterns.md).
 
 ---
 
@@ -174,7 +174,7 @@ What to gate, what to give freely.
 
 **The transparent-tool win.** The result is free; the additional value is gated. Conversion is honest; lead quality is high because the lead opted in for the additional value, which signals real interest.
 
-Detail in `references/email-capture-decision-tree.md`.
+Detail in [`references/email-capture-decision-tree.md`](references/email-capture-decision-tree.md).
 
 ---
 
@@ -206,7 +206,7 @@ A B2B SaaS pricing calculator.
 
 Each tier earns its gate.
 
-Detail in `references/tiered-value-structures.md`.
+Detail in [`references/tiered-value-structures.md`](references/tiered-value-structures.md).
 
 ---
 
@@ -230,13 +230,13 @@ Patterns that look like calculators but degrade trust.
 
 **The mobile-broken calculator.** Calculator works fine on desktop, breaks on mobile. The mobile audience either bounces or gets a worse experience that misrepresents the brand.
 
-Detail in `references/calculator-anti-patterns.md`.
+Detail in [`references/calculator-anti-patterns.md`](references/calculator-anti-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-calculator-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-calculator-failures.md`](references/common-calculator-failures.md).
 
 - "Conversion rate is high; downstream conversion is near zero." Lead-trap or vanity-output pattern; the audience captured did not get value, did not engage with the follow-up, did not convert.
 - "Audience visits the calculator, runs it once, never returns." Calculator does not produce a save-worthy or share-worthy result; no reason to come back.

--- a/skills/chatbot-flow-design/SKILL.md
+++ b/skills/chatbot-flow-design/SKILL.md
@@ -57,7 +57,7 @@ Before designing the chatbot, decide whether a chatbot is the right tool.
 
 The decision is not "should we have a chatbot"; it is "is the chatbot the right tool for this specific audience and conversation."
 
-Detail in `references/chatbot-decision-criteria.md`.
+Detail in [`references/chatbot-decision-criteria.md`](references/chatbot-decision-criteria.md).
 
 ---
 
@@ -91,7 +91,7 @@ Defining what the bot can and cannot handle.
 
 **Intent maintenance.** Intents drift as products evolve, audiences shift, and conversations change. Periodic review surfaces which intents are useful and which need refining.
 
-Detail in `references/intent-architecture-patterns.md`.
+Detail in [`references/intent-architecture-patterns.md`](references/intent-architecture-patterns.md).
 
 ---
 
@@ -112,7 +112,7 @@ The bot's responses must come from real knowledge, not made-up confidence.
 
 **The structured-guided win.** Grounded answers. The bot's responses match the source-of-truth. Customer-facing accuracy is maintained.
 
-Detail in `references/knowledge-base-grounding-patterns.md`.
+Detail in [`references/knowledge-base-grounding-patterns.md`](references/knowledge-base-grounding-patterns.md).
 
 ---
 
@@ -133,7 +133,7 @@ How the bot adapts the conversation based on user input.
 
 **Branching limits.** Bots that branch too deeply lose users. 3-5 turns is often the practical limit before the user wants resolution.
 
-Detail in `references/branching-and-conditional-logic.md`.
+Detail in [`references/branching-and-conditional-logic.md`](references/branching-and-conditional-logic.md).
 
 ---
 
@@ -154,7 +154,7 @@ What happens when intent is unclear or out-of-scope.
 
 **The fallback-as-honesty principle.** A bot that admits it does not know earns more trust than a bot that fakes confidence. Audiences forgive limitations they were told about; audiences punish wrong answers they were given confidently.
 
-Detail in `references/fallback-pattern-design.md`.
+Detail in [`references/fallback-pattern-design.md`](references/fallback-pattern-design.md).
 
 ---
 
@@ -176,7 +176,7 @@ When, how, with what context handoff.
 
 **The escalation-quality test.** Does the human pick up the context smoothly, or do they have to ask the user to repeat everything? The latter signals broken handoff.
 
-Detail in `references/escalation-to-human-patterns.md`.
+Detail in [`references/escalation-to-human-patterns.md`](references/escalation-to-human-patterns.md).
 
 ---
 
@@ -201,13 +201,13 @@ Measuring what the bot is and is not doing well.
 - High escalation rate per intent: the intent may not be appropriate for bot handling.
 - High repeat-fallback within conversations: clarifying questions not landing; redesign clarification.
 
-Detail in `references/conversation-analytics-patterns.md`.
+Detail in [`references/conversation-analytics-patterns.md`](references/conversation-analytics-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-chatbot-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-chatbot-failures.md`](references/common-chatbot-failures.md).
 
 - "Bot makes up answers about pricing." Hallucinating-bot pattern; no grounding to pricing source-of-truth.
 - "Users say the bot is rigid and unhelpful." Scripted-bot pattern; intents do not cover real questions.

--- a/skills/code-review-web/SKILL.md
+++ b/skills/code-review-web/SKILL.md
@@ -159,7 +159,7 @@ Patterns that recur across stacks and are worth checking on every review.
 3. **Run through the 5 dimensions.** Note issues by severity (blocker, important, minor).
 4. **Check stack-specific patterns.** Reference the appropriate stack guide.
 5. **For incidents:** identify the smallest hypothesis-driven fix. Reproduce locally if possible.
-6. **Write the review.** Use the template in `references/review-template.md` for formal reviews.
+6. **Write the review.** Use the template in [`references/review-template.md`](references/review-template.md) for formal reviews.
 
 ---
 
@@ -208,6 +208,6 @@ For incidents: a postmortem document. See `after-action-report` for that format.
 
 ## Reference files
 
-- `references/review-template.md` - Markdown template for formal code reviews.
-- `references/nextjs-patterns.md` - Stack-specific patterns for Next.js (App Router, ISR, Server Components, common bugs).
-- `references/wordpress-headless-patterns.md` - Stack-specific patterns for headless WordPress integrations.
+- [`references/review-template.md`](references/review-template.md) - Markdown template for formal code reviews.
+- [`references/nextjs-patterns.md`](references/nextjs-patterns.md) - Stack-specific patterns for Next.js (App Router, ISR, Server Components, common bugs).
+- [`references/wordpress-headless-patterns.md`](references/wordpress-headless-patterns.md) - Stack-specific patterns for headless WordPress integrations.

--- a/skills/code-review-web/references/nextjs-patterns.md
+++ b/skills/code-review-web/references/nextjs-patterns.md
@@ -1,6 +1,6 @@
 # Next.js Patterns
 
-Stack-specific patterns and anti-patterns for Next.js projects. Covers App Router and Pages Router. Stack-agnostic principles live in SKILL.md.
+Stack-specific patterns and anti-patterns for Next.js projects. Covers App Router and Pages Router. Stack-agnostic principles live in [SKILL.md](../SKILL.md).
 
 ---
 

--- a/skills/code-review-web/references/wordpress-headless-patterns.md
+++ b/skills/code-review-web/references/wordpress-headless-patterns.md
@@ -2,7 +2,7 @@
 
 Stack-specific patterns for WordPress as a headless CMS, integrated with a separate frontend (Next.js, Astro, Eleventy, custom, etc.).
 
-The principles in SKILL.md apply universally. This file covers the WordPress-specific patterns that recur in headless setups.
+The principles in [SKILL.md](../SKILL.md) apply universally. This file covers the WordPress-specific patterns that recur in headless setups.
 
 ---
 

--- a/skills/comparison-tool-design/SKILL.md
+++ b/skills/comparison-tool-design/SKILL.md
@@ -56,7 +56,7 @@ Before designing the tool, decide whether a comparison tool is the right answer.
 
 The decision is not "should we have a comparison tool"; it is "is the comparison tool the right tool for this decision."
 
-Detail in `references/comparison-tool-decision-criteria.md`.
+Detail in [`references/comparison-tool-decision-criteria.md`](references/comparison-tool-decision-criteria.md).
 
 ---
 
@@ -97,7 +97,7 @@ The single most consequential decision in comparison tool design.
 
 **The 8-12 axis rule.** Most production comparison tools work well with 8-12 axes. Beyond that, decision paralysis sets in.
 
-Detail in `references/axis-selection-patterns.md`.
+Detail in [`references/axis-selection-patterns.md`](references/axis-selection-patterns.md).
 
 ---
 
@@ -126,7 +126,7 @@ Which options compare by default, and why.
 
 The discipline. Defaults serve the audience, not the brand. When defaults must reflect brand strength, do so honestly with disclosure.
 
-Detail in `references/default-comparison-logic.md`.
+Detail in [`references/default-comparison-logic.md`](references/default-comparison-logic.md).
 
 ---
 
@@ -150,7 +150,7 @@ When to recommend, how to defend the recommendation.
 
 **Anti-pattern: hidden recommendation.** Tool that defaults to one option's victory through axis selection and framing, without explicit recommendation. Users feel manipulated when they catch the pattern.
 
-Detail in `references/recommendation-engine-design.md` and `references/honest-recommendation-discipline.md`.
+Detail in [`references/recommendation-engine-design.md`](references/recommendation-engine-design.md) and [`references/honest-recommendation-discipline.md`](references/honest-recommendation-discipline.md).
 
 ---
 
@@ -176,7 +176,7 @@ What users can adjust, what should stay fixed.
 
 The discipline. Filters that materially help; not filters for the sake of customization.
 
-Detail in `references/filter-and-toggle-patterns.md`.
+Detail in [`references/filter-and-toggle-patterns.md`](references/filter-and-toggle-patterns.md).
 
 ---
 
@@ -198,13 +198,13 @@ Why most comparisons fail to produce decisions.
 
 The cumulative effect. The tool produces no decision; users default to the brand they already heard of.
 
-Detail in `references/comparison-fatigue-patterns.md`.
+Detail in [`references/comparison-fatigue-patterns.md`](references/comparison-fatigue-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-comparison-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-comparison-failures.md`](references/common-comparison-failures.md).
 
 - "Tool gets traffic; conversion is unchanged." Likely feature-list-dump; no decision support.
 - "Sales says competitor leads cite our tool as biased." Hidden-recommendation pattern; trust damage.

--- a/skills/content-and-copy/SKILL.md
+++ b/skills/content-and-copy/SKILL.md
@@ -214,5 +214,5 @@ category: [category]
 
 ## Reference files
 
-- `references/content-brief-template.md` - The brief that should exist before any content is written.
-- `references/content-edit-checklist.md` - Pre-publish editing checklist.
+- [`references/content-brief-template.md`](references/content-brief-template.md) - The brief that should exist before any content is written.
+- [`references/content-edit-checklist.md`](references/content-edit-checklist.md) - Pre-publish editing checklist.

--- a/skills/content-brief-authoring/SKILL.md
+++ b/skills/content-brief-authoring/SKILL.md
@@ -73,7 +73,7 @@ The fields that do not earn their keep, and should be omitted from briefs unless
 - Comprehensive competitive landscape (link to research; do not dump)
 - Brief history of the publication, company, or brand (irrelevant to this piece)
 
-Detail and templates per content type in `references/brief-templates.md`.
+Detail and templates per content type in [`references/brief-templates.md`](references/brief-templates.md).
 
 ---
 
@@ -92,7 +92,7 @@ The override pattern. When the intent feels informational but the SERP shows mos
 
 The AEO/GEO consideration. AI engines tend to favor pieces that match SERP intent format because the intent classification was trained on the SERP corpus. Mismatched format is a citation risk in addition to a ranking risk.
 
-Detail in `references/search-intent-classification.md`.
+Detail in [`references/search-intent-classification.md`](references/search-intent-classification.md).
 
 ---
 
@@ -111,7 +111,7 @@ Anti-patterns the brief should explicitly forbid:
 - Buried lede: H2 #4 has the actual answer. The reader bounced at H2 #2.
 - Section length wildly uneven: H2 #1 is 1,500 words, H2 #2 is 80 words. The 80-word section reads as a placeholder.
 
-Detail in `references/heading-structure-patterns.md`.
+Detail in [`references/heading-structure-patterns.md`](references/heading-structure-patterns.md).
 
 ---
 
@@ -130,7 +130,7 @@ The brief lists the entities the writer must mention, with light context on why 
 
 Tools that automate this: Frase has entity-gap analysis built in; AirOps composes the same analysis through its workflow builder; Surfer SEO ships entity coverage scoring. The skill is tool-agnostic; the workflow is what matters.
 
-Detail in `references/entity-coverage-checklist.md`.
+Detail in [`references/entity-coverage-checklist.md`](references/entity-coverage-checklist.md).
 
 ---
 
@@ -145,7 +145,7 @@ The orphan-content failure mode: piece publishes, no other piece links to it, se
 
 The self-cannibalization check: if this piece would compete with an existing piece for the same keyword cluster, the brief flags it explicitly. The options are consolidate (merge into the existing piece), differentiate (the brief sharpens the angle so the two do not compete), or kill one. Flagging late, after the piece is written, costs more than flagging in the brief.
 
-Detail in `references/internal-linking-strategy.md`.
+Detail in [`references/internal-linking-strategy.md`](references/internal-linking-strategy.md).
 
 ---
 
@@ -160,7 +160,7 @@ Different content types call for different brief shapes. The 12 fields are const
 - **How-to guide.** Informational, step-by-step, screenshots. Brief emphasizes step granularity, prerequisites, troubleshooting section.
 - **Thought leadership / opinion.** Commercial or branding, distinctive POV, signal of expertise. Brief emphasizes thesis, supporting arguments, anticipated counter-arguments.
 
-Each template gets a worked example in `references/brief-templates.md`.
+Each template gets a worked example in [`references/brief-templates.md`](references/brief-templates.md).
 
 ---
 
@@ -176,7 +176,7 @@ Whether the writer is human or AI, the handoff has the same shape.
 
 For AI handoff specifically, the brief becomes a structured prompt or a tool input. Frase, AirOps, and similar tools structure briefs as YAML or JSON for machine consumption; the same 12 fields apply. The structured format is the only difference; the contract is the same.
 
-Detail in `references/writer-handoff-protocols.md`.
+Detail in [`references/writer-handoff-protocols.md`](references/writer-handoff-protocols.md).
 
 ---
 
@@ -188,13 +188,13 @@ Approval. The brief approver is the editorial owner of the content program. Sing
 
 Archival. After publish, the brief is archived alongside the content piece (Notion database row, dbt model, content management system metadata, whatever the team's source of truth is). Future content audits reference both brief and published piece to assess gap between intent and execution. Without the brief in the archive, a content audit cannot tell whether the piece succeeded against the original goal or drifted from it.
 
-Detail in `references/brief-governance-patterns.md`.
+Detail in [`references/brief-governance-patterns.md`](references/brief-governance-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses and fixes in `references/common-brief-failures.md`.
+Rapid-fire. Diagnoses and fixes in [`references/common-brief-failures.md`](references/common-brief-failures.md).
 
 - "The brief was too thin." Fill all 12 fields or accept generic output.
 - "The brief was too thick." Every field needs a job; remove the rest.

--- a/skills/content-distribution/SKILL.md
+++ b/skills/content-distribution/SKILL.md
@@ -80,7 +80,7 @@ Three categories with sub-types within each.
 - **Search advertising for content.** Paying for clicks on content pieces (less common; usually content is the organic side and paid is the conversion side).
 - **Sponsored podcast or content placements.** Pre-rolls, mid-rolls, sponsored segments in industry podcasts or newsletters.
 
-Detail in `references/channel-taxonomy.md`.
+Detail in [`references/channel-taxonomy.md`](references/channel-taxonomy.md).
 
 ---
 
@@ -105,7 +105,7 @@ Where the target audience actually consumes content. The distribution decision s
 
 **The mismatch failure.** Distributing on channels where the audience is present but not engaged produces low reach and low engagement. A B2B technical program publishing TikToks may technically reach audiences on TikTok but engage few of them; the audience is on TikTok for entertainment, not for technical learning.
 
-Detail in `references/audience-channel-matching.md`.
+Detail in [`references/audience-channel-matching.md`](references/audience-channel-matching.md).
 
 ---
 
@@ -124,7 +124,7 @@ Which formats fit which channels. Beyond audience match, the format must fit the
 
 **The compose-with-repurposing pattern.** When the audience is on a channel but the format does not fit, the right answer is often to repurpose into a format that does fit (see `content-repurposing`), then distribute. The composition is "repurpose for fit, distribute on channel."
 
-Detail in `references/content-channel-matching.md`.
+Detail in [`references/content-channel-matching.md`](references/content-channel-matching.md).
 
 ---
 
@@ -151,7 +151,7 @@ How often, what mix, sustaining vs campaign rhythm.
 
 **The cadence audit.** Programs that publish in fits and starts (3 posts in one week, then nothing for 3 weeks) underperform programs with steady cadence. Audience attention rewards predictability.
 
-Detail in `references/distribution-cadence-patterns.md`.
+Detail in [`references/distribution-cadence-patterns.md`](references/distribution-cadence-patterns.md).
 
 ---
 
@@ -171,7 +171,7 @@ Owned channels are the program's most reliable distribution. The discipline keep
 
 **The owned-channel anti-pattern: starvation.** Programs that under-invest in owned channels become dependent on third-party distribution. When platforms change algorithms, when paid costs rise, when earned channels go quiet, the program's reach collapses. Owned-channel investment is the durable foundation.
 
-Detail in `references/owned-channel-discipline.md`.
+Detail in [`references/owned-channel-discipline.md`](references/owned-channel-discipline.md).
 
 ---
 
@@ -191,7 +191,7 @@ Earned channels reach audiences the program cannot reach directly. The work to e
 
 **The earned-channel investment.** Earned channels require relationship-building, pitch quality, and content quality. Programs that try to "do PR" with mass-blast pitches earn nothing; programs that invest in genuine relationships earn ongoing channel access.
 
-Detail in `references/earned-channel-work.md`.
+Detail in [`references/earned-channel-work.md`](references/earned-channel-work.md).
 
 ---
 
@@ -215,7 +215,7 @@ When boosting organic content earns its keep.
 
 **The mix.** Most strong programs allocate 0-20% of distribution capacity to paid content amplification. Programs heavily dependent on paid promotion are usually programs that have not yet built owned and earned distribution.
 
-Detail in `references/paid-promotion-patterns.md`.
+Detail in [`references/paid-promotion-patterns.md`](references/paid-promotion-patterns.md).
 
 ---
 
@@ -240,13 +240,13 @@ Which channels actually drive value. The discipline that prevents distribution-t
 
 **The measurement-honest program.** Cuts channels that consistently underperform. Increases investment in channels that consistently produce. Adjusts cadence based on engagement patterns, not on arbitrary publishing schedules.
 
-Detail in `references/distribution-measurement.md`.
+Detail in [`references/distribution-measurement.md`](references/distribution-measurement.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-distribution-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-distribution-failures.md`](references/common-distribution-failures.md).
 
 - "We publish but reach is low." Hope-and-pray pattern; no deliberate distribution work happening.
 - "We post on every channel and engagement is flat." Spam-everywhere pattern; distribution capacity diluted across channels where the audience is not engaged.

--- a/skills/content-migration/SKILL.md
+++ b/skills/content-migration/SKILL.md
@@ -256,4 +256,4 @@ A migration plan document includes:
 
 ## Reference files
 
-- `references/migration-runbook.md`: Step-by-step runbook for cutover day, including pre-flight checks, the actual switch, immediate verification, and the first 24 hours of monitoring.
+- [`references/migration-runbook.md`](references/migration-runbook.md): Step-by-step runbook for cutover day, including pre-flight checks, the actual switch, immediate verification, and the first 24 hours of monitoring.

--- a/skills/content-refresh-system/SKILL.md
+++ b/skills/content-refresh-system/SKILL.md
@@ -67,7 +67,7 @@ Five categories of signal that trigger refresh consideration. Pieces that show n
 
 The audit. Every piece in the library can be characterized by which signals it shows. Pieces with zero signals are stable; pieces with one or two signals warrant attention; pieces with three or more signals are typically in active decay.
 
-Detail in `references/refresh-signals-checklist.md`.
+Detail in [`references/refresh-signals-checklist.md`](references/refresh-signals-checklist.md).
 
 ---
 
@@ -87,7 +87,7 @@ How often to look. Two cadences with different tradeoffs.
 
 **The hybrid pattern.** Most strong refresh programs run both. Quarterly audits catch slow decay, content drift, and pieces that are stable but no longer match the brand's current positioning. Continuous monitoring catches sharp decay and algorithm-update fallout. The two cadences cover different failure modes.
 
-Detail in `references/audit-cadence-patterns.md`.
+Detail in [`references/audit-cadence-patterns.md`](references/audit-cadence-patterns.md).
 
 ---
 
@@ -105,7 +105,7 @@ The 2x2 matrix: piece value (high vs low) crossed with traffic state (decaying v
 
 **Low-value, stable.** Leave alone. Low traffic is the floor; the piece is not costing anything to keep. Touching these pieces in a refresh program burns capacity for no return.
 
-The matrix shifts the program from refresh-everything to refresh-the-quadrant-that-warrants-it. Detail in `references/refresh-prioritization-matrix.md`.
+The matrix shifts the program from refresh-everything to refresh-the-quadrant-that-warrants-it. Detail in [`references/refresh-prioritization-matrix.md`](references/refresh-prioritization-matrix.md).
 
 ---
 
@@ -123,7 +123,7 @@ Not every refresh is the same kind of work. Four depth levels.
 
 The depth-decision discipline. Match depth to signal strength. Sharp decay or major SERP intent shift may warrant full rewrite; slow decay with stale stats may warrant only a light edit. Treating every refresh as a full rewrite is refresh-everything energy in a different shape.
 
-Detail in `references/refresh-depth-decision.md`.
+Detail in [`references/refresh-depth-decision.md`](references/refresh-depth-decision.md).
 
 ---
 
@@ -141,7 +141,7 @@ The decision criteria. Refresh when the piece has demand and a path back. Merge 
 
 The under-recognized failure mode: refreshing pieces that should have been merged or deleted. The team spends hours improving a low-value piece that even at its best will not recover meaningful traffic, while a merge candidate that would have produced a stronger consolidated piece sits unaddressed.
 
-Detail in `references/refresh-vs-merge-vs-delete.md`.
+Detail in [`references/refresh-vs-merge-vs-delete.md`](references/refresh-vs-merge-vs-delete.md).
 
 ---
 
@@ -157,7 +157,7 @@ Who does the work, how it ships.
 
 **Refresh batching.** Some teams batch refresh work into dedicated weeks or sprints; others integrate one refresh per week into the steady-state production cadence. Batching produces focus but interrupts new production; integration sustains new production but slows refresh velocity. Either works; the failure mode is no allocation discipline at all, which produces refresh work happening in the cracks at unpredictable cadence.
 
-Detail in `references/refresh-execution-patterns.md`.
+Detail in [`references/refresh-execution-patterns.md`](references/refresh-execution-patterns.md).
 
 ---
 
@@ -173,7 +173,7 @@ Refreshed pieces need to signal to search engines and audiences that they have b
 
 **The refresh that nobody tells anyone about.** A refreshed piece that is not re-promoted often performs only marginally better than the original. The refresh's signal to search engines is the modified date; the refresh's value to the program is partly the audience re-engagement.
 
-Detail in `references/re-promotion-after-refresh.md`.
+Detail in [`references/re-promotion-after-refresh.md`](references/re-promotion-after-refresh.md).
 
 ---
 
@@ -189,13 +189,13 @@ The discipline that prevents refresh-theater: tracking which refreshes worked, w
 
 **The refresh-that-did-not-work review.** Refreshes that did not produce the expected recovery should get a structured review. Was the depth wrong? Was the merge or delete decision the right disposition that we did not take? Did the underlying problem turn out to be something refresh cannot fix?
 
-Detail in `references/effectiveness-measurement.md`.
+Detail in [`references/effectiveness-measurement.md`](references/effectiveness-measurement.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-refresh-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-refresh-failures.md`](references/common-refresh-failures.md).
 
 - "We refresh every piece annually and traffic is still declining." Refresh-everything pattern; the calendar-based work is not catching the actual decay signals.
 - "We have not touched the library in 18 months and traffic has eroded 30%." Refresh-nothing pattern; the decay went uncaught.

--- a/skills/content-repurposing/SKILL.md
+++ b/skills/content-repurposing/SKILL.md
@@ -77,7 +77,7 @@ Not every piece is worth repurposing. Selection is the first discipline.
 
 **The selection audit.** Run candidate pieces through these questions before committing to repurposing. Pieces that fail the audit may still be valuable but as one-and-done; programs that try to repurpose unsuitable pieces produce derivatives that feel forced.
 
-Detail in `references/source-piece-selection-criteria.md`.
+Detail in [`references/source-piece-selection-criteria.md`](references/source-piece-selection-criteria.md).
 
 ---
 
@@ -101,7 +101,7 @@ Eight common source-to-derivative adaptations with worked examples.
 
 **Multi-piece source to ebook.** Several related pieces (blog posts, articles, even social threads) consolidated into an ebook, with new connective tissue, an introduction that frames the body, and a conclusion that synthesizes.
 
-Detail in `references/format-adaptation-patterns.md`.
+Detail in [`references/format-adaptation-patterns.md`](references/format-adaptation-patterns.md).
 
 ---
 
@@ -148,7 +148,7 @@ Each medium demands and forbids specific things. Repurposing that ignores the co
 - Slide design matters; text-heavy slides fail.
 - Length: 30-60 minutes typical; longer requires high engagement design.
 
-Detail in `references/per-format-constraints.md`.
+Detail in [`references/per-format-constraints.md`](references/per-format-constraints.md).
 
 ---
 
@@ -174,7 +174,7 @@ The source piece's voice anchors the derivatives. The discipline is staying reco
 
 **The AI-repurposing voice problem.** AI-assisted repurposing is particularly prone to voice drift. The source piece may have specific voice characteristics; AI generation of derivatives without strong voice prompts produces derivatives that sound more generic than the source. See `ai-content-collaboration` for the voice-preservation discipline that applies to repurposing workflows.
 
-Detail in `references/voice-consistency-across-formats.md`.
+Detail in [`references/voice-consistency-across-formats.md`](references/voice-consistency-across-formats.md).
 
 ---
 
@@ -196,7 +196,7 @@ When to release derivatives relative to the source, and at what pace.
 
 **The pacing audit.** Match cadence to the source's traffic curve. Pieces with sharp early traffic (trending topics) benefit from concentrated rollout; pieces with sustained evergreen traffic can support distributed rollout over many months.
 
-Detail in `references/sequencing-and-cadence-patterns.md`.
+Detail in [`references/sequencing-and-cadence-patterns.md`](references/sequencing-and-cadence-patterns.md).
 
 ---
 
@@ -214,7 +214,7 @@ Derivatives that link to each other and to the source compound. Derivatives that
 
 **Co-promotion across channels.** A blog post derivative can be re-shared on social where the original blog post was; a social post derivative can be promoted in the email newsletter. Cross-channel flow extends each derivative's reach.
 
-Detail in `references/cross-promotion-patterns.md`.
+Detail in [`references/cross-promotion-patterns.md`](references/cross-promotion-patterns.md).
 
 ---
 
@@ -232,13 +232,13 @@ A specific repurposing pattern worth its own treatment.
 
 **The AI-search-derivative discipline.** Treat AI-search optimization as a derivative format with its own conventions: specific question framings, named-source citations, standalone-paragraph design. Pieces that do this well earn AI citations; pieces that do not still get cited but at lower rates and with less control over framing.
 
-Detail in `references/aeo-extraction-patterns.md`.
+Detail in [`references/aeo-extraction-patterns.md`](references/aeo-extraction-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-repurposing-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-repurposing-failures.md`](references/common-repurposing-failures.md).
 
 - "Our derivatives feel like AI slop." Mass-blast pattern; AI-assisted repurposing without per-format adaptation. Cure: add adaptation discipline, voice prompts, per-format review.
 - "We repurposed but engagement is low." Format constraints ignored. Cure: audit each derivative against per-format conventions.

--- a/skills/content-strategy/SKILL.md
+++ b/skills/content-strategy/SKILL.md
@@ -169,7 +169,7 @@ Idea → Brief → Outline → Draft → Edit → Review → Publish → Measure
 4. **Choose formats.** 3 to 5 formats the program returns to consistently.
 5. **Build the calendar.** Cadence, pillar rotation, format mix, flex slots.
 6. **Set up governance.** Roles, workflow, quality bar, lifecycle rules.
-7. **Document.** Use the template in `references/content-strategy-template.md`.
+7. **Document.** Use the template in [`references/content-strategy-template.md`](references/content-strategy-template.md).
 8. **Operationalize.** Set up the editorial calendar in whatever tool the team uses (CMS, Notion, Airtable, etc.).
 
 ---
@@ -207,5 +207,5 @@ Editorial calendar (separate, ongoing):
 
 ## Reference files
 
-- `references/content-strategy-template.md` - Strategy document template.
-- `references/editorial-calendar-template.md` - Spreadsheet column definitions and calendar structure.
+- [`references/content-strategy-template.md`](references/content-strategy-template.md) - Strategy document template.
+- [`references/editorial-calendar-template.md`](references/editorial-calendar-template.md) - Spreadsheet column definitions and calendar structure.

--- a/skills/cost-optimization/SKILL.md
+++ b/skills/cost-optimization/SKILL.md
@@ -336,4 +336,4 @@ A cost optimization document includes:
 
 ## Reference files
 
-- `references/cloud-audit-checklist.md`: A practical walkthrough for auditing a cloud account (compute, storage, database, network, monitoring) for waste and rightsizing opportunities.
+- [`references/cloud-audit-checklist.md`](references/cloud-audit-checklist.md): A practical walkthrough for auditing a cloud account (compute, storage, database, network, monitoring) for waste and rightsizing opportunities.

--- a/skills/creative-brief/SKILL.md
+++ b/skills/creative-brief/SKILL.md
@@ -69,7 +69,7 @@ What success looks like. Pair every objective with a measurable signal.
 The one thing you want a visitor to walk away knowing. If they see only the homepage hero and bounce, what should they remember? One sentence.
 
 ### 5. Voice and tone
-Pick three to five adjectives. Pair each with what you are NOT (e.g. "confident, not arrogant"). See `references/voice-and-tone-guide.md` for frameworks and worked examples.
+Pick three to five adjectives. Pair each with what you are NOT (e.g. "confident, not arrogant"). See [`references/voice-and-tone-guide.md`](references/voice-and-tone-guide.md) for frameworks and worked examples.
 
 ### 6. Visual direction
 Mood, palette, type, and imagery direction. Three to five reference URLs are worth more than 500 words. Note what you like AND what you would reject.
@@ -122,7 +122,7 @@ Do not ask all of these. Pick the ones that fill the actual gaps.
 1. **Read the conversation.** Pull every fact already given. Do not ask questions you can answer from context.
 2. **Identify gaps.** Which of the ten required inputs are missing or thin?
 3. **Run intake.** Ask three to five targeted questions to fill the gaps. Group related questions to keep the conversation tight.
-4. **Draft the brief.** Use `references/creative-brief-template.md` as the structure. Keep it under 1500 words.
+4. **Draft the brief.** Use [`references/creative-brief-template.md`](references/creative-brief-template.md) as the structure. Keep it under 1500 words.
 5. **Stress-test.** Before delivering, check the brief against the failure patterns below. If any apply, revise before showing the user.
 6. **Deliver.** Save as `creative-brief.md` in the project root. Offer to make it a Word doc or PDF if the user wants something to share with stakeholders.
 7. **Hand off for aesthetic depth (optional).** For projects where sections 5 (voice and tone) and 6 (visual direction) need more rigor than this brief surfaces, run `creative-direction` next. It produces a structured aesthetic brief using four directional axes (tone register, aesthetic philosophy, audience relationship, sensory ambition) that content, copy, and art-direction skills consume directly.
@@ -151,8 +151,8 @@ If the project is large, split: keep the main brief under 1500 words and put det
 
 ## Reference files
 
-- `references/creative-brief-template.md` - Fillable template. Copy and use as the starting point.
-- `references/voice-and-tone-guide.md` - Voice frameworks, brand archetypes, and worked patterns.
-- `references/example-brief.md` - A worked example for a fictional B2B SaaS, showing what a "good" filled brief looks like.
+- [`references/creative-brief-template.md`](references/creative-brief-template.md) - Fillable template. Copy and use as the starting point.
+- [`references/voice-and-tone-guide.md`](references/voice-and-tone-guide.md) - Voice frameworks, brand archetypes, and worked patterns.
+- [`references/example-brief.md`](references/example-brief.md) - A worked example for a fictional B2B SaaS, showing what a "good" filled brief looks like.
 
 Read the template before drafting. Read the voice guide if the user has not already specified a voice. Read the example if you are unsure how filled-out a section should be.

--- a/skills/creative-direction/SKILL.md
+++ b/skills/creative-direction/SKILL.md
@@ -113,7 +113,7 @@ How much is the work asking of the reader emotionally?
 3. **Capture inspiration references.** For each provided reference URL, ask what specifically resonates. The answer often clarifies which axis position fits better than abstract description does.
 4. **Surface tensions.** Some combinations are difficult to execute well. Functional + Provocative is rare since provocation usually requires emotional engagement that pure functional work resists. Authority + Functional often slides into preachy without warming up at least slightly. Flag tensions and ask the user to confirm or reconsider.
 5. **Synthesize.** Write a one-paragraph synthesis describing what this combination produces in practice.
-6. **Output the brief.** Markdown format using the structure in `references/brief-template.md`. The brief becomes a project artifact (typically saved as `BRIEF.md` at the project root).
+6. **Output the brief.** Markdown format using the structure in [`references/brief-template.md`](references/brief-template.md). The brief becomes a project artifact (typically saved as `BRIEF.md` at the project root).
 7. **Hand off.** Reference the brief in any downstream skill that produces aesthetic output. Required reading before `landing-page-copy`, `art-direction`, `content-and-copy`, `brand-style-guide`, or any other skill where coherence matters.
 
 ---
@@ -148,6 +148,6 @@ The brief is reference material for the project's life, not a one-time deliverab
 
 ## Reference files
 
-- `references/axes-explained.md` - The four axes in depth, with positions, signals, and short brand examples per position to calibrate the user's eye.
-- `references/brief-template.md` - Blank template for the brief output.
-- `references/example-aesthetic-brief.md` - A fully completed brief from a representative project, showing how the abstract axes translate into concrete creative direction.
+- [`references/axes-explained.md`](references/axes-explained.md) - The four axes in depth, with positions, signals, and short brand examples per position to calibrate the user's eye.
+- [`references/brief-template.md`](references/brief-template.md) - Blank template for the brief output.
+- [`references/example-aesthetic-brief.md`](references/example-aesthetic-brief.md) - A fully completed brief from a representative project, showing how the abstract axes translate into concrete creative direction.

--- a/skills/cro-optimization/SKILL.md
+++ b/skills/cro-optimization/SKILL.md
@@ -268,4 +268,4 @@ Because [observation], we believe that [change] will produce [outcome] for [segm
 
 ## Reference files
 
-- `references/hypothesis-library.md` - Common high-impact hypothesis patterns by funnel stage.
+- [`references/hypothesis-library.md`](references/hypothesis-library.md) - Common high-impact hypothesis patterns by funnel stage.

--- a/skills/data-warehouse-experimentation/SKILL.md
+++ b/skills/data-warehouse-experimentation/SKILL.md
@@ -53,7 +53,7 @@ Five factors push toward platform.
 4. **Mobile experimentation.** SDK-based assignment with offline support is the platform's job, not the warehouse's.
 5. **Out-of-the-box sequential testing with strict guarantees.** Statsig and Eppo ship mSPRT with calibrated alpha-spending. Building this in-house is real work.
 
-Detail and a decision tree in `references/warehouse-vs-platform-decision.md`. Many mature teams use both; warehouse-native for the hard cases, platform for fast iteration on standard experiments.
+Detail and a decision tree in [`references/warehouse-vs-platform-decision.md`](references/warehouse-vs-platform-decision.md). Many mature teams use both; warehouse-native for the hard cases, platform for fast iteration on standard experiments.
 
 ---
 
@@ -108,7 +108,7 @@ WHERE eligible = true;
 
 Less common; useful when the eligibility set is fixed at experiment start and you want assignment to be deterministic and explicit (e.g., for compliance audit). The downside: new users joining mid-experiment are not in the table; either skip them or fall back to hash assignment.
 
-The deterministic hash approach is the default for warehouse-native because it requires no service dependency and produces stable, auditable assignments. Detail in `references/assignment-and-exposure-patterns.md`.
+The deterministic hash approach is the default for warehouse-native because it requires no service dependency and produces stable, auditable assignments. Detail in [`references/assignment-and-exposure-patterns.md`](references/assignment-and-exposure-patterns.md).
 
 ---
 
@@ -134,7 +134,7 @@ Worked example. The treatment shows a new pricing page; the control shows the ol
 
 The "always-fire" trap. Some implementations fire exposure on every variant-specific interaction. The user clicks the button five times; exposure fires five times. The exposure log is now five times larger than it should be, and analysis tools that count distinct user_ids in exposure handle this correctly while tools that count rows do not.
 
-The discipline. Fire exactly one exposure event per user per experiment, at the moment of first variant-specific exposure. Use a deterministic flag in the client (or a server-side cache) to enforce single-fire. Detail in `references/assignment-and-exposure-patterns.md`.
+The discipline. Fire exactly one exposure event per user per experiment, at the moment of first variant-specific exposure. Use a deterministic flag in the client (or a server-side cache) to enforce single-fire. Detail in [`references/assignment-and-exposure-patterns.md`](references/assignment-and-exposure-patterns.md).
 
 ---
 
@@ -164,7 +164,7 @@ The experiment analysis joins this to the exposure log on `user_id` and computes
 
 The variance discipline. The same metric definition is used in board dashboards AND in experiment analysis. No "experiment-specific revenue calculation" that is slightly different. Otherwise you get the "the experiment said the revenue lifted but the board did not move" problem, which is almost always a metric-definition mismatch.
 
-The namespace pattern. Use `exp_metrics_*` for experiment-shaped models that group by `user_id` and produce one row per user. Use `fct_*` for the underlying fact tables that feed both metric models and dashboards. Detail in `references/metric-definitions-in-dbt.md`.
+The namespace pattern. Use `exp_metrics_*` for experiment-shaped models that group by `user_id` and produce one row per user. Use `fct_*` for the underlying fact tables that feed both metric models and dashboards. Detail in [`references/metric-definitions-in-dbt.md`](references/metric-definitions-in-dbt.md).
 
 ---
 
@@ -202,7 +202,7 @@ Convert the t-statistic to a p-value or confidence interval using a SQL function
 
 The SQL pattern is fine for simple t-tests on continuous metrics. For proportions tests, swap variance for `p * (1 - p)`. For non-parametric tests (Mann-Whitney), the SQL gets ugly fast; switch to Python.
 
-Anything more complex than a simple t-test (CUPED, bootstrap, doubly robust estimation, sequential testing) is easier in Python. Use SQL for the SUM-and-AVG aggregations; ship the result to Python for the statistical math. Detail in `references/statistical-analysis-templates.md`.
+Anything more complex than a simple t-test (CUPED, bootstrap, doubly robust estimation, sequential testing) is easier in Python. Use SQL for the SUM-and-AVG aggregations; ship the result to Python for the statistical math. Detail in [`references/statistical-analysis-templates.md`](references/statistical-analysis-templates.md).
 
 ---
 
@@ -241,7 +241,7 @@ Python gives you access to the full statistical ecosystem (`scipy`, `statsmodels
 
 The notebook pattern. One notebook per experiment, parameterized by `experiment_id`. Version-controlled in git or as Hex projects. Each notebook produces a written-up decision document at the end, archived in a queryable repository (Notion, GitHub markdown, or a dedicated experiment-results table in the warehouse).
 
-Detail and bootstrap templates in `references/statistical-analysis-templates.md`.
+Detail and bootstrap templates in [`references/statistical-analysis-templates.md`](references/statistical-analysis-templates.md).
 
 ---
 
@@ -272,7 +272,7 @@ Other variance reduction techniques.
 - **Regression adjustment.** Fit an OLS regression with covariates; the residual analysis has lower variance. Generalizes CUPED to multiple covariates.
 - **Doubly robust estimation.** Combines outcome modeling and propensity-score weighting. Useful in observational and quasi-experimental settings where randomization was imperfect. Outside the scope of typical A/B tests; pointer to academic references in the variance-reduction reference file.
 
-Detail with worked examples in `references/variance-reduction-techniques.md`.
+Detail with worked examples in [`references/variance-reduction-techniques.md`](references/variance-reduction-techniques.md).
 
 ---
 
@@ -304,7 +304,7 @@ The "we need 10x more users than we thought" lesson. Most underpowered experimen
 
 The fix. Use the historical distribution of past experiments' observed effects to set realistic MDE expectations. If the median observed effect across the last 30 experiments is 0.5%, plan for a 0.5% MDE on new experiments. The optimism asymmetry is real; correcting it requires looking at the actual distribution of effects, not the wished-for distribution.
 
-Detail in `references/power-analysis-calculations.md`.
+Detail in [`references/power-analysis-calculations.md`](references/power-analysis-calculations.md).
 
 ---
 
@@ -322,13 +322,13 @@ For warehouse-native, the practical recommendation is mSPRT in Python. Document 
 
 The honest version. If you do not have someone on the team who understands sequential testing math, just do not peek. Pre-register sample size, run to completion, analyze once. Sequential testing is statistically correct only when implemented correctly; an incorrect implementation is worse than no peeking discipline at all.
 
-Detail in `references/sequential-testing-patterns.md`.
+Detail in [`references/sequential-testing-patterns.md`](references/sequential-testing-patterns.md).
 
 ---
 
 ## Common pitfalls
 
-Eleven patterns recur in warehouse-native experimentation. Detail in `references/common-pitfalls.md`.
+Eleven patterns recur in warehouse-native experimentation. Detail in [`references/common-pitfalls.md`](references/common-pitfalls.md).
 
 - "Our exposure log fires at page load." Should fire when the variant-specific behavior is shown, not at page load. The "delayed exposure" trap dilutes the effect.
 - "We see lift in control, not treatment." Assignment-hash collision or salt reuse. Audit the salt; check that different experiments produce different bucket assignments for the same user.

--- a/skills/dependency-management/SKILL.md
+++ b/skills/dependency-management/SKILL.md
@@ -323,4 +323,4 @@ A dependency policy document includes:
 
 ## Reference files
 
-- `references/upgrade-checklist.md`: Step-by-step checklist for performing a major version upgrade of a critical dependency, from changelog reading to staged rollout.
+- [`references/upgrade-checklist.md`](references/upgrade-checklist.md): Step-by-step checklist for performing a major version upgrade of a critical dependency, from changelog reading to staged rollout.

--- a/skills/design-standards/SKILL.md
+++ b/skills/design-standards/SKILL.md
@@ -39,7 +39,7 @@ This skill complements `brand-identity` (which defines the visual system) and `b
 - The brand's design tokens (colors, type, spacing) - or willingness to define them
 - The target devices and viewports
 
-If brand tokens are undefined, define a working set first using the template in `references/design-tokens-template.md`.
+If brand tokens are undefined, define a working set first using the template in [`references/design-tokens-template.md`](references/design-tokens-template.md).
 
 ---
 
@@ -178,7 +178,7 @@ The same thing should look the same everywhere. Variations should be intentional
 4. **Apply tokens.** All values come from the token set. No hardcoded colors, sizes, or spacing.
 5. **Run contrast checks.** Every text-on-background combination passes AA. Every UI element passes 3:1.
 6. **Test at viewport breakpoints.** 375, 768, 1024, 1440 minimum. Confirm nothing breaks.
-7. **Run the pre-ship checklist** in `references/preship-checklist.md`.
+7. **Run the pre-ship checklist** in [`references/preship-checklist.md`](references/preship-checklist.md).
 
 ---
 
@@ -208,6 +208,6 @@ When generating component code (HTML, CSS, framework-specific markup), the SKILL
 
 ## Reference files
 
-- `references/design-tokens-template.md` - Template for setting up tokens for any project.
-- `references/preship-checklist.md` - Final design review checklist before shipping.
-- `references/tailwind-patterns.md` - Optional. Tailwind-specific component patterns (hero, cards, buttons, data rows) for projects on that stack.
+- [`references/design-tokens-template.md`](references/design-tokens-template.md) - Template for setting up tokens for any project.
+- [`references/preship-checklist.md`](references/preship-checklist.md) - Final design review checklist before shipping.
+- [`references/tailwind-patterns.md`](references/tailwind-patterns.md) - Optional. Tailwind-specific component patterns (hero, cards, buttons, data rows) for projects on that stack.

--- a/skills/design-standards/references/tailwind-patterns.md
+++ b/skills/design-standards/references/tailwind-patterns.md
@@ -1,6 +1,6 @@
 # Tailwind Component Patterns
 
-Optional reference. Tailwind-specific component patterns for projects on that stack. The principles in `SKILL.md` are stack-agnostic; this file translates them into Tailwind utilities.
+Optional reference. Tailwind-specific component patterns for projects on that stack. The principles in [`SKILL.md`](../SKILL.md) are stack-agnostic; this file translates them into Tailwind utilities.
 
 If you are not using Tailwind, skip this file. The patterns translate to any utility framework or CSS approach with minor changes.
 

--- a/skills/design-system/SKILL.md
+++ b/skills/design-system/SKILL.md
@@ -197,6 +197,6 @@ For a design system audit, output is a markdown report at `design-system-audit.m
 
 ## Reference files
 
-- `references/system-architecture.md` - The four-layer model (tokens, primitives, patterns, templates) and how to decide where new work belongs.
-- `references/system-audit-template.md` - Template for auditing an existing design system.
-- `references/governance-playbook.md` - Contribution model, ownership, and decision process for an active system.
+- [`references/system-architecture.md`](references/system-architecture.md) - The four-layer model (tokens, primitives, patterns, templates) and how to decide where new work belongs.
+- [`references/system-audit-template.md`](references/system-audit-template.md) - Template for auditing an existing design system.
+- [`references/governance-playbook.md`](references/governance-playbook.md) - Contribution model, ownership, and decision process for an active system.

--- a/skills/discovery-research-synthesis/SKILL.md
+++ b/skills/discovery-research-synthesis/SKILL.md
@@ -69,7 +69,7 @@ Five common research types, each with different artifacts and synthesis needs.
 
 Different research types compose. A discovery cycle often pairs interviews (depth) with support ticket review (volume) with survey data (validation at scale). The synthesis combines them.
 
-Detail in `references/research-types-and-when-each-fits.md`.
+Detail in [`references/research-types-and-when-each-fits.md`](references/research-types-and-when-each-fits.md).
 
 ---
 
@@ -91,7 +91,7 @@ Six stages from raw artifacts to decisions. Skipping stages is where synthesis f
 
 The sequence is non-negotiable. Teams that skip tagging and jump to pattern naming hallucinate patterns; teams that skip implications produce findings without product direction; teams that skip so-what produce documentation, not synthesis.
 
-Detail in `references/synthesis-sequence-walkthrough.md`.
+Detail in [`references/synthesis-sequence-walkthrough.md`](references/synthesis-sequence-walkthrough.md).
 
 ---
 
@@ -109,7 +109,7 @@ The middle stages of the synthesis sequence have specific failure modes.
 
 **Tag dissent and contradictions explicitly.** Some users will contradict the dominant pattern. Those contradictions are signal: either there is a sub-segment with different needs, or the pattern is weaker than the volume suggests. Tag the dissent so the synthesis can address it.
 
-Detail in `references/tagging-and-clustering-discipline.md`.
+Detail in [`references/tagging-and-clustering-discipline.md`](references/tagging-and-clustering-discipline.md).
 
 ---
 
@@ -127,7 +127,7 @@ The work that distinguishes synthesis from documentation.
 
 **Name with conviction.** Hedged pattern names ("users sometimes seem to maybe struggle with...") signal a researcher who did not commit to what the data showed. Patterns named with conviction are more useful even if they overstate slightly; they invite challenge and produce decisions.
 
-Detail in `references/pattern-naming-patterns.md`.
+Detail in [`references/pattern-naming-patterns.md`](references/pattern-naming-patterns.md).
 
 ---
 
@@ -145,7 +145,7 @@ The bridge from observation to decision.
 
 **Some patterns imply not-acting.** Sometimes the pattern reveals friction the team should not address: it affects too few users, it represents segment misfit, addressing it would compromise other priorities. Naming the not-act implication is honest synthesis.
 
-Detail in `references/from-pattern-to-product-implication.md`.
+Detail in [`references/from-pattern-to-product-implication.md`](references/from-pattern-to-product-implication.md).
 
 ---
 
@@ -163,7 +163,7 @@ Synthesis output should be optimized for decision use, not for presentation.
 
 **Include a decision-input section.** What does this synthesis recommend the team do? Where should priorities shift? Which roadmap items does this validate, which does it challenge? The decision-input section is the synthesis's reason for existing.
 
-Detail in `references/writing-for-decisions-not-decks.md`.
+Detail in [`references/writing-for-decisions-not-decks.md`](references/writing-for-decisions-not-decks.md).
 
 ---
 
@@ -181,7 +181,7 @@ How the synthesis gets pressure-tested before it drives decisions.
 
 **Iterate before publishing.** Synthesis goes through revision based on the review loop. Synthesis that ships in the first draft state usually carries unacknowledged blind spots.
 
-Detail in `references/synthesis-review-and-validation.md`.
+Detail in [`references/synthesis-review-and-validation.md`](references/synthesis-review-and-validation.md).
 
 ---
 
@@ -199,13 +199,13 @@ Synthesis sometimes reveals that the research did not collect enough.
 
 **The "we have enough" trap.** Teams that have invested in research often want to declare the data sufficient even when the synthesis reveals gaps. The discipline is naming gaps even when uncomfortable.
 
-Detail in `references/when-to-gather-more-data.md`.
+Detail in [`references/when-to-gather-more-data.md`](references/when-to-gather-more-data.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-discovery-synthesis-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-discovery-synthesis-failures.md`](references/common-discovery-synthesis-failures.md).
 
 - "We did the research but never made decisions from it." Data-dump or insight-theater; synthesis sequence skipped or stopped at findings.
 - "Our synthesis deck got a polite review and was never referenced again." Insight-theater; output was performative rather than load-bearing.

--- a/skills/documentation-strategy/SKILL.md
+++ b/skills/documentation-strategy/SKILL.md
@@ -425,4 +425,4 @@ A documentation strategy document includes:
 
 ## Reference files
 
-- `references/doc-types-guide.md`: Detailed guide to the four doc types (reference, how-to, explanation, tutorial) with examples and templates for each.
+- [`references/doc-types-guide.md`](references/doc-types-guide.md): Detailed guide to the four doc types (reference, how-to, explanation, tutorial) with examples and templates for each.

--- a/skills/domain-strategy/SKILL.md
+++ b/skills/domain-strategy/SKILL.md
@@ -215,4 +215,4 @@ A domain strategy document includes:
 
 ## Reference files
 
-- `references/dns-record-reference.md`: Common DNS records explained, with the syntax for the most useful ones (A, AAAA, CNAME, MX, TXT, CAA, SRV, etc.) and when each is needed.
+- [`references/dns-record-reference.md`](references/dns-record-reference.md): Common DNS records explained, with the syntax for the most useful ones (A, AAAA, CNAME, MX, TXT, CAA, SRV, etc.) and when each is needed.

--- a/skills/editorial-qa/SKILL.md
+++ b/skills/editorial-qa/SKILL.md
@@ -70,7 +70,7 @@ The brief-adherence check is the cheapest, fastest, highest-value QA gate. It ru
 
 If briefs are vague, this check is impossible. Fix briefs first; the QA process cannot enforce a contract that does not exist.
 
-Detail in `references/brief-adherence-checklist.md`.
+Detail in [`references/brief-adherence-checklist.md`](references/brief-adherence-checklist.md).
 
 ---
 
@@ -86,7 +86,7 @@ Does the piece sound like the brand?
 
 For AI-co-authored pieces, voice drift is the dominant failure mode. AI assistants regress to a model-default voice unless the writer actively pulls them back. The QA check needs to read for the brand voice as much as for the words.
 
-Detail in `references/voice-consistency-patterns.md`.
+Detail in [`references/voice-consistency-patterns.md`](references/voice-consistency-patterns.md).
 
 ---
 
@@ -109,7 +109,7 @@ Citation discipline:
 - Avoid citing other content marketing pages (citation laundering).
 - Date the source; sources older than 3 years for fast-moving topics need refresh.
 
-Detail in `references/fact-accuracy-and-citation-discipline.md`.
+Detail in [`references/fact-accuracy-and-citation-discipline.md`](references/fact-accuracy-and-citation-discipline.md).
 
 ---
 
@@ -124,7 +124,7 @@ Does the piece work as a piece?
 - **Specificity vs abstraction.** Claims are concrete, not vague.
 - **Endings.** Piece concludes with something specific (action, question, idea), not throat-clearing filler.
 
-Detail in `references/structure-and-clarity-review.md`.
+Detail in [`references/structure-and-clarity-review.md`](references/structure-and-clarity-review.md).
 
 ---
 
@@ -163,7 +163,7 @@ The QA check that did not exist as prominently 2 years ago. AI-co-authored conte
 
 The audit shape. Read with these patterns top-of-mind. Flag any match. The bar is not "AI was used" (it almost always is now); the bar is "would a careful human editor have shipped this." If the patterns above are present, the piece needs another revision pass with the patterns called out.
 
-Detail in `references/ai-content-audit-patterns.md`.
+Detail in [`references/ai-content-audit-patterns.md`](references/ai-content-audit-patterns.md).
 
 ---
 
@@ -190,7 +190,7 @@ Does the piece serve search engines AND answer engines?
 - Named entities (experts, methods, tools) consistently mentioned (entity coverage signals)
 - Distinctive POV that is attributable to the brand
 
-Detail in `references/seo-aeo-compliance-checklist.md`.
+Detail in [`references/seo-aeo-compliance-checklist.md`](references/seo-aeo-compliance-checklist.md).
 
 ---
 
@@ -210,7 +210,7 @@ Detail in `references/seo-aeo-compliance-checklist.md`.
 - Schema validates against schema.org definitions (no missing required fields, no malformed JSON-LD)
 - Schema is consistent with on-page content (do not claim 5-star rating in schema if no rating on page)
 
-Detail in `references/internal-linking-and-schema-validation.md`.
+Detail in [`references/internal-linking-and-schema-validation.md`](references/internal-linking-and-schema-validation.md).
 
 ---
 
@@ -247,7 +247,7 @@ For pieces shipping at programmatic-SEO scale (100s to 100,000s of pages), full-
 - Fix the template OR data quality issue before resuming
 - Document the threshold breach in the QA log so patterns become visible
 
-Detail in `references/qa-at-scale-patterns.md`.
+Detail in [`references/qa-at-scale-patterns.md`](references/qa-at-scale-patterns.md).
 
 ---
 
@@ -267,13 +267,13 @@ Ownership and sequencing.
 
 **Escalation.** When QA finds a pattern (multiple pieces failing the same check), escalate to the brief author, the writer, or the editorial process owner. Pattern signals process problem, not just per-piece problem.
 
-Detail in `references/qa-workflow-templates.md`.
+Detail in [`references/qa-workflow-templates.md`](references/qa-workflow-templates.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-qa-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-qa-failures.md`](references/common-qa-failures.md).
 
 - "Our QA process is a 47-item checklist nobody completes." Checkbox theater; cut to the checks that earned their keep.
 - "We caught zero problems in QA last quarter." Either the process is broken or the writers are extraordinary; investigate.

--- a/skills/email-deliverability/SKILL.md
+++ b/skills/email-deliverability/SKILL.md
@@ -280,4 +280,4 @@ A deliverability audit document includes:
 
 ## Reference files
 
-- `references/dmarc-rollout-playbook.md`: Step-by-step for moving from no DMARC to `p=reject`, with timing, monitoring, and how to handle problems found along the way.
+- [`references/dmarc-rollout-playbook.md`](references/dmarc-rollout-playbook.md): Step-by-step for moving from no DMARC to `p=reject`, with timing, monitoring, and how to handle problems found along the way.

--- a/skills/email-sequences/SKILL.md
+++ b/skills/email-sequences/SKILL.md
@@ -277,5 +277,5 @@ For a single broadcast, just one email block.
 
 ## Reference files
 
-- `references/subject-line-patterns.md` - Subject line patterns with examples for each sequence type.
-- `references/sequence-templates.md` - Skeleton templates for the 6 sequence types.
+- [`references/subject-line-patterns.md`](references/subject-line-patterns.md) - Subject line patterns with examples for each sequence type.
+- [`references/sequence-templates.md`](references/sequence-templates.md) - Skeleton templates for the 6 sequence types.

--- a/skills/experiment-design/SKILL.md
+++ b/skills/experiment-design/SKILL.md
@@ -43,7 +43,7 @@ A defensible experiment design sits at the intersection of twelve considerations
 9. **Sequential testing and the peeking problem.** Daily peeking inflates false positive rates. Use sequential testing methods when available; pre-commit otherwise.
 10. **Pre-commitment vs p-hacking.** Write down the primary metric, MDE, duration, segments, and decision rule before launch. Apply mechanically when results come in.
 11. **Reading results and making the call.** Three buckets: clear win, clear loss, inconclusive. The inconclusive bucket exists for a reason; resist the pull to ship anyway.
-12. **Common failures and fixes.** A short rapid-fire pattern catalog, expanded in `references/common-failures.md`.
+12. **Common failures and fixes.** A short rapid-fire pattern catalog, expanded in [`references/common-failures.md`](references/common-failures.md).
 
 The sections below cover each consideration in turn. Read the relevant section before running the experiment, not after.
 
@@ -65,7 +65,7 @@ Falsifiability test. Before launching the experiment, write down what would make
 
 Directional vs magnitude distinction. Knowing the change moves the needle is different from knowing it moves the needle enough to matter. A 0.3 percent absolute lift on signup conversion may be statistically significant with enough traffic and still not justify the engineering cost of maintaining the change. Magnitude matters as much as direction; the hypothesis names the magnitude that would justify shipping.
 
-For templates and worked examples across common metric types, see `references/hypothesis-templates.md`.
+For templates and worked examples across common metric types, see [`references/hypothesis-templates.md`](references/hypothesis-templates.md).
 
 ---
 
@@ -81,7 +81,7 @@ Power. The test's ability to detect an effect that is actually present. The conv
 
 One-sided vs two-sided. Most PM tests are two-sided despite the temptation to claim otherwise. A one-sided test says "I only care about the positive direction; if the change makes things worse, I do not need to detect it." That is rarely true. If the new pricing page tanks conversion, you want to know. Default to two-sided. If you genuinely want one-sided, document the asymmetry before running.
 
-For pre-calculated sample size tables across common conversion rate baselines and MDEs, see `references/sample-size-tables.md`. The tables are starting points, not substitutes for running the math against your specific traffic and metric.
+For pre-calculated sample size tables across common conversion rate baselines and MDEs, see [`references/sample-size-tables.md`](references/sample-size-tables.md). The tables are starting points, not substitutes for running the math against your specific traffic and metric.
 
 ---
 
@@ -215,13 +215,13 @@ Bayesian thinking layer. If your prior was strong (this should obviously work, g
 
 The hardest version. Positive primary metric, ambiguous guardrail. Revenue went up but support tickets ticked up. Conversion went up but session length went down. Use the pre-committed decision rule. If you did not pre-commit on the guardrail trade-off, default to "do not ship." The guardrails exist because you cared about them before you saw the result. Do not lower the bar after the fact.
 
-For a step-by-step results-reading checklist, see `references/results-interpretation-checklist.md`.
+For a step-by-step results-reading checklist, see [`references/results-interpretation-checklist.md`](references/results-interpretation-checklist.md).
 
 ---
 
 ## Common failures and fixes
 
-Rapid-fire reference. Each pattern is described in more detail in `references/common-failures.md`.
+Rapid-fire reference. Each pattern is described in more detail in [`references/common-failures.md`](references/common-failures.md).
 
 - "We did not have enough traffic" means the MDE was too small. Pick bigger changes worth detecting.
 - "The lift disappeared after launch" means the test ran for 5 days and caught a novelty effect. Run longer next time; minimum two weeks for UI changes.
@@ -236,13 +236,13 @@ Rapid-fire reference. Each pattern is described in more detail in `references/co
 
 ## Reference files
 
-- `references/hypothesis-templates.md`. Concrete formats for writing hypotheses that pass the cause-effect-magnitude-mechanism test, with worked examples across conversion, engagement, revenue, retention, and funnel-step metric types.
-- `references/sample-size-tables.md`. Pre-calculated sample size tables for the most common conversion-rate experiments, with how-to-use guidance and the common pitfalls in sample-size planning.
-- `references/common-failures.md`. Fifteen anti-patterns that produce wrong shipping decisions, each with symptom, root cause, fix, and prevention.
-- `references/results-interpretation-checklist.md`. Step-by-step checklist for reading results, the three-bucket decision matrix (win, loss, inconclusive), and the post-launch monitoring discipline.
-- `references/platform-comparison.md`. Profiles of the major experimentation platforms (Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon) with strengths, gotchas, and a decision matrix for choosing.
-- `references/pre-experiment-readiness-checklist.md`. Ten-item go/no-go checklist run through before launch.
-- `references/post-experiment-decision-framework.md`. The moment-of-decision framework: confirm pre-commitment, apply rule mechanically, route to ship/kill/inconclusive paths, write the post-mortem within a week.
+- [`references/hypothesis-templates.md`](references/hypothesis-templates.md). Concrete formats for writing hypotheses that pass the cause-effect-magnitude-mechanism test, with worked examples across conversion, engagement, revenue, retention, and funnel-step metric types.
+- [`references/sample-size-tables.md`](references/sample-size-tables.md). Pre-calculated sample size tables for the most common conversion-rate experiments, with how-to-use guidance and the common pitfalls in sample-size planning.
+- [`references/common-failures.md`](references/common-failures.md). Fifteen anti-patterns that produce wrong shipping decisions, each with symptom, root cause, fix, and prevention.
+- [`references/results-interpretation-checklist.md`](references/results-interpretation-checklist.md). Step-by-step checklist for reading results, the three-bucket decision matrix (win, loss, inconclusive), and the post-launch monitoring discipline.
+- [`references/platform-comparison.md`](references/platform-comparison.md). Profiles of the major experimentation platforms (Statsig, PostHog, GrowthBook, Optimizely, Amplitude, Eppo, Kameleoon) with strengths, gotchas, and a decision matrix for choosing.
+- [`references/pre-experiment-readiness-checklist.md`](references/pre-experiment-readiness-checklist.md). Ten-item go/no-go checklist run through before launch.
+- [`references/post-experiment-decision-framework.md`](references/post-experiment-decision-framework.md). The moment-of-decision framework: confirm pre-commitment, apply rule mechanically, route to ship/kill/inconclusive paths, write the post-mortem within a week.
 
 ---
 

--- a/skills/experiment-design/references/common-failures.md
+++ b/skills/experiment-design/references/common-failures.md
@@ -10,7 +10,7 @@ Anti-patterns that produce confidently wrong shipping decisions, with the sympto
 
 **Root cause.** The hypothesis lacks magnitude and mechanism. When the result comes in, there is no pre-committed bar to compare against, so the decision becomes political.
 
-**Fix.** Rewrite the hypothesis with the cause-effect-magnitude-mechanism format from SKILL.md. Save it before launching.
+**Fix.** Rewrite the hypothesis with the cause-effect-magnitude-mechanism format from [SKILL.md](../SKILL.md). Save it before launching.
 
 **Prevention.** Make hypothesis review part of the experiment kickoff. A peer reads the hypothesis and confirms all four parts are present before the test launches.
 

--- a/skills/experiment-design/references/hypothesis-templates.md
+++ b/skills/experiment-design/references/hypothesis-templates.md
@@ -1,6 +1,6 @@
 # Hypothesis templates
 
-Concrete formats for writing hypotheses that pass the cause-effect-magnitude-mechanism test from SKILL.md. Each template names the right shape, shows two or three worked examples in different domains, and calls out the most common mistakes specific to that template type.
+Concrete formats for writing hypotheses that pass the cause-effect-magnitude-mechanism test from [SKILL.md](../SKILL.md). Each template names the right shape, shows two or three worked examples in different domains, and calls out the most common mistakes specific to that template type.
 
 The unifying format across all templates: replace [bracketed slots] with concrete project-specific values. If a slot reads as a vague phrase after replacement, the hypothesis is not specific enough.
 

--- a/skills/experiment-design/references/sample-size-tables.md
+++ b/skills/experiment-design/references/sample-size-tables.md
@@ -50,7 +50,7 @@ Total sample size required (across both groups) for a two-sided test, alpha 0.05
 - Four weeks supports ~2 percent absolute lift
 - Six weeks supports ~1.5 percent absolute lift
 
-Beyond six weeks the test runs into seasonality and product-evolution problems described in SKILL.md. If the change you want to test would only produce a 1 percent absolute lift and your traffic supports 5 percent MDE in a reasonable window, the test is not worth running. Pick a bigger change.
+Beyond six weeks the test runs into seasonality and product-evolution problems described in [SKILL.md](../SKILL.md). If the change you want to test would only produce a 1 percent absolute lift and your traffic supports 5 percent MDE in a reasonable window, the test is not worth running. Pick a bigger change.
 
 ---
 

--- a/skills/experimentation-analytics/SKILL.md
+++ b/skills/experimentation-analytics/SKILL.md
@@ -64,7 +64,7 @@ Practical decision rules, in order of importance:
 4. If the CI straddles zero but is narrow (e.g., [-0.5%, +0.5%]), this is a real null result. The effect is small enough to call essentially zero. Useful information; do not ship the change for "lift" reasons (you found none) but do not panic about harm either.
 5. If the CI straddles zero and is wide (e.g., [-5%, +8%]), the test is inconclusive. The data is consistent with a moderate win, no effect, or a moderate loss. Run longer, run bigger, or accept that the question cannot be answered at the available traffic.
 
-For a worked-example cheatsheet, see `references/confidence-interval-cheatsheet.md`.
+For a worked-example cheatsheet, see [`references/confidence-interval-cheatsheet.md`](references/confidence-interval-cheatsheet.md).
 
 ---
 
@@ -82,7 +82,7 @@ The 0.05 cutoff is convention, not law. If you pre-committed to alpha equals 0.0
 
 Always read the CI alongside the p-value. The p-value tells you about the null hypothesis; the CI tells you about the magnitude. Both matter; neither is sufficient alone. A p-value of 0.001 with a CI of [+0.1%, +0.3%] is a real but practically tiny effect; a p-value of 0.08 with a CI of [-1%, +12%] is a noisy estimate that could be huge or zero. The former is technically significant and not worth shipping; the latter is technically not significant and you might still want to dig deeper.
 
-The peeking problem applies to p-values directly. Standard p-values assume one analysis at the end of the test. Multiple analyses inflate the false positive rate. Modern platforms with sequential testing report "always-valid" or "anytime-valid" p-values that survive peeking; older platforms do not. Know which you are looking at. See `references/p-value-interpretation-guide.md` for deeper coverage.
+The peeking problem applies to p-values directly. Standard p-values assume one analysis at the end of the test. Multiple analyses inflate the false positive rate. Modern platforms with sequential testing report "always-valid" or "anytime-valid" p-values that survive peeking; older platforms do not. Know which you are looking at. See [`references/p-value-interpretation-guide.md`](references/p-value-interpretation-guide.md) for deeper coverage.
 
 ---
 
@@ -148,7 +148,7 @@ A common confusion: "CUPED made our lift smaller, so we should ship the unadjust
 
 Platform support: Statsig, Eppo, GrowthBook, parts of PostHog, Amplitude (Experiment product). Optimizely has equivalent variance reduction. If your platform offers CUPED, turn it on for any metric where pre-experiment data exists.
 
-For deeper coverage of CUPED, the delta method, and other statistical methods, see `references/statistical-method-reference.md`.
+For deeper coverage of CUPED, the delta method, and other statistical methods, see [`references/statistical-method-reference.md`](references/statistical-method-reference.md).
 
 ---
 
@@ -252,7 +252,7 @@ Reconciliation discipline: never report experiment results as "the feature drove
 
 The "blended attribution" trap is the most common reconciliation failure. PM takes the experiment lift (say +2% revenue per user) and multiplies by the total user base for a company-wide impact estimate ("$10M in incremental revenue"). This is wrong twice over. The lift only applies to enrolled users (typically 10% to 50% of the base). Even within the enrolled group, the lift was measured during the test conditions; long-term and at full scale, the effect can be different. The right phrasing is "during the four-week test, enrolled users (about 30% of the active base) showed a 2% revenue-per-user lift relative to control." Then leadership can do the careful arithmetic of how that translates at full launch.
 
-For deeper reconciliation patterns and stakeholder-facing language, see `references/dashboard-vs-experiment-reconciliation.md`.
+For deeper reconciliation patterns and stakeholder-facing language, see [`references/dashboard-vs-experiment-reconciliation.md`](references/dashboard-vs-experiment-reconciliation.md).
 
 ---
 
@@ -272,7 +272,7 @@ Practical heuristic: any feature with novelty risk (new UI, new mechanic, new pr
 
 ## Common interpretation failures
 
-Rapid-fire reference. Each pattern is described in more detail in `references/common-interpretation-failures.md`.
+Rapid-fire reference. Each pattern is described in more detail in [`references/common-interpretation-failures.md`](references/common-interpretation-failures.md).
 
 - "P equals 0.04, ship it." No consideration of CI width, magnitude, or guardrails. Significance is a necessary condition, not a sufficient one.
 - "We saw +5% on day 3, ending early." Peeking, novelty effect, or both. Day-3 lifts are routinely larger than day-14 lifts; ending early ships noise.

--- a/skills/experimentation-analytics/references/statistical-method-reference.md
+++ b/skills/experimentation-analytics/references/statistical-method-reference.md
@@ -1,6 +1,6 @@
 # Statistical method reference
 
-The technical reference for analysts. Covers the methods named in the SKILL.md with enough depth to verify a platform's implementation, recognize when a method is needed, and explain the choice to a skeptical reviewer.
+The technical reference for analysts. Covers the methods named in the [SKILL.md](../SKILL.md) with enough depth to verify a platform's implementation, recognize when a method is needed, and explain the choice to a skeptical reviewer.
 
 ---
 

--- a/skills/experimentation-platform-orchestrator/SKILL.md
+++ b/skills/experimentation-platform-orchestrator/SKILL.md
@@ -132,7 +132,7 @@ Specialty platform focused on the winning-experiment-to-production-code workflow
 
 ## Decision matrix: which platform for which context
 
-The matrix lives in `references/platform-decision-matrix.md` with worked examples. The summary:
+The matrix lives in [`references/platform-decision-matrix.md`](references/platform-decision-matrix.md) with worked examples. The summary:
 
 - Pure SaaS, fast-growing, want one platform for flags and experiments. Choose Statsig. Choose PostHog if you also want analytics.
 - Open-source preference, want data sovereignty, warehouse-native. Choose GrowthBook or Eppo.
@@ -155,7 +155,7 @@ Multi-platform is a mess when the surfaces overlap. Running both Statsig and Opt
 
 The 80/20 rule. Eighty percent of teams should pick one platform and consolidate. The 20% with genuine multi-surface needs (marketing site plus product app plus content site) can justify multi-platform with clear ownership boundaries.
 
-When multi-platform is genuine, three coordination patterns are non-negotiable. An ownership matrix names which platform owns which surface. Shared metric definitions ensure that "activation rate" computes the same way in both platforms (this is hard, and it is the reason most multi-platform setups quietly drift). Reconcilable dashboards let you see the same metric across both platforms with the same definitions. Detail in `references/multi-platform-orchestration.md`.
+When multi-platform is genuine, three coordination patterns are non-negotiable. An ownership matrix names which platform owns which surface. Shared metric definitions ensure that "activation rate" computes the same way in both platforms (this is hard, and it is the reason most multi-platform setups quietly drift). Reconcilable dashboards let you see the same metric across both platforms with the same definitions. Detail in [`references/multi-platform-orchestration.md`](references/multi-platform-orchestration.md).
 
 ---
 
@@ -173,7 +173,7 @@ Migration is the unglamorous engineering work that makes the platform decision r
 
 **Any to Statsig.** Typical consolidation move from multi-platform mess. Effort scales with the number of platforms and in-flight experiments; a clean consolidation can run 6 to 12 engineer-weeks.
 
-The migration discipline is in `references/migration-playbook.md`. Three rules apply to every migration: do not parallel-run forever, do not big-bang switch, and do not retire the old platform before all in-flight experiments complete.
+The migration discipline is in [`references/migration-playbook.md`](references/migration-playbook.md). Three rules apply to every migration: do not parallel-run forever, do not big-bang switch, and do not retire the old platform before all in-flight experiments complete.
 
 ---
 
@@ -183,7 +183,7 @@ Plain talk. Vendor-native (Statsig, Optimizely) bills on events, typically $0.10
 
 Free tiers. PostHog gives 1M events per month free. Statsig gives 1M events free. Amplitude gives 10M events per month free with basic features. GrowthBook is free open-source. Optimizely and Eppo do not have meaningful free tiers.
 
-The trap. Optimizing for sticker price ignores total cost. Total cost includes engineer time, statistical correctness (a wrong-result experiment can cost more than a year of platform fees), governance overhead, and migration risk. Sticker price matters for finance; total cost matters for product velocity. Detail and finance conversation patterns in `references/cost-and-pricing-models.md`.
+The trap. Optimizing for sticker price ignores total cost. Total cost includes engineer time, statistical correctness (a wrong-result experiment can cost more than a year of platform fees), governance overhead, and migration risk. Sticker price matters for finance; total cost matters for product velocity. Detail and finance conversation patterns in [`references/cost-and-pricing-models.md`](references/cost-and-pricing-models.md).
 
 ---
 
@@ -193,7 +193,7 @@ Permission tiers, approval workflows, audit trails, and environment promotion ar
 
 Team fit shapes the decision more than most evaluations admit. PostHog and GrowthBook suit engineer-led and PLG teams. Optimizely suits marketing-led teams. Eppo and GrowthBook suit data-team-led teams. Statsig suits PM-led teams. The platform's defaults will pull your team's experimentation culture in the direction of its primary user; pick the alignment that matches who you actually want running experiments.
 
-Onboarding cost. How long until a new PM can ship their first experiment? Statsig and PostHog: hours to days. Optimizely: days to weeks. Eppo and GrowthBook: depends on whether the warehouse and metrics are already wired in (days if yes, weeks if no). Detail in `references/governance-and-team-setup.md`.
+Onboarding cost. How long until a new PM can ship their first experiment? Statsig and PostHog: hours to days. Optimizely: days to weeks. Eppo and GrowthBook: depends on whether the warehouse and metrics are already wired in (days if yes, weeks if no). Detail in [`references/governance-and-team-setup.md`](references/governance-and-team-setup.md).
 
 ---
 
@@ -206,7 +206,7 @@ For AI-forward teams, the MCP capability layer is becoming the deciding factor. 
 - For agentic workflows where AI agents run experiments end to end, prefer platforms with full CRUD via MCP: Statsig, PostHog, GrowthBook, Optimizely.
 - For human-driven workflows where MCP supplements human action, any of the seven works (Eppo via the REST path).
 
-MCP availability is evolving fast. Check the current state of any platform before committing. Eppo is worth tracking for a future MCP release that would close its current gap. Side-by-side capability matrix in `references/mcp-capability-comparison.md`.
+MCP availability is evolving fast. Check the current state of any platform before committing. Eppo is worth tracking for a future MCP release that would close its current gap. Side-by-side capability matrix in [`references/mcp-capability-comparison.md`](references/mcp-capability-comparison.md).
 
 ---
 
@@ -241,7 +241,7 @@ Twelve patterns recur across platform decisions. The short version:
 - Locked the brief on the demo, not the trial. Brief assumptions did not survive contact with real usage.
 - Renewed without re-evaluating. The market changed; the brief did not.
 
-Detail in `references/common-mistakes.md` with symptoms, root causes, fixes, and prevention.
+Detail in [`references/common-mistakes.md`](references/common-mistakes.md) with symptoms, root causes, fixes, and prevention.
 
 ---
 

--- a/skills/feature-flagging/SKILL.md
+++ b/skills/feature-flagging/SKILL.md
@@ -46,7 +46,7 @@ Each type has different lifecycle, governance, and removal expectations. Mixing 
 
 ## Flag naming conventions
 
-A flag name encodes type, owner, and purpose. Without that encoding, a flag list at month nine is unreadable and the cleanup playbook from `references/stale-flag-cleanup-playbook.md` cannot tell what is safe to remove.
+A flag name encodes type, owner, and purpose. Without that encoding, a flag list at month nine is unreadable and the cleanup playbook from [`references/stale-flag-cleanup-playbook.md`](references/stale-flag-cleanup-playbook.md) cannot tell what is safe to remove.
 
 The convention this skill recommends is `<type>_<owner>_<semantic_name>_<version_or_date>`:
 
@@ -58,7 +58,7 @@ The convention this skill recommends is `<type>_<owner>_<semantic_name>_<version
 
 Pick snake_case or kebab-case once, organization-wide, and stick with it. Mixing both in the same platform produces typo-driven bugs that bite at 3 AM. Vague names die a slow death: `new_feature`, `temp_toggle`, `test_flag`, `pricing_update_v3`. Within months, no one knows which `pricing_update` shipped and which is dead.
 
-For deeper coverage including the table of typed prefixes, owner conventions, and the migration plan for existing badly-named flags, see `references/flag-naming-conventions.md`.
+For deeper coverage including the table of typed prefixes, owner conventions, and the migration plan for existing badly-named flags, see [`references/flag-naming-conventions.md`](references/flag-naming-conventions.md).
 
 ---
 
@@ -70,7 +70,7 @@ Every flag has five life phases. Each phase has explicit entry and exit criteria
 
 **Adolescence.** The feature behind the flag is being built. Code paths exist for both the disabled (current production) branch and the enabled (new) branch. Both are tested. The flag remains off in production.
 
-**Launch.** Production rollout begins. Percentage starts low (1 or 5 percent), monitored at each step, ramps if metrics hold. Ramp gates documented in `references/flag-rollout-strategies.md`.
+**Launch.** Production rollout begins. Percentage starts low (1 or 5 percent), monitored at each step, ramps if metrics hold. Ramp gates documented in [`references/flag-rollout-strategies.md`](references/flag-rollout-strategies.md).
 
 **Maturity.** The flag is at 100 percent rollout. The new code path is the production path. Monitoring continues for at least 30 days to catch issues that did not show up during the ramp.
 
@@ -78,7 +78,7 @@ Every flag has five life phases. Each phase has explicit entry and exit criteria
 
 The asymmetry: birth is fast (one PR creates the flag and gates the new code), death requires intentional cleanup. Most flag mess is unfinished death. Birth-and-death have to be planned together; the death plan is part of the birth metadata.
 
-For the per-phase checklist, see `references/flag-lifecycle-checklist.md`.
+For the per-phase checklist, see [`references/flag-lifecycle-checklist.md`](references/flag-lifecycle-checklist.md).
 
 ---
 
@@ -95,7 +95,7 @@ Compose with AND, OR, and NOT. Keep the expressions simple. If your rule needs t
 
 The most common pitfall: targeting on attributes that change frequently. If the rule is `user.last_login_date > "2026-04-01"`, a user who logs in on May 1 sees the treatment, then their value changes the next day, and they see the control again. The user experience whiplashes. Volatile attributes belong in segments computed off snapshots, not in live targeting rules.
 
-For pattern catalog and anti-patterns, see `references/targeting-rule-patterns.md`.
+For pattern catalog and anti-patterns, see [`references/targeting-rule-patterns.md`](references/targeting-rule-patterns.md).
 
 ---
 
@@ -113,7 +113,7 @@ Different launches deserve different rollout strategies. Match the strategy to t
 
 The "ramp and watch" rule: at each percentage step, monitor the system for at least one peak hour before advancing. The peak hour is when the rate of any new failure mode is highest; if the system holds at peak for an hour, the next step is safe. If you ramp during off-peak and immediately advance, you have not actually tested the change.
 
-For full strategy detail and a worked example for a checkout redesign, see `references/flag-rollout-strategies.md`.
+For full strategy detail and a worked example for a checkout redesign, see [`references/flag-rollout-strategies.md`](references/flag-rollout-strategies.md).
 
 ---
 
@@ -133,7 +133,7 @@ The cleanup playbook is mechanical:
 
 The reason cleanup does not happen by default: removing a flag is a code change PR with review, testing, and deploy overhead. PMs do not reward it (the feature already shipped). SREs eventually get fed up with the noise. The fix is to make removal part of the launch checklist, not a separate effort. When a flag is created, the removal date is in the metadata. The launch ticket has a follow-up sub-ticket scheduled 30 days out that says "remove flag X." If the launch goes well, the sub-ticket gets done.
 
-For the full quarterly cadence including ownership rotation for orphan flags, see `references/stale-flag-cleanup-playbook.md`.
+For the full quarterly cadence including ownership rotation for orphan flags, see [`references/stale-flag-cleanup-playbook.md`](references/stale-flag-cleanup-playbook.md).
 
 ---
 

--- a/skills/feature-flagging/references/governance-and-permissions.md
+++ b/skills/feature-flagging/references/governance-and-permissions.md
@@ -112,4 +112,4 @@ Bureaucracy substitutes for trust. Trust is built via the audit log and the appr
 
 When a flag's surface overlaps with another team's work, coordinate before the change. The experiment registry pattern from the `experiment-design` skill applies here too: maintain a shared list (in the platform, in a wiki, in a shared doc) of flags currently being modified or rolled out per surface. Before launching a flag rollout, check the registry for conflicts.
 
-Cross-team coordination does not have to be heavy. A 5-minute Slack check ("we're rolling out flag X on the checkout flow tomorrow at 1 PM, anyone working on adjacent flags?") is enough for most cases. The cost of skipping the check is the cross-team conflict scenario from the SKILL.md, where two flags interact and produce broken UI.
+Cross-team coordination does not have to be heavy. A 5-minute Slack check ("we're rolling out flag X on the checkout flow tomorrow at 1 PM, anyone working on adjacent flags?") is enough for most cases. The cost of skipping the check is the cross-team conflict scenario from the [SKILL.md](../SKILL.md), where two flags interact and produce broken UI.

--- a/skills/feature-launch-playbook/SKILL.md
+++ b/skills/feature-launch-playbook/SKILL.md
@@ -71,7 +71,7 @@ The trap on either side.
 
 Match the tier to the feature. This skill primarily covers Tier 1 and Tier 2. Tier 3 is mostly the changelog discipline; the launch playbook applies but compressed to the changelog entry plus light monitoring.
 
-Detail in `references/launch-tier-decision.md`.
+Detail in [`references/launch-tier-decision.md`](references/launch-tier-decision.md).
 
 ---
 
@@ -90,7 +90,7 @@ The positioning canvas. One page, filled out before any comms drafting.
 
 The most common positioning failure is a vague target user. "It is for PMs" is not a target. "It is for B2B SaaS PMs at companies with 50 to 500 customers who need to coordinate roadmap discussions across engineering and customer success" is a target. The specificity is what lets sales, marketing, and support speak the same language about who this is for.
 
-Detail in `references/positioning-canvas.md`.
+Detail in [`references/positioning-canvas.md`](references/positioning-canvas.md).
 
 ---
 
@@ -109,7 +109,7 @@ The discipline. A single internal launch brief, distributed two to four weeks be
 
 The most common internal alignment failure: launching without sales knowing. Sales finds out from a customer asking about it. Trust erodes for the next launch. The fix is the launch brief plus a sales-specific briefing one to two weeks before customer-facing launch.
 
-Detail in `references/internal-alignment-checklist.md`.
+Detail in [`references/internal-alignment-checklist.md`](references/internal-alignment-checklist.md).
 
 ---
 
@@ -129,7 +129,7 @@ For each channel: who drafts, who approves, what is the timing, what is the call
 
 The comms calendar pattern. A single document with all channels and dates, distributed in the internal launch brief. Prevents the "blog post went out before sales got the briefing" failure. Ordering typically goes: sales briefing first, support training second, customer success outreach to top accounts third, public comms fourth.
 
-Detail in `references/customer-comms-playbook.md`.
+Detail in [`references/customer-comms-playbook.md`](references/customer-comms-playbook.md).
 
 ---
 
@@ -147,7 +147,7 @@ The "shadow launch" failure. Feature ships, sales hears about it from product te
 
 For B2C and PLG products, this section is mostly skipped. The user is the buyer; there is no sales motion. Note this explicitly so PMs in those contexts do not feel they are missing the discipline.
 
-Detail in `references/sales-enablement-template.md`.
+Detail in [`references/sales-enablement-template.md`](references/sales-enablement-template.md).
 
 ---
 
@@ -162,7 +162,7 @@ Support is often the first to encounter the failure modes of a new feature. They
 
 The discipline. The support team's confusion is the test customer's confusion. If support does not understand the feature, neither will customers. Train support before customer-facing launch comms go out.
 
-Detail in `references/support-readiness-checklist.md`.
+Detail in [`references/support-readiness-checklist.md`](references/support-readiness-checklist.md).
 
 ---
 
@@ -184,7 +184,7 @@ The decision framework. Feature blast radius times confidence in correctness tim
 - Low blast radius plus high confidence plus external launch date: all-at-once.
 - The middle (most launches): gradual percentage rollout.
 
-Detail in `references/rollout-strategy-patterns.md`.
+Detail in [`references/rollout-strategy-patterns.md`](references/rollout-strategy-patterns.md).
 
 ---
 
@@ -207,7 +207,7 @@ Define the rollback trigger explicitly before launch. Examples.
 
 The "no rollback trigger" failure. Launch goes sideways. The team debates whether to roll back for an hour while the issue compounds. Pre-defined triggers remove the debate; the rule fires automatically and the team executes the rollback.
 
-Detail in `references/monitoring-readiness-checklist.md`.
+Detail in [`references/monitoring-readiness-checklist.md`](references/monitoring-readiness-checklist.md).
 
 ---
 
@@ -242,7 +242,7 @@ Time horizons. Most launches need two to four weeks of post-launch data for enga
 
 The "no measurement plan" failure. Feature ships; the team moves on; six months later nobody knows if it worked. The feature becomes maintenance debt; the team cannot decide whether to invest in it further.
 
-Detail in `references/post-launch-measurement-framework.md`.
+Detail in [`references/post-launch-measurement-framework.md`](references/post-launch-measurement-framework.md).
 
 ---
 
@@ -274,7 +274,7 @@ The fix. Declare success or failure based on a stable post-launch trend, not the
 
 ## Common failure modes
 
-Twelve patterns recur across feature launches. Detail in `references/common-launch-failures.md`.
+Twelve patterns recur across feature launches. Detail in [`references/common-launch-failures.md`](references/common-launch-failures.md).
 
 - "We shipped it but nothing happened." Unlaunched. No comms plan, no internal alignment, no measurement.
 - "Sales is confused and selling it wrong." No enablement. Battlecard, demo, training were skipped or rushed.

--- a/skills/form-strategy/SKILL.md
+++ b/skills/form-strategy/SKILL.md
@@ -254,4 +254,4 @@ A form audit document includes:
 
 ## Reference files
 
-- `references/form-anatomy-checklist.md`: A field-by-field, behavior-by-behavior checklist for auditing or designing a form, covering structure, accessibility, validation, and spam defense.
+- [`references/form-anatomy-checklist.md`](references/form-anatomy-checklist.md): A field-by-field, behavior-by-behavior checklist for auditing or designing a form, covering structure, accessibility, validation, and spam defense.

--- a/skills/frontend-component-build/SKILL.md
+++ b/skills/frontend-component-build/SKILL.md
@@ -179,6 +179,6 @@ A complete component delivery includes:
 
 ## Reference files
 
-- `references/component-spec-template.md` - Template for documenting a component (props, states, accessibility, edge cases) before building.
-- `references/component-api-patterns.md` - Common patterns for designing flexible component APIs (compound components, controlled vs uncontrolled, polymorphic `as` prop, render props, slots).
-- `references/accessibility-patterns.md` - ARIA patterns for common interactive components.
+- [`references/component-spec-template.md`](references/component-spec-template.md) - Template for documenting a component (props, states, accessibility, edge cases) before building.
+- [`references/component-api-patterns.md`](references/component-api-patterns.md) - Common patterns for designing flexible component APIs (compound components, controlled vs uncontrolled, polymorphic `as` prop, render props, slots).
+- [`references/accessibility-patterns.md`](references/accessibility-patterns.md) - ARIA patterns for common interactive components.

--- a/skills/funnel-flow-architecture/SKILL.md
+++ b/skills/funnel-flow-architecture/SKILL.md
@@ -77,7 +77,7 @@ The foundation.
 
 **Segmentation discipline.** Start with 3-5 audiences and 3 stages. 9-15 cells in the matrix. Some cells may share paths; some may have unique paths. The discipline is naming the segments deliberately rather than treating "everyone" as the audience.
 
-Detail in `references/audience-and-stage-segmentation.md`.
+Detail in [`references/audience-and-stage-segmentation.md`](references/audience-and-stage-segmentation.md).
 
 ---
 
@@ -104,7 +104,7 @@ How visitors land vs how they're routed.
 
 **Worked example.** A visitor arriving via a paid ad about "B2B SaaS pricing" is likely in consideration stage looking for pricing information. The landing page should serve that need (clear pricing, comparison, calculator); the next-step offer should match consideration (demo, talk to sales). Same visitor arriving via an organic blog post about "B2B SaaS pricing strategy" is likely in awareness stage; the landing page should serve education (depth on pricing strategy); the next-step offer should match awareness (subscribe to content, get the framework).
 
-Detail in `references/entry-point-architecture-patterns.md`.
+Detail in [`references/entry-point-architecture-patterns.md`](references/entry-point-architecture-patterns.md).
 
 ---
 
@@ -126,7 +126,7 @@ Which tools serve which entry points.
 
 **The portfolio approach.** A team often has multiple tools serving different segments. The architecture maps each tool to its specific segments and stages.
 
-Detail in `references/tool-to-funnel-mapping.md`.
+Detail in [`references/tool-to-funnel-mapping.md`](references/tool-to-funnel-mapping.md).
 
 ---
 
@@ -152,7 +152,7 @@ Per-segment, per-stage.
 
 **The matched sequence win.** Sequence specific to segment-and-stage. The audience perceives the brand as understanding their situation; conversion compounds.
 
-Detail in `references/nurture-sequence-architecture.md`.
+Detail in [`references/nurture-sequence-architecture.md`](references/nurture-sequence-architecture.md).
 
 ---
 
@@ -173,7 +173,7 @@ Capturing context from tool to tool.
 
 **The integrated-funnel win.** Data flows. The audience experiences continuity; the brand can match content and offers to the audience's specific journey.
 
-Detail in `references/cross-tool-data-flow-patterns.md`.
+Detail in [`references/cross-tool-data-flow-patterns.md`](references/cross-tool-data-flow-patterns.md).
 
 ---
 
@@ -196,7 +196,7 @@ What to measure, what is noise.
 
 **Architecture-level vs tool-level.** Tool-level metrics tell you whether each tool is working; architecture-level metrics tell you whether the tools work together. Both matter; architecture is often the missing measurement.
 
-Detail in `references/funnel-measurement-patterns.md`.
+Detail in [`references/funnel-measurement-patterns.md`](references/funnel-measurement-patterns.md).
 
 ---
 
@@ -226,7 +226,7 @@ When to redesign, when to refine.
 
 The middle ground. Refine continuously; redesign infrequently and deliberately.
 
-Detail in `references/funnel-iteration-discipline.md`.
+Detail in [`references/funnel-iteration-discipline.md`](references/funnel-iteration-discipline.md).
 
 ---
 
@@ -250,7 +250,7 @@ Patterns that look like funnel architecture but degrade conversion.
 
 **The hand-off-broken-funnel.** Tools work individually but the transitions between them break.
 
-Detail in `references/architecture-anti-patterns.md`.
+Detail in [`references/architecture-anti-patterns.md`](references/architecture-anti-patterns.md).
 
 ---
 

--- a/skills/incident-response/SKILL.md
+++ b/skills/incident-response/SKILL.md
@@ -257,4 +257,4 @@ After incident close: a brief incident summary feeding into the AAR.
 
 ## Reference files
 
-- `references/incident-playbook.md` - Severity definitions, roles, status page templates, decision rubrics.
+- [`references/incident-playbook.md`](references/incident-playbook.md) - Severity definitions, roles, status page templates, decision rubrics.

--- a/skills/information-architecture/SKILL.md
+++ b/skills/information-architecture/SKILL.md
@@ -210,7 +210,7 @@ What you call things.
 5. **Design navigation.** Primary, secondary, utility, footer, breadcrumbs.
 6. **Build taxonomy.** Categories (controlled, small) and tags (open, large).
 7. **Validate labels.** Tree test or closed card sort with target users.
-8. **Document.** Use the template in `references/ia-document-template.md`.
+8. **Document.** Use the template in [`references/ia-document-template.md`](references/ia-document-template.md).
 9. **Hand off to design and development.** IA decisions inform navigation components, URL routing, and taxonomy implementation.
 
 ---
@@ -250,5 +250,5 @@ Visual deliverables:
 
 ## Reference files
 
-- `references/ia-document-template.md` - Template for the IA deliverable.
-- `references/url-pattern-library.md` - URL pattern conventions for common content types.
+- [`references/ia-document-template.md`](references/ia-document-template.md) - Template for the IA deliverable.
+- [`references/url-pattern-library.md`](references/url-pattern-library.md) - URL pattern conventions for common content types.

--- a/skills/integration-orchestrator/SKILL.md
+++ b/skills/integration-orchestrator/SKILL.md
@@ -162,10 +162,10 @@ The document is the orchestration plan. The next step after delivery is for the 
 
 ## Reference files
 
-- `references/cadence-patterns.md`. The 7 project-type cadences in detail with phase decomposition, timelines, gate definitions, and tool-stack implementation skeletons.
-- `references/gate-definitions.md`. Each standard gate with trigger, approver, pass criteria, what's blocked, what's already locked, and change-request protocols.
-- `references/handoff-protocols.md`. The standard handoffs between phases and skills, plus the adjacent observation handoff for filing things noticed while working nearby.
-- `references/platform-implementation.md`. How the orchestration maps to Jira, Linear, Notion, Figma, and GitHub, including MCP integration notes per platform and CLI alternatives where MCP is the wrong tool.
-- `references/team-size-modulation.md`. How cadences scale across solo, small, medium, and large teams.
-- `references/automation-and-qa-tooling.md`. The QA verification gate pattern, MCP vs CLI tradeoffs, session memory and momentum patterns, code-to-ticket linkage, and evidence trails.
-- `references/example-orchestration.md`. A complete worked example showing all sections populated for a representative scenario.
+- [`references/cadence-patterns.md`](references/cadence-patterns.md). The 7 project-type cadences in detail with phase decomposition, timelines, gate definitions, and tool-stack implementation skeletons.
+- [`references/gate-definitions.md`](references/gate-definitions.md). Each standard gate with trigger, approver, pass criteria, what's blocked, what's already locked, and change-request protocols.
+- [`references/handoff-protocols.md`](references/handoff-protocols.md). The standard handoffs between phases and skills, plus the adjacent observation handoff for filing things noticed while working nearby.
+- [`references/platform-implementation.md`](references/platform-implementation.md). How the orchestration maps to Jira, Linear, Notion, Figma, and GitHub, including MCP integration notes per platform and CLI alternatives where MCP is the wrong tool.
+- [`references/team-size-modulation.md`](references/team-size-modulation.md). How cadences scale across solo, small, medium, and large teams.
+- [`references/automation-and-qa-tooling.md`](references/automation-and-qa-tooling.md). The QA verification gate pattern, MCP vs CLI tradeoffs, session memory and momentum patterns, code-to-ticket linkage, and evidence trails.
+- [`references/example-orchestration.md`](references/example-orchestration.md). A complete worked example showing all sections populated for a representative scenario.

--- a/skills/interactive-product-tour/SKILL.md
+++ b/skills/interactive-product-tour/SKILL.md
@@ -56,7 +56,7 @@ Before designing the tour system, decide whether tours are the right tool.
 
 The decision is not "should we have a tour system"; it is "is in-product tour the right tool for this product and audience."
 
-Detail in `references/tour-decision-criteria.md`.
+Detail in [`references/tour-decision-criteria.md`](references/tour-decision-criteria.md).
 
 ---
 
@@ -94,7 +94,7 @@ When to use. When the help differs by user segment. State-based triggers persona
 
 The discipline. The trigger answers "when does this help surface and why." Decorative triggers (showing help when it is not needed) become tooltip-spam.
 
-Detail in `references/trigger-logic-patterns.md`.
+Detail in [`references/trigger-logic-patterns.md`](references/trigger-logic-patterns.md).
 
 ---
 
@@ -110,7 +110,7 @@ How help is organized.
 
 **The choice.** Most modern systems use the micro-tour library approach. Single tours feel canned; branched tours are hard to maintain at scale; a library of contextual micro-tours matches how users actually explore.
 
-Detail in `references/tour-architecture-patterns.md`.
+Detail in [`references/tour-architecture-patterns.md`](references/tour-architecture-patterns.md).
 
 ---
 
@@ -134,7 +134,7 @@ The visual design of help.
 
 **Non-intrusion principle.** Help should be findable when wanted, ignorable when not. Modal help that blocks the screen is intrusive; help that disappears too easily fails to teach.
 
-Detail in `references/contextual-placement-patterns.md` and `references/dismissal-and-non-intrusion-patterns.md`.
+Detail in [`references/contextual-placement-patterns.md`](references/contextual-placement-patterns.md) and [`references/dismissal-and-non-intrusion-patterns.md`](references/dismissal-and-non-intrusion-patterns.md).
 
 ---
 
@@ -160,7 +160,7 @@ Knowing what each user has seen, deciding when to show again.
 
 **The under-trigger trap.** Tours never re-surfacing when the user hits the same friction again. Help fails at the moment of need.
 
-Detail in `references/completion-tracking-and-re-trigger.md`.
+Detail in [`references/completion-tracking-and-re-trigger.md`](references/completion-tracking-and-re-trigger.md).
 
 ---
 
@@ -187,13 +187,13 @@ Different users need different help.
 
 **The under-helping trap.** Treating all users as power users. New users miss critical help.
 
-Detail in `references/power-user-vs-new-user-patterns.md`.
+Detail in [`references/power-user-vs-new-user-patterns.md`](references/power-user-vs-new-user-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-tour-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-tour-failures.md`](references/common-tour-failures.md).
 
 - "Tours show but feature adoption does not improve." Help may be visually present but not contextually relevant. Audit trigger logic.
 - "Users disable tours globally." The system is annoying users. Audit frequency, dismissal, and over-triggering.

--- a/skills/internationalization/SKILL.md
+++ b/skills/internationalization/SKILL.md
@@ -275,4 +275,4 @@ An internationalization plan includes:
 
 ## Reference files
 
-- `references/locale-checklist.md`: Per-locale checklist of everything that needs to adapt beyond translation, organized by category (URL, content, UX, format, legal).
+- [`references/locale-checklist.md`](references/locale-checklist.md): Per-locale checklist of everything that needs to adapt beyond translation, organized by category (URL, content, UX, format, legal).

--- a/skills/journey-mapping/SKILL.md
+++ b/skills/journey-mapping/SKILL.md
@@ -241,4 +241,4 @@ Markdown narrative version of journey map:
 
 ## Reference files
 
-- `references/journey-map-template.md` - Fillable journey map and service blueprint template.
+- [`references/journey-map-template.md`](references/journey-map-template.md) - Fillable journey map and service blueprint template.

--- a/skills/jtbd-framing/SKILL.md
+++ b/skills/jtbd-framing/SKILL.md
@@ -76,7 +76,7 @@ The canonical structure: "When [situation], I want to [motivation], so I can [ou
 
 The structure forces specificity at all three levels. Vague situations, vague motivations, or vague outcomes produce job statements that drive nothing.
 
-Detail in `references/job-statement-structure-patterns.md`.
+Detail in [`references/job-statement-structure-patterns.md`](references/job-statement-structure-patterns.md).
 
 ---
 
@@ -92,7 +92,7 @@ Jobs become visible at struggling moments: when the user's current solution is f
 
 **The pitfall.** Teams that interview without grounding in specific moments produce abstracted job descriptions that cannot drive decisions. "Users want to be more productive" is not a struggling moment; "I lost an hour on Tuesday assembling the board metrics from three different dashboards because none of them had the slice I needed" is.
 
-Detail in `references/identifying-struggling-moments.md`.
+Detail in [`references/identifying-struggling-moments.md`](references/identifying-struggling-moments.md).
 
 ---
 
@@ -122,7 +122,7 @@ Why users adopt a product (hire), why they switch away (fire). The two questions
 
 **The methodology.** Customer interviews surface hire/fire through specific prompts: "What were you doing before you adopted X?" "What made you switch?" "If you switched away from X tomorrow, what would the trigger be?" Recent switch decisions are particularly rich; users remember the specific moment.
 
-Detail in `references/hire-and-fire-criteria.md`.
+Detail in [`references/hire-and-fire-criteria.md`](references/hire-and-fire-criteria.md).
 
 ---
 
@@ -156,7 +156,7 @@ Jobs have three dimensions. Strong JTBD work surfaces all three; weak work treat
 
 **The discipline.** For each job statement, ask the three dimensions explicitly. Most early job statements are functional-only; the addition of emotional and social often reveals what the product actually needs to address.
 
-Detail in `references/functional-emotional-social-dimensions.md`.
+Detail in [`references/functional-emotional-social-dimensions.md`](references/functional-emotional-social-dimensions.md).
 
 ---
 
@@ -187,21 +187,21 @@ The three modes where JTBD genuinely contributes.
 
 **Discovery.** Structure interviews around recent struggling moments, hire decisions, and fire decisions. Gather job statements after the interviews from the data, not before. Cluster jobs across users. Name jobs from the clusters. Pair with `discovery-research-synthesis` for the broader synthesis discipline.
 
-Detail in `references/applying-jtbd-to-discovery.md`.
+Detail in [`references/applying-jtbd-to-discovery.md`](references/applying-jtbd-to-discovery.md).
 
 **Prioritization.** When evaluating roadmap candidates, frame each candidate by the job(s) it addresses. Ask: which jobs is the product currently doing badly? Which candidates address those jobs vs adjacent or unrelated work? Pair with `roadmap-planning` for the broader prioritization discipline.
 
-Detail in `references/applying-jtbd-to-prioritization.md`.
+Detail in [`references/applying-jtbd-to-prioritization.md`](references/applying-jtbd-to-prioritization.md).
 
 **Positioning.** When articulating what the product is for, lead with the job rather than the features. "Help product teams synthesize discovery research into decisions" is a job framing; "AI-powered research synthesis with collaboration tools" is a feature framing. Pair with `creative-direction` and `brand-discovery` for the broader positioning work.
 
-Detail in `references/applying-jtbd-to-positioning.md`.
+Detail in [`references/applying-jtbd-to-positioning.md`](references/applying-jtbd-to-positioning.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-jtbd-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-jtbd-failures.md`](references/common-jtbd-failures.md).
 
 - "We did the JTBD workshop but nothing changed in our roadmap." Job-statement workshop as deliverable; no analytical work after the workshop.
 - "Our job statements all sound the same." Generic job statements; not grounded in specific struggling moments. Re-ground in interview data.

--- a/skills/landing-page-copy/SKILL.md
+++ b/skills/landing-page-copy/SKILL.md
@@ -256,5 +256,5 @@ Structure:
 
 ## Reference files
 
-- `references/hero-formulas.md` - Patterns and formulas for hero headlines.
-- `references/objection-library.md` - Common objections by category, with handling strategies.
+- [`references/hero-formulas.md`](references/hero-formulas.md) - Patterns and formulas for hero headlines.
+- [`references/objection-library.md`](references/objection-library.md) - Common objections by category, with handling strategies.

--- a/skills/launch-runbook/SKILL.md
+++ b/skills/launch-runbook/SKILL.md
@@ -233,4 +233,4 @@ Structure:
 
 ## Reference files
 
-- `references/runbook-template.md` - Fillable runbook template with example cutover sequences.
+- [`references/runbook-template.md`](references/runbook-template.md) - Fillable runbook template with example cutover sequences.

--- a/skills/lead-magnet-design/SKILL.md
+++ b/skills/lead-magnet-design/SKILL.md
@@ -59,7 +59,7 @@ Before designing the magnet, decide whether a magnet is the right investment.
 
 The decision is not "should we have a magnet"; it is "is the magnet the right next investment for this specific audience and goal."
 
-Detail in `references/lead-magnet-decision-criteria.md`.
+Detail in [`references/lead-magnet-decision-criteria.md`](references/lead-magnet-decision-criteria.md).
 
 ---
 
@@ -97,7 +97,7 @@ Magnets come in formats. Each format has strengths, weaknesses, audience-fit sig
 
 The choice depends on the audience's preferred consumption mode, the topic's natural shape, and the production overhead the team can sustain. A great template often outperforms a mediocre ebook on the same topic.
 
-Detail in `references/format-selection-patterns.md`.
+Detail in [`references/format-selection-patterns.md`](references/format-selection-patterns.md).
 
 ---
 
@@ -125,7 +125,7 @@ The test the magnet should pass.
 
 If the magnet passes the test, it earns the email. If it fails, redesign before launching.
 
-Detail in `references/would-they-pay-for-this-test.md`.
+Detail in [`references/would-they-pay-for-this-test.md`](references/would-they-pay-for-this-test.md).
 
 ---
 
@@ -145,7 +145,7 @@ A great magnet does two things at once. It delivers value (which earns the email
 
 The filtering principle. A magnet that converts 50 percent of visitors but produces 5 percent qualified leads is worse than a magnet that converts 15 percent of visitors and produces 40 percent qualified leads. Optimize for the qualified lead, not for the surface conversion rate.
 
-Detail in `references/audience-fit-qualification.md`.
+Detail in [`references/audience-fit-qualification.md`](references/audience-fit-qualification.md).
 
 ---
 
@@ -173,7 +173,7 @@ The magnet's title is the conversion lever and the qualification filter at the s
 - The landing page (handled by `landing-page-copy`) should preview the magnet, not just describe it.
 - The first page of the magnet should deliver value within the first read, not warm up with author bio and brand-positioning.
 
-Detail in `references/title-and-presentation-discipline.md`.
+Detail in [`references/title-and-presentation-discipline.md`](references/title-and-presentation-discipline.md).
 
 ---
 
@@ -191,7 +191,7 @@ The sequence is the magnet's second act. Without it, the magnet is one transacti
 
 **The opt-out.** A reader who unsubscribes from the magnet sequence is not a failure; they are a clean filter. The list quality stays higher when the unfit subscribers leave on their own.
 
-Detail in `references/delivery-and-follow-up-sequences.md`.
+Detail in [`references/delivery-and-follow-up-sequences.md`](references/delivery-and-follow-up-sequences.md).
 
 ---
 
@@ -215,13 +215,13 @@ Each format has quality gates specific to that format. A great template fails di
 
 Each format's gates exist because thin-bait can hide in any format. The quality gates make hiding harder.
 
-Detail in `references/format-specific-quality-gates.md`.
+Detail in [`references/format-specific-quality-gates.md`](references/format-specific-quality-gates.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-lead-magnet-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-lead-magnet-failures.md`](references/common-lead-magnet-failures.md).
 
 - "Conversion rate is great, list quality is terrible." Thin-bait pattern; magnet attracts the wrong audience or fails to deliver the promised value.
 - "We ship a magnet; nothing happens after." No follow-up sequence; the magnet is one transaction rather than the start of a relationship.

--- a/skills/logo-design/SKILL.md
+++ b/skills/logo-design/SKILL.md
@@ -197,9 +197,9 @@ The spec is decision material. The next step after delivery is selection plus pr
 
 ## Reference files
 
-- `references/architectures-explained.md`. The 5 mark architectures with examples, when each fits, when each fails, and how to combine them in a primary plus fallback hierarchy.
-- `references/typographic-registers.md`. The typographic registers with named typefaces, category-fit notes, and example brands per register.
-- `references/symbol-approaches.md`. The 5 symbol approaches with pattern examples, calibrating the agent's vocabulary for symbol generation.
-- `references/application-contexts.md`. The contexts every logo must pass, with constraint specs (favicon size, embroidery color count, single-color rules, motion entry recommendations).
-- `references/category-conventions.md`. A survey of common conventions across major brand categories, with defaults that work, conventions worth honoring, conventions worth breaking for positioning, and category-specific application contexts.
-- `references/example-variant-spec.md`. A complete example showing all nine per-variant fields filled in for a representative project.
+- [`references/architectures-explained.md`](references/architectures-explained.md). The 5 mark architectures with examples, when each fits, when each fails, and how to combine them in a primary plus fallback hierarchy.
+- [`references/typographic-registers.md`](references/typographic-registers.md). The typographic registers with named typefaces, category-fit notes, and example brands per register.
+- [`references/symbol-approaches.md`](references/symbol-approaches.md). The 5 symbol approaches with pattern examples, calibrating the agent's vocabulary for symbol generation.
+- [`references/application-contexts.md`](references/application-contexts.md). The contexts every logo must pass, with constraint specs (favicon size, embroidery color count, single-color rules, motion entry recommendations).
+- [`references/category-conventions.md`](references/category-conventions.md). A survey of common conventions across major brand categories, with defaults that work, conventions worth honoring, conventions worth breaking for positioning, and category-specific application contexts.
+- [`references/example-variant-spec.md`](references/example-variant-spec.md). A complete example showing all nine per-variant fields filled in for a representative project.

--- a/skills/logo-design/references/application-contexts.md
+++ b/skills/logo-design/references/application-contexts.md
@@ -1,6 +1,6 @@
 # Application contexts
 
-A logo is not a single drawing. It is a system of marks that must work in every context the brand touches. Most logo failure happens because a designer optimized for one context (typically the web header at 200px wide) and never tested the others. This file expands the application contexts in SKILL.md with specific constraint specs, common failure modes, and mitigation patterns. Use it as the working checklist for every variant before declaring a candidate ready for review.
+A logo is not a single drawing. It is a system of marks that must work in every context the brand touches. Most logo failure happens because a designer optimized for one context (typically the web header at 200px wide) and never tested the others. This file expands the application contexts in [SKILL.md](../SKILL.md) with specific constraint specs, common failure modes, and mitigation patterns. Use it as the working checklist for every variant before declaring a candidate ready for review.
 
 The discipline is to design for the smallest, harshest application FIRST, then scale up. Most brand systems do the opposite: they design at the marketing scale and discover at production time that the mark cannot survive its smaller, harsher applications.
 

--- a/skills/logo-design/references/architectures-explained.md
+++ b/skills/logo-design/references/architectures-explained.md
@@ -1,6 +1,6 @@
 # Mark architectures explained
 
-The architectural decision is the foundational one. Every other choice (typographic register, symbol approach, application context discipline) flows from it. This file expands the five architectures listed in SKILL.md with reference brands, fit and failure modes, and a working pattern for combining them in a primary-plus-fallback hierarchy.
+The architectural decision is the foundational one. Every other choice (typographic register, symbol approach, application context discipline) flows from it. This file expands the five architectures listed in [SKILL.md](../SKILL.md) with reference brands, fit and failure modes, and a working pattern for combining them in a primary-plus-fallback hierarchy.
 
 ---
 

--- a/skills/logo-design/references/symbol-approaches.md
+++ b/skills/logo-design/references/symbol-approaches.md
@@ -1,6 +1,6 @@
 # Symbol approaches
 
-A symbol is the part of the logo that does the most work outside of literacy. It travels where wordmarks cannot fit (favicon, embroidery, app icon, signet) and where wordmarks would not register (signage at distance, motion lockups, square contexts). The symbol approach is the question of WHAT KIND of symbol the brand needs. This file expands the five approaches in SKILL.md with reference brands, pattern vocabulary, decision criteria, and the cliches each approach has to escape.
+A symbol is the part of the logo that does the most work outside of literacy. It travels where wordmarks cannot fit (favicon, embroidery, app icon, signet) and where wordmarks would not register (signage at distance, motion lockups, square contexts). The symbol approach is the question of WHAT KIND of symbol the brand needs. This file expands the five approaches in [SKILL.md](../SKILL.md) with reference brands, pattern vocabulary, decision criteria, and the cliches each approach has to escape.
 
 ---
 

--- a/skills/logo-design/references/typographic-registers.md
+++ b/skills/logo-design/references/typographic-registers.md
@@ -1,6 +1,6 @@
 # Typographic registers
 
-Type carries the wordmark. Type carries half the lockup. Type drives more of a logo's read than any other single decision because type is the voice of the brand, frozen. This file expands the seven registers listed in SKILL.md with named typefaces, category-fit notes, example brands, pairing guidance, and the failure mode each register tends toward.
+Type carries the wordmark. Type carries half the lockup. Type drives more of a logo's read than any other single decision because type is the voice of the brand, frozen. This file expands the seven registers listed in [SKILL.md](../SKILL.md) with named typefaces, category-fit notes, example brands, pairing guidance, and the failure mode each register tends toward.
 
 ---
 

--- a/skills/long-form-content-frameworks/SKILL.md
+++ b/skills/long-form-content-frameworks/SKILL.md
@@ -72,7 +72,7 @@ Seven formats, each with a different structural shape and a different reader con
 
 **Long-form tutorial.** Instructional content where the reader is following along. Reader contract: "Take me from where I am to where I want to be, step by step." Length: 3,000 to 8,000 words. Structural archetype: problem-solution with sequential steps. The long-form-tutorial tax: every step actually works; gaps in the sequence break the reader.
 
-Detail in `references/format-decision-framework.md`.
+Detail in [`references/format-decision-framework.md`](references/format-decision-framework.md).
 
 ---
 
@@ -92,7 +92,7 @@ Five archetypes that fit different long-form problems.
 
 Most strong long-form pieces use one archetype as the spine and borrow from another for variation. A whitepaper might be a layered argument with comparative-analysis sections. A definitive guide might be a taxonomic survey with problem-solution chapters. The archetype is the spine; variation prevents the piece feeling formulaic.
 
-Detail in `references/structural-archetype-patterns.md`.
+Detail in [`references/structural-archetype-patterns.md`](references/structural-archetype-patterns.md).
 
 ---
 
@@ -114,7 +114,7 @@ The general principle: section weights match how much load the section is bearin
 
 The audit. If one section is more than 3x the length of another bearing similar argumentative load, the piece is structurally unbalanced. Either the long section needs to be split, or the short section needs to be deepened, or the imbalance reflects an actual content problem the writer has not surfaced.
 
-Detail in `references/section-weight-calibration.md`.
+Detail in [`references/section-weight-calibration.md`](references/section-weight-calibration.md).
 
 ---
 
@@ -141,7 +141,7 @@ A blog-post lede answers the user's likely query in the first 200 words. A long-
 
 The first paragraph of a long-form piece is the writer's only sales pitch for the next 30+ minutes of the reader's attention. Spending it on filler is the most common long-form failure.
 
-Detail in `references/lede-patterns-for-long-form.md`.
+Detail in [`references/lede-patterns-for-long-form.md`](references/lede-patterns-for-long-form.md).
 
 ---
 
@@ -159,7 +159,7 @@ Long pieces that hold readers vary their density, register, and rhythm. Pieces t
 
 **Mid-piece micro-thesis.** Around the 40-60% mark, restate the central claim with new framing. Long-form readers' attention naturally dips mid-piece; the mid-piece restatement reorients them and refreshes engagement.
 
-Detail in `references/attention-sustaining-techniques.md`.
+Detail in [`references/attention-sustaining-techniques.md`](references/attention-sustaining-techniques.md).
 
 ---
 
@@ -181,7 +181,7 @@ Long-form pieces cite more, and cite more authoritatively, than blog posts. The 
 
 **Inline vs endnote citations.** Long-form on the web typically uses inline links to authoritative sources. For research-heavy pieces, endnote-style citations (numbered footnotes) signal academic rigor; for editorial whitepapers, inline links keep momentum. Either works; pick one and stay consistent within the piece.
 
-Detail in `references/citation-and-source-authority.md`.
+Detail in [`references/citation-and-source-authority.md`](references/citation-and-source-authority.md).
 
 ---
 
@@ -204,7 +204,7 @@ Long-form earns visual breakouts; blog posts often do not. The discipline is whi
 
 **Anti-pattern: the stock-image header.** Generic stock imagery at the top of a long-form piece signals the writer did not commission visual work for the piece. Either commission specific visual work (custom illustrations, branded data visualizations, scene photography) or skip the hero image.
 
-Detail in `references/breakouts-and-visualization.md`.
+Detail in [`references/breakouts-and-visualization.md`](references/breakouts-and-visualization.md).
 
 ---
 
@@ -229,7 +229,7 @@ Long-form pieces with strong closings get shared, get linked, and get remembered
 
 The audit. Ask of any long-form closing: does this leave the reader with something specific to do, decide, or think about, or does it just signal the piece is ending? If the latter, rewrite.
 
-Detail in `references/closing-patterns.md`.
+Detail in [`references/closing-patterns.md`](references/closing-patterns.md).
 
 ---
 
@@ -251,7 +251,7 @@ The decision sequence: format first, distribution shape second. A research repor
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-long-form-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-long-form-failures.md`](references/common-long-form-failures.md).
 
 - "We wrote 5,000 words and traffic is flat." Bloggy-long: stretched to length, no structural depth. Cut to 1,800 words or rewrite as publication-quality.
 - "Our whitepaper looked authoritative but nobody finished it." Academic-bloat: comprehensive but not load-bearing. Cut sections that did not move the argument.

--- a/skills/media-asset-management/SKILL.md
+++ b/skills/media-asset-management/SKILL.md
@@ -302,4 +302,4 @@ A media pipeline document includes:
 
 ## Reference files
 
-- `references/responsive-image-patterns.md`: Copy-paste HTML patterns for common responsive image scenarios (hero, content, art-directed, format negotiation), with explanations.
+- [`references/responsive-image-patterns.md`](references/responsive-image-patterns.md): Copy-paste HTML patterns for common responsive image scenarios (hero, content, art-directed, format negotiation), with explanations.

--- a/skills/monitoring-and-alerting/SKILL.md
+++ b/skills/monitoring-and-alerting/SKILL.md
@@ -253,4 +253,4 @@ A monitoring plan includes:
 
 ## Reference files
 
-- `references/slo-design-guide.md`: Detailed walkthrough of writing SLOs, error budget policies, and common SLO mistakes for web services.
+- [`references/slo-design-guide.md`](references/slo-design-guide.md): Detailed walkthrough of writing SLOs, error budget policies, and common SLO mistakes for web services.

--- a/skills/multi-step-form-design/SKILL.md
+++ b/skills/multi-step-form-design/SKILL.md
@@ -56,7 +56,7 @@ Before designing the steps, decide whether the form should be multi-step at all.
 
 The decision is not "should the form be multi-step"; it is "is multi-step the right structure for this specific data collection and audience."
 
-Detail in `references/multi-step-decision-criteria.md`.
+Detail in [`references/multi-step-decision-criteria.md`](references/multi-step-decision-criteria.md).
 
 ---
 
@@ -92,7 +92,7 @@ The structure that makes steps coherent.
 
 **Step coherence test.** Can each step be described in one sentence as a unit of work? "Step 2: tell us about your company's situation" beats "Step 2: company name, size, industry, and revenue range."
 
-Detail in `references/step-architecture-patterns.md`.
+Detail in [`references/step-architecture-patterns.md`](references/step-architecture-patterns.md).
 
 ---
 
@@ -117,7 +117,7 @@ When to show progress, what to show, how it builds momentum.
 
 **Progress indicator discipline.** The indicator must reflect the actual remaining work, not flatter the user.
 
-Detail in `references/progress-indicator-patterns.md`.
+Detail in [`references/progress-indicator-patterns.md`](references/progress-indicator-patterns.md).
 
 ---
 
@@ -148,7 +148,7 @@ Branching that responds to earlier answers.
 
 **The simplicity preference.** Add conditional logic only when it produces real value. Conditional logic for decoration adds maintenance without lift.
 
-Detail in `references/conditional-logic-patterns.md`.
+Detail in [`references/conditional-logic-patterns.md`](references/conditional-logic-patterns.md).
 
 ---
 
@@ -177,7 +177,7 @@ When to offer save-and-resume, how to communicate trust.
 
 **Trust communication.** Users hesitate to save partial sensitive information. The form should communicate clearly: what is saved, how long it persists, who can access it, how to resume.
 
-Detail in `references/save-and-resume-mechanics.md`.
+Detail in [`references/save-and-resume-mechanics.md`](references/save-and-resume-mechanics.md).
 
 ---
 
@@ -218,7 +218,7 @@ Per-step vs end-only.
 - Inline placement: errors appear next to the field, not in a banner.
 - Specific guidance: "Try a value between 1 and 1000" beats "Out of range."
 
-Detail in `references/validation-strategy-patterns.md`.
+Detail in [`references/validation-strategy-patterns.md`](references/validation-strategy-patterns.md).
 
 ---
 
@@ -242,7 +242,7 @@ Where users abandon, and how to fix it.
 
 **The instrumentation requirement.** Without per-step tracking, drop-off remediation is guesswork. Set up tracking before the form launches.
 
-Detail in `references/drop-off-measurement-and-remediation.md`.
+Detail in [`references/drop-off-measurement-and-remediation.md`](references/drop-off-measurement-and-remediation.md).
 
 ---
 
@@ -268,13 +268,13 @@ Patterns that look like multi-step forms but degrade conversion.
 
 **The variable-step form.** Conditional logic that changes the step count visibly; user feels misled about remaining work.
 
-Detail in `references/form-anti-patterns.md`.
+Detail in [`references/form-anti-patterns.md`](references/form-anti-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-multi-step-form-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-multi-step-form-failures.md`](references/common-multi-step-form-failures.md).
 
 - "Form converts at 4 percent; we expected 12 percent." Likely too long, or the value of completing is not clear, or the form is mobile-broken.
 - "Drop-off concentrates at step 3." Specific-step issue; audit step 3's field count, sensitivity, and clarity.

--- a/skills/okr-design/SKILL.md
+++ b/skills/okr-design/SKILL.md
@@ -75,7 +75,7 @@ Objectives are outcome statements. They name what the team is trying to achieve 
 - Too tactical. "Refactor the auth service" is a tactical decision, not a quarterly objective.
 - Too many. 8 objectives produces no focus; the team works on too many things and excels at none.
 
-Detail in `references/objective-design-patterns.md`.
+Detail in [`references/objective-design-patterns.md`](references/objective-design-patterns.md).
 
 ---
 
@@ -109,7 +109,7 @@ Each key result is measurable, ties to activation, the team can influence it thr
 
 **The 3-5 key results rule.** Most objectives benefit from 3-5 key results. One key result is fragile (single measurement may not capture the outcome); 6+ key results dilute focus.
 
-Detail in `references/key-result-design-patterns.md`.
+Detail in [`references/key-result-design-patterns.md`](references/key-result-design-patterns.md).
 
 ---
 
@@ -135,7 +135,7 @@ When and how to cascade OKRs from leadership to teams.
 
 **The honest disclosure.** Cascading is harder than conference talks suggest. Most orgs over-cascade in the first few cycles and learn to relax it; some never learn and produce OKRs that are increasingly performative as they propagate down.
 
-Detail in `references/cascading-okrs-decisions.md`.
+Detail in [`references/cascading-okrs-decisions.md`](references/cascading-okrs-decisions.md).
 
 ---
 
@@ -159,7 +159,7 @@ End-of-quarter scoring is where OKR practice succeeds or decays.
 
 **The compensation question.** OKRs work best when not directly tied to compensation. When OKRs determine bonuses, sandbagging incentives become severe; teams set OKRs they know they can hit. Most healthy OKR cultures separate goal-setting from compensation.
 
-Detail in `references/scoring-discipline.md`.
+Detail in [`references/scoring-discipline.md`](references/scoring-discipline.md).
 
 ---
 
@@ -183,7 +183,7 @@ When OKRs should change vs when teams should adapt.
 
 **The recalibration discipline.** Recalibration should be rare (1-2 quarters out of 8). Frequent recalibration signals OKR design failure: either too aggressive or not strategically aligned. The recalibration itself should be transparent: surface what changed, why, and what the new targets are.
 
-Detail in `references/mid-quarter-recalibration.md`.
+Detail in [`references/mid-quarter-recalibration.md`](references/mid-quarter-recalibration.md).
 
 ---
 
@@ -215,7 +215,7 @@ OKRs benefit from a structured review rhythm.
 - Distinct from the scoring review. The retrospective examines the OKR practice itself: were the OKRs the right ones, did the cadence work, what should change.
 - Often combined with the next-quarter OKR setting session.
 
-Detail in `references/review-cadence-templates.md`.
+Detail in [`references/review-cadence-templates.md`](references/review-cadence-templates.md).
 
 ---
 
@@ -242,13 +242,13 @@ Three concepts often conflated. Each serves a different purpose.
 - Treating every metric as needing an OKR. Some metrics matter for the team to track without setting quarterly targets on them.
 - Treating OKRs as roadmap commitments. OKRs name outcomes; the team is committed to pursuing them but may shift tactics; treating OKRs as roadmap commitments locks in tactics that may need to change.
 
-Detail in `references/okrs-vs-roadmap-vs-metrics.md`.
+Detail in [`references/okrs-vs-roadmap-vs-metrics.md`](references/okrs-vs-roadmap-vs-metrics.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-okr-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-okr-failures.md`](references/common-okr-failures.md).
 
 - "Our OKRs are always 100% and produce no signal." Sandbagged. Set with stretch ambition; expect 60-70% scores.
 - "Our OKRs are always 30% and demoralizing." Fantasy. Recalibrate to genuine stretch; investigate whether the targets are achievable in any realistic effort path.

--- a/skills/onboarding-wizard-design/SKILL.md
+++ b/skills/onboarding-wizard-design/SKILL.md
@@ -56,7 +56,7 @@ Before designing the wizard, decide whether a wizard is the right tool.
 
 The decision is not "should we have an onboarding wizard"; it is "is the wizard the right tool for this specific product and audience."
 
-Detail in `references/wizard-decision-criteria.md`.
+Detail in [`references/wizard-decision-criteria.md`](references/wizard-decision-criteria.md).
 
 ---
 
@@ -91,7 +91,7 @@ The structure that makes wizards actually work.
 
 **Step coherence test.** Each step should answer: did this step move the user closer to value? Steps that exist for completeness or feature-pride should be cut.
 
-Detail in `references/step-architecture-patterns.md`.
+Detail in [`references/step-architecture-patterns.md`](references/step-architecture-patterns.md).
 
 ---
 
@@ -121,7 +121,7 @@ What the wizard is actually trying to engineer.
 - **First saved configuration.** The user set up something they will return to.
 - **First value-demonstrating insight.** The user saw a metric, recommendation, or pattern that surprised them.
 
-Detail in `references/ah-ha-moment-engineering.md`.
+Detail in [`references/ah-ha-moment-engineering.md`](references/ah-ha-moment-engineering.md).
 
 ---
 
@@ -141,7 +141,7 @@ How to surface only what is needed at each step.
 
 The discipline. Each piece of information shown in the wizard must justify its inclusion. Decorative information adds friction; surface it later.
 
-Detail in `references/progressive-disclosure-patterns.md`.
+Detail in [`references/progressive-disclosure-patterns.md`](references/progressive-disclosure-patterns.md).
 
 ---
 
@@ -168,7 +168,7 @@ When users skip, where they land. When they resume, what they see.
 
 **The cure.** Skip is honest about consequences and offers a path back. The user who skips knows what they skipped.
 
-Detail in `references/skip-and-resume-mechanics.md`.
+Detail in [`references/skip-and-resume-mechanics.md`](references/skip-and-resume-mechanics.md).
 
 ---
 
@@ -192,7 +192,7 @@ Where users abandon the wizard, and how to fix it.
 
 **The instrumentation requirement.** Without per-step tracking, drop-off remediation is guesswork. Set up tracking before launch.
 
-Detail in `references/drop-off-measurement-templates.md`.
+Detail in [`references/drop-off-measurement-templates.md`](references/drop-off-measurement-templates.md).
 
 ---
 
@@ -214,13 +214,13 @@ Different users may need different wizards.
 
 **The over-differentiated trap.** Too many variants produce unmaintainable wizards. Most wizards work with 2-3 variants at most.
 
-Detail in `references/user-type-variation-patterns.md`.
+Detail in [`references/user-type-variation-patterns.md`](references/user-type-variation-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-onboarding-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-onboarding-failures.md`](references/common-onboarding-failures.md).
 
 - "Activation rate is low; completion rate is high." Wizard completed but did not engineer the ah-ha moment. Audit what users did after completing.
 - "Skip rate is over 50 percent." Either the wizard is not earning its time or skip is too prominent. Audit both.

--- a/skills/paid-media-strategy/SKILL.md
+++ b/skills/paid-media-strategy/SKILL.md
@@ -60,7 +60,7 @@ Pick the channel where intent matches your offer. Run the wrong channel and your
 
 **YouTube (Google).** Video at scale. Best for awareness or for B2C consideration. Underrated for B2B SaaS in some categories where the buyer-research path includes long-form video.
 
-The decision rule. Start with the channel where intent matches your offer. Search for high-intent demand capture. Meta or TikTok for demand creation. LinkedIn for B2B precision. Do not run all of them at once until you have proven any of them. Detail in `references/channel-decision-matrix.md`.
+The decision rule. Start with the channel where intent matches your offer. Search for high-intent demand capture. Meta or TikTok for demand creation. LinkedIn for B2B precision. Do not run all of them at once until you have proven any of them. Detail in [`references/channel-decision-matrix.md`](references/channel-decision-matrix.md).
 
 ---
 
@@ -78,7 +78,7 @@ Four splits operate at the same time. Get them all right and the budget compound
 
 Budget pacing matters too. Front-load some weeks to test creative aggressively. Back-load others to capture seasonality (holiday, end-of-quarter, category-specific moments). Do not run flat; flat budgets miss the demand peaks.
 
-Detail and templates in `references/budget-allocation-templates.md`.
+Detail and templates in [`references/budget-allocation-templates.md`](references/budget-allocation-templates.md).
 
 ---
 
@@ -94,7 +94,7 @@ Three audience types. Treat them as separate strategies.
 
 Common mistakes. Prospecting too narrow (not enough audience for the platform to optimize). Retargeting too aggressive (cannibalizing organic conversions). No exclusions (paying to advertise to your own paying customers). Lookalikes off the wrong source (use top-LTV customers, not all customers).
 
-Detail in `references/audience-segmentation-patterns.md`.
+Detail in [`references/audience-segmentation-patterns.md`](references/audience-segmentation-patterns.md).
 
 ---
 
@@ -116,7 +116,7 @@ Bid strategy depends on data state. New campaigns need a different strategy than
 
 The progression for new campaigns: start manual or maximize conversions to gather data, switch to tCPA or tROAS once you have 30+ conversions, revisit periodically.
 
-Common mistakes. Using tCPA before you have 30+ conversions (no data to optimize against). Setting tROAS too aggressively (platform throttles delivery). Switching strategies too often (each change resets the learning phase). Detail in `references/bid-strategy-reference.md`.
+Common mistakes. Using tCPA before you have 30+ conversions (no data to optimize against). Setting tROAS too aggressively (platform throttles delivery). Switching strategies too often (each change resets the learning phase). Detail in [`references/bid-strategy-reference.md`](references/bid-strategy-reference.md).
 
 ---
 
@@ -132,7 +132,7 @@ For each major platform, the campaign types and when to use them.
 
 **TikTok.** In-Feed, TopView, Spark Ads, Branded Hashtag Challenge. Spark Ads (boost organic posts) outperform pure paid creative because they retain organic-feel signal. Use Spark when you have organic posts performing.
 
-Detail per platform in `references/campaign-type-reference.md`.
+Detail per platform in [`references/campaign-type-reference.md`](references/campaign-type-reference.md).
 
 ---
 
@@ -190,13 +190,13 @@ The trap. Platform-reported conversions are inflated by view-through attribution
 
 The discipline. Single source of truth in your warehouse or analytics platform. Report against that for incrementality decisions. Use platform metrics for in-flight optimization only. The deeper interpretation work belongs in `ads-performance-analytics` (forthcoming); this skill names the trap so you do not optimize against the wrong number.
 
-Per-platform reporting quirks in `references/ads-platform-comparison.md`.
+Per-platform reporting quirks in [`references/ads-platform-comparison.md`](references/ads-platform-comparison.md).
 
 ---
 
 ## Common failures
 
-Twelve patterns recur across paid media work. The short version. Detail in `references/common-failures.md`.
+Twelve patterns recur across paid media work. The short version. Detail in [`references/common-failures.md`](references/common-failures.md).
 
 - "We are scaling but CAC went up." Saturation on the primary audience. Expand the audience or diversify the channel mix.
 - "Conversions look fine in the platform, terrible in revenue." Attribution mismatch plus customer quality, not just count. The platform is selecting low-LTV converters because they are easier to find.

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -269,6 +269,6 @@ For complex audits, include:
 
 ## Reference files
 
-- `references/audit-template.md` - Full performance audit report template.
-- `references/optimization-checklist.md` - Quick-reference checklist of common optimizations by priority.
-- `references/optimization-playbook.md` - Symptom-to-fix playbook for the common Core Web Vitals problems (LCP, INP, CLS).
+- [`references/audit-template.md`](references/audit-template.md) - Full performance audit report template.
+- [`references/optimization-checklist.md`](references/optimization-checklist.md) - Quick-reference checklist of common optimizations by priority.
+- [`references/optimization-playbook.md`](references/optimization-playbook.md) - Symptom-to-fix playbook for the common Core Web Vitals problems (LCP, INP, CLS).

--- a/skills/pillar-content-architecture/SKILL.md
+++ b/skills/pillar-content-architecture/SKILL.md
@@ -49,7 +49,7 @@ The pathology. Most content programs are 80% orphans, 15% accidental clusters, 5
 
 The reading model. Search engines and AI engines both read internal-link graphs to infer topical authority. A pillar with 12 well-linked cluster pieces signals depth on a topic. 12 orphans on the same topic signal scattered, less-authoritative coverage. The architecture is the signal.
 
-Detail and decision tree in `references/pillar-cluster-decision.md`.
+Detail and decision tree in [`references/pillar-cluster-decision.md`](references/pillar-cluster-decision.md).
 
 ---
 
@@ -65,7 +65,7 @@ Not every topic deserves a pillar. The five-criterion selection framework:
 
 The "everything is a pillar" anti-pattern. Teams call any 3,000-word piece a pillar. Length does not make a pillar. The architecture does. Pillar is the role a piece plays in the hub structure, not the word count.
 
-Detail in `references/topic-selection-criteria.md`.
+Detail in [`references/topic-selection-criteria.md`](references/topic-selection-criteria.md).
 
 ---
 
@@ -79,7 +79,7 @@ Once a pillar is selected, plan its cluster:
 4. **Cluster heterogeneity.** Clusters should cover the topic from multiple angles (definition, how-to, comparison, examples, common mistakes, costs, alternatives, case studies) rather than 12 variations of "what is X."
 5. **Sequence.** Ship pillar first (or alongside the first 3 to 5 clusters). The link graph will not form without the pillar in place; clusters that link to a non-existent pillar are orphans-in-waiting.
 
-Detail in `references/cluster-planning-patterns.md`.
+Detail in [`references/cluster-planning-patterns.md`](references/cluster-planning-patterns.md).
 
 ---
 
@@ -97,7 +97,7 @@ The hub's internal-link graph is what actually produces topical authority signal
 
 The "linking inventory" pattern. Maintain a sheet (or database row, or dbt model) tracking every link in the hub, who links to whom, and the anchor text used. Audit quarterly to catch broken links, anchor-text drift, and missing connections that should exist.
 
-Detail in `references/internal-linking-architecture.md`.
+Detail in [`references/internal-linking-architecture.md`](references/internal-linking-architecture.md).
 
 ---
 
@@ -115,7 +115,7 @@ URL patterns matter for both crawl clarity and reader navigation. Decision facto
 
 The "/blog/ trap." Teams put pillar and clusters under `/blog/` because that is where the CMS folder is. This works structurally but loses the URL signal that says "these pieces belong together as a topical hub."
 
-Detail in `references/url-structure-patterns.md`.
+Detail in [`references/url-structure-patterns.md`](references/url-structure-patterns.md).
 
 ---
 
@@ -133,7 +133,7 @@ A pillar page does specific work. The standard sections:
 
 Pillar length. 3,000 to 5,000 words is the typical range. Pillar quality is comprehensiveness AND depth, not just word count. A 6,000-word pillar that covers 3 facets is worse than a 4,000-word pillar that covers 12 facets.
 
-Detail in `references/pillar-page-anatomy.md`.
+Detail in [`references/pillar-page-anatomy.md`](references/pillar-page-anatomy.md).
 
 ---
 
@@ -149,7 +149,7 @@ Cluster pieces have a different shape:
 
 Cluster length. 800 to 2,000 words typical. A cluster piece longer than 2,500 words is probably a mini-pillar that should either get promoted to its own pillar or be split into two cluster pieces.
 
-Detail in `references/cluster-piece-anatomy.md`.
+Detail in [`references/cluster-piece-anatomy.md`](references/cluster-piece-anatomy.md).
 
 ---
 
@@ -177,7 +177,7 @@ Signals that make hub architecture compound into authority. The two-engine view:
 
 The two-engine optimization is complementary, not competing. Both reward depth, structure, and entity coverage. The hub architecture creates more surface area for both signal types than scattered orphan content can.
 
-Detail in `references/topical-authority-signals.md` and the `seo-aeo-geo` skill for AEO/GEO strategy at the program level.
+Detail in [`references/topical-authority-signals.md`](references/topical-authority-signals.md) and the `seo-aeo-geo` skill for AEO/GEO strategy at the program level.
 
 ---
 
@@ -193,13 +193,13 @@ Hubs decay if not maintained. The discipline:
 
 The "set and forget" failure. Hub launches, ranks, drives traffic for 2 years, then decays without anyone noticing because nobody owns the hub long-term. Hub ownership is durable: single owner across 3 to 5 year horizons, not "the team that launched it."
 
-Detail in `references/content-refresh-patterns.md`.
+Detail in [`references/content-refresh-patterns.md`](references/content-refresh-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-pillar-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-pillar-failures.md`](references/common-pillar-failures.md).
 
 - "We have 80 blog posts but no rankings." Orphan content; no hub architecture.
 - "Our 8,000-word pillar does not rank." Comprehensive but no cluster support; pillar without a hub is just a long article.

--- a/skills/pm-spec-writing/SKILL.md
+++ b/skills/pm-spec-writing/SKILL.md
@@ -221,6 +221,6 @@ specs/
 
 ## Reference files
 
-- `references/feature-spec-template.md` - Full feature spec template.
-- `references/dev-brief-template.md` - Compact dev brief template for tactical work.
-- `references/prioritization-frameworks.md` - Beyond impact/effort: RICE, weighted scoring, MoSCoW.
+- [`references/feature-spec-template.md`](references/feature-spec-template.md) - Full feature spec template.
+- [`references/dev-brief-template.md`](references/dev-brief-template.md) - Compact dev brief template for tactical work.
+- [`references/prioritization-frameworks.md`](references/prioritization-frameworks.md) - Beyond impact/effort: RICE, weighted scoring, MoSCoW.

--- a/skills/product-analytics-setup/SKILL.md
+++ b/skills/product-analytics-setup/SKILL.md
@@ -56,7 +56,7 @@ The verbs vs states trap.
 
 How many events to design. Thirty to fifty events is the sweet spot for a typical SaaS product. Below twenty means under-instrumented; above one hundred almost always means tracking UI noise or duplicating events in different formats.
 
-Detail and a canonical event spec in `references/event-taxonomy-template.md`.
+Detail and a canonical event spec in [`references/event-taxonomy-template.md`](references/event-taxonomy-template.md).
 
 ---
 
@@ -78,7 +78,7 @@ Data type discipline.
 - **Timestamps** in ISO 8601, always. Always. The number of bugs caused by inconsistent date formats is uncountable.
 - **Arrays** rarely. An array property is usually a sign you should split into multiple events with one item per event.
 
-Worked example in `references/property-design-patterns.md` showing right and wrong design for a `product_viewed` event.
+Worked example in [`references/property-design-patterns.md`](references/property-design-patterns.md) showing right and wrong design for a `product_viewed` event.
 
 ---
 
@@ -99,7 +99,7 @@ What NOT to do.
 
 The naming convention reference file provides a complete style guide. Cite it in your team's data contract.
 
-Detail in `references/naming-convention-reference.md`.
+Detail in [`references/naming-convention-reference.md`](references/naming-convention-reference.md).
 
 ---
 
@@ -123,7 +123,7 @@ The data contract idea.
 - Code review every schema change. Schema is product, not afterthought.
 - CI lint rejects schema violations before they hit production. The deploy that adds an event with the wrong type fails the build.
 
-Detail in `references/schema-versioning-patterns.md`.
+Detail in [`references/schema-versioning-patterns.md`](references/schema-versioning-patterns.md).
 
 ---
 
@@ -143,7 +143,7 @@ Common funnel mistakes.
 - Funnels with the same event in multiple positions. The platform handles this poorly; the analyst handles it worse.
 - Mixing different time windows in one funnel. "Users who signed up within 7 days AND converted within 30 days" is two different cohort definitions glued together.
 
-Common funnel shapes and time-window guidance in `references/funnel-design-templates.md`.
+Common funnel shapes and time-window guidance in [`references/funnel-design-templates.md`](references/funnel-design-templates.md).
 
 ---
 
@@ -162,7 +162,7 @@ Cohort discipline.
 - Version them when criteria change. Compare apples-to-apples.
 - Do not compare a 30-day-old cohort to a 365-day-old cohort on retention; the older cohort has had more time to retain by definition.
 
-Detail in `references/cohort-definition-patterns.md`.
+Detail in [`references/cohort-definition-patterns.md`](references/cohort-definition-patterns.md).
 
 ---
 
@@ -182,7 +182,7 @@ Retention curve interpretation.
 - Gradual decay across weeks with no plateau. No one is sticking. Usually a value-prop or onboarding problem; the product is not delivering recurring value.
 - Flat line at low percentage. A power-user product with a small but engaged base. Not a problem; just a different shape.
 
-Detail in `references/retention-measurement-patterns.md`.
+Detail in [`references/retention-measurement-patterns.md`](references/retention-measurement-patterns.md).
 
 ---
 
@@ -205,7 +205,7 @@ Supporting metrics framework.
 - Three to five input metrics that drive the NSM. For "weekly active editors" these might be: signups per week, signup-to-active conversion rate, week-over-week active retention.
 - Five to ten health metrics that warn of problems. Monthly churn rate, account-level concentration, support ticket volume.
 
-Detail and product-type-specific examples in `references/north-star-metric-selection.md`.
+Detail and product-type-specific examples in [`references/north-star-metric-selection.md`](references/north-star-metric-selection.md).
 
 ---
 
@@ -239,7 +239,7 @@ Instrumentation debt is real and compounds like technical debt. The discipline.
 - Quarterly schema audits. Identify orphan events (firing but not used in any dashboard or query) and deprecate them. Identify gaps (features without events) and fill them.
 - "If we cannot measure it, we do not ship it" with explicit exceptions for genuinely experimental features where the cost of instrumentation exceeds the value of the data.
 
-Detail in `references/instrumentation-audit-checklist.md`.
+Detail in [`references/instrumentation-audit-checklist.md`](references/instrumentation-audit-checklist.md).
 
 ---
 
@@ -260,7 +260,7 @@ Twelve patterns recur across product analytics setups. The short version.
 - "Two analysts compute different MAU." Different identity stitching. Pick one canonical identity layer and make everyone query from it.
 - "Numbers are different than last quarter for no reason." Underlying schema changed without versioning. The dashboard quietly broke; nobody noticed until the gap got large.
 
-Detail in `references/common-failures.md`.
+Detail in [`references/common-failures.md`](references/common-failures.md).
 
 ---
 

--- a/skills/product-configurator-design/SKILL.md
+++ b/skills/product-configurator-design/SKILL.md
@@ -57,7 +57,7 @@ Before designing the configurator, decide whether a configurator is the right an
 
 The decision is not "should we have a configurator"; it is "is the configurator the right tool for this product and audience."
 
-Detail in `references/configurator-decision-criteria.md`.
+Detail in [`references/configurator-decision-criteria.md`](references/configurator-decision-criteria.md).
 
 ---
 
@@ -97,7 +97,7 @@ The starting point.
 
 **The cure.** Default-heavy. The user adjusts; never builds from zero.
 
-Detail in `references/default-configuration-design.md`.
+Detail in [`references/default-configuration-design.md`](references/default-configuration-design.md).
 
 ---
 
@@ -124,7 +124,7 @@ Preventing invalid combinations; surfacing why.
 
 **The under-constrained trap.** User builds configuration that fails at checkout or fulfillment.
 
-Detail in `references/constraint-logic-patterns.md`.
+Detail in [`references/constraint-logic-patterns.md`](references/constraint-logic-patterns.md).
 
 ---
 
@@ -151,7 +151,7 @@ Pricing that responds to choices.
 
 **The cure.** Price visible throughout. No surprises at checkout.
 
-Detail in `references/real-time-pricing-patterns.md`.
+Detail in [`references/real-time-pricing-patterns.md`](references/real-time-pricing-patterns.md).
 
 ---
 
@@ -177,7 +177,7 @@ When the configurator catches invalid input.
 
 **The validation-loose trap.** Configurator accepts inputs that fail downstream.
 
-Detail in `references/validation-and-error-patterns.md`.
+Detail in [`references/validation-and-error-patterns.md`](references/validation-and-error-patterns.md).
 
 ---
 
@@ -205,7 +205,7 @@ Configurations users return to or send to others.
 - B2B configurations often need stakeholder review.
 - Returning users continue rather than restart.
 
-Detail in `references/save-and-share-mechanics.md`.
+Detail in [`references/save-and-share-mechanics.md`](references/save-and-share-mechanics.md).
 
 ---
 
@@ -225,13 +225,13 @@ When the user commits.
 
 **The cure.** Handoff loop closed. Configuration visible in cart; price matches; edits possible.
 
-Detail in `references/configurator-to-cart-handoff.md`.
+Detail in [`references/configurator-to-cart-handoff.md`](references/configurator-to-cart-handoff.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-configurator-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-configurator-failures.md`](references/common-configurator-failures.md).
 
 - "Users abandon halfway through configuration." Likely infinite-options pattern; too many decisions.
 - "Configurator generates valid-looking configs that fail at fulfillment." Under-constrained; constraint logic missing.

--- a/skills/programmatic-seo/SKILL.md
+++ b/skills/programmatic-seo/SKILL.md
@@ -58,7 +58,7 @@ pSEO does NOT work when:
 
 The honest framing. Most teams that ask "should we do pSEO?" should hear "probably not, unless the underlying data is unique or first-party expertise makes the pages actually useful." The reputation problem is not the technique; it is the technique applied without underlying value.
 
-Detail in `references/when-pseo-works-decision.md`.
+Detail in [`references/when-pseo-works-decision.md`](references/when-pseo-works-decision.md).
 
 ---
 
@@ -78,7 +78,7 @@ The data source is the pSEO program. Common sources with different defensibility
 
 The "moat" question. Would a competitor be able to replicate the data source? If yes, the pSEO program has no defensibility; anyone can copy. If no, the data source becomes a moat that compounds. Zillow's MLS partnerships, Glassdoor's employee reviews, Crunchbase's funding data, are moats. "Scraped Wikipedia plus AI rewrite" is not.
 
-Detail in `references/data-source-identification-patterns.md`.
+Detail in [`references/data-source-identification-patterns.md`](references/data-source-identification-patterns.md).
 
 ---
 
@@ -100,7 +100,7 @@ The template is the structure that data fills. Design principles.
 
 The template's quality bar. A randomly sampled page from the set, viewed in isolation, should answer the user's likely query competently. If a randomly sampled page is thin, the entire set is thin.
 
-Detail in `references/template-design-patterns.md`.
+Detail in [`references/template-design-patterns.md`](references/template-design-patterns.md).
 
 ---
 
@@ -120,7 +120,7 @@ The data shape that drives the template. Design principles.
 
 The "schema-as-product" principle. The schema that drives pSEO IS the product surface. Treat it with the same rigor as a database schema for a customer-facing application. Versioned, reviewed, documented, breaking-change-aware.
 
-Detail in `references/schema-design-patterns.md`.
+Detail in [`references/schema-design-patterns.md`](references/schema-design-patterns.md).
 
 ---
 
@@ -140,7 +140,7 @@ Auditing all 100,000 pages individually is infeasible. The discipline.
 
 The team budget question. A 10,000-page pSEO set requires roughly 0.5 to 1.0 FTE of ongoing quality control discipline. If that is not budgeted, the program will decay. The set will look fine on launch and degrade over 6 to 12 months as data drifts, templates ship without QC, and the gap between the QC plan and the actual cadence widens.
 
-Detail in `references/quality-control-at-scale.md`.
+Detail in [`references/quality-control-at-scale.md`](references/quality-control-at-scale.md).
 
 ---
 
@@ -160,7 +160,7 @@ pSEO sets need intentional internal linking architecture to compound.
 
 The PageRank flow principle. Internal linking is what makes pSEO sets compound. A well-linked set distributes ranking signal across all pages; a poorly-linked set has hub pages ranking and child pages orphaned. The link architecture is half the program; the data is the other half.
 
-Detail in `references/internal-linking-at-scale.md`.
+Detail in [`references/internal-linking-at-scale.md`](references/internal-linking-at-scale.md).
 
 ---
 
@@ -178,7 +178,7 @@ Search engines have crawl budgets. Large pSEO sets can exhaust them.
 
 **Pruning criteria.** Pages that fail to attract clicks or impressions for 6+ months should noindex or 410. Pruning is hygiene, not failure. A 100,000-page set with 60% earning traffic is healthier than the same set with 40% earning traffic plus 60% dead weight crawlers waste budget on.
 
-Detail in `references/crawl-budget-management.md`.
+Detail in [`references/crawl-budget-management.md`](references/crawl-budget-management.md).
 
 ---
 
@@ -196,7 +196,7 @@ Answer engines treat programmatic pages differently from editorial pages.
 
 The "two-engine optimization" framing applies. pSEO pages should serve both search engines and answer engines. Most pSEO programs were designed pre-AEO and need template updates for the new surface: stronger top-200-word answers, deeper schema markup, FAQPage schema where the page contains FAQ structure.
 
-Detail in `references/aeo-geo-for-programmatic-pages.md`.
+Detail in [`references/aeo-geo-for-programmatic-pages.md`](references/aeo-geo-for-programmatic-pages.md).
 
 ---
 
@@ -212,13 +212,13 @@ pSEO sets decay if not maintained.
 
 **Set-level refresh.** Occasionally the entire set's template needs a refresh as user expectations evolve, AI engine signals shift, or category conventions change. Set-level refreshes are 6-month projects, not weekend cleanups.
 
-Detail in `references/refresh-at-scale.md`.
+Detail in [`references/refresh-at-scale.md`](references/refresh-at-scale.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-pseo-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-pseo-failures.md`](references/common-pseo-failures.md).
 
 - "We generated 50,000 pages and got penalized." Thin content, scaled too fast, no QC discipline.
 - "We have 10,000 pages but only 200 rank." Internal linking architecture missing; child pages are orphans.

--- a/skills/qa-testing/SKILL.md
+++ b/skills/qa-testing/SKILL.md
@@ -266,7 +266,7 @@ if (issues.length) {
 3. **Note failures.** Each failure either gets fixed before ship or filed as a known issue.
 4. **For Standard tier**, add: visual review at 375px, 768px, 1440px. Test the primary user flow.
 5. **For Full tier**, add: cross-browser testing, Lighthouse audit, schema validation, security headers, 404 handling.
-6. **Document.** Use the template in `references/qa-report-template.md` for full audits.
+6. **Document.** Use the template in [`references/qa-report-template.md`](references/qa-report-template.md) for full audits.
 
 ---
 
@@ -285,10 +285,10 @@ if (issues.length) {
 
 For smoke tests: console output is the report.
 
-For standard and full audits: a markdown report at `qa-report-[date].md`. Use the template in `references/qa-report-template.md`.
+For standard and full audits: a markdown report at `qa-report-[date].md`. Use the template in [`references/qa-report-template.md`](references/qa-report-template.md).
 
 ---
 
 ## Reference files
 
-- `references/qa-report-template.md` - Markdown report template for standard and full audits.
+- [`references/qa-report-template.md`](references/qa-report-template.md) - Markdown report template for standard and full audits.

--- a/skills/quiz-and-assessment-design/SKILL.md
+++ b/skills/quiz-and-assessment-design/SKILL.md
@@ -58,7 +58,7 @@ Before designing the quiz, decide whether a quiz is the right tool for the audie
 
 The decision is not "should we have a quiz"; it is "is the quiz the right next investment for this specific audience and decision."
 
-Detail in `references/quiz-investment-criteria.md`.
+Detail in [`references/quiz-investment-criteria.md`](references/quiz-investment-criteria.md).
 
 ---
 
@@ -101,7 +101,7 @@ The questions are the mechanism that produces the segmentation. Bad questions pr
 
 **Question-segment mapping.** Each question should contribute to the segmentation in a defined way. Questions that do not affect the result are filler; remove them.
 
-Detail in `references/question-architecture-patterns.md`.
+Detail in [`references/question-architecture-patterns.md`](references/question-architecture-patterns.md).
 
 ---
 
@@ -126,7 +126,7 @@ The math that turns answers into a segment.
 
 **Scoring transparency.** Some quizzes show the score during or after the quiz; others present only the segment. The choice depends on whether the score is meaningful to the user. Personality assessments benefit from showing dimensions; recommendation quizzes often do not.
 
-Detail in `references/scoring-algorithm-patterns.md`.
+Detail in [`references/scoring-algorithm-patterns.md`](references/scoring-algorithm-patterns.md).
 
 ---
 
@@ -147,7 +147,7 @@ How many segments, named how, distinguishable from each other.
 
 **Segment balance.** The quiz should not always route 80 percent of takers to one segment. Balanced segmentation (each segment receives a meaningful share of takers) signals that the questions actually distinguish.
 
-Detail in `references/result-categorization-patterns.md`.
+Detail in [`references/result-categorization-patterns.md`](references/result-categorization-patterns.md).
 
 ---
 
@@ -176,7 +176,7 @@ The action attached to each category. This is where the quiz earns its conversio
 
 **The actionable-segmentation win.** Result describes the segment, then says: "Strategic Planners benefit most from [specific resource or product or path]. Here is the next step." The taker has a specific action.
 
-Detail in `references/result-to-recommendation-mapping.md`.
+Detail in [`references/result-to-recommendation-mapping.md`](references/result-to-recommendation-mapping.md).
 
 ---
 
@@ -196,7 +196,7 @@ When and where to ask for the email, with what value-add.
 
 **Conversion vs lead quality.** Pattern A converts higher; Pattern B and C produce higher lead quality. Pattern choice depends on what the program optimizes for.
 
-Detail in `references/lead-capture-integration-patterns.md`.
+Detail in [`references/lead-capture-integration-patterns.md`](references/lead-capture-integration-patterns.md).
 
 ---
 
@@ -220,13 +220,13 @@ Patterns that look like quizzes but degrade trust.
 
 **The mismatched-recommendation quiz.** Recommendation does not match the segment. Audience that catches the mismatch loses trust.
 
-Detail in `references/quiz-anti-patterns.md`.
+Detail in [`references/quiz-anti-patterns.md`](references/quiz-anti-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-quiz-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-quiz-failures.md`](references/common-quiz-failures.md).
 
 - "Quiz gets shared widely; lead quality is poor." Clickbait pattern; the audience taking and sharing is not the audience the brand serves.
 - "Engagement is high; downstream conversion is near zero." Vanity-result pattern; takers enjoyed the segment but had no next step.

--- a/skills/roadmap-planning/SKILL.md
+++ b/skills/roadmap-planning/SKILL.md
@@ -141,7 +141,7 @@ Inside each theme, rank the initiatives. Use one prioritization framework consis
 
 The framework matters less than the consistency. Pick one. Use it the same way for every initiative. Document the math.
 
-See `references/prioritization-frameworks.md` for the full breakdown.
+See [`references/prioritization-frameworks.md`](references/prioritization-frameworks.md) for the full breakdown.
 
 ### Step 4: Build the dependency map
 
@@ -225,4 +225,4 @@ The roadmap is a living document. Plan to revisit it monthly. Replan it formally
 
 ## Reference files
 
-- `references/prioritization-frameworks.md` - Detailed breakdown of RICE, MoSCoW, Kano, Cost of Delay, and Strategic Alignment frameworks. When to use each, how to apply them, common mistakes.
+- [`references/prioritization-frameworks.md`](references/prioritization-frameworks.md) - Detailed breakdown of RICE, MoSCoW, Kano, Cost of Delay, and Strategic Alignment frameworks. When to use each, how to apply them, common mistakes.

--- a/skills/scheduler-and-booking-design/SKILL.md
+++ b/skills/scheduler-and-booking-design/SKILL.md
@@ -56,7 +56,7 @@ Before designing the scheduler, decide whether a scheduler is the right tool.
 
 The decision is not "should we have a scheduler"; it is "is the scheduler the right next investment for this audience and goal."
 
-Detail in `references/scheduler-decision-criteria.md`.
+Detail in [`references/scheduler-decision-criteria.md`](references/scheduler-decision-criteria.md).
 
 ---
 
@@ -97,7 +97,7 @@ Which fields earn their place; which create friction.
 
 **The five-field rule.** Most production schedulers work well with 3-5 qualification fields. More than 5 starts producing interrogation-gate dynamics. Less than 3 does not give the rep useful prep context.
 
-Detail in `references/qualification-field-design.md`.
+Detail in [`references/qualification-field-design.md`](references/qualification-field-design.md).
 
 ---
 
@@ -127,7 +127,7 @@ When to use. Most production teams.
 
 **The match-to-rep discipline.** The qualification fields feed routing logic. Routing fails if qualification does not capture routing-relevant data.
 
-Detail in `references/availability-logic-patterns.md`.
+Detail in [`references/availability-logic-patterns.md`](references/availability-logic-patterns.md).
 
 ---
 
@@ -147,7 +147,7 @@ Different reps for different lead types.
 
 **The unrouted lead.** Some leads do not fit obvious routing. Default rule needed: round-robin or specific catchall.
 
-Detail in `references/routing-patterns.md`.
+Detail in [`references/routing-patterns.md`](references/routing-patterns.md).
 
 ---
 
@@ -168,7 +168,7 @@ Briefing the rep before the call.
 
 **Weak prep automation.** The rep has the qualification data but it is buried in a CRM field nobody opens. The rep starts the call cold despite the data.
 
-Detail in `references/prep-automation-patterns.md`.
+Detail in [`references/prep-automation-patterns.md`](references/prep-automation-patterns.md).
 
 ---
 
@@ -186,7 +186,7 @@ The communications around the booking.
 
 **The reminder discipline.** Reminders are useful; over-reminding is friction. Two reminders (24-hour and 1-hour) is typical.
 
-Detail in `references/reminder-sequence-patterns.md`.
+Detail in [`references/reminder-sequence-patterns.md`](references/reminder-sequence-patterns.md).
 
 ---
 
@@ -209,13 +209,13 @@ What happens when meetings do not go to plan.
 
 **The respect-the-no principle.** Prospects who no-show twice often do not want the meeting. Multiple aggressive reschedule attempts feel like pressure.
 
-Detail in `references/reschedule-and-no-show-handling.md`.
+Detail in [`references/reschedule-and-no-show-handling.md`](references/reschedule-and-no-show-handling.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-scheduler-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-scheduler-failures.md`](references/common-scheduler-failures.md).
 
 - "Booking conversion is high; demo conversion to sale is low." Qualification too thin; cold demos do not convert.
 - "Booking conversion is low; demo conversion to sale is high." Interrogation-gate; qualification scares off would-be buyers.

--- a/skills/security-baseline/SKILL.md
+++ b/skills/security-baseline/SKILL.md
@@ -293,4 +293,4 @@ A security baseline document includes:
 
 ## Reference files
 
-- `references/headers-checklist.md`: A copy-paste checklist of recommended security headers with example values, organized by tier of importance.
+- [`references/headers-checklist.md`](references/headers-checklist.md): A copy-paste checklist of recommended security headers with example values, organized by tier of importance.

--- a/skills/seo-aeo-geo/SKILL.md
+++ b/skills/seo-aeo-geo/SKILL.md
@@ -84,7 +84,7 @@ Schema is how you speak machine-readable language. AI assistants parse it heavil
 
 Beyond traditional SEO, AI tools need access patterns of their own.
 
-- **llms.txt at the site root.** A markdown file at `/llms.txt` describing the site's content, key URLs, and what topics the site covers. See `references/llms-txt-guide.md`.
+- **llms.txt at the site root.** A markdown file at `/llms.txt` describing the site's content, key URLs, and what topics the site covers. See [`references/llms-txt-guide.md`](references/llms-txt-guide.md).
 - **llms-full.txt** (optional) - a complete content dump for AI training and context, if the site permits it.
 - **robots.txt allowing AI crawlers.** Decide explicitly which AI crawlers to allow (GPTBot, ClaudeBot, Google-Extended, PerplexityBot, etc.) or disallow. Do not block by default if visibility matters.
 - **Clean HTML semantics.** Semantic tags (`article`, `section`, `nav`, `main`) help AI parse structure.
@@ -146,5 +146,5 @@ Default output is a markdown plan at `aeo-geo-strategy.md`. Structure:
 
 ## Reference files
 
-- `references/llms-txt-guide.md` - How to write a useful llms.txt, with examples.
-- `references/extraction-friendly-patterns.md` - Content patterns that AI extracts cleanly, with before/after examples.
+- [`references/llms-txt-guide.md`](references/llms-txt-guide.md) - How to write a useful llms.txt, with examples.
+- [`references/extraction-friendly-patterns.md`](references/extraction-friendly-patterns.md) - Content patterns that AI extracts cleanly, with before/after examples.

--- a/skills/seo-audit-orchestration/SKILL.md
+++ b/skills/seo-audit-orchestration/SKILL.md
@@ -120,7 +120,7 @@ Tie each theme to a measurable target (organic clicks, ranked keywords in target
 
 ### Phase 6: Deliver
 
-Produce the rollup report. See `references/audit-rollup-template.md`.
+Produce the rollup report. See [`references/audit-rollup-template.md`](references/audit-rollup-template.md).
 
 Structure:
 
@@ -179,4 +179,4 @@ Total length: 15-30 pages including appendices. Executive summary readable in 5 
 
 ## Reference files
 
-- `references/audit-rollup-template.md` - Template for the rollup report including executive summary, theme structure, and roadmap format.
+- [`references/audit-rollup-template.md`](references/audit-rollup-template.md) - Template for the rollup report including executive summary, theme structure, and roadmap format.

--- a/skills/seo-backlink-audit/SKILL.md
+++ b/skills/seo-backlink-audit/SKILL.md
@@ -122,7 +122,7 @@ Healthy signal: the gap is shrinking over time. A widening gap is a strategic ri
 2. **Pull baseline data.** Referring domains, anchor text, link types, lost links, competitor overlap.
 3. **Map the profile across 5 dimensions.** One section per dimension.
 4. **Identify red flags.** Velocity spikes, anchor concentration, low-DR concentration, suspect TLDs, repeated footprints.
-5. **Build the toxic list (if needed).** Use the criteria in `references/toxic-link-criteria.md`.
+5. **Build the toxic list (if needed).** Use the criteria in [`references/toxic-link-criteria.md`](references/toxic-link-criteria.md).
 6. **Build the reclamation list.** Lost links worth recovering via outreach.
 7. **Build the gap list.** Domains linking to peers, prioritized by relevance.
 8. **Synthesize.** Profile health verdict, top 3 risks, top 3 opportunities.
@@ -163,4 +163,4 @@ Length: 8-15 pages depending on profile complexity.
 
 ## Reference files
 
-- `references/toxic-link-criteria.md` - Decision framework for classifying a link as toxic, including the disavow file format and threshold guidance.
+- [`references/toxic-link-criteria.md`](references/toxic-link-criteria.md) - Decision framework for classifying a link as toxic, including the disavow file format and threshold guidance.

--- a/skills/seo-competitor/SKILL.md
+++ b/skills/seo-competitor/SKILL.md
@@ -99,7 +99,7 @@ How well-known are they outside organic search?
 4. **Score each angle.** Where does the user lead? Where do they trail?
 5. **Identify gaps.** Specific content gaps, specific backlink gaps, specific technical gaps.
 6. **Prioritize.** Which gaps are highest leverage to close? (Big traffic potential, achievable effort, strategic fit.)
-7. **Write the report.** Use the template in `references/competitive-audit-template.md`.
+7. **Write the report.** Use the template in [`references/competitive-audit-template.md`](references/competitive-audit-template.md).
 
 ---
 
@@ -131,5 +131,5 @@ Structure:
 
 ## Reference files
 
-- `references/competitive-audit-template.md` - Fillable competitive audit template.
-- `references/content-gap-method.md` - Detailed methodology for finding content gaps with example.
+- [`references/competitive-audit-template.md`](references/competitive-audit-template.md) - Fillable competitive audit template.
+- [`references/content-gap-method.md`](references/content-gap-method.md) - Detailed methodology for finding content gaps with example.

--- a/skills/seo-content-audit/SKILL.md
+++ b/skills/seo-content-audit/SKILL.md
@@ -189,5 +189,5 @@ Default output: a spreadsheet with one row per URL, plus a summary markdown repo
 
 ## Reference files
 
-- `references/audit-template.md` - Spreadsheet column definitions and report template.
-- `references/cannibalization-resolution.md` - Detailed methodology for resolving cannibalization clusters.
+- [`references/audit-template.md`](references/audit-template.md) - Spreadsheet column definitions and report template.
+- [`references/cannibalization-resolution.md`](references/cannibalization-resolution.md) - Detailed methodology for resolving cannibalization clusters.

--- a/skills/seo-content-gap-audit/SKILL.md
+++ b/skills/seo-content-gap-audit/SKILL.md
@@ -95,7 +95,7 @@ Pulled from:
 3. **Pull competitor coverage.** Top pages and content clusters from each competitor.
 4. **Classify each existing page.** Healthy / thin / outdated / decaying / off-topic.
 5. **Identify missing topics.** Cross-reference competitor top pages and keyword gap output.
-6. **Score each opportunity.** See `references/content-decision-matrix.md`.
+6. **Score each opportunity.** See [`references/content-decision-matrix.md`](references/content-decision-matrix.md).
 7. **Cluster.** Group related missing topics into pillar concepts.
 8. **Decide actions.** Create / update / merge / redirect / prune for each opportunity.
 9. **Sequence the roadmap.** Quarter by quarter, with effort estimates and traffic forecasts.
@@ -154,4 +154,4 @@ Length: 8-15 pages plus an attached inventory spreadsheet.
 
 ## Reference files
 
-- `references/content-decision-matrix.md` - Detailed decision tree for classifying pages and choosing the create/update/merge/prune action, with worked examples.
+- [`references/content-decision-matrix.md`](references/content-decision-matrix.md) - Detailed decision tree for classifying pages and choosing the create/update/merge/prune action, with worked examples.

--- a/skills/seo-keyword-gap-audit/SKILL.md
+++ b/skills/seo-keyword-gap-audit/SKILL.md
@@ -116,7 +116,7 @@ Where each input is normalized to 0-100. The result is a 0-100 score.
 3. **Build the gap matrix.** Label each keyword with which property ranks where.
 4. **Filter to the pure gap cell.** Strip out the other cells for now.
 5. **Validate intent.** For each keyword, confirm the SERP intent matches what the target can produce.
-6. **Score by opportunity.** Use the formula. See `references/opportunity-scoring-rubric.md`.
+6. **Score by opportunity.** Use the formula. See [`references/opportunity-scoring-rubric.md`](references/opportunity-scoring-rubric.md).
 7. **Cluster.** Group related keywords into topics. One topic, one piece of content.
 8. **Map to existing content.** Some gap keywords are addressable by updating an existing page rather than creating new.
 9. **Sequence.** Build the prioritized list with action (create / update / merge / new pillar).
@@ -158,4 +158,4 @@ Length: 6-15 pages plus an attached opportunity spreadsheet.
 
 ## Reference files
 
-- `references/opportunity-scoring-rubric.md` - Scoring rubric with normalization rules, formula, and worked examples.
+- [`references/opportunity-scoring-rubric.md`](references/opportunity-scoring-rubric.md) - Scoring rubric with normalization rules, formula, and worked examples.

--- a/skills/seo-keyword/SKILL.md
+++ b/skills/seo-keyword/SKILL.md
@@ -120,7 +120,7 @@ Rank the clusters. Top 20 percent get produced first.
 5. **Cluster.** Group into topical clusters. Aim for 20 to 50 clusters.
 6. **Score each cluster** on opportunity, difficulty, and strategic fit.
 7. **Prioritize.** Rank by composite score. Identify the top 10 to 20 clusters to produce first.
-8. **Output.** Use the template in `references/keyword-research-template.md`.
+8. **Output.** Use the template in [`references/keyword-research-template.md`](references/keyword-research-template.md).
 
 ---
 
@@ -159,5 +159,5 @@ Recommended columns for the keyword sheet:
 
 ## Reference files
 
-- `references/keyword-research-template.md` - Spreadsheet column definitions and a markdown summary template.
-- `references/intent-classification-guide.md` - Detailed examples of each of the four intent categories.
+- [`references/keyword-research-template.md`](references/keyword-research-template.md) - Spreadsheet column definitions and a markdown summary template.
+- [`references/intent-classification-guide.md`](references/intent-classification-guide.md) - Detailed examples of each of the four intent categories.

--- a/skills/seo-offpage/SKILL.md
+++ b/skills/seo-offpage/SKILL.md
@@ -164,5 +164,5 @@ Structure:
 
 ## Reference files
 
-- `references/outreach-templates.md` - Templates for guest posting, expert quotes, broken-link outreach, podcast pitches.
-- `references/linkable-assets-guide.md` - Categories of linkable assets with examples and effort estimates.
+- [`references/outreach-templates.md`](references/outreach-templates.md) - Templates for guest posting, expert quotes, broken-link outreach, podcast pitches.
+- [`references/linkable-assets-guide.md`](references/linkable-assets-guide.md) - Categories of linkable assets with examples and effort estimates.

--- a/skills/seo-onpage/SKILL.md
+++ b/skills/seo-onpage/SKILL.md
@@ -111,7 +111,7 @@ A complete on-page audit covers eight dimensions. Score each as Pass, Needs work
 3. **View the rendered HTML.** Inspect the actual served markup, not just the visual page. Check `<title>`, `<meta>`, headers, and schema in the source.
 4. **Run the 8-dimension framework.** Score each, note specific fixes.
 5. **Prioritize.** Group fixes into Critical (broken or missing), Important (suboptimal), and Nice-to-have (polish).
-6. **Write the report.** Use the template in `references/audit-template.md`.
+6. **Write the report.** Use the template in [`references/audit-template.md`](references/audit-template.md).
 7. **Offer to draft fixes.** If the user wants, draft the new title, meta, headers, or copy directly.
 
 ---
@@ -145,6 +145,6 @@ Keep audits under 1500 words. If a page needs more detail, link to deeper append
 
 ## Reference files
 
-- `references/audit-template.md` - Fillable audit template, copy and use.
-- `references/onpage-checklist.md` - Quick-reference checklist for the 8 dimensions.
-- `references/title-and-meta-patterns.md` - Patterns for writing strong titles and meta descriptions.
+- [`references/audit-template.md`](references/audit-template.md) - Fillable audit template, copy and use.
+- [`references/onpage-checklist.md`](references/onpage-checklist.md) - Quick-reference checklist for the 8 dimensions.
+- [`references/title-and-meta-patterns.md`](references/title-and-meta-patterns.md) - Patterns for writing strong titles and meta descriptions.

--- a/skills/seo-rank-tracking/SKILL.md
+++ b/skills/seo-rank-tracking/SKILL.md
@@ -208,7 +208,7 @@ Adjust thresholds based on volatility of the niche. High-competition spaces need
 5. **Configure tracking.** Set up Ahrefs Rank Tracker projects with tags and locations.
 6. **Capture baseline.** Day-one positions and SERP composition.
 7. **Define alert thresholds.** By bucket. Wire to notification system.
-8. **Build the dashboard.** See `references/dashboard-template.md`.
+8. **Build the dashboard.** See [`references/dashboard-template.md`](references/dashboard-template.md).
 9. **Set the cadence.** Weekly review of money + brand. Monthly review of all. Quarterly rebuild of opportunity bucket.
 10. **Iterate.** Drop dead keywords. Add new ones. Recalibrate thresholds based on noise.
 
@@ -247,4 +247,4 @@ Plus a recurring rank report at the chosen cadence (typically weekly or monthly)
 
 ## Reference files
 
-- `references/dashboard-template.md` - Template for the rank tracking dashboard layout, including the recurring report structure for weekly and monthly cadences.
+- [`references/dashboard-template.md`](references/dashboard-template.md) - Template for the rank tracking dashboard layout, including the recurring report structure for weekly and monthly cadences.

--- a/skills/seo-site-health-audit/SKILL.md
+++ b/skills/seo-site-health-audit/SKILL.md
@@ -181,4 +181,4 @@ Length: 5-12 pages plus a backlog spreadsheet.
 
 ## Reference files
 
-- `references/issue-impact-table.md` - Mapping table of common crawler issues to mechanism impact and typical fix effort, plus the triage matrix in detailed form.
+- [`references/issue-impact-table.md`](references/issue-impact-table.md) - Mapping table of common crawler issues to mechanism impact and typical fix effort, plus the triage matrix in detailed form.

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -117,7 +117,7 @@ Does the site meet the page experience baseline?
 4. **Run the 6-layer framework.** Score each, note specific issues with example URLs.
 5. **Cross-reference.** Search console for what's actually indexed. Compare to sitemap and crawl output.
 6. **Prioritize.** Critical (blocks indexing or causes traffic loss), Important (suboptimal), Nice-to-have (polish).
-7. **Write the report.** Use the template in `references/audit-template.md`.
+7. **Write the report.** Use the template in [`references/audit-template.md`](references/audit-template.md).
 
 ---
 
@@ -150,5 +150,5 @@ For migrations, include a redirect map as a CSV alongside the report.
 
 ## Reference files
 
-- `references/audit-template.md` - Fillable technical SEO audit template.
-- `references/migration-checklist.md` - Pre and post-migration checklist (covers the highest-risk scenario).
+- [`references/audit-template.md`](references/audit-template.md) - Fillable technical SEO audit template.
+- [`references/migration-checklist.md`](references/migration-checklist.md) - Pre and post-migration checklist (covers the highest-risk scenario).

--- a/skills/seo-traffic-diagnosis/SKILL.md
+++ b/skills/seo-traffic-diagnosis/SKILL.md
@@ -137,7 +137,7 @@ If layers 1-4 do not explain the change, look outward.
 5. **Technical check.** Layer 4. Recent deploys, robots, canonicals, redirects.
 6. **External check.** Layer 5. Algorithm updates, competitors, industry.
 7. **Build the hypothesis.** State the cause as a single sentence.
-8. **Validate the hypothesis.** Find the evidence that confirms or refutes it. See `references/diagnosis-checklist.md`.
+8. **Validate the hypothesis.** Find the evidence that confirms or refutes it. See [`references/diagnosis-checklist.md`](references/diagnosis-checklist.md).
 9. **Action plan.** Specific fixes mapped to specific evidence.
 10. **Communicate.** Write up the diagnosis. Stakeholders want clarity, not exhaustive analysis.
 
@@ -175,4 +175,4 @@ Length: 4-10 pages. Stakeholders read this fast.
 
 ## Reference files
 
-- `references/diagnosis-checklist.md` - Layer-by-layer diagnostic checklist with the specific data to pull at each layer and how to interpret each signal.
+- [`references/diagnosis-checklist.md`](references/diagnosis-checklist.md) - Layer-by-layer diagnostic checklist with the specific data to pull at each layer and how to interpret each signal.

--- a/skills/skill-creation-walkthrough/SKILL.md
+++ b/skills/skill-creation-walkthrough/SKILL.md
@@ -241,7 +241,7 @@ You iterate until the triggers fire correctly, then ship.
 - **No examples.** A framework without a worked example is hard to apply. Include at least one in the reference material.
 - **Optimizing for one example.** A skill written around your single use case fails at adjacent ones. Generalize.
 - **No iteration.** Shipping a skill once and never revisiting it. Skills decay. Audit yearly.
-- **Branding or product-specific assumptions in a public skill.** Skills meant to be general should not hardcode your stack. Public skills teach methodology (frameworks, decision criteria, taxonomies, anti-patterns); implementation specifics (specific page architectures, type definitions, component code, framework-specific patterns) belong in internal playbooks. See `references/methodology-vs-implementation.md` for the full discipline and the user-outcome reasons it matters.
+- **Branding or product-specific assumptions in a public skill.** Skills meant to be general should not hardcode your stack. Public skills teach methodology (frameworks, decision criteria, taxonomies, anti-patterns); implementation specifics (specific page architectures, type definitions, component code, framework-specific patterns) belong in internal playbooks. See [`references/methodology-vs-implementation.md`](references/methodology-vs-implementation.md) for the full discipline and the user-outcome reasons it matters.
 
 ## Output format
 
@@ -256,6 +256,6 @@ When using this skill to create another skill, deliver:
 
 ## Reference files
 
-- `references/skill-template.md`: A blank SKILL.md template with annotated section guidance, ready to copy and fill in.
-- `references/description-cookbook.md`: A library of description patterns with worked examples for common skill types (audits, templates, frameworks, walkthroughs).
-- `references/methodology-vs-implementation.md`: What belongs in a public skill, what stays internal, and the user-outcome reasons the discipline matters. The audit pattern and the authoring checklist for keeping skills methodology-pure.
+- [`references/skill-template.md`](references/skill-template.md): A blank SKILL.md template with annotated section guidance, ready to copy and fill in.
+- [`references/description-cookbook.md`](references/description-cookbook.md): A library of description patterns with worked examples for common skill types (audits, templates, frameworks, walkthroughs).
+- [`references/methodology-vs-implementation.md`](references/methodology-vs-implementation.md): What belongs in a public skill, what stays internal, and the user-outcome reasons the discipline matters. The audit pattern and the authoring checklist for keeping skills methodology-pure.

--- a/skills/stakeholder-communication/SKILL.md
+++ b/skills/stakeholder-communication/SKILL.md
@@ -357,4 +357,4 @@ For individual communications:
 
 ## Reference files
 
-- `references/update-templates.md`: Ready-to-use templates for the most common stakeholder communications, with annotated examples.
+- [`references/update-templates.md`](references/update-templates.md): Ready-to-use templates for the most common stakeholder communications, with annotated examples.

--- a/skills/team-onboarding-playbook/SKILL.md
+++ b/skills/team-onboarding-playbook/SKILL.md
@@ -186,4 +186,4 @@ Deliverables:
 
 ## Reference files
 
-- `references/onboarding-checklist.md`: A day-by-day, week-by-week checklist for the first 30 days, with role-specific variants and a 30/60/90 review template.
+- [`references/onboarding-checklist.md`](references/onboarding-checklist.md): A day-by-day, week-by-week checklist for the first 30 days, with role-specific variants and a 30/60/90 review template.

--- a/skills/upgrade-flow-design/SKILL.md
+++ b/skills/upgrade-flow-design/SKILL.md
@@ -71,7 +71,7 @@ When it works: enterprise products, high-touch sales, products where free would 
 
 The decision is upstream of upgrade flow design. Different free-tier structures warrant different upgrade flows.
 
-Detail in `references/free-tier-decision-criteria.md`.
+Detail in [`references/free-tier-decision-criteria.md`](references/free-tier-decision-criteria.md).
 
 ---
 
@@ -112,7 +112,7 @@ The single most consequential decision in upgrade flow design.
 
 **The discipline.** Each paywall should answer: what value did the user just demonstrate, and how does the paid plan extend that value?
 
-Detail in `references/trigger-moment-design.md`.
+Detail in [`references/trigger-moment-design.md`](references/trigger-moment-design.md).
 
 ---
 
@@ -148,7 +148,7 @@ When to use. Soft prompts; low-priority upgrade asks.
 - "You have used [feature] 50 times. Upgrade to remove the limit and unlock [related capabilities]." matches the trigger.
 - "Upgrade for more features" is generic and weak.
 
-Detail in `references/paywall-presentation-patterns.md`.
+Detail in [`references/paywall-presentation-patterns.md`](references/paywall-presentation-patterns.md).
 
 ---
 
@@ -172,7 +172,7 @@ When the user does not accept the primary upgrade.
 
 **Anti-pattern.** Aggressive downsell that makes the user feel manipulated. Honest framing: "If Pro is more than you need, here is something that fits."
 
-Detail in `references/upsell-vs-downsell-logic.md`.
+Detail in [`references/upsell-vs-downsell-logic.md`](references/upsell-vs-downsell-logic.md).
 
 ---
 
@@ -198,7 +198,7 @@ Lapsed users, downgrades, partial-churn.
 - Discounts to win back can create reverse-incentive (user churns to get discount).
 - Discount sparingly; emphasize new value first.
 
-Detail in `references/win-back-flow-patterns.md`.
+Detail in [`references/win-back-flow-patterns.md`](references/win-back-flow-patterns.md).
 
 ---
 
@@ -221,7 +221,7 @@ The best upgrade flow is the one the user does not need because they did not chu
 
 **The prevention-vs-recovery economics.** Preventing churn is much cheaper than winning back churned users. Invest upstream.
 
-Detail in `references/churn-prevention-upstream.md`.
+Detail in [`references/churn-prevention-upstream.md`](references/churn-prevention-upstream.md).
 
 ---
 
@@ -245,13 +245,13 @@ The plans that the upgrade flow leads to.
 
 **Pricing-page design.** The pricing page is downstream of plan structure but lives close to upgrade flow. Detail in `landing-page-copy` for pricing-page copy specifically.
 
-Detail in `references/plan-structure-patterns.md`.
+Detail in [`references/plan-structure-patterns.md`](references/plan-structure-patterns.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-upgrade-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-upgrade-failures.md`](references/common-upgrade-failures.md).
 
 - "Conversion rate is low; users churn before reaching upgrade." Paywall-everywhere; gates blocking value demonstration.
 - "Conversion rate is single-digit; free users use the product for years." Free-forever-trap; no upgrade path surfaces.

--- a/skills/usability-testing/SKILL.md
+++ b/skills/usability-testing/SKILL.md
@@ -235,4 +235,4 @@ Default outputs:
 
 ## Reference files
 
-- `references/task-script-patterns.md` - Task framing patterns by common product type, with good and bad examples.
+- [`references/task-script-patterns.md`](references/task-script-patterns.md) - Task framing patterns by common product type, with good and bad examples.

--- a/skills/user-feedback-aggregation/SKILL.md
+++ b/skills/user-feedback-aggregation/SKILL.md
@@ -71,7 +71,7 @@ Six common channels. Each surfaces different signal at different reliability.
 
 Each channel has strengths and weaknesses. Strong feedback aggregation triangulates across channels rather than relying on one.
 
-Detail in `references/channel-types-and-what-each-surfaces.md`.
+Detail in [`references/channel-types-and-what-each-surfaces.md`](references/channel-types-and-what-each-surfaces.md).
 
 ---
 
@@ -92,7 +92,7 @@ The discipline that distinguishes triaged-synthesis from averaged-noise.
 
 **The averaged-noise failure.** Decisions made on aggregate volume regardless of source. The enterprise admin feature gets deprioritized because more total feedback came from small-team customers who do not need it; enterprise customers churn because their needs went unaddressed.
 
-Detail in `references/channel-source-weighting.md`.
+Detail in [`references/channel-source-weighting.md`](references/channel-source-weighting.md).
 
 ---
 
@@ -117,7 +117,7 @@ How feedback gets organized when it arrives at high volume.
 
 **The volume challenge.** A program receiving 500-2000 feedback items per week needs aggregation tooling that supports tagging at scale. Manual tagging at scale burns out the team; AI-assisted tagging with human review on patterns is often the practical middle path.
 
-Detail in `references/categorization-and-tagging-at-scale.md`.
+Detail in [`references/categorization-and-tagging-at-scale.md`](references/categorization-and-tagging-at-scale.md).
 
 ---
 
@@ -144,7 +144,7 @@ Two dimensions of feedback signal.
 
 **The discipline.** Triage assigns each piece of feedback a frequency-intensity assessment. The combination informs prioritization weight.
 
-Detail in `references/frequency-vs-intensity.md`.
+Detail in [`references/frequency-vs-intensity.md`](references/frequency-vs-intensity.md).
 
 ---
 
@@ -169,7 +169,7 @@ The synthesis loop that turns aggregated feedback into roadmap input.
 
 **The discipline.** Feedback aggregation has cadence. Without cadence, feedback accumulates without producing decisions.
 
-Detail in `references/from-feedback-to-product-decision.md`.
+Detail in [`references/from-feedback-to-product-decision.md`](references/from-feedback-to-product-decision.md).
 
 ---
 
@@ -191,7 +191,7 @@ When feedback shapes product, telling users matters.
 
 **The risk of over-promising.** Promising changes that do not ship erodes trust faster than not promising. Communicate what shipped, not what might ship.
 
-Detail in `references/closing-the-loop-with-users.md`.
+Detail in [`references/closing-the-loop-with-users.md`](references/closing-the-loop-with-users.md).
 
 ---
 
@@ -208,7 +208,7 @@ What changes in feedback signal over time can reveal.
 
 **The investigation discipline.** Drift signals warrant investigation. Why did the volume increase? Why did this pattern emerge? The root cause often informs product decisions more than the surface signal.
 
-Detail in `references/detecting-drift-in-feedback.md`.
+Detail in [`references/detecting-drift-in-feedback.md`](references/detecting-drift-in-feedback.md).
 
 ---
 
@@ -234,13 +234,13 @@ Tooling choices without endorsing specific products.
 
 **The build-vs-buy tension.** Many programs end up with a mix: dedicated tooling for some channels, custom dashboards for cross-channel synthesis. Pure single-tool solutions often miss the multi-channel pattern detection.
 
-Detail in `references/tooling-considerations.md`.
+Detail in [`references/tooling-considerations.md`](references/tooling-considerations.md).
 
 ---
 
 ## Common failure modes
 
-Rapid-fire. Diagnoses in `references/common-feedback-aggregation-failures.md`.
+Rapid-fire. Diagnoses in [`references/common-feedback-aggregation-failures.md`](references/common-feedback-aggregation-failures.md).
 
 - "Loudest customers steer the roadmap." Loudest-voice pattern; vocal minorities dominate; silent majority underaddressed.
 - "We have lots of feedback but no decisions." Aggregation without synthesis; no triage cadence.

--- a/skills/ux-research/SKILL.md
+++ b/skills/ux-research/SKILL.md
@@ -249,4 +249,4 @@ Findings document structure:
 
 ## Reference files
 
-- `references/interview-guide-template.md` - Structured interview guide template with example openings, probes, and closes.
+- [`references/interview-guide-template.md`](references/interview-guide-template.md) - Structured interview guide template with example openings, probes, and closes.

--- a/skills/vendor-evaluation/SKILL.md
+++ b/skills/vendor-evaluation/SKILL.md
@@ -277,4 +277,4 @@ A vendor evaluation document includes:
 
 ## Reference files
 
-- `references/evaluation-rubric.md` - Scoring template with weighted dimensions, 1-5 scale criteria for each dimension, and a worked vendor-comparison example.
+- [`references/evaluation-rubric.md`](references/evaluation-rubric.md) - Scoring template with weighted dimensions, 1-5 scale criteria for each dimension, and a worked vendor-comparison example.


### PR DESCRIPTION
Three items from community feedback, single branch, three commits.

## Item 1: CONTRIBUTING.md typo fix

"this section order, in this exact order" -> "these sections, in this exact order"

## Item 2: Cross-link reference files and SKILL.md across the catalog

Programmatic pass converting plain-text mentions of references and SKILL.md into markdown links so readers can navigate between SKILL.md and reference files in rendered markdown (GitHub web view, README catalog).

- SKILL.md files: 443 replacements across all 98 skills. Inline-code mentions of \`references/X.md\` (when not already part of a markdown link) become \[\`references/X.md\`\](references/X.md).
- reference files: 11 replacements across 11 files. Plain-text mentions of SKILL.md become \[SKILL.md\](../SKILL.md). The skill-template.md file is skipped because its mentions are templating instructions, not references to a sibling SKILL.md.
- Manual fix: skills/design-standards/references/tailwind-patterns.md used \`SKILL.md\` (with backticks) which the regex correctly skipped. Linked manually to \[\`SKILL.md\`\](../SKILL.md).

Script: scripts/crosslink_pass.py. Idempotent.

## Item 3: Add ARIA patterns reference to accessibility-audit

New reference file skills/accessibility-audit/references/aria-patterns.md covering the semantic-HTML-first principle, common interactive widget patterns (accordion, tabs, modal, toggle, disclosure, navigation), live regions (aria-live, aria-atomic, role status/alert), hiding patterns (aria-hidden, visually-hidden), description and labeling (aria-label, aria-labelledby, aria-describedby), state indicators (aria-busy, aria-disabled, aria-invalid), common ARIA anti-patterns, and the testing approach.

Includes the methodology-level / implementation choices closing section.

accessibility-audit/SKILL.md updated to reference the new file. Catalog: 423 to 424 reference files.

## Quality gates

- Lint passes (98 skills validated, 1 pre-existing warning preserved).
- Cross-linking pass is idempotent.
- ARIA patterns reference: zero em-dashes, no forbidden phrases, methodology-level / implementation choices closing section present.

## Credit

Reported via community feedback. Andy: please add the contributor's name and link to the original feedback (Discussion or issue) before merging.