### PR TITLE
feat(skills): add brand-archetype-system (12 archetypes x 18 verticals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-98-blue.svg)](#the-98-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-99-blue.svg)](#the-99-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 98 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 99 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -40,7 +40,7 @@
 - [How the catalog connects](#how-the-catalog-connects)
 - [Surfaces](#surfaces)
 <!-- COUNT_TOC:START -->
-- [The 98-skill catalog](#the-98-skill-catalog)
+- [The 99-skill catalog](#the-99-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -69,8 +69,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **98 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
-- **425 reference files** (templates, checklists, decision matrices, worked examples)
+- **99 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
+- **427 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -456,11 +456,11 @@ The skills in this repository remain free, open-source, and stack-agnostic. The 
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 98-skill catalog
+## The 99-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 98 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 99 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -475,7 +475,7 @@ All 98 skills are shipped. Each has a complete SKILL.md plus at least one refere
 | [`information-architecture`](skills/information-architecture/SKILL.md) | Sitemap, navigation, URL structure, content types, taxonomy |
 | [`content-strategy`](skills/content-strategy/SKILL.md) | Editorial strategy, content calendar, topical authority planning |
 
-### Brand (5)
+### Brand (6)
 
 | Skill | What it does |
 |---|---|
@@ -483,6 +483,7 @@ All 98 skills are shipped. Each has a complete SKILL.md plus at least one refere
 | [`brand-identity`](skills/brand-identity/SKILL.md) | Logo system, color, typography, imagery, iconography, motion |
 | [`brand-style-guide`](skills/brand-style-guide/SKILL.md) | The canonical reference document for the full brand system |
 | [`brand-voice`](skills/brand-voice/SKILL.md) | Voice attributes, tone shifts, vocabulary, paired-example library |
+| [`brand-archetype-system`](skills/brand-archetype-system/SKILL.md) | 12 archetype defaults across 18 verticals: color, type, voice, imagery starters |
 | [`logo-design`](skills/logo-design/SKILL.md) | Logo variants across architectures (wordmark, lockup, monogram, letterform-as-symbol), with rationale and application specs |
 
 ### Design (3)

--- a/skills/brand-archetype-system/SKILL.md
+++ b/skills/brand-archetype-system/SKILL.md
@@ -45,7 +45,7 @@ Direct verbatim copying of an archetype's default palette into a new brand is a 
 
 ---
 
-## The system structure
+## The framework: 12 core archetypes plus 18 vertical applications
 
 Two layers of content in `references/`:
 
@@ -131,3 +131,13 @@ Each archetype positions on the 4 axes defined in the `creative-direction` skill
 - **Sensory ambition**: Functional, Considered, Immersive, Theatrical
 
 Each core archetype file specifies its position on each axis.
+
+---
+
+## Reference files
+
+- [`references/00-archetype-system-overview.md`](references/00-archetype-system-overview.md) - How the two-layer system fits together, entry patterns, when archetypes compose, and the recurring failure modes.
+- [`references/01-how-to-apply-an-archetype.md`](references/01-how-to-apply-an-archetype.md) - The 5-step adaptation process: locate the design space, map the brief to adjustable dimensions, adapt color, adapt type, write voice samples. Includes the cross-archetype coherence check.
+
+The 12 core archetype files live in the `core-archetypes/` subdirectory under references, numbered 01 (Editorial Restrained) through 12 (Documentary Honest). The 18 vertical application files live in the `by-vertical/` subdirectory under references, numbered 01 (B2B SaaS Developer Tools) through 18 (Real Estate and Proptech). Load the relevant core archetype file plus the relevant vertical file together for any brief that names both an aesthetic family and an industry.
+

--- a/skills/brand-archetype-system/SKILL.md
+++ b/skills/brand-archetype-system/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: brand-archetype-system
+description: "Apply pre-composed aesthetic archetype defaults to jumpstart brand design work covering color, typography, layout, voice, and imagery direction. Use this skill whenever the user wants a starting point for brand visual and verbal direction, references a brand they want to design near (for example 'something like Stripe' or 'editorial like Linear'), needs to converge faster from many directions to one, or wants known-good defaults for a specific industry vertical. Triggers on archetype, design archetype, brand archetype, near to (brand), in the style of, similar aesthetic, design starting point, brand template, vertical-typical, industry-typical. Also triggers when the user has a brief and wants to map it to a known aesthetic family rather than design from first principles."
+category: brand
+catalog_summary: "12 archetype defaults across 18 verticals: color, type, voice, imagery starters"
+display_order: 5
+---
+
+# Brand Archetype System
+
+Pre-composed aesthetic archetype defaults that jumpstart brand design work. Each archetype bundles color tendencies, type pairings, layout patterns, voice samples, and imagery direction for a recognizable aesthetic family. Stack-agnostic. Tool-agnostic.
+
+This is a starting-point library, not a methodology library. The agent applies archetype defaults to a specific brief; the archetypes themselves provide anchor points, not endpoints.
+
+---
+
+## When to use
+
+- The user wants a starting point rather than designing from first principles
+- The user references a brand or aesthetic family they want to design near
+- Need to converge faster from many directions to one
+- The user wants vertical-typical defaults (for example fintech consumer, B2B developer tools)
+- The user wants to test what a brief would look like in a different archetype
+
+## When NOT to use
+
+- The user wants pure methodology guidance (use `brand-identity`)
+- The user is in early ideation needing positioning territories (use `brand-ideation`)
+- Defining voice for an existing brand (use `brand-voice`)
+- Documenting a finished brand (use `brand-style-guide`)
+
+---
+
+## How this composes with other skills
+
+This skill works upstream of `brand-identity` (provides starting defaults that brand-identity refines into a finished system) and parallel to `creative-direction` (archetypes can be located by position on the 4 creative-direction axes).
+
+Typical flow when this skill is invoked:
+1. User provides a brief or references a target archetype
+2. Agent picks the most relevant core archetype, or composes from 2 adjacent archetypes
+3. Agent adapts the archetype's defaults to the brief (color tokens shift, type swaps to vertical-appropriate fonts, voice samples rewrite for the brand)
+4. Agent flags adaptation choices made
+
+Direct verbatim copying of an archetype's default palette into a new brand is a failure mode. Archetypes constrain the design space; the brief specifies the point within that space.
+
+---
+
+## The system structure
+
+Two layers of content in `references/`:
+
+### Core archetypes (12 files)
+
+Located in `references/core-archetypes/`. Each is an aesthetic family with:
+- Aesthetic summary
+- Position on the 4 `creative-direction` axes
+- Color palette starter (4 to 6 hex values with token names and rationale)
+- Type pairing starter (Google Fonts pairing with size scale)
+- Layout and composition patterns
+- Voice samples (5 to 10 representative lines)
+- Component pattern descriptions (heroes, buttons, cards, tables)
+- Imagery direction
+- When to pick and when to avoid
+- Adaptation guidance
+- Exemplar brands with attribution language
+
+### Vertical applications (18 files)
+
+Located in `references/by-vertical/`. Each maps named brands to core archetypes in that vertical with:
+- Vertical summary
+- Common archetypes
+- Brand-to-archetype mapping (5 to 10 brands per vertical)
+- Vertical-specific adaptation notes
+- Common archetype evolution patterns as brands mature
+
+### Two overview files
+
+- `00-archetype-system-overview.md`: how the system works, the taxonomy
+- `01-how-to-apply-an-archetype.md`: the adaptation discipline, the failure modes
+
+---
+
+## The 12 core archetypes
+
+| # | Archetype | Single-line summary |
+|---|---|---|
+| 01 | Editorial Restrained | Low-saturation, type-led, generous whitespace, considered |
+| 02 | Technical Precise | Monospace and grid prominent, data-dense, system-feeling |
+| 03 | Warm Conversational | Human imagery, mid-saturation, friendly type, approachable |
+| 04 | Bold Confident | High-contrast, large display type, saturated, direct |
+| 05 | Playful Energetic | Bright colors, illustration-led, dynamic, character-driven |
+| 06 | Luxe Considered | Serif-led, generous spacing, restrained palette, premium |
+| 07 | Clinical Trustworthy | Cool palette, sans-serif, clean medical or financial register |
+| 08 | Rugged Utilitarian | Earth tones, workwear influence, no-nonsense type |
+| 09 | Retro Nostalgic | Period-specific palette and type, intentional vintage reference |
+| 10 | Minimal Essentialist | Black, white, single accent, sans-serif only, sparse |
+| 11 | Vibrant Saturated | High-saturation across full palette, color as character |
+| 12 | Documentary Honest | Photography-led, real people, low-touched imagery |
+
+## The 18 vertical applications
+
+- B2B SaaS: Developer Tools, Business Productivity, Marketing and Sales, Data and Analytics
+- Fintech: Consumer, Enterprise
+- DTC: Fashion, Beauty, Home and Lifestyle, Food and Beverage
+- Consumer Health and Wellness
+- Hospitality and Travel
+- Media and Publishing
+- EdTech
+- Gaming and Entertainment
+- Marketplace
+- Crypto and Web3
+- Real Estate and Proptech
+
+---
+
+## Trademark and attribution
+
+Archetypes are NAMED for aesthetic families, NOT for brands. "Editorial Restrained" not "Stripe-like." Brands are referenced as exemplars in description text using attribution language: "exemplified by [brands]", "common among [brands]", "characteristic of [brands]".
+
+This is descriptive and nominative fair use territory, durable across brand redesigns. A brand that pivots its identity does not invalidate the archetype it once exemplified.
+
+---
+
+## The four creative-direction axes (reference)
+
+Each archetype positions on the 4 axes defined in the `creative-direction` skill. Brief summary for cross-reference:
+
+- **Tone register**: Professional, Conversational, Playful
+- **Aesthetic register**: Restrained, Considered, Expressive, Maximal
+- **Audience relationship**: Authority, Peer, Companion, Performer
+- **Sensory ambition**: Functional, Considered, Immersive, Theatrical
+
+Each core archetype file specifies its position on each axis.

--- a/skills/brand-archetype-system/references/00-archetype-system-overview.md
+++ b/skills/brand-archetype-system/references/00-archetype-system-overview.md
@@ -1,0 +1,40 @@
+# Archetype system overview
+
+This document explains the taxonomy and how the layers fit together. Read this first when working with the archetype system for the first time.
+
+## The two layers
+
+**Core archetypes** (12 files) are the aesthetic families themselves. They span verticals; an archetype like Editorial Restrained appears in B2B SaaS, in media publishing, in DTC fashion. The core archetype files describe the family in pure form: what makes it recognizable, the color tendencies, the type pairings, the voice character.
+
+**Vertical applications** (18 files) describe how the archetypes manifest in specific industries with named brands. They are discovery surfaces: a user working on a fintech brand should be able to find their vertical, see which archetypes are common, see specific brand-to-archetype mappings, and decide which core archetype to start from.
+
+## How the agent should use the system
+
+Two entry patterns:
+
+**Entry by archetype** (user references an aesthetic family): "I want something Editorial Restrained for my analytics product." Agent loads the Editorial Restrained core archetype file, plus the B2B SaaS Data and Analytics vertical file for context. Composes defaults adapted to the brief.
+
+**Entry by vertical** (user references their industry): "I'm designing a consumer fintech app, what archetypes work here?" Agent loads the Fintech Consumer vertical file first, sees the brand-to-archetype mappings, picks the most relevant core archetype, then loads that for full defaults.
+
+## What this system is and is not
+
+**It is**: a library of pre-composed defaults that accelerate brand work by providing known-good starting points with documented rationale.
+
+**It is not**: a substitute for design judgment. The defaults are anchor points; the brief specifies where to land within the archetype's design space.
+
+**It is not**: a comprehensive theory of brand aesthetics. The 12 archetypes capture the most recognizable contemporary Western brand aesthetics. They are not exhaustive. Regional, cultural, and historical archetypes are deferred to future expansions of the catalog.
+
+## When archetypes compose
+
+Two archetypes can blend. Linear is Editorial Restrained with Technical Precise undertones. Stripe is Technical Precise with Editorial Restrained surfaces. Glossier is Vibrant Saturated with Minimal Essentialist composition.
+
+When the brief calls for blending, the agent picks two core archetypes and notes which contributes which dimension (for example "Editorial Restrained for type and whitespace, Technical Precise for color and density").
+
+## The failure modes
+
+1. **Verbatim copying**: pulling the exact starter palette into a new brand without adaptation. Produces generic output.
+2. **Archetype mismatch with audience**: picking an archetype because the user likes its exemplars rather than because it fits the audience.
+3. **Cross-archetype tokens**: pulling a color from one archetype and type from another without considering coherence. Often produces incoherent output.
+4. **Stale exemplars**: assuming a brand still exemplifies an archetype after a redesign. The archetype is durable; the brand is not.
+
+Each core archetype file's "Adaptation guidance" section addresses these.

--- a/skills/brand-archetype-system/references/01-how-to-apply-an-archetype.md
+++ b/skills/brand-archetype-system/references/01-how-to-apply-an-archetype.md
@@ -1,0 +1,69 @@
+# How to apply an archetype
+
+This document is the operating manual. Once an archetype is picked, follow this process to adapt it to the specific brief.
+
+## The 5-step adaptation process
+
+### Step 1: Locate the archetype's design space
+
+Read the core archetype file. Understand:
+- Position on the 4 creative-direction axes
+- The non-negotiable structural choices (for example "single accent" for Editorial Restrained, "monospace prominent" for Technical Precise)
+- The adjustable dimensions (specific hue of the accent, specific serif, specific density)
+
+The structural choices are what make the archetype recognizable. The adjustable dimensions are where the brief lands.
+
+### Step 2: Map the brief to adjustable dimensions
+
+For each adjustable dimension, ask: what does the brief specify or imply?
+
+- **Audience character**: Younger audience usually wants warmer accent; older wants cooler. Technical audience tolerates more density; consumer audience needs more whitespace.
+- **Category context**: Crowded categories need stronger contrast; quiet categories can be more restrained.
+- **Emotional direction**: Trust-needing brands lean cooler; warmth-needing brands lean warmer.
+- **Competitive position**: If the closest competitor is in the same archetype, shift one adjustable dimension hard to differentiate.
+
+### Step 3: Adapt the color palette
+
+The starter palette is a relationship between values, not absolute hex codes. Preserve the relationship; shift the values.
+
+Example with Editorial Restrained:
+- Default: ink #0F1B2D (navy), accent #5B8B85 (muted teal)
+- Adaptation for a finance brief: ink #1A1F2E (deeper navy), accent #4A5D6E (slate blue), reads more institutional
+- Adaptation for a consumer wellness brief: ink #2A2520 (warm dark brown), accent #7A9B7C (sage green), reads more grounded and warm
+
+Preserve: low saturation, single accent, paper-not-white background, ink-not-black text. Shift: specific hues to match emotional direction.
+
+### Step 4: Adapt the type pairing
+
+The starter pairing is a relationship between display and body, not specific fonts. Preserve the relationship; shift the fonts.
+
+Example with Editorial Restrained:
+- Default: IBM Plex Serif (display) plus Inter (body)
+- Adaptation for luxe-leaning brief: Tiempos Display (display) plus Inter (body) preserves the pairing, shifts the serif character
+- Adaptation for technical-leaning brief: IBM Plex Serif (display) plus IBM Plex Sans (body) keeps within one family, reads more system-like
+
+Preserve: serif display plus sans body, modular scale, single weight per role. Shift: specific font choices to match register.
+
+### Step 5: Write voice samples for the specific brand
+
+The voice samples in the core archetype show character; they are not copy to lift directly. Write 5 to 10 new voice samples for the specific brand using the archetype's cadence and register.
+
+## The cross-archetype check
+
+Before finalizing, verify the output reads as coherent within the archetype:
+
+- Color: matches the archetype's saturation and contrast character?
+- Type: matches the archetype's display and body relationship?
+- Voice: matches the archetype's cadence and register?
+- Layout: matches the archetype's density and whitespace tendency?
+
+If two of the four diverge from the archetype, either pick a different archetype or accept that the brand is a blend (and document which archetype contributes which dimension).
+
+## When to abandon an archetype mid-flow
+
+The archetype is wrong if:
+- Three or more dimensions resist adaptation to the brief
+- The audience signals reject the archetype's defaults (for example picking Editorial Restrained for a children's app)
+- Direct competitors all live in the same archetype and your brief needs differentiation
+
+When abandoning, return to the vertical file for that industry and pick a different starting archetype. Do not try to retrofit an archetype that does not fit.

--- a/skills/brand-archetype-system/references/by-vertical/01-b2b-saas-developer-tools.md
+++ b/skills/brand-archetype-system/references/by-vertical/01-b2b-saas-developer-tools.md
@@ -1,0 +1,44 @@
+# B2B SaaS: Developer Tools
+
+## Vertical summary
+
+Brands serving developers building software. Audience values: technical precision, documentation depth, time-to-first-API-call. Brands compete on developer experience, primitive quality, observability, and composition. The category is mature with established archetypes.
+
+## Common archetypes in this vertical
+
+The dominant archetype is **Technical Precise** (Stripe docs, Sentry, Datadog). **Editorial Restrained** is the rising adjacent archetype (Linear, Vercel, Resend). **Bold Confident** appears at the consumer-edge (Loom, formerly Heroku). Other archetypes are rare in this space; warmth and play do not read as credibility to developers building production systems.
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Stripe | Technical Precise with Editorial undertones | Best-in-category documentation aesthetic; navy and violet accents; serif display creeping into marketing |
+| Linear | Editorial Restrained | Single-accent restraint; brutal type hierarchy; muted palette |
+| Vercel | Editorial Restrained leaning Technical Precise | Black and white; Geist font system; minimal accents |
+| Sentry | Technical Precise | Dark mode dominant; purple accent; data-dense |
+| Datadog | Technical Precise | Cool palette; UI-led marketing; dense |
+| Resend | Editorial Restrained | New entrant; serif display; warm paper background |
+| Cloudflare | Bold Confident | Orange brand color; energetic; consumer-tilted |
+| GitHub | Editorial Restrained adjacent | Octocat character softens the precision |
+| Supabase | Bold Confident leaning Technical Precise | Green primary; recently more restrained |
+| Cursor | Technical Precise | Dark-mode-first; tool-focused; understated |
+
+## Vertical-specific adaptation notes
+
+- **Documentation surfaces are first-class**: developer brands need documentation as part of the brand surface, not an afterthought. The type system must scale to long-form technical reading.
+- **Code samples are brand assets**: how code renders (syntax highlighting palette, line numbers, copy buttons) is brand expression.
+- **Dark mode is required**, not optional. Most developers spend their day in dark interfaces.
+- **Performance signals as brand signals**: page load time, animation frame rate, perceived speed are part of how developers judge developer brands.
+- **Density tolerance**: developers tolerate (and often prefer) higher information density than other B2B audiences.
+
+## Common archetype evolution
+
+Developer brands frequently start Technical Precise and add Editorial Restrained as they mature. Stripe's evolution from pure technical to editorial-influenced marketing is the canonical example. Conversely, brands that start Bold Confident (Cloudflare, Supabase) sometimes retreat toward restraint as they target enterprise.
+
+The early-stage developer brand archetype shift is almost always: drop the consumer-tinted color, add a serif, lean into restraint. The mature-stage shift is sometimes: re-introduce a careful illustration system to soften pure restraint (GitHub's Octocat-era is the canonical case).
+
+## Vertical anti-patterns
+
+- **Playful Energetic in developer tools**: reads as unserious. Developers building production systems do not want a mascot taking up screen real estate in their dashboard.
+- **Luxe Considered in developer tools**: reads as out-of-touch. Developer tools differentiate on substance, not premium feel.
+- **Vibrant Saturated in developer tools**: rare and risky; works only when the brand is consumer-tilted (Cloudflare manages it with discipline).

--- a/skills/brand-archetype-system/references/by-vertical/02-b2b-saas-business-productivity.md
+++ b/skills/brand-archetype-system/references/by-vertical/02-b2b-saas-business-productivity.md
@@ -1,0 +1,43 @@
+# B2B SaaS: Business Productivity
+
+## Vertical summary
+
+Brands serving teams getting work done across documents, projects, communications, and design. Audience is prosumer-tilted: knowledge workers who self-serve, evaluate based on demos and free trials, and bring tools into their organizations from the bottom up. Brands compete on approachability, integration depth, and brand likeability alongside functional differentiation.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Warm Conversational** (Slack, Mailchimp, Figma in marketing) and **Bold Confident** (Notion, Linear in launches). **Playful Energetic** appears at the edges (Asana classic era). **Editorial Restrained** is rising (Coda, Notion's recent surfaces). The category rewards personality more than developer tools but less than consumer apps.
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Notion | Bold Confident leaning Warm Conversational | Black on white plus illustration character; emoji-rich; oversized type |
+| Figma | Warm Conversational | Multi-hue creative palette; illustration-led; community-driven |
+| Loom | Bold Confident | Recent rebrand bold-purple-and-black; high contrast |
+| Slack | Warm Conversational | Multi-hue saturated brand colors; hands-and-objects illustration era |
+| Airtable | Warm Conversational | Multi-color brand; spreadsheet-meets-database approachable |
+| Coda | Editorial Restrained | Type-led; restrained palette; document-first feeling |
+| Asana | Playful Energetic moving to Warm Conversational | Mascot-era to recent considered warmth |
+| ClickUp | Vibrant Saturated | Multi-hue palette; expressive; consumer-tilted |
+| Monday.com | Vibrant Saturated | Saturated multi-hue; bold UI; high energy |
+| Dropbox | Vibrant Saturated leaning Editorial Restrained | 2017 rebrand era is the canonical example of the shift |
+
+## Vertical-specific adaptation notes
+
+- **Illustration budget matters**: brands without illustration capacity should pick Editorial Restrained or Bold Confident rather than Warm Conversational or Playful Energetic. Bad illustration kills the warm archetypes immediately.
+- **Onboarding surface as brand surface**: in productivity, onboarding flows are heavily branded and high-impact. The archetype must extend cleanly into product chrome.
+- **Self-serve discovery**: pricing pages, signup flows, and product tours carry brand weight. Restraint in these surfaces signals trust; warmth signals approachability.
+- **Bottom-up adoption pattern**: brands are evaluated by individual users before procurement. The archetype should not require enterprise sign-off to feel right.
+
+## Common archetype evolution
+
+Productivity brands often start Warm Conversational with heavy illustration and pull back toward Editorial Restrained or Bold Confident as they scale into enterprise. Slack's evolution shows this: early Slack was warm-illustration-heavy; current Slack reads more restrained while retaining color personality. Notion's evolution is similar.
+
+The mature-stage shift is frequently: keep the personality in voice and color, remove decorative illustration from primary surfaces, lean into typographic hierarchy.
+
+## Vertical anti-patterns
+
+- **Pure Technical Precise in productivity**: reads as developer tool rather than productivity tool. Audience expects warmth.
+- **Luxe Considered in productivity**: reads as enterprise theatre. Self-serve audiences read restraint as remote.
+- **Rugged Utilitarian**: completely incompatible with the audience.

--- a/skills/brand-archetype-system/references/by-vertical/03-b2b-saas-marketing-sales.md
+++ b/skills/brand-archetype-system/references/by-vertical/03-b2b-saas-marketing-sales.md
@@ -1,0 +1,43 @@
+# B2B SaaS: Marketing and Sales
+
+## Vertical summary
+
+Brands serving marketers, sales teams, growth professionals, and revenue operations. Audience is mixed prosumer and enterprise: bottom-up adoption among individual marketers, top-down evaluation by RevOps and procurement. Brands compete on platform breadth, integration ecosystems, attribution claims, and trust signals to budget-holders.
+
+## Common archetypes in this vertical
+
+The dominant archetypes split by audience tier. **Warm Conversational** dominates SMB and prosumer (Mailchimp, Intercom, ConvertKit). **Bold Confident** appears at the growth-energy edge (Drift, Mutiny). **Clinical Trustworthy** dominates enterprise (Salesforce, Marketo). **Editorial Restrained** is the rising adjacent archetype (Webflow's marketing surfaces).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Mailchimp | Warm Conversational | Multi-hue brand; mascot-era illustration; SMB-focused |
+| Webflow | Editorial Restrained | Serif-led marketing; typographic hierarchy; designer audience |
+| HubSpot | Warm Conversational | Orange and white; rounded illustration; inbound voice |
+| Intercom | Warm Conversational | Friendly conversational brand; chat-first UX |
+| Drift | Bold Confident | Bold colors; conversational-AI positioning |
+| Marketo | Clinical Trustworthy | Cool palette; enterprise-trust signals; B2B authority |
+| Salesforce | Clinical Trustworthy at enterprise edge | Cloud iconography; trust-blue; enterprise authority |
+| ConvertKit (Kit) | Warm Conversational | Creator-focused warmth; muted palette |
+| Mutiny | Bold Confident | Saturated personalization-as-brand |
+| Apollo | Editorial Restrained leaning Bold Confident | Recent restrained typography redesign |
+
+## Vertical-specific adaptation notes
+
+- **Enterprise versus prosumer split is wide**: prosumer leans warm and friendly; enterprise leans clinical and authoritative. The brand should pick a lane and commit; trying to do both produces neither.
+- **Trust signals matter**: customer logo strips, peer-reviewed comparison tables, security certifications carry brand weight in this vertical.
+- **Demo and trial flows**: a high portion of brand perception forms during the demo or free trial. The archetype must extend cleanly into in-product surfaces.
+- **AI-positioning surge**: many brands in this category have recent AI-features positioning that affects archetype choice; AI features tend to pull brands toward Technical Precise or Bold Confident.
+
+## Common archetype evolution
+
+Marketing and sales brands frequently start Warm Conversational at SMB and evolve toward Clinical Trustworthy or Editorial Restrained as they target upmarket. Mailchimp's evolution from playful-illustration to more restrained type-led marketing reflects this. HubSpot's evolution from friendly orange to a more institutional brand presence is another example.
+
+The mature-stage shift is frequently: drop heavy illustration, narrow the palette, lean into customer evidence rather than personality.
+
+## Vertical anti-patterns
+
+- **Playful Energetic in enterprise marketing tools**: reads as unserious to budget-holders.
+- **Luxe Considered in mass-market marketing tools**: reads as out-of-touch with the SMB user base.
+- **Pure Technical Precise**: works for some categories (analytics, attribution) but feels wrong for relationship-building tools (CRM, email).

--- a/skills/brand-archetype-system/references/by-vertical/04-b2b-saas-data-analytics.md
+++ b/skills/brand-archetype-system/references/by-vertical/04-b2b-saas-data-analytics.md
@@ -1,0 +1,43 @@
+# B2B SaaS: Data and Analytics
+
+## Vertical summary
+
+Brands serving data teams, analysts, product managers, and engineers working with data infrastructure, business intelligence, and product analytics. Audience values: query power, schema clarity, time-to-first-insight, and trust in numbers. The category overlaps with developer tools at the infrastructure end and with marketing analytics at the application end.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Technical Precise** (Mixpanel, Amplitude, Snowflake) and **Editorial Restrained** (dbt, Hex, Threshold the fictional reference build). The category rewards precision; **Clinical Trustworthy** appears at the enterprise BI edge (Tableau historically); **Bold Confident** appears at the new-entrant edge (Hex at launch).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Mixpanel | Technical Precise | Cool palette; product analytics rigor; chart-as-hero |
+| Amplitude | Technical Precise | Blue and white; data-density tolerant; PLG positioning |
+| Looker | Technical Precise | Enterprise BI restraint; Google acquired |
+| Snowflake | Editorial Restrained adjacent | Restrained type; cloud-native confidence |
+| Tableau | Clinical Trustworthy historically, Editorial Restrained recently | Recent rebrand pulled toward typographic restraint |
+| dbt | Editorial Restrained | Type-led; community-driven; restraint as differentiator |
+| Hex | Bold Confident | Saturated brand; modern data workspace positioning |
+| Census | Editorial Restrained | Recent shift toward type-led restraint |
+| Hightouch | Bold Confident | Strong brand colors; reverse ETL positioning |
+| Threshold (fictional reference) | Editorial Restrained | Catalog reference build; PLG onboarding analytics |
+
+## Vertical-specific adaptation notes
+
+- **Chart and table rendering as brand**: how a chart looks, how table cells align, how numbers format are core brand expression. The archetype must extend cleanly into data visualization conventions.
+- **Documentation depth**: data tools live and die on documentation. Long-form technical reading is core to the brand surface, not auxiliary.
+- **Trust through precision**: vague claims undermine the archetype. Specific numbers, specific schemas, specific examples carry the brand.
+- **SQL and code as content**: query examples, schema definitions, and code samples are first-class brand assets.
+
+## Common archetype evolution
+
+Data brands frequently start Technical Precise and add Editorial Restrained as they mature into prosumer territory. Snowflake's evolution from pure technical to restrained editorial is the canonical case. Conversely, brands that start Bold Confident (Hex, Hightouch) often pull back toward restraint as they target enterprise.
+
+The early-stage shift is usually: keep the technical precision in product surfaces, add editorial restraint to marketing.
+
+## Vertical anti-patterns
+
+- **Playful Energetic in data tools**: reads as untrustworthy with numbers. Audiences expecting analytical rigor reject playful brand expression.
+- **Luxe Considered in data tools**: reads as marketing rather than substance.
+- **Rugged Utilitarian**: completely incompatible with the audience and the category.

--- a/skills/brand-archetype-system/references/by-vertical/05-fintech-consumer.md
+++ b/skills/brand-archetype-system/references/by-vertical/05-fintech-consumer.md
@@ -1,0 +1,43 @@
+# Fintech: Consumer
+
+## Vertical summary
+
+Brands serving individual consumers across banking, investing, payments, lending, and budgeting. Audience splits sharply by age and risk tolerance: younger audiences tolerate (and prefer) energy and playfulness; older audiences require clinical trust signals. Brands compete on trust, fee transparency, and emotional positioning around money.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Bold Confident** (Cash App, Robinhood for younger audiences) and **Clinical Trustworthy** (Chime, SoFi, Wealthfront for trust-needing positions). **Warm Conversational** appears at the savings-and-budgeting edge (Acorns). **Playful Energetic** appears at the consumer-payments edge (Venmo historically).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Cash App | Bold Confident | Black plus saturated green; oversized type; consumer-payments register |
+| Robinhood | Bold Confident | Saturated green plus black; recently more institutional |
+| Chime | Clinical Trustworthy | Trust-blue palette; calm voice; banking-not-bank positioning |
+| SoFi | Clinical Trustworthy | Multi-product trust signals; restrained palette |
+| Venmo | Playful Energetic historically | Multi-color personality; payments-as-social positioning |
+| Wealthfront | Editorial Restrained | Type-led; institutional confidence; long-term-investing register |
+| Acorns | Warm Conversational | Warm palette; round-up framing; approachable savings |
+| Mint | Clinical Trustworthy historically | Cool palette; budgeting-trust positioning |
+| Current | Bold Confident | Saturated brand; younger-audience positioning |
+| Step | Playful Energetic leaning Bold Confident | Teen-banking; character-driven |
+
+## Vertical-specific adaptation notes
+
+- **Trust versus energy is the central design tension**: every consumer fintech brand sits somewhere on this spectrum. Picking the archetype is picking the position.
+- **Regulatory and compliance copy** affects voice. The brand's voice must accommodate disclosures, terms, and risk language without breaking the archetype.
+- **Money is emotional**: the archetype carries emotional positioning about money (excitement, security, freedom, control). The visual must match the emotional position.
+- **Mobile-first**: most consumer fintech brand exposure is on phone screens. The archetype must extend cleanly to small screens with reduced ornamentation.
+
+## Common archetype evolution
+
+Consumer fintech brands frequently shift archetype as they target older audiences. Robinhood's evolution from pure bold-energy to more institutional restraint as it added retirement and IRA products is the canonical case. Cash App's evolution into financial-products-beyond-payments shows similar restraint additions.
+
+The mature-stage shift is usually: keep the brand color, add restraint to type, dial back the swagger in voice, add trust signals.
+
+## Vertical anti-patterns
+
+- **Luxe Considered in mass-market fintech**: reads as out-of-touch.
+- **Documentary Honest in payments and investing**: photography of real people does not communicate the right thing in this category; the value is the product, not the experience.
+- **Rugged Utilitarian**: completely incompatible.

--- a/skills/brand-archetype-system/references/by-vertical/06-fintech-enterprise.md
+++ b/skills/brand-archetype-system/references/by-vertical/06-fintech-enterprise.md
@@ -1,0 +1,43 @@
+# Fintech: Enterprise
+
+## Vertical summary
+
+Brands serving businesses with payments, treasury, banking, spend management, and financial infrastructure. Audience splits between developer-touching (payment infrastructure) and finance-touching (corporate cards, spend management, treasury). Brands compete on integration depth, control surfaces, and operational trust.
+
+## Common archetypes in this vertical
+
+The dominant archetypes split by audience. **Editorial Restrained** with Technical Precise undertones dominates developer-touching fintech (Stripe, Modern Treasury). **Bold Confident** dominates finance-touching B2B (Ramp, Brex, recent Mercury). **Technical Precise** dominates pure infrastructure (Plaid).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Stripe | Editorial Restrained with Technical Precise undertones | Best-in-category fintech brand; serif marketing, technical product |
+| Plaid | Technical Precise | Developer-first; cool palette; integration-as-product |
+| Mercury | Bold Confident, recently shifting to Editorial Restrained | Recent rebrand pulled back toward restraint |
+| Brex | Bold Confident | Bold colors; corporate-card energy; recent restraint additions |
+| Ramp | Bold Confident | Saturated palette; spend-management-with-energy positioning |
+| Modern Treasury | Editorial Restrained | Type-led; payments-infrastructure restraint |
+| Adyen | Editorial Restrained leaning Clinical Trustworthy | Enterprise-payments authority |
+| Square (now Block) | Bold Confident historically | Black plus accent; SMB-payments register |
+| Bill.com | Clinical Trustworthy | Cool palette; finance-team-tool positioning |
+| Carta | Editorial Restrained | Recent rebrand pulled toward editorial type-led |
+
+## Vertical-specific adaptation notes
+
+- **Developer-touching versus finance-touching split**: payment infrastructure (Stripe, Plaid) is evaluated by developers; spend management (Ramp, Brex) is evaluated by finance. The archetype must match the evaluator.
+- **Compliance and trust copy** is heavier than in consumer fintech: SOC 2, PCI-DSS, certifications must appear above the fold and be visually weighty.
+- **Documentation depth**: developer-facing fintech needs documentation as primary surface; finance-facing needs reporting and dashboards as primary surface.
+- **Multi-product expansion**: many enterprise fintech brands expand from a single product (payments, cards, banking) into a platform. The archetype must extend to multiple product lines coherently.
+
+## Common archetype evolution
+
+Enterprise fintech brands frequently start Bold Confident as challengers and shift toward Editorial Restrained as they target larger customers. Mercury's recent rebrand from bold-pastel to restrained-serif is the canonical example. Carta's recent restraint shift follows the same pattern.
+
+The mature-stage shift is usually: dial back the saturated color, lean into typographic restraint, add institutional confidence to voice.
+
+## Vertical anti-patterns
+
+- **Playful Energetic in enterprise fintech**: reads as financially unserious. Finance buyers reject playful brand expression even in modern challenger brands.
+- **Vibrant Saturated**: tolerated only when the brand is a category challenger; mature enterprise positions require restraint.
+- **Documentary Honest**: incompatible with the category; product surfaces and dashboards carry the brand, not real photography.

--- a/skills/brand-archetype-system/references/by-vertical/07-dtc-fashion.md
+++ b/skills/brand-archetype-system/references/by-vertical/07-dtc-fashion.md
@@ -1,0 +1,43 @@
+# DTC: Fashion
+
+## Vertical summary
+
+Brands selling apparel directly to consumers. Audience values: aesthetic taste alignment, quality signals, sustainability or ethical positioning where relevant. The category is dominated by photography quality; brand archetypes ride on photo direction more than on type or color. Price point splits the vertical: above 80 dollars per piece favors Luxe Considered, mass-market favors Minimal Essentialist or Warm Conversational.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Luxe Considered** (Aritzia, Reformation, COS at the premium end) and **Minimal Essentialist** (Everlane, Allbirds at launch, Cuyana). **Bold Confident** appears at streetwear and challenger brands (Stüssy digital, Kith). **Documentary Honest** appears in heritage and outdoor-adjacent fashion (Patagonia, Filson).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Aritzia | Luxe Considered | Editorial photography; serif type; mid-premium positioning |
+| Reformation | Luxe Considered with sustainability voice | Cream and earthy palette; sustainability framing |
+| Everlane | Minimal Essentialist | Black plus white; transparency narrative |
+| Allbirds (launch era) | Minimal Essentialist | Warm white plus single accent; sustainable-essentials |
+| Cuyana | Luxe Considered | Cream and warm-neutral; fewer-better-things positioning |
+| Stüssy | Bold Confident at streetwear edge | High-contrast; oversized lockup; streetwear authority |
+| COS | Minimal Essentialist | Black on white; architectural typography; H and M premium tier |
+| Filson | Documentary Honest with Rugged Utilitarian | Heritage workwear; earned authenticity |
+| Outdoor Voices (historical) | Vibrant Saturated leaning Warm Conversational | Multi-hue palette; recreation-not-sport positioning |
+| Universal Standard | Editorial Restrained | Size-inclusive premium; serif-led type-first |
+
+## Vertical-specific adaptation notes
+
+- **Photography quality is the gating factor**: every archetype in this vertical depends on excellent product and lifestyle photography. Brands without photography budget should pick Minimal Essentialist (which can survive on product-on-white) over the other archetypes.
+- **Model casting** is brand expression: who appears in the photography signals the audience the brand is speaking to. Casting decisions are archetype-relevant.
+- **Sustainability framing** is increasingly default in this vertical: the archetype may need to accommodate sustainability narrative without leaning preachy.
+- **Seasonal updates** affect archetype continuity: brands must be able to refresh imagery seasonally without breaking the brand system.
+
+## Common archetype evolution
+
+Fashion brands frequently start Minimal Essentialist at launch (low-cost archetype with high signal) and migrate toward Luxe Considered as they raise prices and add product lines. Allbirds' evolution shows this: launch era was pure Minimal Essentialist; recent surfaces lean warmer and more storied (Warm Conversational with Documentary Honest notes).
+
+Conversely, brands that start Luxe Considered sometimes pull back toward Minimal Essentialist when they target younger or more digitally-native audiences.
+
+## Vertical anti-patterns
+
+- **Technical Precise in fashion**: completely incompatible.
+- **Playful Energetic in mass-market fashion**: reads as costume; works only at children's-or-novelty edge.
+- **Bold Confident in heritage fashion**: undermines the heritage positioning.

--- a/skills/brand-archetype-system/references/by-vertical/08-dtc-beauty.md
+++ b/skills/brand-archetype-system/references/by-vertical/08-dtc-beauty.md
@@ -1,0 +1,43 @@
+# DTC: Beauty
+
+## Vertical summary
+
+Brands selling skincare, cosmetics, hair care, and personal care directly to consumers. Audience values: ingredient evidence (in clinical positions), aesthetic alignment (in aspirational positions), and category authority (in challenger positions). The vertical splits sharply across three lanes that map cleanly onto archetypes.
+
+## Common archetypes in this vertical
+
+Three clear lanes: **Vibrant Saturated** for personality-driven challenger brands (Glossier, Drunk Elephant); **Luxe Considered** for premium and aspirational (Aesop, Augustinus Bader); **Minimal Essentialist** for clinical-and-rational positioning (The Ordinary). **Documentary Honest** appears at the editorial-skincare edge (Topicals).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Glossier | Vibrant Saturated with restraint | Pink-and-white world; soft typography; community-as-brand |
+| Drunk Elephant | Vibrant Saturated | Multi-hue saturated palette; clinical ingredient framing |
+| Aesop | Luxe Considered | Apothecary aesthetic; restrained palette; editorial confidence |
+| The Ordinary | Minimal Essentialist | Black on white; ingredient-as-name; clinical transparency |
+| Fenty Beauty | Bold Confident | Saturated brand; inclusivity-as-positioning |
+| Topicals | Vibrant Saturated with editorial photography | Saturated palette plus documentary photo direction |
+| Sunday Riley | Luxe Considered | Premium clinical; warm palette; ingredient narrative |
+| Augustinus Bader | Luxe Considered | Pure luxury skincare; serif-led; minimal product range |
+| Tatcha | Luxe Considered | Japanese-influenced premium; cream palette; heritage narrative |
+| Bubble | Vibrant Saturated leaning Playful Energetic | Gen-Z skincare; bright multi-hue; accessible price point |
+
+## Vertical-specific adaptation notes
+
+- **Three-lane decision is the central archetype choice**: Vibrant Saturated (personality), Luxe Considered (premium), Minimal Essentialist (clinical). Commit to one lane; trying to do two reads as confused.
+- **Ingredient communication**: how ingredients are presented carries archetype weight. Clinical lane presents ingredients as data; premium lane treats ingredients as story; personality lane treats ingredients as character.
+- **Packaging design** is integrated with the digital brand: the bottle, jar, or tube on the page is brand expression. Packaging design must match the archetype.
+- **Photography conventions**: clinical lane uses product-on-white; premium lane uses editorial styled photography; personality lane uses saturated lifestyle and product-on-color.
+
+## Common archetype evolution
+
+Beauty brands frequently stay within their original archetype but refine over time. Glossier has stayed Vibrant Saturated with increasing restraint as the brand has matured. The Ordinary has stayed Minimal Essentialist with subtle additions for new product lines. Aesop has stayed Luxe Considered with consistent discipline since launch.
+
+Brands that try to switch archetypes (for example a clinical brand adding personality) usually undermine their original positioning.
+
+## Vertical anti-patterns
+
+- **Technical Precise in beauty**: incompatible; reads as cold and clinical without the trust signals to justify it.
+- **Rugged Utilitarian**: completely incompatible.
+- **Mixed clinical-and-personality**: a brand that tries to be both The Ordinary and Glossier ends up neither.

--- a/skills/brand-archetype-system/references/by-vertical/09-dtc-home-lifestyle.md
+++ b/skills/brand-archetype-system/references/by-vertical/09-dtc-home-lifestyle.md
@@ -1,0 +1,43 @@
+# DTC: Home and Lifestyle
+
+## Vertical summary
+
+Brands selling bedding, furniture, kitchenware, home accessories, and lifestyle goods directly to consumers. Audience values: aesthetic taste alignment, quality signals, sustainability framing where relevant. The vertical rides on lifestyle photography quality more than any other element; the archetype is downstream of how the brand photographs interiors and objects in use.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Warm Conversational** (Brooklinen, Article, Floyd in marketing) and **Luxe Considered** (Parachute, West Elm, Pottery Barn premium tier). **Minimal Essentialist** appears at the design-purist edge (Floyd in product surfaces, Hem). **Bold Confident** appears at the challenger-mattress edge (Tuft and Needle historically, Casper historically).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Brooklinen | Warm Conversational | Friendly bedding brand; mid-saturation palette; clear value framing |
+| Parachute | Luxe Considered | Cream and warm-neutral; aspirational bedding |
+| Article | Warm Conversational | Mid-century furniture; muted palette; design-led |
+| Floyd | Minimal Essentialist | Minimal modular furniture; clean type; restrained palette |
+| West Elm | Luxe Considered | Premium home; serif type; lifestyle photography |
+| Tuft and Needle (historical) | Bold Confident historical, Warm Conversational now | Direct-to-consumer mattress positioning |
+| Casper (historical) | Bold Confident historical | Original sleep-better-everything campaign register |
+| Hem | Minimal Essentialist | Scandinavian-influenced minimal; modular furniture |
+| Quince | Minimal Essentialist leaning Luxe Considered | Premium-quality at accessible pricing; restraint as positioning |
+| Snowe | Luxe Considered | Cream palette; minimal kitchenware aesthetic |
+
+## Vertical-specific adaptation notes
+
+- **Lifestyle photography is the foundation**: the archetype rides on environmental photography quality. Bad room photography kills any archetype in this vertical.
+- **Product-in-context dominates**: the bedding on a real bed, the chair in a real room. Product-on-white works only for technical specifications, not for hero photography.
+- **Material and craftsmanship narrative**: how the brand discusses what the product is made of carries archetype weight. Luxe Considered uses material story heavily; Warm Conversational uses it lightly.
+- **Sustainability framing**: increasingly default in this vertical; the archetype must accommodate it without leaning preachy.
+
+## Common archetype evolution
+
+Home brands frequently start Warm Conversational at launch and pull toward Luxe Considered as they raise prices and add product lines. Parachute's evolution shows this: launch era was more Warm Conversational; current Parachute is firmly Luxe Considered. Brooklinen has stayed Warm Conversational by intentionally holding its accessibility positioning.
+
+The mature-stage shift is usually: dial back the brand color, lean into typography and photography, drop overt accessibility framing.
+
+## Vertical anti-patterns
+
+- **Technical Precise in home goods**: completely incompatible.
+- **Vibrant Saturated in home goods**: works only at the kids and novelty edge; reads as cheap on premium furniture and bedding.
+- **Rugged Utilitarian**: works only when the brand is genuinely heritage-craftsman (cast iron, woodworking); slips into costume on mainstream home goods.

--- a/skills/brand-archetype-system/references/by-vertical/10-dtc-food-beverage.md
+++ b/skills/brand-archetype-system/references/by-vertical/10-dtc-food-beverage.md
@@ -1,0 +1,43 @@
+# DTC: Food and Beverage
+
+## Vertical summary
+
+Brands selling beverages, snacks, supplements, and packaged food directly to consumers. Audience values: ingredient transparency, taste promise, and category disruption framing. The vertical is dominated by challenger brands using nostalgic-or-bold positioning to break into commoditized categories (soda, water, snacks, protein, energy drinks).
+
+## Common archetypes in this vertical
+
+The dominant archetype right now is **Retro Nostalgic** (Olipop, Liquid Death, Poppi), differentiating by era pick more than by archetype switch. **Bold Confident** appears at the energy and functional drink edge (AG1, Athletic Brewing). **Minimal Essentialist** appears at the clean-label edge (RXBar). **Vibrant Saturated** appears at the wellness-with-personality edge (Recess).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Olipop | Retro Nostalgic (70s lean) | Wellness-soda category creator; 70s wellness palette and type |
+| Liquid Death | Retro Nostalgic (80s metal lean) | Water with metal-band branding; saturated metal aesthetic |
+| Poppi | Retro Nostalgic (90s lean) | Pastel 90s palette; gut-health soda |
+| AG1 (Athletic Greens) | Bold Confident | Black plus saturated green; premium green-powder positioning |
+| RXBar | Minimal Essentialist | Black on white; no-bullshit label as brand identity |
+| Athletic Brewing | Bold Confident with retro undertones | Non-alcoholic beer; heritage type plus modern energy |
+| Recess | Retro Nostalgic (70s wellness lean) | Pastel palette; CBD and adaptogens with chill positioning |
+| Magic Spoon | Retro Nostalgic (90s cereal lean) | Adult cereal with 90s saturated palette |
+| Olly | Retro Nostalgic with Playful Energetic notes | Mass-market vitamins with playful 70s wellness register |
+| Bare Performance Nutrition | Bold Confident | Black plus saturated accent; performance-supplement register |
+
+## Vertical-specific adaptation notes
+
+- **Era pick is the differentiation strategy**: the F and B challenger category is dominated by Retro Nostalgic right now. Brands differentiate primarily by which era they reference, not by which archetype they pick.
+- **Packaging design is integrated with digital**: the can, bottle, or box on the website is the brand. Packaging design must lead the digital brand expression.
+- **Ingredient transparency is default**: nutrition facts, ingredient lists, and provenance stories must accommodate the archetype.
+- **Subscription mechanics**: many F and B brands are subscription-driven; the archetype must extend cleanly into subscription management and unsubscribe surfaces.
+
+## Common archetype evolution
+
+F and B challenger brands frequently start strong in Retro Nostalgic and stay there. The brand identity is the era choice. Brands that try to evolve away from their original era reference usually lose differentiation.
+
+Mature brands sometimes dial back the era reference as they enter mass distribution: Olipop's recent surfaces are subtler about the 70s reference than its original launch.
+
+## Vertical anti-patterns
+
+- **Editorial Restrained in F and B**: works only at premium spirits and craft chocolate; reads as wrong-category for mass beverage and snack.
+- **Technical Precise**: completely incompatible.
+- **Generic minimalism**: F and B is so saturated with retro-and-bold brands that Minimal Essentialist works only when the brand has a sharp specific reason to be minimal (RXBar's no-bullshit label is the canonical case).

--- a/skills/brand-archetype-system/references/by-vertical/11-consumer-health-wellness.md
+++ b/skills/brand-archetype-system/references/by-vertical/11-consumer-health-wellness.md
@@ -1,0 +1,43 @@
+# Consumer Health and Wellness
+
+## Vertical summary
+
+Brands serving consumers across telehealth, mental wellness, fitness, supplements, and self-care. Audience values: trust signals, clinical credibility, and emotional positioning around health. The vertical splits between mental health (which leans warmer and softer) and physical health (which leans clinical and trust-led).
+
+## Common archetypes in this vertical
+
+The dominant archetypes split by mental versus physical: **Clinical Trustworthy** for telehealth and physical-meds (Hims, Ro, Cerebral, Care/of); **Warm Conversational** and **Playful Energetic** for mental wellness (Calm, Headspace); **Vibrant Saturated** at the gen-Z mental health edge (Bumble Health). **Editorial Restrained** appears at the longevity-clinic edge (Function Health).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Hims | Clinical Trustworthy with peach warmth | Mens-health telehealth; warm tone breaks pharmaceutical cold |
+| Hers | Clinical Trustworthy with warm accent | Womens-health telehealth; same brand system, womens lens |
+| Ro | Clinical Trustworthy | Trust-blue palette; multi-condition telehealth |
+| Care/of | Clinical Trustworthy with Warm Conversational | Personalized supplements; warm trust register |
+| Cerebral | Clinical Trustworthy | Mental-health telehealth; restraint signals seriousness |
+| Calm | Vibrant Saturated with restraint | Sleep-and-meditation; gradient-rich; soft palette |
+| Headspace | Playful Energetic | Orange brand; character-illustration-driven; meditation-with-personality |
+| Talkspace | Clinical Trustworthy | Therapy access; cool palette; trust signals |
+| Function Health | Editorial Restrained | Longevity testing; type-led restraint; institutional confidence |
+| Whoop | Technical Precise | Performance health; data-density; athlete positioning |
+
+## Vertical-specific adaptation notes
+
+- **Mental versus physical health split**: mental health brands lean warmer (Calm, Headspace, Talkspace); physical health brands lean clinical (Hims, Ro). The audience signals differ; the archetype must match.
+- **Regulatory copy** affects voice. FDA disclaimers, medical disclaimers, prescription-required notices must accommodate the archetype.
+- **Trust through specificity**: vague claims undermine the archetype. Specific dosages, specific evidence, specific licensed-clinician credentials carry the brand.
+- **Subscription-and-cancellation flows**: the archetype must extend into ongoing subscription management; brands often lose trust here when the archetype breaks.
+
+## Common archetype evolution
+
+Health and wellness brands frequently stay in their original archetype but refine. Hims has stayed Clinical Trustworthy with growing warmth as it expanded categories. Calm has stayed in its restrained-vibrant lane as it expanded from meditation to sleep to broader wellness.
+
+Mental wellness brands that try to add physical-health products (or vice versa) often struggle to extend the archetype; the brand may need to operate two parallel archetypes for two product lines.
+
+## Vertical anti-patterns
+
+- **Bold Confident in clinical wellness**: reads as overpromising. Health categories punish overpromise heavily.
+- **Rugged Utilitarian**: works only in performance-athletic wellness; reads wrong in mainstream health.
+- **Vibrant Saturated in physical health**: works only at younger-audience edges (Bumble Health for college students); reads wrong in mainstream telehealth.

--- a/skills/brand-archetype-system/references/by-vertical/12-hospitality-travel.md
+++ b/skills/brand-archetype-system/references/by-vertical/12-hospitality-travel.md
@@ -1,0 +1,43 @@
+# Hospitality and Travel
+
+## Vertical summary
+
+Brands across hotels, short-term rentals, travel platforms, and travel-adjacent services. Audience values: trust signals (especially for booking platforms), aesthetic alignment (for hotels and properties), and experiential promise. The vertical is photography-dominated; the archetype rides on photo direction.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Documentary Honest** (Airbnb in marketing, Selina, Hostelworld) and **Luxe Considered** (Aman, Four Seasons, premium hotel collections). **Editorial Restrained** appears at the hotel-tech edge (Sonder). **Minimal Essentialist** appears at travel-product brands (Away). **Bold Confident** at the disruptor edge (Hopper).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Airbnb | Documentary Honest | Real-photography of real homes; experiential framing |
+| Aman | Luxe Considered (extreme) | Pure luxury hospitality; serif-led; understated authority |
+| Four Seasons | Luxe Considered | Premium hotel chain; institutional luxury aesthetic |
+| Selina | Documentary Honest | Lifestyle hotels; real-photography; community framing |
+| Sonder | Editorial Restrained | Boutique short-stay; type-led; quiet confidence |
+| Away | Minimal Essentialist | Travel luggage; minimal product photography; restrained type |
+| Marriott Bonvoy | Luxe Considered | Loyalty program brand; aspirational typography |
+| Hopper | Bold Confident | Saturated brand; price-prediction positioning |
+| Hostelworld | Playful Energetic | Backpacker positioning; multi-color; younger-audience |
+| Tripadvisor | Warm Conversational | Trust-through-reviews; friendly approachable register |
+
+## Vertical-specific adaptation notes
+
+- **Photography defines the vertical**: the archetype is downstream of photo direction. Brands without exceptional photography cannot execute Documentary Honest or Luxe Considered.
+- **Booking flow versus discovery flow**: the brand must extend across both surfaces. Booking flow leans toward trust signals (Clinical Trustworthy notes); discovery flow leans toward aspiration (the chosen archetype).
+- **Trust signals matter**: reviews, ratings, cancellation policies must appear with archetype-appropriate weight. Luxe Considered makes trust signals understated; Documentary Honest puts them alongside imagery.
+- **Multi-property versus single-property**: hotel chains (Marriott, Hilton) face different brand challenges than single-property luxury (Aman individual properties). The archetype must scale.
+
+## Common archetype evolution
+
+Hospitality brands frequently stay in their original archetype. Airbnb has stayed Documentary Honest through multiple rebrand iterations. Aman has stayed Luxe Considered since launch. Travel-product brands (Away) have stayed Minimal Essentialist.
+
+Brands that try to switch archetypes (for example a budget brand trying to feel premium without raising prices) usually fail to land.
+
+## Vertical anti-patterns
+
+- **Technical Precise in hospitality**: completely incompatible.
+- **Rugged Utilitarian in mainstream hospitality**: works only at adventure-travel edges (REI Adventures); reads wrong in city hotels.
+- **Vibrant Saturated in luxury hospitality**: undermines the premium positioning immediately.

--- a/skills/brand-archetype-system/references/by-vertical/13-media-publishing.md
+++ b/skills/brand-archetype-system/references/by-vertical/13-media-publishing.md
@@ -1,0 +1,43 @@
+# Media and Publishing
+
+## Vertical summary
+
+Brands across digital publications, newsletters, books, podcasts, and editorial platforms. Audience values: editorial voice, intellectual rigor, and reading experience quality. The vertical is dominated by typography; the archetype rides on type system more than on color or photography.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Editorial Restrained** (Substack, The Browser, Bloomberg, NYT Cooking) and **Luxe Considered** (Stripe Press, premium book design). **Minimal Essentialist** appears at the classic-publishing edge (Medium in its restrained era). **Documentary Honest** appears at journalism-as-brand (NYT visual journalism).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Substack | Editorial Restrained | Serif-led; cream paper; type-as-product |
+| Stripe Press | Luxe Considered | Premium book design; typography excellence; collector-grade |
+| The Browser | Editorial Restrained | Restrained newsletter; type-led; institutional reading register |
+| NYT Cooking | Editorial Restrained | Recipe-focused; serif typography; brand-trust-through-restraint |
+| Bloomberg | Editorial Restrained | Financial publishing; high-density information; institutional confidence |
+| The Information | Editorial Restrained | Tech business journalism; type-led; subscriber-business model |
+| Medium (classic) | Minimal Essentialist | Original era was pure restrained sans; recent evolution warmer |
+| The New York Times | Editorial Restrained | Canonical example; serif-led; institutional journalism |
+| Defector | Editorial Restrained with personality | Worker-owned sports; restrained with editorial voice |
+| Lithub | Editorial Restrained | Literary publishing; serif throughout; reading-first |
+
+## Vertical-specific adaptation notes
+
+- **Type system carries the brand**: in media and publishing, the typography is the brand. Most archetype decisions are font-pair decisions.
+- **Reading experience as primary surface**: the article page must lead the brand expression. Marketing surfaces follow the article-reading experience.
+- **Long-form versus short-form**: long-form journalism brands lean Editorial Restrained or Documentary Honest; newsletter and short-form brands have more archetype range.
+- **Subscription mechanics**: paywall surfaces, subscription management, and unsubscribe flows must extend the archetype. Brands often lose archetype coherence at these surfaces.
+
+## Common archetype evolution
+
+Media brands frequently stay in their original archetype. Substack has stayed Editorial Restrained since launch. The New York Times has stayed Editorial Restrained for over a century. Bloomberg has stayed Editorial Restrained through multiple redesigns.
+
+Brands that try to add personality to a restrained archetype (Medium's attempts to feel warmer over time) often produce confusion. The discipline is the brand.
+
+## Vertical anti-patterns
+
+- **Bold Confident in journalism**: undermines credibility; reads as opinion-blog rather than reporting.
+- **Vibrant Saturated in publishing**: works only at children's-publishing and novelty edges.
+- **Technical Precise in media**: works only at niche publications (tech-focused) and reads wrong elsewhere.

--- a/skills/brand-archetype-system/references/by-vertical/14-edtech.md
+++ b/skills/brand-archetype-system/references/by-vertical/14-edtech.md
@@ -1,0 +1,43 @@
+# EdTech
+
+## Vertical summary
+
+Brands across K-12 learning, higher education, professional development, and consumer learning apps. Audience splits sharply by age and learning context: children's apps lean playful; professional development leans clinical; consumer learning leans warm; technical education leans precise. The vertical rewards personality on the consumer side and authority on the institutional side.
+
+## Common archetypes in this vertical
+
+The dominant archetypes split by audience. **Playful Energetic** for K-12 and habit-forming consumer learning (Duolingo, Khan Academy Kids). **Warm Conversational** for adult consumer learning (Khan Academy, Brilliant). **Clinical Trustworthy** for professional development (Coursera, edX). **Luxe Considered** for premium adult education (MasterClass). **Technical Precise** for technical education (Codecademy, Frontend Masters).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Duolingo | Playful Energetic (canonical) | Owl mascot; saturated green; character-driven habit formation |
+| Khan Academy | Warm Conversational | Friendly approachable; muted palette; non-profit mission framing |
+| Brilliant | Bold Confident leaning Warm Conversational | Math-and-science learning; saturated palette; problem-solving register |
+| MasterClass | Luxe Considered | Premium adult education; editorial photography; celebrity-instructor positioning |
+| Codecademy | Technical Precise | Developer education; dark mode; code-first |
+| Coursera | Clinical Trustworthy | Higher-ed-credentialed; cool palette; institutional partnerships |
+| edX | Clinical Trustworthy | University-courses-online; restrained academic register |
+| Udemy | Warm Conversational | Mass-market courses; multi-hue palette; accessible pricing |
+| Outschool | Playful Energetic with Warm Conversational | K-12 small-group learning; warm illustration; family register |
+| Frontend Masters | Technical Precise | Developer-focused; dark mode; instructor-as-authority |
+
+## Vertical-specific adaptation notes
+
+- **Audience age determines archetype**: K-12 leans playful; teens lean bold; adults lean warm or clinical; technical learners lean precise. Pick the audience first.
+- **Habit formation versus information transfer**: habit-formation products (language apps, daily-skill apps) lean playful. Information-transfer products (course platforms, lectures) lean restrained or clinical.
+- **Credential signaling**: institutional partnerships, certifications, accreditation must appear with archetype-appropriate weight. Clinical Trustworthy makes them prominent; Playful Energetic makes them secondary.
+- **Progress mechanics**: streaks, badges, leveling are core to many edtech products. The archetype must extend into gamification surfaces.
+
+## Common archetype evolution
+
+Edtech brands frequently start in their target audience archetype and stay. Duolingo has stayed Playful Energetic since launch (with increasing character development). Coursera has stayed Clinical Trustworthy. MasterClass has stayed Luxe Considered.
+
+Brands that try to switch (a K-12 brand attempting to add adult learning) usually need to operate two parallel archetypes for two product lines.
+
+## Vertical anti-patterns
+
+- **Playful Energetic for adult professional development**: reads as unserious; adult learners reject playful brand expression for credential-building.
+- **Clinical Trustworthy for K-12**: reads as cold and unfriendly to children and parents.
+- **Rugged Utilitarian**: works only at outdoor-education edge (NOLS, Outward Bound); reads wrong elsewhere.

--- a/skills/brand-archetype-system/references/by-vertical/15-gaming-entertainment.md
+++ b/skills/brand-archetype-system/references/by-vertical/15-gaming-entertainment.md
@@ -1,0 +1,43 @@
+# Gaming and Entertainment
+
+## Vertical summary
+
+Brands across gaming platforms, streaming services, game studios, and entertainment apps. Audience values: cultural alignment with the gaming or entertainment subculture, content discovery, and community signals. The vertical splits between platform brands (chrome that hosts content) and content brands (the games or shows themselves). Platforms tend toward restraint to let content carry; content brands lean toward expression.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Bold Confident** (Epic Games, Riot, Discord) and **Vibrant Saturated** (Discord with character, Twitch). **Editorial Restrained** appears at the platform-chrome edge (Steam at category level). **Retro Nostalgic** appears at indie-gaming and arcade-revival brands. **Minimal Essentialist** appears at platform-distributor edges (Itch.io).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Discord | Vibrant Saturated with character | Multi-hue brand palette; community-focused; playful chrome |
+| Steam | Editorial Restrained at category level | Platform chrome restrained to let games lead; dark mode dominant |
+| Twitch | Vibrant Saturated | Saturated purple; live-streaming positioning |
+| Epic Games | Bold Confident | Strong brand colors; platform energy |
+| Riot Games | Bold Confident | Saturated brand; competitive-gaming positioning |
+| Itch.io | Minimal Essentialist | Indie game platform; minimal chrome; lets games carry |
+| Spotify (entertainment) | Vibrant Saturated | Saturated green; mood-based personalization |
+| Netflix | Bold Confident | Black plus red; content-as-hero; minimal platform chrome |
+| HBO Max (Max) | Editorial Restrained leaning Luxe Considered | Premium streaming positioning; restrained type |
+| Roblox | Playful Energetic | Multi-color brand; family-friendly positioning |
+
+## Vertical-specific adaptation notes
+
+- **Platform versus content distinction**: platform brands (the place where games or shows live) lean toward restraint to avoid competing with content. Content brands (individual games, shows, studios) lean toward expression.
+- **Dark mode dominance**: most gaming and entertainment surfaces lean dark-mode-first to support content viewing.
+- **Subculture signaling**: gaming brands often signal subculture alignment (esports, indie, MMO, casual mobile). The archetype must extend to subculture-appropriate visual cues.
+- **Live and real-time experiences**: many brands in this vertical have real-time surfaces (live streams, multiplayer lobbies) that affect archetype expression.
+
+## Common archetype evolution
+
+Gaming brands frequently choose archetypes orthogonal to their content. Discord is Vibrant Saturated despite hosting communities of every register. Steam is Editorial Restrained despite hosting saturated games. The platform chrome makes a brand decision separate from the content's character.
+
+Mature platforms sometimes pull back ornamentation to let content lead (Netflix's evolution toward minimalist chrome shows this).
+
+## Vertical anti-patterns
+
+- **Clinical Trustworthy in gaming**: incompatible; gaming audiences reject clinical framing.
+- **Rugged Utilitarian**: works only at simulation-and-mil-sim edges; reads wrong on mainstream gaming.
+- **Luxe Considered in mass gaming**: works only at premium subscription tiers (Max, Apple TV Plus); reads wrong on free-to-play and casual.

--- a/skills/brand-archetype-system/references/by-vertical/16-marketplace.md
+++ b/skills/brand-archetype-system/references/by-vertical/16-marketplace.md
@@ -1,0 +1,43 @@
+# Marketplace
+
+## Vertical summary
+
+Brands operating two-sided platforms connecting buyers and sellers across categories: handmade goods, secondhand, niche-expert, livestream commerce, B2B wholesale. Audience values: trust signals, seller quality verification, and category authority. Marketplace brands face a unique brand challenge: the platform brand interacts with hundreds or thousands of seller brands, and the platform must hold an identity that does not compete with seller identities.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Warm Conversational** (Etsy, Faire in marketing) and **Bold Confident** (StockX, Whatnot). **Editorial Restrained** appears at the niche-expert edge (Reverb). **Vibrant Saturated** appears at the gen-Z commerce edge (Depop). **Documentary Honest** at the artisan-commerce edge (Etsy's seller stories).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Etsy | Warm Conversational with craft emphasis | Handmade marketplace; warm palette; seller-story framing |
+| Reverb | Editorial Restrained with niche-expert voice | Musical instruments; type-led; expertise-as-trust |
+| Faire | Editorial Restrained | Wholesale marketplace; restrained type; B2B confidence |
+| StockX | Bold Confident | Sneakers and streetwear; saturated brand; market-data positioning |
+| Whatnot | Bold Confident | Livestream commerce; saturated palette; energy register |
+| Depop | Vibrant Saturated | Gen-Z fashion resale; bright multi-hue palette |
+| Vinted | Warm Conversational | European resale; cream palette; friendly approach |
+| eBay | Bold Confident | Established marketplace; high-energy multi-color brand |
+| Mercari | Warm Conversational | Resale marketplace; soft palette; approachable |
+| Substack (creator marketplace) | Editorial Restrained | Newsletter marketplace; serif type; creator-economy framing |
+
+## Vertical-specific adaptation notes
+
+- **Platform brand versus seller brands**: the marketplace brand must hold an identity that does not compete with seller brands. Restraint often wins; let sellers carry visual energy.
+- **Trust signals matter heavily**: ratings, reviews, return policies, seller verification carry brand weight. The archetype must give trust signals appropriate space.
+- **Multi-category challenge**: marketplaces frequently span many product categories. The brand must work for fashion, electronics, home goods, and handmade simultaneously.
+- **Buyer-side versus seller-side surfaces**: marketplace brands often have parallel surfaces for buyers (consumer-facing) and sellers (creator-or-merchant facing). The archetype must extend coherently to both.
+
+## Common archetype evolution
+
+Marketplace brands frequently start in their original archetype and stay. Etsy has stayed Warm Conversational since its early days (with refinements). StockX has stayed Bold Confident since launch.
+
+Brands that try to switch archetypes (Etsy's brief attempts at more polished marketing in the late 2010s) usually pull back to their original positioning.
+
+## Vertical anti-patterns
+
+- **Luxe Considered in mass-market marketplaces**: works only at curated-luxury marketplaces (1stDibs, Sotheby's); reads out-of-place elsewhere.
+- **Technical Precise**: works only at B2B infrastructure marketplaces (Faire's developer-tools edge); reads wrong on consumer.
+- **Clinical Trustworthy**: incompatible; reads as cold and corporate where marketplaces need community feeling.

--- a/skills/brand-archetype-system/references/by-vertical/17-crypto-web3.md
+++ b/skills/brand-archetype-system/references/by-vertical/17-crypto-web3.md
@@ -1,0 +1,43 @@
+# Crypto and Web3
+
+## Vertical summary
+
+Brands across crypto exchanges, wallets, NFT platforms, DeFi protocols, and Web3 infrastructure. Audience splits between consumer (Coinbase-tier accessibility) and infrastructure (developer-and-builder-tier precision). The vertical has unusual archetype range because crypto culture spans speculative-energy to cypherpunk-minimal to artist-luxe.
+
+## Common archetypes in this vertical
+
+The dominant archetypes split by audience. **Bold Confident** for consumer crypto (Coinbase, OpenSea, Rainbow). **Technical Precise** for protocol and infrastructure (Anchor, Alchemy). **Editorial Restrained** at the writing-and-publishing edge (Mirror). **Luxe Considered** at the NFT-art edge (Foundation, Async Art). **Vibrant Saturated** at the consumer-wallet edge (Rainbow).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Coinbase | Bold Confident with blue | Trust-blue palette; mainstream-consumer positioning |
+| OpenSea | Bold Confident | Saturated palette; NFT marketplace energy |
+| Mirror | Editorial Restrained | Decentralized publishing; serif-led; restrained confidence |
+| Foundation | Luxe Considered | NFT art marketplace; cream palette; curated-gallery feeling |
+| Rainbow | Vibrant Saturated | Multi-hue wallet brand; gradient-rich; consumer-friendly |
+| Phantom | Bold Confident with purple | Solana wallet; saturated brand; consumer-tilted |
+| Uniswap | Bold Confident with Vibrant Saturated | DeFi protocol; pink-and-saturated brand; consumer-DeFi |
+| Alchemy | Technical Precise | Web3 infrastructure; developer-facing; cool palette |
+| Polygon | Bold Confident | Layer-2 infrastructure; saturated purple; institutional positioning |
+| Async Art | Luxe Considered | Programmable art; restrained gallery aesthetic |
+
+## Vertical-specific adaptation notes
+
+- **Consumer versus infrastructure split**: consumer brands (Coinbase, Rainbow, Phantom) lean energetic and friendly. Infrastructure brands (Alchemy, Anchor) lean toward Technical Precise. The archetype must match the audience.
+- **Trust signals matter**: regulatory framing, audit reports, security signals must accommodate the archetype. Bold Confident makes them inline; Technical Precise gives them dedicated surfaces.
+- **Cultural alignment**: crypto culture has subcultures (cypherpunk, DeFi-degen, NFT-collector, builder). Brands must signal which subculture they speak to.
+- **Compliance copy**: increasing regulatory pressure (especially post-2024) affects brand voice; the archetype must accommodate disclaimers without breaking.
+
+## Common archetype evolution
+
+Crypto brands frequently shift archetype as the regulatory environment matures and as they target broader audiences. Coinbase has moved from more energetic to more institutional over its lifetime. Many crypto brands started Vibrant Saturated (matching crypto culture energy of 2021-2022) and pulled back toward Bold Confident or Editorial Restrained.
+
+The mature-stage shift is typically: dial back the saturation, add trust signals, lean into typographic restraint without losing the consumer accessibility.
+
+## Vertical anti-patterns
+
+- **Warm Conversational in crypto**: works only at extremely consumer-tilted onboarding products; reads wrong on most surfaces.
+- **Rugged Utilitarian**: incompatible.
+- **Clinical Trustworthy in pure DeFi**: reads as trying to be a bank; works only at the regulated-stablecoin edge.

--- a/skills/brand-archetype-system/references/by-vertical/18-real-estate-proptech.md
+++ b/skills/brand-archetype-system/references/by-vertical/18-real-estate-proptech.md
@@ -1,0 +1,44 @@
+# Real Estate and Proptech
+
+## Vertical summary
+
+Brands across residential real estate platforms, premium real estate, proptech tools, and home-buying products. Audience splits sharply by price point: premium residential real estate leans Luxe Considered universally; mass-market platforms split between Warm Conversational, Bold Confident, and Clinical Trustworthy. The vertical rewards trust signals across every archetype because real estate transactions are high-value, high-friction, and infrequent.
+
+## Common archetypes in this vertical
+
+The dominant archetypes are **Luxe Considered** at the premium tier (Compass, Sotheby's International Realty, Pacaso). **Bold Confident** at the disruptor tier (Opendoor, Sundae). **Warm Conversational** at the consumer-information tier (Zillow). **Clinical Trustworthy** at the technology-platform tier (Redfin). **Editorial Restrained** at the proptech-software edge (some commercial real estate platforms).
+
+## Brand-to-archetype mapping
+
+| Brand | Archetype | What's distinctive |
+|---|---|---|
+| Compass | Luxe Considered | Premium residential; serif typography; agent-network positioning |
+| Zillow | Warm Conversational at consumer edge | Friendly approachable; muted palette; consumer-information register |
+| Redfin | Clinical Trustworthy | Cool palette; technology-platform positioning; agent-as-employee model |
+| Opendoor | Bold Confident | Saturated brand; instant-offer disruption framing |
+| Sundae | Bold Confident | Saturated brand; off-market-property positioning |
+| Pacaso | Luxe Considered | Co-ownership of vacation homes; premium photography; lifestyle framing |
+| Sotheby's International Realty | Luxe Considered (extreme) | Pure premium real estate; serif throughout; institutional luxury |
+| Cadre | Editorial Restrained | Commercial real estate investment platform; restrained type |
+| Knock | Bold Confident | Home-trade-in services; saturated brand |
+| Vacasa | Warm Conversational with Documentary Honest | Vacation rental management; real-photography of properties |
+
+## Vertical-specific adaptation notes
+
+- **Premium versus mass-market split is sharp**: premium real estate is universally Luxe Considered; mass-market splits into three or four archetypes based on positioning.
+- **Photography is critical**: real estate brands depend on excellent property photography. The archetype rides on photo direction.
+- **Trust signals across every archetype**: license info, agent credentials, customer reviews, third-party certifications must appear with appropriate weight. Premium archetypes make these understated; consumer archetypes make them prominent.
+- **Local versus national**: many real estate brands operate hyper-locally (individual agents and small brokerages). The archetype must extend to local agent-branded surfaces.
+
+## Common archetype evolution
+
+Real estate brands frequently stay in their original archetype. Compass has stayed Luxe Considered since launch. Zillow has stayed Warm Conversational. Redfin has stayed Clinical Trustworthy.
+
+Brands that try to switch archetypes (a mass-market brand attempting to feel premium) usually struggle to convince either audience. Real estate is unusually punishing of inauthentic positioning.
+
+## Vertical anti-patterns
+
+- **Vibrant Saturated in real estate**: incompatible; reads as untrustworthy with high-value transactions.
+- **Playful Energetic**: incompatible.
+- **Rugged Utilitarian**: works only at vacation-property and recreational-land edges; reads wrong on mainstream residential.
+- **Technical Precise**: works only at commercial real estate analytics platforms (CoStar tier); reads wrong on consumer.

--- a/skills/brand-archetype-system/references/core-archetypes/01-editorial-restrained.md
+++ b/skills/brand-archetype-system/references/core-archetypes/01-editorial-restrained.md
@@ -1,0 +1,119 @@
+# Editorial Restrained
+
+## Aesthetic summary
+
+Low-saturation, type-led, generous whitespace. Considered rather than performed. The brand earns attention through restraint instead of demanding it through volume. Reads as institutional confidence without stiffness.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Conversational (warm but precise, comfortable with first person)
+- **Aesthetic register**: Restrained
+- **Audience relationship**: Peer
+- **Sensory ambition**: Considered
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #0F1B2D | Primary text, body, anchors |
+| ink-muted | #1F2D44 | Secondary text |
+| paper | #FAF9F6 | Warm off-white background |
+| paper-soft | #F3F1EC | Card surfaces, subtle elevation |
+| accent | #5B8B85 | Single accent for links and key actions |
+| accent-muted | #3F6E55 | Hover states, secondary accent applications |
+| highlight | #C9A227 | Numeric callouts, display sizes only |
+| highlight-body | #8E6E1A | Same hue at body-text contrast (WCAG AA) |
+| line | #EDEFF2 | Borders, separators |
+
+Rationale:
+- Ink at #0F1B2D not pure black. Pure black on warm paper feels harsh; navy ink reads as ink-on-paper.
+- Paper at #FAF9F6 not pure white. Warm tint signals editorial register versus UI register.
+- Accent restricted to one hue. Two-color systems read as institutional; multi-color reads as consumer.
+- Highlight restricted to display sizes; the body-contrast variant (#8E6E1A) covers WCAG AA at smaller scales without losing the warm-gold character.
+
+## Type pairing starter
+
+- **Display**: IBM Plex Serif (Google Fonts, free). 700 for hero, 600 for sections.
+- **Body**: Inter (Google Fonts, free). 400 for prose, 500 for UI labels.
+- **Numerics**: JetBrains Mono (Google Fonts, free). 400 to 500 for KPIs and code.
+
+Size scale (modular, 1.2 ratio anchored at 16px):
+- Hero: 56 to 72px serif
+- H2: 32 to 40px serif
+- H3: 22 to 26px serif
+- Body: 16 to 18px sans
+- Small: 13 to 14px sans
+- Mono: 14 to 16px monospace
+
+Pairing rationale: serif display plus sans body is the classic editorial pairing (NYT, magazines). IBM Plex specifically has open apertures and modest contrast that reads as institutional but modern. JetBrains Mono for numbers communicates precision without being overtly technical.
+
+## Layout and composition
+
+- Generous whitespace. Sections separated by 96 to 128px vertical rhythm minimum.
+- Single-column hero, content left-aligned, max-width around 720px for prose.
+- Asymmetric grids on landing pages: 2-column with deliberate imbalance (40/60 or 60/40) more often than centered or 50/50.
+- Density: low. The page should breathe.
+- Cards: subtle elevation via 1px line border at line color, no drop shadows.
+
+## Imagery direction
+
+- Photography: editorial, low-touched, real environments, natural light.
+- Illustration: rare. If used, line-only, single color, technical drawing register.
+- Product UI: shown in stylized chrome with branded surfaces; rarely the actual app screenshot.
+- Decorative imagery: avoided. Everything earns its place.
+
+## Voice samples
+
+- "Built around the question, not against the event stream."
+- "Real components, real brand foundations, real working forms."
+- "The measurement surface PLG teams actually need."
+- "Onboarding metrics live in the cracks between general-purpose tools."
+- "Focused, not just smaller."
+- "Sample funnel, real benchmarks, your cohort."
+- "Pre-built activation funnels. Time-to-first-value benchmarking."
+
+Cadence: complete sentences. Comma-separated qualifiers more often than dashed asides. Direct claims with built-in qualification. No exclamation marks. Numerals over written numbers.
+
+## Component pattern descriptions
+
+**Hero**: Eyebrow (uppercase, accent color, letterspaced 0.16em), then serif headline 56 to 72px, then sans subhead 18px paragraph, then 2 buttons (primary solid ink, secondary outline), optional KPI strip below.
+
+**Buttons**: Primary is solid ink, white text. Secondary is white surface, ink border 1px, ink text. No gradients. No drop shadows. Hover state shifts opacity to 0.9 or fills the secondary surface.
+
+**Cards**: Paper-soft background, 1px line border, 24 to 32px internal padding. Numerals top-left in mono. Title in serif. Body in sans.
+
+**Tables**: Paper-soft header row, line color separators between rows, monospace numerics aligned right.
+
+## When to pick this
+
+- B2B brand for a measured, considered audience (PMs, engineers, founders, finance)
+- Category is loud and your differentiation is calm
+- Product earns attention through depth rather than novelty
+- Audience reads documentation and trusts restraint
+
+## When to avoid
+
+- Consumer brand for an audience that wants energy and warmth
+- Product that needs to feel inviting at first touch
+- Category where competitors are already restrained (you will disappear)
+- Brand that needs to communicate playfulness or character
+
+## Adaptation guidance
+
+When applying this archetype to a specific brief:
+
+1. **Keep the structure** (whitespace, single-accent, restrained type pairing). Adapt specific values.
+2. **Color**: shift accent hue to match emotional direction. Muted teal feels rational; muted plum feels considered; muted moss feels grounded; muted slate feels institutional.
+3. **Type**: IBM Plex Serif is a starting point. Substitutes that fit: GT Sectra, Tiempos, Fraunces, Source Serif.
+4. **Density**: dial up or down based on audience. Developers tolerate more density; founders prefer more whitespace.
+5. **Highlight color**: optional. Brands without a numeric story do not need it.
+
+Direct copying of all defaults verbatim produces generic Editorial Restrained output. The brief should produce a meaningful variant.
+
+## Exemplar brands
+
+Editorial Restrained is exemplified by Linear, Vercel, Stripe Press, Resend, and the fictional Threshold reference build in this catalog. Earlier examples include Pentagram's institutional work and the early Medium publication system.
+
+These brands share: serif display, sans body, single accent, generous whitespace, editorial photography or stylized product UI, peer-relationship voice.
+
+The archetype overlaps with Technical Precise (Stripe docs, Sentry); blended brands typically use Editorial Restrained for marketing surfaces and Technical Precise for documentation surfaces.

--- a/skills/brand-archetype-system/references/core-archetypes/02-technical-precise.md
+++ b/skills/brand-archetype-system/references/core-archetypes/02-technical-precise.md
@@ -1,0 +1,122 @@
+# Technical Precise
+
+## Aesthetic summary
+
+Monospace prominent in display and numerics. Grid visible in compositions. Data density tolerated and embraced. Dark mode often dominant. Cool palette with high precision feel. The brand communicates that it understands the technical substance of what it is selling, and that its audience does too.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Professional (precise, low-affect, treats the reader as informed)
+- **Aesthetic register**: Restrained
+- **Audience relationship**: Authority
+- **Sensory ambition**: Functional
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #0A0E1A | Light-mode primary text |
+| ink-muted | #1F2937 | Light-mode secondary text |
+| paper | #FFFFFF | Light-mode background |
+| paper-soft | #F6F8FA | Light-mode card surface |
+| surface-dark | #0F1117 | Dark-mode primary background |
+| surface-dark-elevated | #161922 | Dark-mode card surface |
+| text-dark | #E6E9F2 | Dark-mode primary text |
+| text-dark-muted | #9DA4B4 | Dark-mode secondary text |
+| accent | #7C5CFF | Saturated single accent (violet shown) |
+| accent-muted | #5B3FD6 | Active state |
+| signal-success | #16A34A | Positive numeric signal |
+| signal-warn | #F59E0B | Caution signal |
+| signal-error | #DC2626 | Error signal |
+| line | #2A2F3C | Dark-mode line, panel separators |
+
+Rationale:
+- Dark mode is first-class; the palette is built dark-mode primary with light-mode adaptations.
+- Single saturated accent (violet, electric blue, lime, or cyan) lets the rest of the palette stay neutral.
+- Signal colors are functional, not decorative; reserved for status communication in dashboards and logs.
+- Lines visible (#2A2F3C in dark, #E5E7EB in light) to reinforce the grid character.
+
+## Type pairing starter
+
+- **Display**: Geist Sans (Vercel, free) or Inter Display. 600 to 700 weight.
+- **Body**: Geist Sans or Inter. 400 to 500.
+- **Monospace**: Geist Mono or JetBrains Mono. Prominent in display, numerics, code samples, KPIs, badges, and labels.
+
+Size scale (modular, 1.25 ratio anchored at 15px for higher density):
+- Hero: 48 to 64px sans
+- Hero-mono: 36 to 48px mono (for technical brands using mono in display)
+- H2: 28 to 36px sans
+- Body: 15 to 16px sans
+- Small: 13px sans
+- Code: 14 to 15px mono
+
+Pairing rationale: Geist (and its mono variant) was designed specifically for technical product interfaces. Inter plus JetBrains Mono is the equivalent if Geist is not available. The mono should appear regularly enough that the reader registers the brand uses it deliberately.
+
+## Layout and composition
+
+- Higher density than Editorial Restrained. The reader expects information.
+- Grids are visible: hairline borders on cards and tables, monospace coordinates in nav, table-of-contents sidebars.
+- Code samples are treated as primary content, not supplementary.
+- Hero often pairs a clean headline with a live-looking product surface (dashboard, terminal, code editor).
+- Dark mode is the design target; light mode is the adaptation.
+
+## Imagery direction
+
+- Photography: rare. When used, abstract or product-context, not people.
+- Illustration: technical diagrams, network graphs, architecture maps. Single accent color over neutral background.
+- Product UI: shown as real screenshots or near-real chrome. The product surface itself is the brand asset.
+- Decorative imagery: minimal. The information density is the visual.
+
+## Voice samples
+
+- "Latency p99: 47ms across 12 regions."
+- "Idempotent by default. Versioned endpoints. Zero-downtime migrations."
+- "Built for the request volume you actually have at 3am."
+- "Error budgets, not vibes."
+- "Your stack already speaks this protocol."
+- "Run it locally. Deploy it globally. Same primitives."
+- "Observability that does not require its own observability."
+
+Cadence: short. Often fragments. Numerals over words. Technical specificity over abstraction. Comfortable with industry vocabulary.
+
+## Component pattern descriptions
+
+**Hero**: Often split layout: left side is headline plus sub plus 2 CTAs, right side is a live product surface (terminal, dashboard, code editor). Or full-bleed dark with an oversized mono headline.
+
+**Buttons**: Primary is solid accent on dark, or solid ink on light. Secondary is bordered. Often a small mono prefix on labels ("$ deploy" pattern).
+
+**Cards**: Hairline border, dark-elevated background, monospace metadata in the header row, sans body. Often with a small status dot (signal color) in the corner.
+
+**Tables**: Dense. Hairline rows. Mono numerics, right-aligned. Hover state with a faint accent tint. Sortable columns marked.
+
+**Code blocks**: First-class. Syntax highlighting palette is part of the brand. Copy button. Language label.
+
+## When to pick this
+
+- Developer audience
+- Observability, platform, infrastructure, or DX product
+- Audience values data density and precise specification
+- Brand needs to communicate "we built this, we run it, we understand it"
+
+## When to avoid
+
+- Consumer audience that wants warmth
+- Product that is not technically substantive (the archetype will read as costume)
+- Brand needs to communicate approachability over rigor
+- Photography or human imagery is central to the brand story
+
+## Adaptation guidance
+
+1. **Accent hue**: violet for product-first brands, electric blue for infrastructure, lime or cyan for AI-adjacent, soft green for sustainability-leaning.
+2. **Mono density**: dial up for developer brands (mono in hero, mono in nav, mono in labels) and dial down for prosumer brands wanting only the precision signal.
+3. **Dark mode**: required. Skip this archetype if the brand cannot ship a dark mode.
+4. **Photography**: if the brand needs human imagery, blend with Editorial Restrained or Warm Conversational instead of forcing it into Technical Precise.
+5. **Voice density**: stay specific. Vague claims in this archetype read as worse than vague claims elsewhere, because the visual is promising specificity.
+
+## Exemplar brands
+
+Technical Precise is exemplified by Stripe (especially the documentation and developer surfaces), Sentry, Datadog, Vercel, Cursor, and Linear in its most technical surfaces. Adjacent older examples include the early Heroku CLI and the original GitHub UI before its consumer-tilted redesigns.
+
+These brands share: dark-mode-first, monospace prominent, code as first-class content, saturated single accent, dense tables and grids, low-affect voice.
+
+The archetype frequently blends with Editorial Restrained at the marketing surface level (Stripe's marketing pages, Vercel's announcements) while keeping the technical surface pure Technical Precise.

--- a/skills/brand-archetype-system/references/core-archetypes/03-warm-conversational.md
+++ b/skills/brand-archetype-system/references/core-archetypes/03-warm-conversational.md
@@ -1,0 +1,114 @@
+# Warm Conversational
+
+## Aesthetic summary
+
+Human imagery, mid-saturation palette with warm undertones, approachable type, second-person voice. The brand reads as a colleague who genuinely wants to help rather than a vendor selling. Friendly without performance; honest without coldness.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Conversational
+- **Aesthetic register**: Considered
+- **Audience relationship**: Companion
+- **Sensory ambition**: Considered
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #1F2937 | Primary text |
+| ink-muted | #4B5563 | Secondary text |
+| paper | #FFFBF5 | Cream background |
+| paper-soft | #FAF3E7 | Card surface |
+| accent | #D97757 | Warm terracotta primary accent |
+| accent-soft | #F3B690 | Tint of accent for backgrounds |
+| accent-deep | #A75440 | Active state |
+| support-green | #5A8A6E | Sage green secondary |
+| support-blue | #5E8FA8 | Dusty blue secondary |
+| line | #E8DFCF | Borders, separators on cream |
+
+Rationale:
+- Cream background (not white) is the foundation; it signals warmth before any other element fires.
+- Mid-saturation accent (terracotta shown) is warm and human; cooler accents (sage, dusty blue) appear as secondary tones rather than primaries.
+- The palette is calibrated mid-saturation throughout; no value is below 35% or above 70% saturation. This is what produces the "considered warmth" reading instead of either pastel or vivid.
+- Lines use a warm gray rather than neutral gray to keep coherence with the paper.
+
+## Type pairing starter
+
+- **Display**: Hubot Sans or Söhne or GT America. 600 to 700.
+- **Body**: Same family for body, 400 to 500. Single-family systems read warmer than serif plus sans pairings.
+- **Optional accent type**: a friendly humanist serif (Tiempos Text, Source Serif) for editorial moments inside otherwise sans content.
+
+Size scale (modular, 1.2 ratio anchored at 17px for comfortable reading):
+- Hero: 48 to 64px sans
+- H2: 30 to 38px sans
+- H3: 22 to 26px sans
+- Body: 17 to 19px sans (slightly larger than B2B default)
+- Small: 14 to 15px sans
+
+Pairing rationale: single-family sans systems read warm and consistent. Humanist or geometric-humanist sans (Hubot, Söhne, GT America) have rounder shapes than neo-grotesques like Helvetica, which is what produces the "friendly" reading without sliding into childlike. Body sizes run slightly larger than other archetypes because the reader is expected to actually read.
+
+## Layout and composition
+
+- Comfortable density. Not as breathing as Editorial Restrained, not as dense as Technical Precise.
+- Sections frequently use full-bleed photography or illustration as scene-setters.
+- Hero often pairs a human photo (real customer, real team member) with a friendly headline.
+- Generous interior padding inside cards and forms; the page feels welcoming rather than businesslike.
+- Curved corners (8 to 16px) on cards and buttons; sharp corners read colder.
+
+## Imagery direction
+
+- Photography: real people, varied skin tones and body types, candid rather than posed, natural light, real environments (homes, coffee shops, offices that look lived-in).
+- Illustration: custom illustration systems are common (Mailchimp's monkey era, Slack's hands-and-objects era). When used, illustration should have a consistent vocabulary rather than stock-feeling variety.
+- Product UI: shown in real photo-context (laptop on a real desk) more often than stylized chrome.
+- Stock photography pitfall: this archetype dies on bad stock photo selection. Curate hard or commission custom.
+
+## Voice samples
+
+- "Sign up takes about a minute. We will not ask for a credit card."
+- "Here is what we tried, what worked, and what did not."
+- "You probably do not need a meeting for this. But if you do, we can hop on one."
+- "Made for teams who would rather get the work done than configure the tool that does the work."
+- "Yes, we send fewer emails than other tools. On purpose."
+- "We charge what we charge because that is what it costs to run the thing well."
+
+Cadence: complete sentences. Comfortable with first and second person. Contractions and hedging are fine; performed informality ("hey friend!") is not. Reads honest, not chummy.
+
+## Component pattern descriptions
+
+**Hero**: Headline plus subhead plus 1 or 2 CTAs, often paired with a human photo or warm illustration. Background frequently cream (not white). Headline weight is mid-bold (600), not display-heavy.
+
+**Buttons**: Primary is solid accent, white text, 10 to 16px corner radius. Secondary is bordered or text-only. Hover states use a slight color deepening rather than opacity shift.
+
+**Cards**: Soft cream surfaces, 12 to 16px radius, generous padding (32 to 40px), shadow at low intensity (0 4px 12px rgba(0,0,0,0.04)).
+
+**Forms**: Generous field height (48 to 56px). Labels above inputs (not floating). Help text below fields. Pre-fill where possible.
+
+## When to pick this
+
+- Prosumer SaaS, team productivity, marketing tools at the consumer-leaning edge
+- Brand needs to communicate "we get you" more than "we are best in class"
+- Audience values approachability over rigor
+- Brand wants to differentiate in a category of cold competitors
+
+## When to avoid
+
+- Audience that reads warmth as unserious (most developer infrastructure, most enterprise)
+- Brand with limited photography or illustration budget (the archetype dies on bad imagery)
+- Brand needs to communicate authority or expertise as the primary signal
+- Category is already crowded with warm brands (you will disappear)
+
+## Adaptation guidance
+
+1. **Accent hue**: terracotta and warm orange feel grounded; sage green and dusty blue feel calm; coral and peach feel optimistic. Pick one primary based on emotional direction.
+2. **Single-family vs paired type**: single-family sans is the default. If the brand needs editorial moments, add a humanist serif as the accent type, not as the body.
+3. **Illustration vs photography**: pick one as primary. Brands trying to do both usually do neither well.
+4. **Voice**: write honest first, friendly second. Performed friendliness without honest substance reads cheap.
+5. **Density**: avoid over-roominess. The archetype tips into "marketing fluff" when the page is too breathing and the content is too thin.
+
+## Exemplar brands
+
+Warm Conversational is exemplified by Mailchimp (especially the illustration-driven era), Webflow, Slack, Notion in its marketing surfaces, Loom, Intercom, and Figma. Adjacent examples include Khan Academy and Mailchimp's earlier mascot work.
+
+These brands share: cream or warm-white surfaces, single-family sans, mid-saturation warm accent, human or custom-illustration imagery, second-person voice, comfortable density.
+
+The archetype frequently overlaps with Playful Energetic when the illustration system carries character; the difference is that Warm Conversational keeps the illustration in service of communication, while Playful Energetic lets the illustration become the dominant visual.

--- a/skills/brand-archetype-system/references/core-archetypes/04-bold-confident.md
+++ b/skills/brand-archetype-system/references/core-archetypes/04-bold-confident.md
@@ -1,0 +1,115 @@
+# Bold Confident
+
+## Aesthetic summary
+
+High-contrast color (often black plus one saturated accent). Oversized display type used as design element. Direct copy. Strong horizontal grids. The brand walks into the room and says what it is selling without flinching.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Conversational (direct, comfortable with first person)
+- **Aesthetic register**: Expressive
+- **Audience relationship**: Performer
+- **Sensory ambition**: Considered
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #0A0A0A | Near-black primary |
+| paper | #FFFFFF | White surface |
+| paper-soft | #F2F2F2 | Tinted surface |
+| accent | #FF4D2E | Saturated single accent (vibrant orange shown) |
+| accent-deep | #C13A20 | Active state |
+| support | #18181B | Off-black for layered surfaces |
+| line | #1F1F1F | Heavy line color (matches the bold register) |
+
+Alternative accent picks that fit this archetype (one only):
+- Hot pink: #EC2877
+- Lime: #C7F11D
+- Electric blue: #2563EB
+- Saturated yellow: #FFD400 (use with extreme contrast)
+
+Rationale:
+- Two-tone is the move: high-contrast black-and-white plus one saturated accent. Three or more colors dilute the boldness.
+- Pure black (or near-black) and pure white reinforce the contrast register. Off-blacks or warm whites pull the archetype toward Editorial Restrained.
+- The accent is loud enough that it has to be deployed sparingly. Used as background for one section, not as button color everywhere.
+
+## Type pairing starter
+
+- **Display**: Druk Wide, Söhne Breit, GT Sectra Display, Helvetica Now Display, or PP Editorial New (when leaning expressive editorial). Heavy weight (800 to 900) on display.
+- **Body**: Söhne, Inter, or Helvetica Now. Mid-weight (500).
+
+Size scale (extreme contrast between hero and body):
+- Hero: 80 to 140px display (the headline is the hero)
+- H2: 48 to 72px display
+- H3: 28 to 36px
+- Body: 17 to 19px
+- Small: 14 to 15px
+
+Pairing rationale: the archetype is built around extreme type contrast. Hero type runs huge (often 100px or more on desktop); body type is normal. The size ratio itself is the visual signature. Heavy display weights are non-negotiable; light or regular weights produce a different archetype entirely.
+
+## Layout and composition
+
+- Horizontal grids dominate. Heroes often full-bleed with the headline as the design element.
+- Asymmetric layouts with intentional imbalance: text aligned hard-left, oversized headlines that extend past container edges.
+- High contrast section transitions: black section, then white section, then accent section. The page reads as panels.
+- Sharp corners more often than rounded.
+- Minimal decorative imagery; the type IS the visual.
+
+## Imagery direction
+
+- Photography: high-contrast, often desaturated or single-color-tinted, real but stylized.
+- Illustration: bold flat illustration when used, single accent color, no gradients.
+- Product UI: shown in oversized chrome that mirrors the brand's contrast register.
+- Decorative: type-as-image; the headline often becomes the visual.
+
+## Voice samples
+
+- "We do not negotiate with hidden fees."
+- "Built for the people doing the actual work."
+- "This is the version that works. The free trial is the version that works."
+- "No setup call. No demo. Just sign up."
+- "We charge once. You own the thing."
+- "Our competitor's pricing page has a button to talk to sales. Ours has a price."
+
+Cadence: short sentences. Declarative. Contrasts and oppositions ("not X, just Y"). Comfortable with confrontation. Avoids hedging.
+
+## Component pattern descriptions
+
+**Hero**: Oversized headline as the dominant element (80 to 140px). Sub headline below at standard size. 1 to 2 buttons. Often a single bold visual or a horizontal divider in the accent color.
+
+**Buttons**: Primary is solid ink or accent on white. Often oversized (56 to 72px height) to match the bold register. Square or low-radius corners (0 to 4px).
+
+**Cards**: Sharp corners, heavy border (2 to 3px) or strong shadow, large internal padding. Often the card itself uses contrast (black card with white text, or accent card with black text).
+
+**Tables**: Heavy header (black background, white text). Large row height. Bold numerics.
+
+## When to pick this
+
+- Launch moments or rebrand moments where the brand needs to reset attention
+- Category is full of timid competitors and your brief needs differentiation through volume
+- Product confidence is high and the value prop is sharp
+- Brand is comfortable being polarizing
+
+## When to avoid
+
+- Brand needs to communicate care, gentleness, or expertise-through-restraint
+- Audience reads boldness as bro-culture or as insecurity
+- Product value is technical and needs space to explain itself
+- Brand will be embarrassed by the visual in 18 months (this archetype dates faster than restrained ones)
+
+## Adaptation guidance
+
+1. **Accent pick**: hot pink leans consumer, lime leans tech-edgy, electric blue leans fintech, orange leans general-purpose bold, yellow only with extreme contrast discipline.
+2. **Display size**: do not pull this back to "reasonable." If the hero is 56px, you have made an Editorial Restrained brand instead. Commit to 100px+ or pick a different archetype.
+3. **Voice**: easy to slip into bro-culture. Pull back the swagger by writing honest, not performed. The visual is bold; the voice is direct, not bombastic.
+4. **Image strategy**: pick type-as-visual or one strong photo. Mixed imagery dilutes the impact.
+5. **Use the contrast**: panel-by-panel section transitions are core. A single-color page is not Bold Confident.
+
+## Exemplar brands
+
+Bold Confident is exemplified by Loom (current era), Cash App, Robinhood, Mercury (in its recent rebrand), Notion (in product launches), Linear (in major launches), Cloudflare (consumer edge), and Brex. Adjacent older examples include the original Squarespace launch era and the original Mailchimp redesign.
+
+These brands share: high-contrast palette, oversized display type as visual element, direct voice, panel-based section transitions, one strong accent.
+
+The archetype often pairs with Technical Precise on developer-tilted brands (the marketing page is Bold Confident; the product surface is Technical Precise). It also overlaps with Vibrant Saturated when the accent is the brand color rather than a supporting note.

--- a/skills/brand-archetype-system/references/core-archetypes/05-playful-energetic.md
+++ b/skills/brand-archetype-system/references/core-archetypes/05-playful-energetic.md
@@ -1,0 +1,114 @@
+# Playful Energetic
+
+## Aesthetic summary
+
+Bright multi-color palette. Illustration-led, frequently character-driven. Dynamic, sometimes literally animated. Chunky display type or rounded sans. The brand has a personality, often a recurring character or mascot, and that personality is the primary asset.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Playful
+- **Aesthetic register**: Expressive
+- **Audience relationship**: Companion
+- **Sensory ambition**: Immersive
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #1B1B2A | Soft-black text |
+| paper | #FFFDF7 | Cream surface |
+| paper-soft | #FFF4D6 | Pastel surface tint |
+| accent-primary | #58CC02 | High-saturation primary (Duolingo green shown) |
+| accent-secondary | #FF4B4B | Bright contrast accent |
+| accent-tertiary | #FFC800 | Sunny yellow |
+| accent-quaternary | #1CB0F6 | Bright sky blue |
+| accent-quinary | #CE82FF | Bright purple |
+
+Rationale:
+- Multi-hue palette is the signature. Single-accent palettes do not produce Playful Energetic.
+- High saturation (often above 80%) across the full palette. Pastel-only is a different archetype (Vibrant Saturated pulled toward soft).
+- The palette is calibrated so any two colors can sit next to each other without clashing. This is harder than it looks and requires hue and value discipline.
+- Soft black for text (not pure black) keeps the warmth of the palette intact.
+
+## Type pairing starter
+
+- **Display**: Recoleta, Sofia Pro Black, Pangaia, or a chunky humanist serif. Heavy weight, rounded shapes.
+- **Body**: Nunito, Inter, or a rounded humanist sans. 500 to 600.
+- **Character lettering**: Many brands in this archetype use custom wordmark lettering for the brand name itself (Duolingo, Mailchimp, Headspace). The custom mark sits outside the type system.
+
+Size scale (energetic, with playful proportions):
+- Hero: 56 to 80px display (heavy weight)
+- H2: 32 to 44px display
+- H3: 22 to 28px
+- Body: 17 to 19px sans (rounded)
+- Small: 14 to 15px
+
+Pairing rationale: rounded shapes communicate friendliness. Heavy weights communicate playfulness over preciousness. The pairing is "chunky and round" rather than "tall and narrow."
+
+## Layout and composition
+
+- Generous use of decorative elements (mascot illustrations, sparkles, shapes, patterns).
+- Asymmetric layouts; intentional cheerful imbalance.
+- Diagonal motion lines, jaunty rotations on key elements (cards rotated 2 to 4 degrees), bouncy interactions on hover.
+- Heavy use of card-based sections with playful borders (heavy, often colored borders rather than hairlines).
+- Rounded corners are aggressive (16 to 24px); sharp corners feel wrong in this archetype.
+
+## Imagery direction
+
+- Illustration: custom illustration system is the brand's primary visual asset. Often character-driven (mascot has a personality and shows up across surfaces).
+- Animation: motion design is core. The mascot moves; cards bounce on hover; loading states have personality.
+- Photography: rare. When used, candid and bright, never sterile.
+- Stock imagery: forbidden. The archetype requires custom illustration capacity.
+
+## Voice samples
+
+- "Hi! It is time for your daily lesson."
+- "You did the thing. We are very proud."
+- "Skip a day, and the streak ends. We are watching."
+- "Two minutes today is better than zero minutes today."
+- "Surprise! You earned a badge."
+- "Your friend just passed you. Are you going to let that stand?"
+
+Cadence: short, punchy. First and second person. Comfortable with exclamation marks (but not abuse). Frequent direct address. Humor as a primary tool. Occasional knowing winks at the reader.
+
+## Component pattern descriptions
+
+**Hero**: Headline plus subhead plus 1 CTA, paired with a large illustration or animated mascot. The illustration is roughly equal weight to the headline rather than supplementary.
+
+**Buttons**: Heavily rounded (12 to 20px radius). Often with a 2 to 4px solid bottom border in a darker shade (the "neumorphic toy button" pattern). Bouncy hover animations.
+
+**Cards**: 16 to 24px radius, soft drop shadows, often slightly rotated. Sometimes with character illustrations integrated into the card itself.
+
+**Forms**: Inputs are oversized, friendly, with playful focus states. Validation errors are gentle ("Hmm, that does not look right" rather than "Invalid input").
+
+**Loading states**: have personality. The mascot waves, bounces, makes a face. Default spinners are missed opportunities in this archetype.
+
+## When to pick this
+
+- Consumer apps targeting habit formation, learning, or wellness
+- B2B brands intentionally breaking category convention with humor
+- Audience appreciates personality over precision
+- Brand has illustration budget and willingness to build a character system
+
+## When to avoid
+
+- Brand has no illustration budget (this archetype dies on poor illustration)
+- Audience reads playfulness as unserious (most enterprise, most developer tools)
+- Brand is selling to risk-averse buyers (finance, health, B2B procurement)
+- Brand is in a category where competitors are already playful (you will not differentiate)
+
+## Adaptation guidance
+
+1. **Character commitment**: decide early whether the brand has a mascot. Mascot brands need ongoing illustration. Mascot-less playful brands rely on pattern and color systems.
+2. **Palette discipline**: defining 4 to 6 saturated hues that compose together is the hardest part. Spend real time here; the rest of the archetype is downstream.
+3. **Motion**: the archetype needs motion to feel right in product. Static-only execution reads as toy-without-charm.
+4. **Voice**: write to one specific reader, not "users." The archetype falls apart when the voice tries to be funny without commitment.
+5. **Restraint**: even Playful Energetic needs editorial moments. Pages that are 100% playful all the way through exhaust the reader.
+
+## Exemplar brands
+
+Playful Energetic is exemplified by Duolingo (the canonical example, with a full character system), Mailchimp in its monkey-mascot era, Headspace, Asana classic era, Liquid Death (visual side), Ben and Jerry's, and MoonPay. Adjacent examples include the Trello mascot era and the original Slackbot personality.
+
+These brands share: multi-hue saturated palette, custom illustration as primary asset, second-person voice with personality, heavy use of motion, rounded everything.
+
+The archetype overlaps with Warm Conversational when the illustration is friendly but not character-driven; the difference is that Playful Energetic lets the personality become the brand, while Warm Conversational keeps the human relationship in the foreground.

--- a/skills/brand-archetype-system/references/core-archetypes/06-luxe-considered.md
+++ b/skills/brand-archetype-system/references/core-archetypes/06-luxe-considered.md
@@ -1,0 +1,112 @@
+# Luxe Considered
+
+## Aesthetic summary
+
+Serif-led across display and body. Extreme whitespace. Restrained monochromatic palette plus one premium accent. Photography is editorial-grade. Voice is sparse and confident. The brand communicates premium not by saying premium but by behaving premium: in pacing, in spacing, in what it omits.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Professional (formal but not stiff)
+- **Aesthetic register**: Restrained
+- **Audience relationship**: Authority
+- **Sensory ambition**: Theatrical
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #1A1614 | Warm near-black |
+| ink-soft | #3A332E | Secondary text |
+| paper | #F5F1EA | Cream off-white background |
+| paper-warm | #EDE6D9 | Warmer cream surface |
+| accent | #5C2A26 | Deep oxblood (alternative: forest #2D4A38, charcoal navy #1F2A40, champagne #C3A87C) |
+| accent-soft | #8B4843 | Active states |
+| line | #D9D0BC | Warm beige border |
+
+Rationale:
+- Cream and warm-neutral palette is the foundation. Pure white feels cheap in this archetype; cool grays feel corporate. Warmth is the premium signal.
+- Single deep accent (oxblood, forest, navy, champagne, deep emerald). Saturation is restrained; the depth of value carries the premium feel.
+- No bright colors. Even subtle saturation reads as cheap in this archetype.
+- Line color matches paper-warm; lines should be visible but not strong.
+
+## Type pairing starter
+
+- **Display**: Tiempos Headline, GT Super, Reckless, Reforma, or Saol Display. Light to regular weight (300 to 400).
+- **Body**: Tiempos Text, GT Super Text, or Source Serif. Light weight (300 to 400) at comfortable reading size.
+- **Optional sans**: Söhne or GT America at low weight (300) for UI labels and metadata only.
+
+Size scale (editorial proportions, smaller hero than Bold Confident, larger body than Technical Precise):
+- Hero: 48 to 64px serif (light weight)
+- H2: 32 to 42px serif
+- H3: 22 to 26px serif
+- Body: 18 to 20px serif (light weight, comfortable line height)
+- Small: 14 to 15px sans
+
+Pairing rationale: editorial serifs throughout produce the "magazine" feeling. Light weights communicate confidence without aggression. The pairing is rare in B2B (which mostly uses serif display plus sans body) and that rarity is part of the premium signal.
+
+## Layout and composition
+
+- Extreme whitespace. Sections separated by 144 to 200px vertical rhythm.
+- Often centered or left-aligned with massive horizontal margins on desktop (max content width can run 580 to 720px even on wide screens).
+- Asymmetric compositions where the imbalance is intentional and editorial (a 70/30 split with text against a single dominant photograph).
+- Minimal UI chrome. Buttons are often text-only with underlines, or thin-bordered, or absent entirely (the call to action is a single line of body copy with a link).
+- Page transitions are slow and deliberate. Animations cross-fade rather than slide.
+
+## Imagery direction
+
+- Photography: editorial-grade, professionally lit, deliberately styled. Natural light is fine but composition is intentional. Real product, real environment, but elevated.
+- Photography is large. Hero images are full-bleed or near-it. The image carries the page.
+- Illustration: rare. When used, line-only, sometimes hand-drawn or engraved-feeling.
+- Decorative imagery: none. The composition is the visual.
+- This archetype requires real photography or excellent stock curation. Bad photo direction kills it instantly.
+
+## Voice samples
+
+- "Made from cashmere. From goats that live in places we visit."
+- "One garment, one decision."
+- "We do not chase trends. We do not need to."
+- "Built in 1923. Refined since."
+- "If it is not in this collection, it is because it was not ready."
+- "The thing we changed was the thread."
+
+Cadence: short, often fragments. First-person plural ("we") more often than first-person singular. Comfortable with silence. Avoids superlatives ("the best," "the most"); the visual communicates premium without verbal claim. Numbers used sparingly, with deliberate weight when they appear.
+
+## Component pattern descriptions
+
+**Hero**: Single full-bleed photograph or a small serif headline against generous whitespace. No subhead. No CTAs in the visible hero region; the page expects the reader to scroll.
+
+**Buttons**: Often text-only with a serif underline, or thin-bordered with serif label. Solid buttons exist but are rare and reserved for primary purchase moments. Padding is generous (16 to 20px vertical).
+
+**Cards**: Often no card chrome at all; product is shown on a tinted surface with serif type alongside. When cards exist, they are bordered (1px line color) rather than shadowed, with sharp or low-radius corners (0 to 4px).
+
+**Navigation**: Minimal. Often horizontally centered with wide letter spacing. Logo small. The brand does not announce itself loudly.
+
+## When to pick this
+
+- Luxury or premium-priced products (above 50 dollars consumer, premium-tier B2B)
+- Hospitality, fashion, beauty at price points where the visual must signal value
+- Audience explicitly buys premium and is reassured by understated execution
+- Brand has the production budget for premium photography
+
+## When to avoid
+
+- Brand is competing on price or accessibility
+- Audience reads restraint as unfriendly
+- Brand has no photography budget (the archetype dies immediately)
+- Product is not actually premium (the visual will read as costume)
+
+## Adaptation guidance
+
+1. **Accent depth**: oxblood reads heritage, forest reads sustainability, deep navy reads institutional, champagne reads contemporary luxury. Pick based on brand position.
+2. **Photography commitment**: this is a photography archetype before it is a type archetype. Lock photography direction first.
+3. **Type weight discipline**: light weights (300 to 400) only. Bold serif display pulls the archetype toward Bold Confident.
+4. **CTA restraint**: resist adding obvious buy buttons in hero positions. The archetype expects the reader to discover, not be sold to.
+5. **Sans usage**: keep sans confined to UI labels and metadata. Sans body copy breaks the archetype.
+
+## Exemplar brands
+
+Luxe Considered is exemplified by Aesop, Aritzia, Reformation, La Marzocco, Loro Piana, Aman, Bottega Veneta digital, and Stripe Press (in the book design surface). Adjacent examples include the Apple mid-2010s premium product pages, Squarespace's recent rebrands, and the original Goop.
+
+These brands share: cream and neutral palette, serif-throughout type system, generous whitespace, editorial photography, sparse voice, premium pricing.
+
+The archetype overlaps with Editorial Restrained (which is the B2B-tilted cousin) and Minimal Essentialist (which strips out the serif entirely). The key difference: Luxe Considered uses the serif and warmth to signal premium; Minimal Essentialist uses absence of ornament to signal premium; Editorial Restrained uses considered ornament to signal trust.

--- a/skills/brand-archetype-system/references/core-archetypes/07-clinical-trustworthy.md
+++ b/skills/brand-archetype-system/references/core-archetypes/07-clinical-trustworthy.md
@@ -1,0 +1,115 @@
+# Clinical Trustworthy
+
+## Aesthetic summary
+
+Cool palette (blue, teal, soft greens) with optional warm accent for humanity. Sans-serif throughout. Clean compositions. Medical or financial register. Photography of products and clinical environments, occasionally real hands and real people in calm contexts. The brand communicates "trust us with something important" without sliding into cold or pharmaceutical.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Professional (calm, knowledgeable, low-affect)
+- **Aesthetic register**: Considered
+- **Audience relationship**: Authority
+- **Sensory ambition**: Functional
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #0F2540 | Deep navy primary |
+| ink-soft | #344C68 | Secondary text |
+| paper | #FFFFFF | White surface |
+| paper-soft | #F4F8FB | Cool tinted surface |
+| accent-primary | #2D7FB8 | Trust blue |
+| accent-secondary | #4CA8A0 | Soft teal |
+| warm-tone | #F4B69B | Optional peach warm accent for humanity |
+| signal-success | #2F8F5F | Calm success green |
+| line | #DAE3EC | Cool gray border |
+
+Rationale:
+- Cool palette communicates calm authority. Blues and teals are the trust signals; warm tones are optional humanizers, not primary brand colors.
+- Trust blue (#2D7FB8) is calibrated to read confident without sliding into corporate cold. Bluer (toward #1976D2) reads more pharmaceutical; teal-shifted reads more wellness.
+- The optional warm accent (peach, soft coral) is the single move that distinguishes contemporary Clinical Trustworthy from sterile pharma aesthetic. Without it, the brand reads dated.
+- White surfaces. Off-whites and creams pull the archetype toward warmth and away from clinical.
+
+## Type pairing starter
+
+- **Display**: Avenir Next, Circular, Söhne, or GT America. 500 to 700 weight.
+- **Body**: Same family, 400 to 500. Or paired with a soft humanist body (Inter, Source Sans).
+- **Optional accent serif**: A clean serif (Source Serif, Tiempos Text) used sparingly for editorial moments or testimonials.
+
+Size scale (calm, generous, accessible):
+- Hero: 48 to 60px sans
+- H2: 30 to 38px sans
+- H3: 22 to 24px sans
+- Body: 17 to 19px sans (accessible default; this archetype frequently serves older audiences)
+- Small: 14 to 15px
+
+Pairing rationale: geometric sans-serif communicates clinical without medical-sterile. Circular and Avenir specifically have open shapes that read calm rather than clinical. Body sizes run slightly larger because the audience may include older readers and the brand should not require strain.
+
+## Layout and composition
+
+- Comfortable density; not as dense as Technical Precise, not as breathing as Luxe Considered.
+- Generous internal padding inside cards and forms. Trust is communicated partly through "we are not hurrying you."
+- Hero often pairs a clean headline with a calm photograph (a real hand holding a product, a calm clinical environment, a portrait of a doctor or pharmacist).
+- Comfortable line lengths (60 to 80 characters per line) and generous line height (1.6 to 1.8).
+- Soft drop shadows on cards (gentle elevation, not floating). Rounded corners at moderate radius (8 to 12px).
+
+## Imagery direction
+
+- Photography: real hands, real products in real environments. Calm lighting (often natural). Real people who look like the audience.
+- Product packaging: shown clearly, frequently against soft tinted backgrounds.
+- Illustration: rare; when used, technical diagrams of how something works (a calm anatomical illustration, a process flow with annotations).
+- Avoid: aggressive close-ups of medical procedures, stock photos of clinicians in lab coats with crossed arms, hands-only-on-keyboard generic stock.
+
+## Voice samples
+
+- "Reviewed by licensed clinicians."
+- "Effective ingredients at evidence-backed doses."
+- "Same medication. Less hassle."
+- "Your doctor will see this report. So will you."
+- "We do not bill you for what we do not provide."
+- "If it is not safe for you, we will tell you."
+
+Cadence: complete sentences. Comfortable with first and second person. Calm, qualified, specific. Numbers used carefully (specific doses, specific time-to-response). Avoids superlatives. Compliance-aware writing without being legal-coded.
+
+## Component pattern descriptions
+
+**Hero**: Headline plus subhead plus 1 to 2 CTAs, paired with a calm photograph. Trust signals (clinician endorsements, FDA mentions, peer-reviewed citations) appear above the fold but understated.
+
+**Buttons**: Primary is solid trust-blue or solid ink-navy, white text, 8 to 12px corner radius. Secondary is bordered. Hover states use a slight darkening rather than opacity shift.
+
+**Cards**: White or paper-soft surface, 8 to 12px radius, gentle shadow (0 2px 8px rgba(15,37,64,0.06)). Generous internal padding (32 to 40px). Trust signals (clinician credentials, certification marks) frequently appear in cards.
+
+**Forms**: Generous field height (48 to 56px). Labels above inputs. Help text below explaining why each piece of information is needed (trust signal: we explain why we ask).
+
+**Trust strip**: Common pattern. Logo strip of certifications, regulatory bodies, peer-reviewed citations, or major employers using the product.
+
+## When to pick this
+
+- Telehealth, digital health platforms
+- Fintech, especially at the trust-needing edge (banking, insurance, investments for older audiences)
+- Insurance, retirement, anything where the conversion driver is "trust us with this"
+- Health-finance intersection (HSA, healthcare benefits, prescription savings)
+
+## When to avoid
+
+- Audience is young and reads clinical as boring or institutional
+- Brand needs to communicate energy or excitement
+- Category is already dominated by clinical-trustworthy brands (you will disappear)
+- Product is not actually substantive enough to support the trust register (the visual will read as costume)
+
+## Adaptation guidance
+
+1. **Cool to warm balance**: pure clinical cool reads pharmaceutical. The optional warm accent (peach, soft coral, butter yellow) is what distinguishes contemporary from dated.
+2. **Photography**: real hands and real environments are the move. Stock photos of "doctor with arms crossed" date the brand immediately.
+3. **Voice density**: write specific. Vague claims in a clinical archetype read as worse than vague claims in a playful one, because the visual is promising specificity.
+4. **Trust signals**: dedicate space to credentials, certifications, citations. Hide them and the archetype is half-built.
+5. **Density**: keep it comfortable. Both too dense and too breathing read as untrustworthy in this archetype.
+
+## Exemplar brands
+
+Clinical Trustworthy is exemplified by Hims, Ro, Care/of, Cerebral, Mercury (in finance-trust context), and Stripe (in payment-trust context). Older or adjacent examples include early One Medical, the original Headspace landing surfaces before they leaned playful, and the original Robinhood when it was selling trust over excitement.
+
+These brands share: cool palette with optional warm humanizer, geometric or humanist sans throughout, real-hand photography, calm voice with specific evidence, generous form fields with help text.
+
+The archetype frequently splits brands by surface: Clinical Trustworthy for the marketing and conversion surface, with Warm Conversational notes in customer support and post-purchase. The hand-off matters: trust converts, warmth retains.

--- a/skills/brand-archetype-system/references/core-archetypes/08-rugged-utilitarian.md
+++ b/skills/brand-archetype-system/references/core-archetypes/08-rugged-utilitarian.md
@@ -1,0 +1,115 @@
+# Rugged Utilitarian
+
+## Aesthetic summary
+
+Earth tones (clay, olive, charcoal, raw paper). Workwear-influenced type (slab serifs, condensed sans, stencil). Photography of real conditions: outdoor, working, lived-in. Voice is direct and unadorned. The brand reads as built for use rather than for show, and the visual restraint communicates that the product earns its place through function.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Conversational (plain, direct, working-class register without affectation)
+- **Aesthetic register**: Restrained
+- **Audience relationship**: Peer
+- **Sensory ambition**: Considered
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #2C2A26 | Charcoal primary |
+| paper | #F0EAD8 | Raw paper background |
+| paper-soft | #E2DAC2 | Tinted surface |
+| accent-clay | #B8543B | Clay red primary |
+| accent-olive | #5C6B3D | Olive green secondary |
+| accent-sand | #C29A60 | Warm sand tertiary |
+| accent-charcoal | #2C2A26 | Heavy charcoal (alternative primary) |
+| line | #A89B7F | Warm tan border |
+
+Rationale:
+- Earth tones throughout. The palette is derived from natural pigments: oxide reds, military olives, sun-bleached tans, deep charcoals.
+- Saturation is low to medium; nothing in the palette exceeds 60% saturation. Higher saturation pulls toward Bold Confident or Vibrant Saturated.
+- The palette reads as outdoor and used. Pure white feels wrong; cool grays feel wrong. Warmth and weight are signature.
+- Primary color is often the clay red or charcoal; olive functions as a secondary. The reverse also works.
+
+## Type pairing starter
+
+- **Display**: Druk Condensed, Bebas Neue, Roboto Slab, or a workwear-influenced slab (United Sans Slab, Sentinel). Heavy weight, condensed proportions.
+- **Body**: Inter, Söhne, or a clean humanist sans. 400 to 500.
+- **Optional accent type**: stencil or workshop-influenced display for product callouts and signage moments.
+
+Size scale (utilitarian, less extreme than Bold Confident):
+- Hero: 56 to 80px display
+- H2: 32 to 44px display
+- H3: 22 to 26px sans
+- Body: 16 to 18px sans
+- Small: 13 to 14px sans
+- Numeric mono: 14 to 16px (for spec sheets)
+
+Pairing rationale: condensed display type feels like signage on industrial equipment, on workwear labels, on shipping crates. Slab serifs feel like surveyor stamps and field guides. Clean humanist sans body keeps the page legible without dressing it up.
+
+## Layout and composition
+
+- Functional density. Information shown without softening.
+- Heavy use of horizontal rules and labeled sections (the page reads like a spec sheet or field manual).
+- Photography is large and full-bleed; the image carries the page.
+- Cards are bordered (1 to 2px) rather than shadowed. Corners are sharp or low-radius (0 to 4px).
+- Type often allCAPS for labels and section headers (reinforcing the signage register).
+
+## Imagery direction
+
+- Photography: real conditions. Real users in real environments. Dirt, sweat, weather, work. Not staged. Natural light dominant; flash photography rare.
+- Photography subjects: products in use rather than products on white. The brand wants to show what the product looks like after a season of work, not what it looks like in a studio.
+- Illustration: technical diagrams, exploded views, blueprints. Functional rather than decorative.
+- Forbidden: pristine product-on-white shots (those belong to Minimal Essentialist or Luxe Considered), happy-family-lifestyle shots (those belong to Warm Conversational).
+
+## Voice samples
+
+- "Built to outlast you."
+- "If it breaks, send it back. We will fix it."
+- "Designed in Bozeman. Tested where it gets cold."
+- "We made it heavier on purpose."
+- "Spend it on the gear. Save it on the brand."
+- "Lifetime guarantee. Read that again."
+
+Cadence: short. Direct. First-person plural ("we") when the brand speaks. Comfortable with imperative voice. No marketing jargon, no superlatives, no exclamation marks. Honest specifications over emotional appeals.
+
+## Component pattern descriptions
+
+**Hero**: Photograph (full-bleed, real-conditions) with overlaid type, or split layout with text left and photograph right. Headline in display, often condensed or slab. Buttons are direct.
+
+**Buttons**: Primary is solid charcoal or clay, white or cream text, sharp or low-radius corners (0 to 4px). Heavy and substantial; never floaty. Often labeled in all caps or with stencil-style lettering.
+
+**Cards**: Bordered (1 to 2px line), low-radius, generous internal padding. Often with a labeled header strip (uppercase, condensed) that reads like a product tag.
+
+**Tables**: Specification-sheet feel. Labeled rows. Mono numerics. Heavy horizontal rules between sections.
+
+**Product detail**: Honest. Materials listed. Construction methods explained. The reader is expected to care about how it is made.
+
+## When to pick this
+
+- Outdoor, gear, work-tool products
+- Brands where durability and utility are the genuine value proposition
+- Audience values function over fashion
+- Brand has authentic claim to ruggedness (the brand actually serves people doing the work)
+
+## When to avoid
+
+- Brand is not actually utilitarian (the archetype reads as costume when applied to delicate products)
+- Audience reads ruggedness as bro-culture or as anti-intellectual
+- Brand needs to communicate softness, care, or gentleness
+- Brand has no claim to outdoor or work-tool authenticity
+
+## Adaptation guidance
+
+1. **Authenticity test**: if the brand cannot show real photography of real use, this archetype is wrong. Switch to Documentary Honest if real photography is feasible at a different intensity.
+2. **Palette pick**: clay-and-olive feels heritage outdoor (REI, Filson register). Charcoal-and-sand feels industrial workwear (Carhartt, Dickies register). Pick based on category position.
+3. **Type weight**: heavy is non-negotiable. Light or regular weights pull the archetype toward Editorial Restrained.
+4. **Voice**: avoid performed toughness ("BUILT FOR THE GRIND"). Real Rugged Utilitarian voice is matter-of-fact, not bombastic.
+5. **Specification depth**: dedicate page real estate to materials, construction, warranty, repair policy. These are the trust signals.
+
+## Exemplar brands
+
+Rugged Utilitarian is exemplified by Patagonia, Carhartt, Yeti, Filson, Snow Peak, Best Made Co (historical), Topo Designs, REI in its product detail surfaces, Stanley (recently), and Hemlock Goods. Adjacent examples include Tom Bihn and Goruck.
+
+These brands share: earth-tone palette, condensed display or slab serif, real-conditions photography, plainspoken voice, specification depth, lifetime guarantee or repair offering.
+
+The archetype overlaps with Documentary Honest when photography is the dominant visual; the difference is that Rugged Utilitarian has explicit utility framing (this is for working) while Documentary Honest is about authentic representation more broadly (this is what real life looks like).

--- a/skills/brand-archetype-system/references/core-archetypes/09-retro-nostalgic.md
+++ b/skills/brand-archetype-system/references/core-archetypes/09-retro-nostalgic.md
@@ -1,0 +1,136 @@
+# Retro Nostalgic
+
+## Aesthetic summary
+
+Period-specific palette and type. Intentional vintage reference to a specific era (70s, 80s, 90s, or earlier). Often uses textured or grainy compositions. Voice references the era in cadence or vocabulary. The brand asks the audience to associate it with a felt period rather than with a category, and that association does most of the differentiation work.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Playful
+- **Aesthetic register**: Expressive
+- **Audience relationship**: Companion
+- **Sensory ambition**: Theatrical
+
+## Color palette starter
+
+Three era-keyed palette options. Pick ONE era; do not blend.
+
+**70s palette** (warm, earthy, optimistic):
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #2A1810 | Deep brown primary |
+| paper | #F4EAD0 | Cream ground |
+| accent-orange | #D2602B | Burnt orange |
+| accent-avocado | #6A7A3A | Avocado green |
+| accent-mustard | #D4A02E | Harvest gold |
+| accent-rust | #8E3F1E | Deep rust |
+
+**80s palette** (neon, geometric, bold):
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #0D0D2A | Deep navy primary |
+| paper | #FAF5EF | Cream surface |
+| accent-pink | #FF2D87 | Hot pink |
+| accent-cyan | #18C2D9 | Electric cyan |
+| accent-yellow | #FFD30F | Saturated yellow |
+| accent-purple | #6A2EB8 | Bold purple |
+
+**90s palette** (muted, grunge-edged, prosumer):
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #1F1A14 | Warm dark brown |
+| paper | #E8DEC8 | Aged cream |
+| accent-rust | #9C4B2E | Muted rust |
+| accent-teal | #3E7575 | Faded teal |
+| accent-yellow | #C49A35 | Aged mustard |
+| accent-purple | #654273 | Muted purple |
+
+Rationale:
+- Each era has a recognizable palette signature. Mixed-era palettes read confused; the audience cannot place the reference.
+- The 70s palette is warm and earth-toned, optimistic but not bright. The 80s palette is neon and geometric. The 90s palette is muted, with deliberate aged warmth.
+- Pick the era based on the audience's nostalgia moment: 70s for late-30s and older, 80s for late-30s to mid-40s, 90s for late-20s to mid-30s, early 00s for current 20-somethings.
+
+## Type pairing starter
+
+Era-keyed type pairings. Pick ONE era.
+
+- **70s**: Cooper Black or VAG Rounded or ITC Bauhaus (display); Cooper or Avenir (body).
+- **80s**: Eurostile, Avant Garde, or Compacta (display); a clean geometric sans (Avenir, Futura) for body.
+- **90s**: Trade Gothic, a worn grunge serif (Bureau Grot, Knockout), or a digital-feeling sans (Eurostile) for display; classic sans for body.
+
+Size scale (varies by era, but generally expressive):
+- Hero: 56 to 96px display
+- H2: 36 to 48px display
+- Body: 16 to 18px sans
+
+Pairing rationale: type is the era signature. Cooper Black is 70s consumer; Eurostile is 80s tech-future; Trade Gothic worn is 90s grunge. The reader recognizes the era through the type before recognizing it through the color.
+
+## Layout and composition
+
+- Era-specific composition styles. 70s leans toward soft asymmetric blocks and groovy curves. 80s leans toward hard geometric grids, oversized type, and Memphis-influenced shapes. 90s leans toward grunge collage, intentional rough edges, and zine-influenced layouts.
+- Textures matter: grain, scan lines, paper-aged effects, halftone. Pure digital flat surfaces fight the archetype.
+- Iconography is period-keyed: hand-drawn for 70s, geometric for 80s, photocopied-feeling for 90s.
+
+## Imagery direction
+
+- Era-keyed photography: warm-tinted and grainy for 70s, neon-lit and high-contrast for 80s, muted and slightly desaturated for 90s.
+- Often pairs modern product photography with period-accurate styling (the product is contemporary, but the styling and framing reference the era).
+- Pattern: era-accurate decorative elements (sunbursts, stripes, Memphis shapes, halftone dots) are common.
+
+## Voice samples
+
+(80s example for an energy drink brand)
+- "Soda for people who remember what soda was."
+- "From the era when caffeine had personality."
+- "Yes, it tastes like that on purpose."
+- "Made with cane sugar. Like before."
+
+(70s example for a wellness brand)
+- "Roots, herbs, and a generally chill outlook."
+- "Wellness from when wellness was just called feeling good."
+- "Brewed the long way. Drunk the slow way."
+
+Cadence: era-keyed. 70s reads warm and unhurried. 80s reads punchy and confident. 90s reads ironic and self-aware. The voice should evoke the era without quoting it directly.
+
+## Component pattern descriptions
+
+**Hero**: Often centered with oversized era-keyed display type, paired with era-accurate decorative elements (sunburst, Memphis shapes, halftone, scan lines). Background frequently textured.
+
+**Buttons**: Era-keyed. 70s buttons are rounded and warm. 80s buttons are geometric and high-contrast. 90s buttons are flat with rough edges or grunge texture.
+
+**Cards**: Often with era-specific borders (chunky 70s borders, neon 80s outlines, distressed 90s edges). Background textures common.
+
+**Patterns**: Era-keyed pattern systems are common (gingham, paisley, geometric, Memphis, halftone). Used as section backgrounds, packaging, and brand accents.
+
+## When to pick this
+
+- F&B challenger brands in commoditized categories (soda, water, snacks)
+- Lifestyle brands with a clear era-of-inspiration
+- Brands wanting to differentiate in categories crowded with contemporary minimalist competitors
+- Brand has clear position on which era and why
+
+## When to avoid
+
+- Brand has no genuine connection to the era (the archetype reads as costume)
+- Brand needs to communicate forward-looking innovation
+- Audience reads the chosen era as embarrassing or dated rather than nostalgic
+- Brand cannot commit to the era at production cost (this archetype requires real photography styling and packaging design)
+
+## Adaptation guidance
+
+1. **Era commitment**: pick one era and commit. 70s plus 80s blend reads as confused; the audience cannot place the reference.
+2. **Texture investment**: this archetype requires real textures (grain, halftone, paper aging). Flat digital versions read as contemporary-with-retro-fonts rather than genuinely retro.
+3. **Voice**: avoid direct era quotation ("groovy," "rad," "totally tubular"). The voice should feel like the era, not parody it.
+4. **Modern functionality**: the archetype is visual reference, not functional regression. The website should still work well in 2026; the visual reference is decorative.
+5. **Photography**: era-styled photography is expensive. If budget is limited, lean harder into pattern and type as era carriers.
+
+## Exemplar brands
+
+Retro Nostalgic is exemplified by Olipop (70s wellness lean), Liquid Death (80s metal lean), Poppi (90s lean), Recess (70s wellness), Athletic Brewing (early 1900s heritage lean), Magic Spoon (90s cereal lean), and Olly (70s wellness lean). Adjacent examples include Brooklyn Brewery (heritage industrial), Hoxton Hotels (period-specific by property), and Howler Brothers.
+
+These brands share: era-keyed palette and type, period-specific decorative elements, texture-rich compositions, era-aware voice, packaging design that reads as the period.
+
+The archetype frequently anchors F&B challenger brands; the era pick is the differentiation strategy within a crowded category. Olipop and Poppi are both in the gut-health soda space; they differentiate primarily through 70s versus 90s era reference.

--- a/skills/brand-archetype-system/references/core-archetypes/10-minimal-essentialist.md
+++ b/skills/brand-archetype-system/references/core-archetypes/10-minimal-essentialist.md
@@ -1,0 +1,111 @@
+# Minimal Essentialist
+
+## Aesthetic summary
+
+Black, white, single accent maximum. Sans-serif only. Extreme whitespace. Type-led but at smaller scales than Luxe Considered. Compositions almost sparse to the point of empty. Voice is short and declarative. The brand earns attention by removing rather than adding, and the absence of ornament itself becomes the brand signal.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Professional
+- **Aesthetic register**: Restrained
+- **Audience relationship**: Authority
+- **Sensory ambition**: Considered
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #000000 | True black primary |
+| paper | #FFFFFF | Pure white |
+| paper-soft | #F7F7F7 | Tinted gray surface (only when needed) |
+| muted | #888888 | Mid-gray for secondary text |
+| line | #E5E5E5 | Hairline separator |
+| accent | #FF3B30 | Optional single accent (red shown; reserve for one use case) |
+
+Rationale:
+- Pure black and pure white. Off-black or off-white pulls the archetype toward Luxe Considered or Editorial Restrained.
+- Single accent if any. Many Minimal Essentialist brands use no accent at all. When used, the accent appears once per page (a single CTA, a single error state, a single quote).
+- Gray is the secondary palette. Mid-gray for secondary text, hairline gray for borders.
+- No gradients. No tints beyond the gray scale. No color washes.
+
+## Type pairing starter
+
+- **Display and body**: One sans-serif family across all surfaces. Helvetica Now, Söhne, GT America, Inter, or Suisse Int'l. Multiple weights (300 to 700) carry the hierarchy.
+- **Optional secondary**: Sometimes the same family in a tightly-set condensed cut for labels or navigation.
+
+Size scale (modest contrast, hierarchy through weight more than size):
+- Hero: 40 to 56px sans (smaller than Bold Confident; the hero does not need to shout)
+- H2: 28 to 36px sans
+- H3: 20 to 24px sans
+- Body: 16 to 17px sans
+- Small: 13 to 14px sans
+
+Pairing rationale: one family across the system reinforces the discipline. Hierarchy is communicated through weight, size, and color rather than through type pairing. Neo-grotesque sans (Helvetica, Söhne, Suisse) feel pure; geometric sans (Avenir, Circular) feel slightly warmer; humanist sans (GT America, Inter) feel slightly friendlier. Pick based on the temperature you want.
+
+## Layout and composition
+
+- Extreme whitespace, but at smaller scale than Luxe Considered. The page reads as efficient rather than ceremonial.
+- Often a strict grid: 12-column desktop with deliberate column spans. Asymmetry less frequent than in Editorial Restrained.
+- Type-led: type sits in space rather than being framed by photography or color blocks.
+- Cards are rare. Content sits directly on the page surface with hairline separators rather than card containers.
+- Sharp corners (0 to 2px). Curves feel wrong in this archetype.
+
+## Imagery direction
+
+- Photography: product on white. Studio-lit. Considered. No styling beyond the product itself.
+- People photography: rare. When used, portraits against neutral backgrounds, minimal styling.
+- Illustration: extremely rare. Diagrams in line-only black-on-white if at all.
+- Decorative imagery: none. The whitespace is the decoration.
+
+## Voice samples
+
+- "One mattress. One price."
+- "We make the product. We tell you how it works. You decide."
+- "The product is described accurately on the product page."
+- "Returns within 100 days. No questions."
+- "There is no enterprise tier."
+- "The cheapest plan is the only plan."
+
+Cadence: very short. Declarative. First-person plural ("we") common. Numbers when relevant; otherwise sparse. The voice is honest to the point of dryness. No salesmanship, no superlatives, no hedging.
+
+## Component pattern descriptions
+
+**Hero**: Headline plus subhead plus single CTA. Often centered or hard left-aligned. Sometimes paired with a single product photograph against white; often with no imagery at all.
+
+**Buttons**: Solid black, white text, or solid white with black border. Sharp corners or 2 to 4px radius. Single CTA per section.
+
+**Cards**: Rare. When present: hairline border (1px line gray), no shadow, sharp corners, minimal internal styling.
+
+**Tables**: Hairline rows. Sans body throughout (no mono). Left-aligned text, right-aligned numerics.
+
+**Navigation**: Minimal. Logo (often wordmark only), a small number of nav items, a single CTA. No mega-menus, no drawer animations, no decorative chrome.
+
+## When to pick this
+
+- Brand wants to communicate timelessness or rigor
+- Product is design-focused and the audience appreciates restraint as a value signal
+- Brand is competing in a category where every competitor is ornamented; restraint is the differentiator
+- Brand can defend the discipline (saying no to internal requests to add color, illustration, ornament)
+
+## When to avoid
+
+- Brand has rich content that benefits from visual organization (the archetype's lack of cards and color makes dense content hard to scan)
+- Audience reads minimalism as cold or unwelcoming
+- Brand needs to communicate warmth, personality, or specific human values
+- Brand will eventually be tempted to add ornament (better to start in a more flexible archetype)
+
+## Adaptation guidance
+
+1. **Discipline is the brand**: this archetype requires institutional commitment to saying no. Adding decoration over time degrades the archetype faster than other archetypes.
+2. **Type family pick**: Helvetica reads neutral and Swiss; Söhne reads contemporary and sharp; Suisse reads precise and minimal; Inter reads accessible and modern. Pick based on temperature, not novelty.
+3. **Color discipline**: black plus white plus one accent maximum. Brands that "just add one more color" frequently undermine the archetype.
+4. **Photography**: product-on-white only. Lifestyle photography pulls toward Warm Conversational or Luxe Considered.
+5. **Voice**: write honest, not poetic. Minimal Essentialist voice that tries to be evocative reads as Luxe Considered; minimal voice that is too plain reads as Editorial Restrained.
+
+## Exemplar brands
+
+Minimal Essentialist is exemplified by Apple at its most restrained (mid-2010s product pages), Allbirds at launch, Muji, Casper at launch, Everlane, Squarespace (in its minimal era), The Ordinary, and Aritzia in product detail pages. Adjacent examples include Dieter Rams' principles applied to digital and the early Medium publication system.
+
+These brands share: black-white-plus-accent, single sans family, extreme whitespace, product-on-white photography, terse declarative voice, no decorative ornament.
+
+The archetype differs from Editorial Restrained primarily in the absence of serif type and the absence of warm paper backgrounds. Editorial Restrained allows serif display and warm cream; Minimal Essentialist eliminates both. Brands frequently start Minimal Essentialist at launch and migrate toward Warm Conversational or Editorial Restrained as the audience matures and the brand needs more content depth.

--- a/skills/brand-archetype-system/references/core-archetypes/11-vibrant-saturated.md
+++ b/skills/brand-archetype-system/references/core-archetypes/11-vibrant-saturated.md
@@ -1,0 +1,112 @@
+# Vibrant Saturated
+
+## Aesthetic summary
+
+High saturation across the full palette. Color used as primary brand expression. Type often plays second to color. Compositions are color-blocked. Voice is energetic and personality-driven. The brand makes color the primary asset, and the audience remembers the brand by hue before they remember the wordmark.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Playful
+- **Aesthetic register**: Expressive
+- **Audience relationship**: Performer
+- **Sensory ambition**: Immersive
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #181818 | Soft-black text |
+| paper | #FFFFFF | White surface |
+| accent-primary | #FE2D81 | Saturated brand pink |
+| accent-secondary | #2BC8F4 | Bright cyan |
+| accent-tertiary | #FFD426 | Saturated yellow |
+| accent-quaternary | #8B3DFF | Vivid purple |
+| accent-quinary | #21D17C | Bright green |
+| signal | varies | Color-blocking accents derived from the palette |
+
+Rationale:
+- Multi-hue saturated palette is the signature. Single-accent palettes do not produce Vibrant Saturated.
+- Saturation generally above 70% across the palette. The discipline is that all colors are at similar saturation; this is what produces palette coherence despite hue variety.
+- Pure white surfaces. Cream and warm-white pull the archetype toward Warm Conversational.
+- The palette is calibrated so any two colors can sit next to each other. This requires hue and value discipline; brands that wing it produce chaos rather than coherent vibrancy.
+
+## Type pairing starter
+
+- **Display**: A clean geometric or neo-grotesque sans (Söhne, GT America, Helvetica Now, or a brand-custom face). 600 to 800 weight.
+- **Body**: Same family, 400 to 500.
+- **Optional serif**: A clean serif (Source Serif, Tiempos Text) for editorial moments. Used sparingly.
+
+Size scale (color carries the page; type is competent rather than expressive):
+- Hero: 48 to 64px sans
+- H2: 32 to 40px sans
+- Body: 16 to 18px sans
+- Small: 14 to 15px
+
+Pairing rationale: the type is intentionally calmer than the color. Going expressive on both type and color produces visual chaos; one element carries the personality while the other carries the functional load. In Vibrant Saturated, color carries personality and type carries function.
+
+## Layout and composition
+
+- Color-blocked compositions are signature. Sections alternate full-bleed background colors; the page reads as panels.
+- Heavy use of color as section organizer. The brand may use 6 different colors across a single page, each demarcating a different content type.
+- Type sits in color fields rather than on white. White-on-saturated and dark-on-light alternate.
+- Rounded corners are common but not aggressive (8 to 16px).
+- Motion design uses color transitions (sections fade between hues on scroll, hover states shift hue).
+
+## Imagery direction
+
+- Photography: high-saturation, often product-on-color-block, sometimes graphic-treated.
+- Illustration: brand-custom illustration systems often appear, with the brand's color palette as the discipline.
+- Pattern: bold pattern systems common, using the brand palette.
+- Product UI: shown against brand-color backgrounds rather than neutral surfaces. The product takes on the brand's color identity.
+
+## Voice samples
+
+- "Music for whatever you're feeling. All of it. Right now."
+- "The good news: this works. The better news: you do not have to figure it out."
+- "Yes, we are different. That is the point."
+- "Press play. We will handle the rest."
+- "Built for people who pick a color and commit."
+
+Cadence: energetic. First and second person. Comfortable with personality. Direct address. Numbers used playfully ("100 percent honest, 0 percent boring"). The voice is the spoken version of the visual energy.
+
+## Component pattern descriptions
+
+**Hero**: Often a single dominant brand color as background, with white type and a contrasting accent CTA. Sometimes split between two brand colors. The hero is the color, not the photograph.
+
+**Buttons**: Solid brand color, contrast text. 8 to 16px radius. Buttons may use one of several brand colors depending on context (the CTA color signals the section's purpose).
+
+**Cards**: Often colored rather than white. Each card may use a different brand color, with the color carrying meaning (category, type, status). 12 to 16px radius.
+
+**Sections**: Strong color demarcation. Section A is pink-on-white; Section B is cyan-on-white; Section C is yellow-on-dark. The reader navigates by color.
+
+**Patterns and shapes**: Common as section dividers and decorative accents. Always within the brand palette.
+
+## When to pick this
+
+- Consumer apps with strong category brands
+- B2B brands targeting prosumer or creator audiences
+- Brands where memorability through color is the strategy
+- Brand has color system design discipline (this archetype is harder than it looks)
+
+## When to avoid
+
+- B2B brand targeting risk-averse buyers
+- Brand cannot commit to color system discipline (winging it produces chaos)
+- Brand needs to communicate seriousness or rigor as primary signals
+- Category is already crowded with vibrant brands
+
+## Adaptation guidance
+
+1. **Palette discipline first**: defining 4 to 6 saturated hues that compose together is the hardest part of this archetype. Spend real time here; the rest is downstream.
+2. **Saturation calibration**: keep all colors at similar saturation. Mixed high-saturation and low-saturation produces incoherence.
+3. **Type restraint**: the type should not also be expressive. Clean type plus expressive color is the formula; expressive type plus expressive color is chaos.
+4. **Color carries meaning**: in the strongest applications of this archetype, color is functional (different colors signal different content types). Use this rather than decorative color.
+5. **Accessibility**: contrast ratios must work despite saturated palette. Test every color combination against WCAG AA at minimum.
+
+## Exemplar brands
+
+Vibrant Saturated is exemplified by Glossier (with restraint), Spotify, Notion (in its color-era brand expressions), Headspace (overlaps with Playful Energetic), Wise, Klarna, Bumble, and Patreon. Adjacent examples include the Slack rebrand era and the early Stripe consumer-facing surfaces.
+
+These brands share: multi-hue saturated palette, clean sans type, color-blocked compositions, color as section organizer, expressive but not chaotic compositions.
+
+The archetype overlaps with Playful Energetic when illustration becomes the dominant element; the difference is that Vibrant Saturated is color-first while Playful Energetic is character-first. Spotify is Vibrant Saturated; Duolingo is Playful Energetic. Both are colorful; the dominance pattern is what distinguishes them.

--- a/skills/brand-archetype-system/references/core-archetypes/12-documentary-honest.md
+++ b/skills/brand-archetype-system/references/core-archetypes/12-documentary-honest.md
@@ -1,0 +1,111 @@
+# Documentary Honest
+
+## Aesthetic summary
+
+Photography-first. Real people in real conditions. Low touch on imagery. Type recedes to let imagery lead. Compositions are large and image-dominant. Voice is direct and journalistic. The brand uses honest representation as its primary asset, and the visual restraint signals that the product or experience is the real thing rather than the constructed thing.
+
+## Position on the 4 creative-direction axes
+
+- **Tone register**: Conversational
+- **Aesthetic register**: Restrained
+- **Audience relationship**: Peer
+- **Sensory ambition**: Considered
+
+## Color palette starter
+
+| Token | Hex | Role |
+|---|---|---|
+| ink | #1B1B1B | Near-black text |
+| paper | #FAFAF8 | Off-white surface |
+| paper-soft | #F0EFEB | Subtle tinted surface |
+| accent | varies by imagery | Pulled from dominant photography tones |
+| muted | #5C5C5A | Mid-gray for metadata |
+| line | #E2E0DA | Soft line color |
+
+Rationale:
+- The palette derives from photography rather than being imposed on photography. Each brand expression of this archetype has a distinct accent because the accent comes from the imagery world.
+- Off-white surfaces with subtle warmth; the photography sits on the page rather than being framed by aggressive surfaces.
+- Mid-gray secondary text reads as caption-feeling rather than UI-feeling.
+- Saturation throughout the palette is low; photographs may be saturated, but the surrounding UI is muted to let imagery be the contrast.
+
+## Type pairing starter
+
+- **Display**: A clean serif (Tiempos Headline, Source Serif, GT Sectra) or a humanist sans (GT America, Söhne, Inter Display). 500 to 700.
+- **Body**: Same family or matched body weight, 400 to 500.
+- **Caption type**: A subtle italic or smaller weight for image captions and metadata, often in muted gray.
+
+Size scale (modest, deferential to imagery):
+- Hero: 36 to 48px (smaller than most archetypes; the photograph carries hero weight, not type)
+- H2: 26 to 32px
+- Body: 17 to 19px (comfortable reading)
+- Caption: 14 to 15px italic or in muted gray
+
+Pairing rationale: type sits in service of imagery. Restrained scale and weight let the photograph dominate. Italic captions read journalistic, evoking magazine and newspaper conventions. Either serif or sans works; the pairing should be calm.
+
+## Layout and composition
+
+- Photography is large and frequently full-bleed. The image occupies more page real estate than the type.
+- Compositions reference editorial design: photograph with caption, photograph with pull quote, photograph plus body text.
+- Asymmetric layouts where the image leads and text follows. Often 60/40 splits with photography dominant.
+- Generous internal padding around text blocks. The text breathes within the layout.
+- Hover states are subtle. The page reads as a document rather than as an interface.
+
+## Imagery direction
+
+- Real people, real environments, real conditions. Candid more often than posed.
+- Natural light dominant. Studio lighting rare and intentional when used.
+- Documentary photography conventions: telephoto compression for environmental portraits, wide-angle for context shots, intentional grain accepted.
+- The archetype assumes investment in photography. Stock imagery undermines the archetype immediately.
+- Photo direction matters more than photo quantity. A few exceptional images carry the archetype better than many adequate ones.
+
+## Voice samples
+
+- "She has been on the trail for six days. Today is the first day she has had warm feet."
+- "We met him in the workshop where he learned the trade. He has worked there for 31 years."
+- "Three thousand miles. Six time zones. One bag."
+- "Built in Vermont. Tested in places where bad gear ends careers."
+- "This is what we did. These are the people we did it with. These are the results."
+
+Cadence: journalistic. Third-person more often than first. Comfortable with specificity (real dates, real durations, real names where appropriate). The voice reads as reporting rather than selling.
+
+## Component pattern descriptions
+
+**Hero**: Large photograph (full-bleed or near-it) with overlaid restrained type, or photograph above type-only headline section. The photograph IS the hero.
+
+**Buttons**: Restrained. Often text-only with underlines, or thin-bordered with calm labels. The buttons recede; the photography leads.
+
+**Cards**: Often a card is a photograph plus caption plus body excerpt. The card structure mirrors editorial conventions (photo, caption, headline, dek).
+
+**Quotes**: Pulled quotes are a recurring pattern, set in restrained type with attribution beneath.
+
+**Sequences**: This archetype frequently uses image sequences (3 to 6 photographs telling a small story) where most archetypes use a single hero image.
+
+## When to pick this
+
+- Travel, hospitality, lifestyle brands where the experience IS the value proposition
+- Journalism-adjacent brands (publications, archives, documentary work)
+- Brands where real stories are the differentiation
+- Brand has access to genuine documentary photography (either custom or excellently curated)
+
+## When to avoid
+
+- Brand has no real photography access or budget
+- Product is functional rather than experiential
+- Audience expects highly designed marketing rather than journalistic restraint
+- Category is built on aspiration rather than reality (Documentary Honest fights aspirational positioning by definition)
+
+## Adaptation guidance
+
+1. **Photography commitment**: this is a photography archetype before it is anything else. If photography is going to be stock or poorly art-directed, switch archetypes.
+2. **Voice register**: write journalistic, not marketing. Documentary Honest voice that slides into "we are passionate about" undermines the archetype.
+3. **Restraint discipline**: resist adding decorative elements, color accents, or pattern. The photography is the visual; everything else should recede.
+4. **Caption discipline**: captions are first-class content. They carry the story alongside the image. Treat them with the same care as headlines.
+5. **Authenticity test**: the brand should be able to defend each photograph with a real story. Generic stock-feeling images destroy the archetype.
+
+## Exemplar brands
+
+Documentary Honest is exemplified by Airbnb (in its early marketing surfaces), Patagonia (overlaps with Rugged Utilitarian), Outside Magazine, The New York Times' visual journalism work, REI in its editorial content, Selina, and Yeti (in its long-form brand content). Adjacent examples include Field Mag, Topo Designs in long-form marketing, and Filson's historical archives.
+
+These brands share: real photography as primary visual, restrained type system, journalistic voice, image-plus-caption editorial conventions, low-saturation palette derived from imagery.
+
+The archetype overlaps with Rugged Utilitarian (both rely on real photography) and Editorial Restrained (both rely on restrained type). The difference: Rugged Utilitarian has utility framing (this is for working); Editorial Restrained is institutional confidence applied to B2B; Documentary Honest is honest representation applied to experience and story.


### PR DESCRIPTION
Adds a new skill providing pre-composed aesthetic archetype defaults to jumpstart brand design work.

**12 core archetypes** (Editorial Restrained, Technical Precise, Warm Conversational, Bold Confident, Playful Energetic, Luxe Considered, Clinical Trustworthy, Rugged Utilitarian, Retro Nostalgic, Minimal Essentialist, Vibrant Saturated, Documentary Honest).

**18 vertical applications** mapping named brands to archetypes across B2B SaaS (4 sub-verticals), fintech (2), DTC (4), consumer health, hospitality, media, edtech, gaming, marketplace, crypto, and proptech.

**Two layers of content:**

- Core archetype files are rich starting points: color palette with rationale, type pairing with size scale, layout patterns, voice samples, component descriptions, imagery direction, adaptation guidance, exemplar brands.
- Vertical application files are discovery surfaces: brand-to-archetype mappings, vertical-specific notes, archetype evolution patterns as brands mature.

**Composition with existing skills:**

- Upstream: brand-ideation (positioning territories established first)
- Parallel: creative-direction (4-axis framework that archetypes position on)
- Downstream: brand-identity (refines archetype defaults into a finished system)

**Trademark:** archetypes named for aesthetic families, brands referenced as exemplars only. Durable across brand redesigns.

**Scope:** 33 files in a single skill folder organized as SKILL.md plus references/ with two top-level overview files and two subfolders (core-archetypes/, by-vertical/). Future expansion (regional/cultural archetypes, more verticals, cross-references in adjacent SKILL.md files) deferred to follow-up PRs.

**Quality gates:** em-dash audit clean, forbidden-phrase audit clean, real-firm scrub clean, frontmatter valid, display_order 5 (no conflicts in brand category). README counts auto-regenerated by scripts/generate_readme_catalog.py.

**Note on reference counts:** the catalog script counts files at references/ root level only, so this skill registers as 2 reference files in the README count despite containing 32 total reference files. Subdirectory organization (core-archetypes/, by-vertical/) is deliberate and surfaced via SKILL.md so the agent can discover them; flattening would be a larger restructuring decision out of scope here.