### PR TITLE
Surface launch and announcement into email-sequences scored fields

### DIFF
--- a/skills/email-sequences/SKILL.md
+++ b/skills/email-sequences/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: email-sequences
-description: "Design and write email campaigns and sequences including onboarding flows, lifecycle campaigns, transactional emails, newsletters, and broadcast sends. Use this skill whenever the user wants to write email copy, plan an email sequence, design an onboarding drip, or set up lifecycle email campaigns. Triggers on email sequence, drip campaign, onboarding email, lifecycle email, welcome email, transactional email, newsletter, email broadcast, nurture sequence, abandoned cart, re-engagement, win-back. Also triggers when planning email automation flows or writing email subject lines for campaigns."
+description: "Design and write email campaigns and sequences including onboarding flows, lifecycle campaigns, transactional emails, newsletters, broadcast sends, and launch and announcement emails. Use this skill whenever the user wants to write email copy, plan an email sequence, design an onboarding drip, or set up lifecycle email campaigns. Triggers on email sequence, drip campaign, onboarding email, lifecycle email, welcome email, transactional email, newsletter, email broadcast, launch email, announcement email, nurture sequence, abandoned cart, re-engagement, win-back. Also triggers when planning email automation flows or writing email subject lines for campaigns."
 category: content
 catalog_summary: "Onboarding flows, lifecycle campaigns, transactional copy"
 display_order: 5
@@ -19,6 +19,7 @@ Plan and write email campaigns. Sequences (multi-message flows triggered by even
 - Writing transactional emails (receipts, password resets, notifications)
 - Newsletter design and writing
 - Abandoned-cart or re-engagement flows
+- Writing a one-off broadcast, launch announcement, or news email
 - Drafting email subject lines and preview text for any send
 
 ## When NOT to use


### PR DESCRIPTION
## Summary

Adds "launch" and "announcement" to the two scored fields of `email-sequences` (description and when-to-use). The framework body of this skill (type 6: Broadcast) already says it owns "Announcements, launches, news, time-sensitive campaigns," so this edit is additive content matching what the skill already documents itself as covering.

## Why

A real-world selector run on "write the launch email" had been picking `email-deliverability` over `email-sequences`. Looking at both skills' scored fields, the cause was that `email-sequences` did not have the word "launch" or "announcement" anywhere the scorer reads (description, when-to-use, name). The framework body did, but selectors do not read framework body. Meanwhile `email-deliverability` is dense with "email" and out-scored sequences on the task's one distinctive token. This edit closes the gap by adding accurate trigger words to the side of the boundary the catalog already says owns content.

## What changed

`skills/email-sequences/SKILL.md`:

- Description: added "and launch and announcement emails" to the campaign-types phrase, and "launch email, announcement email" to the trigger list.
- When to use: added one bullet: "Writing a one-off broadcast, launch announcement, or news email".

No other field touched. No other skill touched. Framework body, when-NOT-to-use, required inputs all unchanged.

## Proving runs (six tasks, before vs after)

Ran the substrate (private engine in `rampstack/tholo-engine-app`) against a real checkout of this catalog before and after the edit.

| Task | Before | After |
|---|---|---|
| `write the launch email` (target) | `[email-deliverability]` score 36.23 | `[email-sequences]` score 48.42 |
| `audit a page for on-page SEO` (protected) | `[seo-audit-orchestration, seo-onpage, seo-technical, landing-page-copy, seo-site-health-audit]` | identical selection and scores |
| `write a creative brief for a new brand` (protected) | `[art-direction, brand-discovery, creative-brief, brand-voice]` | identical selection and scores |
| `review a finished build before launch` (protected, contains "launch") | `[code-review-web, brand-style-guide, after-action-report]` | identical selection; `after-action-report` score 14.68 → 14.39 from a global idf shift on "launch" |
| `write a welcome email sequence` (sanity) | `[email-sequences]` 64.0 | `[email-sequences]` 69.03 |
| `plan the product launch` (sanity, contains "launch") | `[launch-runbook, feature-launch-playbook, product-analytics-setup, product-configurator-design, ux-research]` | identical selection |

Target case flips as intended. No selection changed on any protected task. `email-sequences` is not over-pulled into the build-review or product-launch tasks even though both contain the word "launch."

## Test plan

- [x] Selector run on the target task selects `email-sequences`.
- [x] Selector run on the four protected tasks unchanged.
- [x] Selector run on the two sanity tasks behaves as expected (`email-sequences` not over-pulled).
- [ ] Reviewer eyeballs the description and when-to-use to confirm wording reads cleanly.