### PR TITLE
feat(readme): add competitive-intelligence MCPs (Ahrefs + Semrush + Similarweb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,14 +551,24 @@ Skills compose best when Claude has live access to your data and tools. [Model C
 
 Below is the MCP shortlist by skill area. None of these are required (except the Ahrefs MCP for the SEO audit suite). All are categorical recommendations: where multiple options exist for the same job, pick the one that fits your stack.
 
-### SEO and search data
+### SEO, competitive intelligence, and search data
 
-The SEO audit suite (skills 23-29) is built around the Ahrefs MCP. The foundation SEO skills (16-22) work with any equivalent.
+The SEO audit suite (skills 23-29) is built around Ahrefs as its primary backend; foundation SEO skills (16-22) work with any equivalent. Competitive intelligence MCPs (Ahrefs, Semrush, Similarweb) cover overlapping but distinct data shapes: backlinks and keywords, traffic estimation, audience behavior. Use them in combination for the strongest signal.
 
-- **Ahrefs MCP** - referenced explicitly by `seo-audit-orchestration` and the 6 audit suite skills (backlink, keyword gap, content gap, traffic, site health, rank tracking)
-- **DataForSEO MCP** - alternative for SERP, keyword, and backlink data; useful as a complement to Ahrefs for cross-validation
-- **Google Search Console MCP** - free, official Google data; essential for `seo-traffic-diagnosis` and any audit that needs ground-truth click and impression data
-- **PageSpeed Insights MCP** - free, paired with `performance-optimization` and `seo-site-health-audit` for Core Web Vitals field data
+**Backlink and keyword data**
+
+- **Ahrefs MCP** - primary backend for the audit suite; backlink profiles, keyword data, content explorer, site audit. Referenced explicitly by `seo-audit-orchestration` and the 6 audit suite skills (backlink, keyword gap, content gap, traffic, site health, rank tracking).
+- **Semrush MCP** - alternative or complement to Ahrefs with stronger US keyword data and SEO-PR features (Topic Research, brand monitoring) Ahrefs does not cover. Pairs with `seo-keyword`, `seo-competitor`, `seo-content-gap-audit`. Verify the official MCP endpoint at authoring time; Semrush has shipped first-party MCP tooling.
+- **DataForSEO MCP** - programmatic SEO data (SERP, keywords, backlinks) at developer-friendly pricing; useful as a third source for cross-validation when methodology decisions hinge on data agreement.
+
+**Traffic estimation and competitive intelligence**
+
+- **Similarweb MCP** - competitive traffic estimation, audience demographics, channel mix (organic, paid, direct, referral, social, email), industry benchmarks, audience overlap analysis. Pairs with `seo-competitor`, `seo-traffic-diagnosis` (external-factor layer), `brand-discovery` (competitive scan), `analytics-strategy` (industry benchmarks). Where Ahrefs answers "how do they rank" and Semrush answers "what keywords drive what," Similarweb answers "how much traffic, from where, from whom."
+
+**Search Console and Core Web Vitals**
+
+- **Google Search Console MCP** - free, official Google data; essential for `seo-traffic-diagnosis` and any audit that needs ground-truth click and impression data.
+- **PageSpeed Insights MCP** - free, paired with `performance-optimization` and `seo-site-health-audit` for Core Web Vitals field data.
 
 ### Development and code
 

--- a/README.md
+++ b/README.md
@@ -555,20 +555,22 @@ Below is the MCP shortlist by skill area. None of these are required (except the
 
 The SEO audit suite (skills 23-29) is built around Ahrefs as its primary backend; foundation SEO skills (16-22) work with any equivalent. Competitive intelligence MCPs (Ahrefs, Semrush, Similarweb) cover overlapping but distinct data shapes: backlinks and keywords, traffic estimation, audience behavior. Use them in combination for the strongest signal.
 
+**A note on MCP costs**: many of these MCPs are wrappers around APIs you are already paying for through a subscription, where MCP calls do not add marginal cost. Others (Ahrefs, Semrush, Similarweb, DataForSEO) use paid API credits per call, and long agentic sessions against these platforms can burn meaningful credit volume quickly. The cost model is documented on each integration's landing page at rampstack.co/integrations. Free with rate limits is called out where it applies (Google Search Console, PageSpeed Insights). When in doubt, check the platform's API pricing before running multi-hour agent workflows.
+
 **Backlink and keyword data**
 
-- **Ahrefs MCP** - primary backend for the audit suite; backlink profiles, keyword data, content explorer, site audit. Referenced explicitly by `seo-audit-orchestration` and the 6 audit suite skills (backlink, keyword gap, content gap, traffic, site health, rank tracking).
-- **Semrush MCP** - alternative or complement to Ahrefs with stronger US keyword data and SEO-PR features (Topic Research, brand monitoring) Ahrefs does not cover. Pairs with `seo-keyword`, `seo-competitor`, `seo-content-gap-audit`. Verify the official MCP endpoint at authoring time; Semrush has shipped first-party MCP tooling.
-- **DataForSEO MCP** - programmatic SEO data (SERP, keywords, backlinks) at developer-friendly pricing; useful as a third source for cross-validation when methodology decisions hinge on data agreement.
+- **Ahrefs MCP** - primary backend for the audit suite; backlink profiles, keyword data, content explorer, site audit. Referenced explicitly by `seo-audit-orchestration` and the 6 audit suite skills (backlink, keyword gap, content gap, traffic, site health, rank tracking). Credits-per-call.
+- **Semrush MCP** - alternative or complement to Ahrefs with stronger US keyword data and SEO-PR features (Topic Research, brand monitoring) Ahrefs does not cover. Pairs with `seo-keyword`, `seo-competitor`, `seo-content-gap-audit`. Verify the official MCP endpoint at authoring time; Semrush has shipped first-party MCP tooling. Credits-per-call.
+- **DataForSEO MCP** - programmatic SEO data (SERP, keywords, backlinks) at developer-friendly pricing; useful as a third source for cross-validation when methodology decisions hinge on data agreement. Credits-per-call (free tier available).
 
 **Traffic estimation and competitive intelligence**
 
-- **Similarweb MCP** - competitive traffic estimation, audience demographics, channel mix (organic, paid, direct, referral, social, email), industry benchmarks, audience overlap analysis. Pairs with `seo-competitor`, `seo-traffic-diagnosis` (external-factor layer), `brand-discovery` (competitive scan), `analytics-strategy` (industry benchmarks). Where Ahrefs answers "how do they rank" and Semrush answers "what keywords drive what," Similarweb answers "how much traffic, from where, from whom."
+- **Similarweb MCP** - competitive traffic estimation, audience demographics, channel mix (organic, paid, direct, referral, social, email), industry benchmarks, audience overlap analysis. Pairs with `seo-competitor`, `seo-traffic-diagnosis` (external-factor layer), `brand-discovery` (competitive scan), `analytics-strategy` (industry benchmarks). Where Ahrefs answers "how do they rank" and Semrush answers "what keywords drive what," Similarweb answers "how much traffic, from where, from whom." Credits-per-call.
 
 **Search Console and Core Web Vitals**
 
-- **Google Search Console MCP** - free, official Google data; essential for `seo-traffic-diagnosis` and any audit that needs ground-truth click and impression data.
-- **PageSpeed Insights MCP** - free, paired with `performance-optimization` and `seo-site-health-audit` for Core Web Vitals field data.
+- **Google Search Console MCP** - free, official Google data; essential for `seo-traffic-diagnosis` and any audit that needs ground-truth click and impression data. Free with rate limits.
+- **PageSpeed Insights MCP** - free, paired with `performance-optimization` and `seo-site-health-audit` for Core Web Vitals field data. Free with rate limits.
 
 ### Development and code
 

--- a/skills/brand-discovery/SKILL.md
+++ b/skills/brand-discovery/SKILL.md
@@ -94,6 +94,8 @@ The third is most often forgotten and most often the actual competitor.
 - Their content and SEO presence (use `seo-competitor` for the search angle)
 - Social proof and customer voices
 
+Competitive scan benefits from quantitative grounding: not just "who are the competitors" but "how much traffic do they earn, where does it come from, who is the audience overlap." Similarweb is the standard for this kind of competitive landscape analysis; pair with Ahrefs for the SEO-specific overlap.
+
 **Output:** Competitor matrix (3 to 8 competitors deep), plus a one-line "what makes them dangerous" for each.
 
 ### 3. Category and problem space

--- a/skills/seo-competitor/SKILL.md
+++ b/skills/seo-competitor/SKILL.md
@@ -36,6 +36,8 @@ Compare a site to its competitors and find the gaps worth closing. Stack-agnosti
 
 If competitors are unknown, start by listing the top 10 ranking domains for the user's top 10 priority keywords. Pick the 3 to 5 that appear most often.
 
+Where competitor traffic estimation is the input you need (relative scale, channel mix, audience overlap), Similarweb MCP is the strongest source. Pair with Ahrefs (for backlink and keyword overlap) and Semrush (for SERP feature presence and SEO-PR overlap). Each platform gives a different cut of the same competitive landscape; using them together produces sharper signal than any one alone.
+
 ---
 
 ## The framework: 5 angles

--- a/skills/seo-content-gap-audit/SKILL.md
+++ b/skills/seo-content-gap-audit/SKILL.md
@@ -46,6 +46,8 @@ Find content gaps and decay using Ahrefs MCP data. Stack-agnostic. Produces a ro
 
 Every content opportunity falls into one of four categories. Different categories need different actions.
 
+Content gap analysis is sharper with multiple data sources. Ahrefs surfaces keyword and topic gaps (the primary backend below). Similarweb surfaces traffic-driving page-level gaps (which of a competitor's pages earn meaningful traffic, not just rankings). Semrush surfaces SERP-feature gaps (where competitors win answer boxes, knowledge panels, People Also Ask placements). The three platforms often disagree on individual data points; that disagreement is itself a useful signal.
+
 ### Category 1: Missing topics
 
 Topics with traffic potential where the property has no relevant page at all. Competitors often rank in the top 10. The fix: create new content.

--- a/skills/seo-traffic-diagnosis/SKILL.md
+++ b/skills/seo-traffic-diagnosis/SKILL.md
@@ -126,6 +126,8 @@ If layers 1-4 do not explain the change, look outward.
 - Manual action (Search Console security and manual actions)
 - Negative SEO (sudden link velocity changes)
 
+External-factor diagnosis benefits from competitive context: did your traffic drop while competitors held steady (suggests an algorithm-specific issue), or did the entire vertical lose ground (suggests a user-behavior shift)? Similarweb shows competitor traffic trends; Ahrefs shows competitor SERP movement; pairing both surfaces whether the issue is yours alone or the category's.
+
 ---
 
 ## Workflow


### PR DESCRIPTION
Restructures the README's SEO MCPs section to surface all three competitive-intelligence platforms at peer status. Promotes Ahrefs to its own properly-positioned bullet, adds Semrush and Similarweb. Light-touch skill body additions (1-3 sentences each) in 4 SEO/brand skills where methodology already calls for this kind of data.

## What changed

- **README MCPs section**: reorganized from flat alphabetical list to data-shape grouping. Header broadened to \"SEO, competitive intelligence, and search data.\" Three sub-groups now: backlink/keyword data (Ahrefs, Semrush, DataForSEO), traffic estimation and competitive intelligence (Similarweb), Search Console/CWV (GSC, PageSpeed Insights).
- **Skill body additions** (1-3 sentences each, no structural changes):
  - \`seo-competitor/SKILL.md\` (Required inputs section)
  - \`seo-traffic-diagnosis/SKILL.md\` (Layer 5 external analysis)
  - \`brand-discovery/SKILL.md\` (competitor sources)
  - \`seo-content-gap-audit/SKILL.md\` (framework intro)

## What did not change

- **No new reference files.** The dispatch was explicit about light-touch additions only.
- **No SEO audit suite restructure.** The audit suite stays Ahrefs-centric per the dispatch's out-of-scope note.
- **\`analytics-strategy/SKILL.md\` skipped.** That skill does not currently frame industry benchmarks; adding the mention would have felt forced.

## Companion PR

\`rampstackco-app\` PR adds the three integration data-layer entries and full landing pages.

## Test plan

- [x] Em-dash audit: 0
- [x] Forbidden-phrase audit: clean (only pre-existing \"highest leverage\" in seo-competitor at line 103, predates this PR; the linter does not flag it)
- [x] \`.github/scripts/lint_skills.py\` passes (98 skills, 1 pre-existing line-length warning)
- [x] \`scripts/generate_readme_catalog.py --check\` exits 0 (catalog still in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)