### PR TITLE
Add Claude Code plugin marketplace and framework-range demo links

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "rampstack",
+  "owner": { "name": "RampStack" },
+  "description": "RampStack Claude Skills: the website lifecycle as installable skills.",
+  "plugins": [
+    {
+      "name": "rampstack-skills",
+      "source": "./",
+      "description": "Full catalog of website-lifecycle skills: research, brand, build, and audit.",
+      "category": "web-development",
+      "keywords": ["agent-skills", "seo", "brand", "web-development"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "rampstack-skills",
+  "description": "Full RampStack catalog of website-lifecycle skills across research, brand, build, and audit.",
+  "version": "1.2.0",
+  "author": { "name": "RampStack" },
+  "homepage": "https://rampstack.co",
+  "repository": "https://github.com/rampstackco/claude-skills",
+  "license": "MIT",
+  "keywords": ["agent-skills", "claude-skills", "seo", "brand", "web-development", "product-management"]
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@
 
 ---
 
+## Install in Claude Code
+
+Add the marketplace, then install the catalog:
+
+```
+/plugin marketplace add rampstackco/claude-skills
+/plugin install rampstack-skills@rampstack
+```
+
+Skills load on demand: each contributes roughly its name and description until Claude needs it.
+
+---
+
 ## Table of contents
 
 - [What are Claude Skills?](#what-are-claude-skills)
@@ -141,16 +154,16 @@ Same skill, same brief format. Four completely different visual systems. Notice 
     <td width="50%"><img src="assets/showcase/archetype-forge-fitness.png" alt="Forge boutique fitness studio. Dark industrial hero with intense typography and motivational copy." /></td>
   </tr>
   <tr>
-    <td><strong>Pulse</strong> · music streaming<br/><em>Sound that moves with you.</em><br/>Playful / Expressive Maximalist / Companion / Resonant</td>
-    <td><strong>Forge</strong> · boutique fitness<br/><em>Show up. Get hammered.</em><br/>Provocative / Expressive Maximalist / Coach / Resonant</td>
+    <td><strong>Pulse</strong> · music streaming<br/><em>Sound that moves with you.</em><br/>Playful / Expressive Maximalist / Companion / Resonant<br/><a href="https://rampstack.co/showcase/creative-direction/pulse-music">See Pulse demo example →</a></td>
+    <td><strong>Forge</strong> · boutique fitness<br/><em>Show up. Get hammered.</em><br/>Provocative / Expressive Maximalist / Coach / Resonant<br/><a href="https://rampstack.co/showcase/creative-direction/forge-fitness">See Forge demo example →</a></td>
   </tr>
   <tr>
     <td><img src="assets/showcase/archetype-bloom-soda.png" alt="Bloom adaptogenic soda brand. Peachy gradient hero with tri-color headline 'Soda that loves you back' and a strawberries-around-soda-can product photo." /></td>
     <td><img src="assets/showcase/archetype-observatory-editorial.png" alt="Observatory Editorial. Cream paper hero with restrained serif headline 'An observability tool for the engineers who already know what they are doing'." /></td>
   </tr>
   <tr>
-    <td><strong>Bloom</strong> · adaptogenic soda<br/><em>Soda that loves you back.</em><br/>Playful / Expressive Maximalist / Companion / Resonant</td>
-    <td><strong>Observatory Editorial</strong> · observability tool<br/><em>An open-source tool that respects engineer time.</em><br/>Conversational / Editorial Restrained / Peer / Considered</td>
+    <td><strong>Bloom</strong> · adaptogenic soda<br/><em>Soda that loves you back.</em><br/>Playful / Expressive Maximalist / Companion / Resonant<br/><a href="https://rampstack.co/showcase/creative-direction/bloom-soda">See Bloom demo example →</a></td>
+    <td><strong>Observatory Editorial</strong> · observability tool<br/><em>An open-source tool that respects engineer time.</em><br/>Conversational / Editorial Restrained / Peer / Considered<br/><a href="https://rampstack.co/showcase/creative-direction/observatory-editorial">See Observatory demo example →</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Summary

Two changes to publish and link the catalog:

1. **Plugin marketplace.** Publishes the full catalog as a single Claude Code plugin via `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`. Default skill discovery finds the `skills/<name>/SKILL.md` layout, so no per-skill plugin config is needed.
2. **Framework-range demo links.** Adds brand-specific showcase links to the four cards under `### The framework's range` (Pulse, Forge, Bloom, Observatory).

## Install

```
/plugin marketplace add rampstackco/claude-skills
/plugin install rampstack-skills@rampstack
```

## Marketplace source form

`claude plugin validate .` passes with the root-as-plugin form `"source": "./"` — that is the form shipped in `marketplace.json`. The explicit GitHub-source fallback was not needed.

## Verification

- `claude plugin validate .` → Validation passed.
- All four showcase demo URLs (`pulse-music`, `forge-fitness`, `bloom-soda`, `observatory-editorial`) load as real content pages.
- Exactly four `See <Brand> demo example` links added; the range table still renders as a 2x2 grid.

## Out of scope

No starter / seo / pm / widgets plugin entries (those land per repo as each ships). No changes to skill content, the linter, catalog counts, the range heading, images, or alt text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)