### PR TITLE
Add starter, seo, and pm to the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,27 @@
       "description": "Full catalog of website-lifecycle skills: research, brand, build, and audit.",
       "category": "web-development",
       "keywords": ["agent-skills", "seo", "brand", "web-development"]
+    },
+    {
+      "name": "rampstack-starter",
+      "source": { "source": "github", "repo": "rampstackco/claude-skills-starter" },
+      "description": "Curated starter subset of the RampStack catalog: a general-purpose skill set for the website lifecycle.",
+      "category": "web-development",
+      "keywords": ["agent-skills", "starter", "web-development"]
+    },
+    {
+      "name": "rampstack-seo",
+      "source": { "source": "github", "repo": "rampstackco/claude-skills-seo" },
+      "description": "Focused SEO skills: keyword research, on-page and technical audits, AI-search optimization, traffic diagnosis, site-health triage, competitor and content audits, and programmatic SEO, with content companions.",
+      "category": "web-development",
+      "keywords": ["agent-skills", "seo", "aeo", "geo"]
+    },
+    {
+      "name": "rampstack-pm",
+      "source": { "source": "github", "repo": "rampstackco/claude-skills-pm" },
+      "description": "Focused product management skills across the lifecycle: discovery, roadmaps and OKRs, PRDs, stakeholder communication, launch and beta programs, and measurement.",
+      "category": "productivity",
+      "keywords": ["agent-skills", "product-management", "roadmap", "okr"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -28,11 +28,18 @@
 
 ## Install in Claude Code
 
-Add the marketplace, then install the catalog:
+Add the marketplace, then install the plugin you want:
 
 ```
 /plugin marketplace add rampstackco/claude-skills
+
+# full catalog (99 skills)
 /plugin install rampstack-skills@rampstack
+
+# focused subsets
+/plugin install rampstack-starter@rampstack
+/plugin install rampstack-seo@rampstack
+/plugin install rampstack-pm@rampstack
 ```
 
 Skills load on demand: each contributes roughly its name and description until Claude needs it.


### PR DESCRIPTION
## Summary

Expands `.claude-plugin/marketplace.json` to publish all four RampStack plugins from the single marketplace, and updates the README install section to list them.

- `rampstack-skills` — full catalog, sourced from this repo via `"./"` (unchanged).
- `rampstack-starter`, `rampstack-seo`, `rampstack-pm` — focused subsets, each sourced from its own repo via the GitHub source form.

## Install

```
/plugin marketplace add rampstackco/claude-skills

# full catalog (99 skills)
/plugin install rampstack-skills@rampstack

# focused subsets
/plugin install rampstack-starter@rampstack
/plugin install rampstack-seo@rampstack
/plugin install rampstack-pm@rampstack
```

## Source form

`claude plugin validate .` passed with the dispatch's documented GitHub source form:

```json
"source": { "source": "github", "repo": "rampstackco/claude-skills-starter" }
```

No fallback (bare `"owner/repo"` string, etc.) was needed.

## Subset description fixes

The seo and pm subset descriptions used in this marketplace match the corrected `plugin.json` descriptions landing in companion PRs in those repos:
- `claude-skills-seo` drops the Ahrefs-powered audits claim (none of the 7 Ahrefs MCP-powered audit skills ship in the seo subset).
- `claude-skills-pm` drops the experimentation/analytics claims (no experimentation or analytics skills ship in the pm subset).

## Out of scope

- No `marketplace.json` in the subset repos.
- No skill content, `package.json`, or other README changes beyond the install section text.
- No version bumps to any `plugin.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)