### PR TITLE
Add framework-range showcase CTA, open demo links in new tabs, log under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+**Distribution**
+
+- Claude Code plugin marketplace. `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` publish the full catalog as an installable plugin: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`.
+
+**README sections**
+
+- "Install in Claude Code" section documenting the one-command marketplace install path.
+
+### Changed
+
+- "The framework's range" cards now link to their live showcase demos (Pulse, Forge, Bloom, Observatory), and the section closes with a CTA to the full creative-direction showcase.
+- Hand-authored rampstack.co showcase demo links across the README now open in a new tab (`target="_blank" rel="noopener"`).
+
 ## [1.2.0] - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Six entry-point skills, one per audience track. Run any of these standalone, or 
 
 ## See it in action
 
-**[The creative-direction skill rendered as a live showcase →](https://rampstack.co/showcase/creative-direction)**
+<strong><a href="https://rampstack.co/showcase/creative-direction" target="_blank" rel="noopener">The creative-direction skill rendered as a live showcase →</a></strong>
 
 Forty-two fictional brands generated from briefs that all use the same skill. Each is a fully styled brand site, not a mockup. The showcase demonstrates what the four-axis framework produces in practice and lets you filter by axis position to see how each combination renders.
 
@@ -154,18 +154,22 @@ Same skill, same brief format. Four completely different visual systems. Notice 
     <td width="50%"><img src="assets/showcase/archetype-forge-fitness.png" alt="Forge boutique fitness studio. Dark industrial hero with intense typography and motivational copy." /></td>
   </tr>
   <tr>
-    <td><strong>Pulse</strong> · music streaming<br/><em>Sound that moves with you.</em><br/>Playful / Expressive Maximalist / Companion / Resonant<br/><a href="https://rampstack.co/showcase/creative-direction/pulse-music">See Pulse demo example →</a></td>
-    <td><strong>Forge</strong> · boutique fitness<br/><em>Show up. Get hammered.</em><br/>Provocative / Expressive Maximalist / Coach / Resonant<br/><a href="https://rampstack.co/showcase/creative-direction/forge-fitness">See Forge demo example →</a></td>
+    <td><strong>Pulse</strong> · music streaming<br/><em>Sound that moves with you.</em><br/>Playful / Expressive Maximalist / Companion / Resonant<br/><a href="https://rampstack.co/showcase/creative-direction/pulse-music" target="_blank" rel="noopener">See Pulse demo example →</a></td>
+    <td><strong>Forge</strong> · boutique fitness<br/><em>Show up. Get hammered.</em><br/>Provocative / Expressive Maximalist / Coach / Resonant<br/><a href="https://rampstack.co/showcase/creative-direction/forge-fitness" target="_blank" rel="noopener">See Forge demo example →</a></td>
   </tr>
   <tr>
     <td><img src="assets/showcase/archetype-bloom-soda.png" alt="Bloom adaptogenic soda brand. Peachy gradient hero with tri-color headline 'Soda that loves you back' and a strawberries-around-soda-can product photo." /></td>
     <td><img src="assets/showcase/archetype-observatory-editorial.png" alt="Observatory Editorial. Cream paper hero with restrained serif headline 'An observability tool for the engineers who already know what they are doing'." /></td>
   </tr>
   <tr>
-    <td><strong>Bloom</strong> · adaptogenic soda<br/><em>Soda that loves you back.</em><br/>Playful / Expressive Maximalist / Companion / Resonant<br/><a href="https://rampstack.co/showcase/creative-direction/bloom-soda">See Bloom demo example →</a></td>
-    <td><strong>Observatory Editorial</strong> · observability tool<br/><em>An open-source tool that respects engineer time.</em><br/>Conversational / Editorial Restrained / Peer / Considered<br/><a href="https://rampstack.co/showcase/creative-direction/observatory-editorial">See Observatory demo example →</a></td>
+    <td><strong>Bloom</strong> · adaptogenic soda<br/><em>Soda that loves you back.</em><br/>Playful / Expressive Maximalist / Companion / Resonant<br/><a href="https://rampstack.co/showcase/creative-direction/bloom-soda" target="_blank" rel="noopener">See Bloom demo example →</a></td>
+    <td><strong>Observatory Editorial</strong> · observability tool<br/><em>An open-source tool that respects engineer time.</em><br/>Conversational / Editorial Restrained / Peer / Considered<br/><a href="https://rampstack.co/showcase/creative-direction/observatory-editorial" target="_blank" rel="noopener">See Observatory demo example →</a></td>
   </tr>
 </table>
+
+<p align="center">
+  <strong><a href="https://rampstack.co/showcase/creative-direction" target="_blank" rel="noopener">See all the brands in the showcase →</a></strong>
+</p>
 
 ### Run this on your own brand
 
@@ -186,7 +190,7 @@ The logo-design skill is rendered on rampstack.co as two parallel surfaces. The 
 
 ### Per-brand depth
 
-**[The variant explorer →](https://rampstack.co/showcase/logo-design)**
+<strong><a href="https://rampstack.co/showcase/logo-design" target="_blank" rel="noopener">The variant explorer →</a></strong>
 
 Each brand has a primary mark plus variants across architectures and applied contexts. The logo-design skill walks through the discipline of choosing one architecture and rendering it consistently across the system the brand will actually use.
 
@@ -201,7 +205,7 @@ The brands are filterable by architecture, typographic register, and category. T
 
 ### Architectural taxonomy
 
-**[The marks gallery →](https://rampstack.co/showcase/logos)**
+<strong><a href="https://rampstack.co/showcase/logos" target="_blank" rel="noopener">The marks gallery →</a></strong>
 
 Ten fictional marks across eight mark architectures: wordmark, lockup, monogram, letterform-as-symbol, abstract, pictorial, combination, emblem. The taxonomy makes the architectural distinctions concrete by showing all eight side-by-side, with three wordmarks at three typographic registers so the architectural label does less work than the execution.
 


### PR DESCRIPTION
## Summary

Follow-on to PR #63 (plugin marketplace + framework-range demo links). Adds the items that landed in the revised dispatch plus the user-requested "open in new tabs" behavior for showcase demo links.

## Changes

**README**
- New centered CTA after the framework's range table: "See all the brands in the showcase →" linking to `https://rampstack.co/showcase/creative-direction`.
- `target="_blank" rel="noopener"` added to the 4 framework-range card demo links (Pulse, Forge, Bloom, Observatory).
- The 3 hand-authored markdown showcase entry-point links converted to HTML so they can also open in new tabs:
  - "The creative-direction skill rendered as a live showcase →" (line ~116)
  - "The variant explorer →" (line ~190)
  - "The marks gallery →" (line ~205)

