### PR TITLE
fix(readme): update archetype count from thirty to forty-two

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Six entry-point skills, one per audience track. Run any of these standalone, or 
 
 **[The creative-direction skill rendered as a live showcase →](https://rampstack.co/showcase/creative-direction)**
 
-Thirty fictional brands generated from briefs that all use the same skill. Each is a fully styled brand site, not a mockup. The showcase demonstrates what the four-axis framework produces in practice and lets you filter by axis position to see how each combination renders.
+Forty-two fictional brands generated from briefs that all use the same skill. Each is a fully styled brand site, not a mockup. The showcase demonstrates what the four-axis framework produces in practice and lets you filter by axis position to see how each combination renders.
 
 <p align="center">
   <img src="assets/showcase/showcase-grid-hero.png" alt="Showcase grid of brand archetypes including Pulse, Volt, Anode, Drift, and others, with type and motion intensity filter pills above the cards." />


### PR DESCRIPTION
Updates the stale archetype count in the README's 'See it in action' section.

Actual count is 42 archetypes across the creative-direction showcase (verified via the archetypes data layer in rampstack/rampstackco-app, which lists 42 entries: 6 framework-canonical + 6 framework-beyond + 6 brand-applied calm + 12 brand-aesthetic-push + 4 Wave 1 + 4 Wave 2 + 4 additional).

Single-line edit. Alt text on the empty-state screenshot is left as-is intentionally: that string is in the screenshot picture, so updating alt without regenerating the screenshot creates an accessibility mismatch. Screenshot regeneration is queued as separate future polish.

If archetype count drifts again, consider introducing a generator-managed COUNT marker via a cross-repo mirror file. Out of scope here.