### PR TITLE
feat: add design principles section and update family cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,37 @@ The skills in this repository remain free, open-source, and stack-agnostic. The 
 
 ---
 
+## Design principles
+
+claude-skills follows four principles that the broader AI agent community is formalizing as composable instruction architecture:
+
+**Single responsibility per skill.** Each skill covers one focused capability rather than trying to be a multi-purpose document. A roadmap-planning skill plans roadmaps. A keyword-research skill researches keywords. Composing them together produces complex workflows; mixing them inside one skill produces unreliable ones.
+
+**Structured frontmatter.** Every skill declares name, description, scope, and metadata in machine-readable YAML. This makes the catalog inspectable by tooling, not just by humans reading prose.
+
+**Composable patterns.** Skills are designed to be called in sequence, with one skill's output becoming another's input. This "skills calling skills" approach, sometimes called skill chaining, requires that each skill's output match the expected input of whatever comes next. claude-skills is built for this pattern: skills compose cleanly into larger workflows without requiring custom glue code at each junction.
+
+**Quality contracts via linting.** Structural and content quality is enforced through automated checks (run `python .github/scripts/lint_skills.py`) rather than convention alone. Every skill is validated against a schema. Every catalog change is validated in CI.
+
+Together these principles make claude-skills a production-tested catalog for composable AI workflows, suitable for standalone use or integration with agent runtime frameworks.
+
+## Family repos
+
+claude-skills is the parent catalog. Curated subsets and companion repos focus on specific specialties:
+
+| Repo | Focus | Skills |
+|---|---|---|
+| [claude-skills](https://github.com/rampstackco/claude-skills) | Full catalog (you are here) | 99 |
+| [claude-skills-starter](https://github.com/rampstackco/claude-skills-starter) | General-purpose lite | 14 |
+| [claude-skills-seo](https://github.com/rampstackco/claude-skills-seo) | SEO consulting | 12 |
+| [claude-skills-pm](https://github.com/rampstackco/claude-skills-pm) | Product management | 12 |
+| [claude-skills-widgets](https://github.com/rampstackco/claude-skills-widgets) | UI patterns + components | 65 + 32 |
+| [awesome-claude-skills](https://github.com/rampstackco/awesome-claude-skills) | Curated discovery list | n/a |
+
+Each family repo is MIT-licensed and stack-agnostic. Use the full catalog for breadth; use a specialty subset when working in one domain.
+
+---
+
 <!-- COUNT_CATALOG_HEADER:START -->
 ## The 99-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->

--- a/README.md
+++ b/README.md
@@ -457,17 +457,19 @@ The skills in this repository remain free, open-source, and stack-agnostic. The 
 
 ## Design principles
 
-claude-skills follows four principles that the broader AI agent community is formalizing as composable instruction architecture:
+claude-skills follows the [Agent Skills Specification](https://agentskills.io), the open standard for portable AI agent skills originally developed by Anthropic and adopted across the AI tooling ecosystem (Claude Code, OpenAI Codex, Gemini CLI, GitHub Copilot, Cursor, VS Code, Goose, Spring AI, and 30+ other platforms as of early 2026).
 
-**Single responsibility per skill.** Each skill covers one focused capability rather than trying to be a multi-purpose document. A roadmap-planning skill plans roadmaps. A keyword-research skill researches keywords. Composing them together produces complex workflows; mixing them inside one skill produces unreliable ones.
+Beyond the format itself, the catalog is designed around three principles aligned with the guidance Anthropic publishes in [Building effective agents](https://www.anthropic.com/engineering/building-effective-agents):
 
-**Structured frontmatter.** Every skill declares name, description, scope, and metadata in machine-readable YAML. This makes the catalog inspectable by tooling, not just by humans reading prose.
+**Simplicity.** Each skill covers one focused capability rather than trying to be a multi-purpose document. A roadmap-planning skill plans roadmaps. A keyword-research skill researches keywords. Composing them together produces complex workflows; mixing them inside one skill produces unreliable ones.
 
-**Composable patterns.** Skills are designed to be called in sequence, with one skill's output becoming another's input. This "skills calling skills" approach, sometimes called skill chaining, requires that each skill's output match the expected input of whatever comes next. claude-skills is built for this pattern: skills compose cleanly into larger workflows without requiring custom glue code at each junction.
+**Transparency.** Every skill declares its scope, dependencies, and expected behavior in machine-readable YAML frontmatter. The catalog is inspectable by tooling, not just by humans reading prose.
 
-**Quality contracts via linting.** Structural and content quality is enforced through automated checks (run `python .github/scripts/lint_skills.py`) rather than convention alone. Every skill is validated against a schema. Every catalog change is validated in CI.
+**Quality contracts via tooling.** Structural and content quality is enforced through automated checks (run `python .github/scripts/lint_skills.py`) rather than convention alone. Every skill is validated against a schema. Every catalog change is validated in CI.
 
-Together these principles make claude-skills a production-tested catalog for composable AI workflows, suitable for standalone use or integration with agent runtime frameworks.
+Skills in this catalog are designed to compose into the common agentic workflow patterns Anthropic documents: prompt chaining (sequential steps), routing (classify and direct), parallelization (sectioning or voting), orchestrator-workers (dynamic delegation), and evaluator-optimizer (iterative refinement).
+
+Because the catalog conforms to the open Agent Skills standard, skills work across any platform supporting the specification without modification.
 
 ## Family repos
 
@@ -482,7 +484,7 @@ claude-skills is the parent catalog. Curated subsets and companion repos focus o
 | [claude-skills-widgets](https://github.com/rampstackco/claude-skills-widgets) | UI patterns + components | 65 + 32 |
 | [awesome-claude-skills](https://github.com/rampstackco/awesome-claude-skills) | Curated discovery list | n/a |
 
-Each family repo is MIT-licensed and stack-agnostic. Use the full catalog for breadth; use a specialty subset when working in one domain.
+Each family repo is MIT-licensed, conforms to the Agent Skills Specification, and is stack-agnostic. Use the full catalog for breadth; use a specialty subset when working in one domain.
 
 ---
 


### PR DESCRIPTION
Anchors claude-skills to the established Agent Skills Specification (agentskills.io) and Anthropic's canonical agentic workflow patterns.

**What's new** (33 lines added, 0 removed, inserted between Surfaces and 'The 99-skill catalog'):
- Design principles section citing the Agent Skills open standard and the five workflow patterns from Anthropic's 'Building effective agents'
- Three principles using canonical vocabulary: Simplicity, Transparency, Quality contracts via tooling
- Family cross-links updated to include all 5 family repos plus awesome-claude-skills, each noted as conforming to the Agent Skills Specification

**External references used (both verified live + content cross-checked)**:
- https://agentskills.io: open standard originally developed by Anthropic, adopted by 30+ AI tooling platforms (Claude Code, OpenAI Codex, Gemini CLI, GitHub Copilot, Cursor, VS Code, Goose, Spring AI, and many more)
- https://www.anthropic.com/engineering/building-effective-agents: canonical names for prompt chaining, routing, parallelization, orchestrator-workers, evaluator-optimizer workflow patterns

**Attribution discipline note**: the source article articulates Simplicity and Transparency by name; its third principle is tool documentation / ACI design rather than quality contracts via linting. The framing here softens to 'three principles aligned with Anthropic's guidance' so the catalog's quality-contracts-via-tooling principle is presented as the catalog's own application rather than misattributed to Anthropic.

**Public-surface conventions enforced** (locked across rampstackco repos):
- No personal GitHub usernames or personal repos linked
- Canonical industry terminology only (prompt chaining, not skill chaining)
- No personal name attributions
- Verified URLs only with content cross-checked

**No changes to**: catalog, skills, linter, CI, existing sections.

Strategic context: anchors claude-skills to the broader open ecosystem rather than a single draft spec. Positions the catalog as a production-tested library of skills in the established Agent Skills format that compose into the standard agentic workflow patterns.