**CHANGELOG**
- New entries under the existing `## [Unreleased]` block:
  - Added: Distribution (Claude Code plugin marketplace files), README section ("Install in Claude Code").
  - Changed: framework-range card demos + section CTA, plus the new-tab behavior.
- No version bump, no new tag. `[Unreleased]: ...v1.2.0...HEAD` compare link unchanged.

## Scope decisions

1. **Plugin marketplace files and Install section** were already merged in PR #63 (squash-merged into main). They are listed in the changelog here since this PR is the first to log them under `[Unreleased]`. The dispatch's Part 1, Part 2, and Part 5 (topics) work is therefore already on main and not re-applied here.
2. **Auto-generated `SURFACES` block left untouched.** The Surfaces section also contains a rampstack.co/showcase link, but that block is regenerated by `scripts/generate_readme_catalog.py`. Per the dispatch's "do not touch auto-generated blocks" guidance, I did not modify it. If we want the Surfaces showcase link to open in a new tab too, that needs to happen in the generator's `SURFACES_CONTENT`.
3. **Marketplace source form**: `claude plugin validate .` was confirmed in PR #63 against the root-as-plugin form `"source": "./"`. The marketplace JSON has not been changed in this PR.

## Verification

- Exactly four `See <Brand> demo example` links remain (unchanged count), each now with `target="_blank" rel="noopener"`.
- Exactly one centered "See all the brands in the showcase" CTA added.
- 8 hand-authored `rampstack.co/showcase` links in the README now carry `target="_blank"`.
- Table still renders as a 2x2 grid.
- All five showcase URLs (`/showcase/creative-direction`, `/pulse-music`, `/forge-fitness`, `/bloom-soda`, `/observatory-editorial`) confirmed live in PR #63 verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)