### PR TITLE
Add competitor-experience-audit skill (the brand/UX/design dimension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-99-blue.svg)](#the-99-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-100-blue.svg)](#the-100-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 99 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 100 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -60,7 +60,7 @@ Skills load on demand: each contributes roughly its name and description until C
 - [How the catalog connects](#how-the-catalog-connects)
 - [Surfaces](#surfaces)
 <!-- COUNT_TOC:START -->
-- [The 99-skill catalog](#the-99-skill-catalog)
+- [The 100-skill catalog](#the-100-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -89,8 +89,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **99 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
-- **427 reference files** (templates, checklists, decision matrices, worked examples)
+- **100 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
+- **429 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -513,11 +513,11 @@ Each family repo is MIT-licensed, conforms to the Agent Skills Specification, an
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 99-skill catalog
+## The 100-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 99 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 100 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -679,7 +679,7 @@ Paid media discipline: strategy, creative, and performance analytics. Pairs with
 | [`ads-creative-development`](skills/ads-creative-development/SKILL.md) | Hook patterns, format selection, video pacing, variation systems, testing methodology, fatigue detection, and the platform-specific creative norms that separate ads from clutter |
 | [`ads-performance-analytics`](skills/ads-performance-analytics/SKILL.md) | Read paid media dashboards without fooling yourself: attribution models, platform reporting quirks, ROAS vs LTV, multi-platform reconciliation, incrementality testing, and the interpretation failures that compound into wasted budget |
 
-### Research (5)
+### Research (6)
 
 | Skill | What it does |
 |---|---|
@@ -688,6 +688,7 @@ Paid media discipline: strategy, creative, and performance analytics. Pairs with
 | [`journey-mapping`](skills/journey-mapping/SKILL.md) | Customer journey maps, service blueprints, friction analysis |
 | [`discovery-research-synthesis`](skills/discovery-research-synthesis/SKILL.md) | Synthesizing customer interviews, research notes, and support tickets into actionable PM decisions. Distinguishes data-dump (no synthesis) from insight-theater (overpolished narrative) from actionable synthesis (decision-grade clarity) |
 | [`user-feedback-aggregation`](skills/user-feedback-aggregation/SKILL.md) | Collecting and synthesizing user feedback across channels into continuous decision signal. Triage discipline that distinguishes loudest-voice (whoever complains most) from averaged-noise (every signal weighted equally) from triaged-synthesis (weighted by source quality and decision relevance) |
+| [`competitor-experience-audit`](skills/competitor-experience-audit/SKILL.md) | Cross-site experience patterns and gaps across a vertical |
 
 ### Cross-cutting workflows (5)
 

--- a/skills/competitor-experience-audit/SKILL.md
+++ b/skills/competitor-experience-audit/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: competitor-experience-audit
+description: "Audit the brand, UX, and site design of the leading sites in a vertical as a set of observable cross-site patterns, producing the experience bar a new build must meet or beat. Use this skill whenever the user wants to assess the competitive design field, capture vertical conventions, identify the design and UX bar of a category, or set the experience standard before a build. Triggers on competitor experience audit, UX audit, site design audit, brand audit, design conventions, what makes these sites good, vertical conventions, storefront patterns, merchandising patterns, layout density, primary task, design bar, category conventions, retail vs marketing register, what does the field do. Also triggers when an audit of the competitive field has captured technical signals (SEO, accessibility) but never named the brand, UX, or design conventions, and the build downstream will read as off-vertical without that bar."
+category: research
+catalog_summary: "Cross-site experience patterns and gaps across a vertical"
+display_order: 6
+---
+
+# Competitor Experience Audit
+
+Capture the brand, UX, and site design that the leading sites in a vertical observably share, and where they fall short. The output is the experience bar a new build must meet or beat, grounded in cross-site patterns rather than aesthetic opinion.
+
+Stack-agnostic. Works on any SiteShape (ecommerce-catalog, inventory-listing, hospitality-food, b2b-manufacturer, and so on). Auto-parts catalogs are the first test case, not the only target.
+
+This skill is the brand / UX / design counterpart to a technical audit like `seo-onpage` or `accessibility-audit`. Technical findings are objective (a missing canonical is missing). Design is more subjective, so this skill is deliberately written to make the subjective assessable: every dimension is judged by observable questions about what the leading sites actually do, reported as patterns and gaps, and marked `not_assessable` whenever the evidence does not support a judgment.
+
+---
+
+## When to use
+
+- Setting the experience bar for a new build in a vertical you have not built in before
+- Capturing the design and UX conventions a credible site in the category is expected to carry
+- Auditing the competitive field for a critic or strategy review where SEO and accessibility have been covered but design and experience have not
+- Naming the positioning opportunity that recurs across the leaders (the gap even the leaders share)
+- Pairing with a technical audit (SEO, accessibility) so the competitor review captures both axes
+
+## When NOT to use
+
+- Rating a single page or one brand's design taste in isolation (use `design-standards` or `brand-style-guide` for production design decisions on a known build)
+- Backlink, keyword, or SERP-overlap competitive analysis (use `seo-competitor`)
+- Generating a creative direction from scratch for a new brand (use `creative-direction` and `brand-discovery`)
+- User research with real participants on your own product (use `ux-research`, `usability-testing`)
+- Auditing a single page's on-page SEO or accessibility against the audit suite (use `seo-onpage`, `accessibility-audit`)
+
+---
+
+## Required inputs
+
+- The vertical and a list of the leading sites in it (3 to 6 sites; more than 6 stops surfacing new patterns)
+- Access to the rendered sites (a real browser view, not just static HTML; see "Static vs rendered" below)
+- The site shape the audit feeds, if known (ecommerce-catalog, inventory-listing, etc.); this scopes which dimensions to weight
+- Any explicit constraint on the build downstream (the brand voice, the audience, the conversion the build will own)
+
+If the list of leading sites is unknown, ask. Picking the wrong field produces an experience bar against the wrong vertical.
+
+### Static vs rendered
+
+Some dimensions can be partially assessed from static HTML (primary navigation, the catalog/category surface count, the presence of search). Most cannot. Layout density, brand register, motion, trust-signal prominence, and the rendered hierarchy of the first viewport all need the rendered page to judge honestly. If you only have static HTML for a site, mark every rendered-only dimension `not_assessable` for that site rather than guessing.
+
+---
+
+## The framework: 7 experience dimensions
+
+Each dimension is judged by observable questions across the leading sites in the field, then reported as a cross-site pattern plus the gap (where the leaders converge, and where even they fall short).
+
+Score each dimension as `Pattern present` (the field converges on a recognizable convention), `Mixed` (the field splits across two or three approaches), or `Gap` (no convention emerges, or every leader misses it). Mark `not_assessable` when the evidence cannot support a judgment.
+
+Never write `Good design` or `Bad design` or any aesthetic verdict. The dimensions are about what the field observably does, not whether you like it.
+
+### 1. Primary-task prominence
+
+Does the site lead with the visitor's primary job, or bury it?
+
+- What is the largest, earliest interactive element on the first viewport? (For auto-parts: typically a fitment selector. For hospitality-food: a menu or reservation entry.)
+- How many clicks or scrolls to the core task?
+- Does the site protect the primary task from competing CTAs in the hero?
+
+Observable signal: count the elements that compete for first attention, identify which one the layout actually privileges, name what the field converges on as the primary task.
+
+### 2. Layout register and density
+
+Is the layout retail-dense, editorial, or marketing-airy? Cross-reference `creative-direction` aesthetic positions (editorial restrained, polished standard, controlled maximalist, expressive maximalist) for vocabulary; do not redefine that here.
+
+- How many distinct modules appear above the fold?
+- What is the content-per-viewport ratio (dense storefront, calm editorial, generous marketing)?
+- Does the page read as a storefront, a catalog, a landing page, or a brochure?
+
+Observable signal: count modules above the fold across the field; describe the register the leaders share, not whether you find it attractive.
+
+### 3. Merchandising and category surface
+
+How much of the catalog or offering is surfaced at once, and in what shape?
+
+- How many category, collection, or entry-point modules appear before scroll?
+- How is depth signaled (mega-menu, grid, side rail, faceted search)?
+- Is the surface flat (one tier visible) or hierarchical (parent plus child categories shown together)?
+
+Observable signal: count the category entry points and describe the navigation depth pattern the field uses.
+
+### 4. Primary navigation and search paths
+
+Do the sites serve both the know-what-I-want path and the browse path?
+
+- Is search prominent and primary, secondary, or absent?
+- What paths are offered (by category, by brand, by attribute, by vehicle, by location, by occasion)?
+- Where does the primary nav sit (top, side, sticky, mega-menu)?
+
+Observable signal: list the paths the field offers, score whether each path is primary, secondary, or missing.
+
+### 5. Brand register and conviction
+
+What brand posture do the leading sites take, and is it consistent across the page?
+
+- Color, type, imagery: utilitarian, premium, friendly, institutional, technical, expressive?
+- Voice in headings and microcopy: direct, persuasive, technical, warm, plain?
+- Trust signals: institutional (long-standing, association badges), social (reviews, community), or operational (in-stock, warranty, fitment confirmation)?
+
+Cross-reference the `creative-direction` and `brand-archetype-system` skills for the vocabulary. Report the register the field converges on. Do not rate the taste; describe what posture the leaders take.
+
+### 6. Trust and conversion signals
+
+What recurring trust and conversion conventions does the field use?
+
+- Reviews, guarantees, social proof, badges
+- Pricing transparency (price visible, no surprises, total cost surfaced)
+- Stock and availability signals
+- Fitment, sizing, eligibility, or compatibility confirmation (where the vertical requires it)
+- Return, shipping, or service-level promises
+
+Observable signal: which signals appear across the field, where they appear, and which the leaders share.
+
+### 7. Recurring vertical conventions (the synthesis)
+
+The patterns that recur across the leaders and define what a credible site in this vertical is expected to have. This is the synthesis of dimensions 1 through 6 into a short list of "if your build does not do this, it will read as off-vertical."
+
+Observable signal: which conventions recur on 3 of N or more of the leading sites; which are absent across the field (the gap that a positioning opportunity exploits).
+
+---
+
+## The honesty guardrail (load-bearing)
+
+This is not negotiable. The credibility of an experience audit erodes the moment it slides into taste:
+
+- Report what the leading sites observably do and where they observably fall short, as cross-site patterns. Do not render personal aesthetic judgments ("this is ugly", "good design", "the typography is clean"). Aesthetic verdicts belong in `art-direction` or `design-standards`, not here.
+- When the evidence does not support a judgment, say so plainly and mark the dimension `not_assessable` for that site or that pattern. Common cases: layout and density cannot be judged from un-rendered static HTML; motion and animation cannot be judged from a screenshot; brand voice cannot be judged from a single page.
+- Do not name a convention from one site. A pattern is a recurrence across the field (3 of N or more); one site doing something distinctive is a single-site observation, not a convention.
+- The output is a grounded experience bar: the conventions and gaps of the field, usable as a standard a build must meet. It is not an opinion piece.
+
+If the user asks "is this design good", redirect to observable patterns ("the leading sites in the field share X, Y, Z; this build does X and W but not Y or Z; that is the gap"). If the user asks for an aesthetic call, point them at `design-standards` or `art-direction`.
+
+---
+
+## Workflow
+
+1. **Confirm the vertical and the leading sites.** Ask if either is unclear; an audit against the wrong field is worse than no audit.
+2. **Render and view each site as a user would.** Open in a real browser, on the device class the field's visitors use (desktop and mobile for ecommerce; mobile-first for hospitality-food; etc.). Do not work from static HTML alone for any dimension marked rendered-only.
+3. **Assess each dimension across the field.** Use [`references/experience-dimensions-checklist.md`](references/experience-dimensions-checklist.md) to score each site on each dimension. Mark `not_assessable` wherever the evidence is thin.
+4. **Synthesize cross-site patterns.** For each dimension, name the recurring convention (or the split, or the gap). Distinguish patterns the field converges on from single-site moves.
+5. **Name the gap (the positioning opportunity).** Where do even the leaders fall short? That is where a new build's positioning can exploit the field.
+6. **Write the bar.** Use the template in [`references/audit-template.md`](references/audit-template.md). Default output is a markdown experience bar, generalized to pattern-level if it will feed a public showcase workup (no named competitors in the public version).
+7. **Hand the bar to the build skills.** The output is the standard `creative-direction`, `design-standards`, `information-architecture`, and the relevant build skill (`landing-page-copy`, `frontend-component-build`) read as the experience bar to meet.
+
+---
+
+## Failure patterns
+
+When you spot one of these, push back before delivering.
+
+- **"Rate the design of these sites."** Vague. Redirect to observable patterns: what the leading sites in the field do across the seven dimensions, not whether you like it.
+- **Judging un-rendered pages for layout, density, or motion.** Mark `not_assessable` and get the rendered view. Static HTML supports only partial assessment; do not guess at design quality you cannot see.
+- **Naming a convention from one site.** A pattern is a recurrence across the field. One site doing something distinctive is a single-site observation; flag it that way, not as a convention.
+- **Substituting personal taste for field patterns.** "I think the colors are good" is not an audit finding. "The field converges on a navy-and-rust register; this site uses it" is.
+- **Aesthetic verdicts dressed as observations.** Watch for "clean", "modern", "professional", "premium-feeling" with no observable signal underneath. If you cannot point at a specific observable thing, you are giving taste, not a pattern.
+- **Skipping the gap.** An audit that names only what the leaders do well is half the value. The recurring weakness across the field is where a positioning opportunity lives; name it.
+- **Generalizing too soon.** A 2-site sample is not the field. If you can only render 2 of 5 leaders, mark the audit `partial` and call out what is assessed vs what is not.
+
+---
+
+## Output format
+
+Default output is a markdown experience bar at `experience-audit-[vertical-slug].md` in the project root. Structure:
+
+1. Vertical and the field surveyed (sites assessed, what could not be rendered)
+2. Score per dimension across the field
+3. Cross-site patterns (the conventions the leaders converge on)
+4. Gaps (where the field falls short, the positioning opportunity)
+5. The experience bar (the synthesis: what a credible build in this vertical must do)
+6. `Not_assessable` items (what could not be judged and why)
+
+Keep the bar under 1500 words. If a dimension needs deeper treatment, link to a deeper appendix rather than expanding inline.
+
+### Scrub for showcase use
+
+If the audit will feed a public showcase workup, scrub for named competitors before publishing. The named version stays operated-side; the public workup carries the patterns and the gaps in generalized form. This mirrors how Basano's competitor review already handles named sites in its model-backed audit.
+
+---
+
+## Reference files
+
+- [`references/audit-template.md`](references/audit-template.md) - Fillable experience-audit template, copy and use. Generalized and named variants both present.
+- [`references/experience-dimensions-checklist.md`](references/experience-dimensions-checklist.md) - The observable questions per dimension, in scoring order.

--- a/skills/competitor-experience-audit/references/audit-template.md
+++ b/skills/competitor-experience-audit/references/audit-template.md
@@ -1,0 +1,136 @@
+# Competitor Experience Audit: [Vertical]
+
+**Site shape:** [ecommerce-catalog / inventory-listing / directory-marketplace / local-service-booking / subscription-app / hospitality-food / institution-mission / b2b-manufacturer / ecommerce-standout / hospitality-experience]
+**Audit date:** [YYYY-MM-DD]
+**Auditor:** [Name]
+**Field assessed:** [N sites]
+**Rendered:** [N of N] **Static-only:** [N of N]
+
+---
+
+## Field surveyed
+
+| Site | Rendered | Notes |
+|---|---|---|
+| [Site 1] | [yes/no] | [any access caveat] |
+| [Site 2] | [yes/no] | |
+| [Site 3] | [yes/no] | |
+| [Site 4] | [yes/no] | |
+| [Site 5] | [yes/no] | |
+
+If publishing the audit publicly, prepare a generalized version that drops the named column; the named version stays operated-side.
+
+---
+
+## Summary
+
+[Two to three sentences. The cross-site picture: what the field converges on, where it falls short, what the positioning opportunity is. Generalized; no aesthetic verdicts.]
+
+| Dimension | Score | One-line pattern |
+|---|---|---|
+| Primary-task prominence | [Pattern present / Mixed / Gap / Not assessable] | |
+| Layout register and density | | |
+| Merchandising and category surface | | |
+| Primary navigation and search paths | | |
+| Brand register and conviction | | |
+| Trust and conversion signals | | |
+| Recurring vertical conventions | | |
+
+---
+
+## Cross-site patterns
+
+### 1. Primary-task prominence
+
+[What the field converges on as the primary task; what element carries it; how protected the task is from competing CTAs. Observable signal: what is the largest, earliest interactive element, and what is the click count to the core task.]
+
+**Pattern:** [The field's convention]
+**Outliers:** [Any leader that breaks the pattern, and what they do instead]
+
+### 2. Layout register and density
+
+[The register the field shares (retail-dense, editorial, marketing-airy, hybrid). Cross-reference `creative-direction` aesthetic positions for vocabulary.]
+
+**Pattern:** [The field's register]
+**Outliers:** [Any leader that uses a different register]
+
+### 3. Merchandising and category surface
+
+[How much of the offering is surfaced before scroll; the navigation depth pattern; mega-menu vs grid vs side rail.]
+
+**Pattern:**
+**Outliers:**
+
+### 4. Primary navigation and search paths
+
+[Which paths the field offers (search-first, by-category, by-brand, by-attribute, by-vehicle, by-location). Score each path as primary / secondary / absent.]
+
+**Pattern:**
+**Outliers:**
+
+### 5. Brand register and conviction
+
+[The brand posture the leaders converge on. Cross-reference `creative-direction` and `brand-archetype-system`.]
+
+**Pattern:**
+**Outliers:**
+
+### 6. Trust and conversion signals
+
+[Which signals appear across the field (reviews, guarantees, pricing transparency, stock, fitment confirmation, return policy). Where they appear.]
+
+**Pattern:**
+**Outliers:**
+
+### 7. Recurring vertical conventions
+
+[The synthesis. The conventions a credible site in this vertical is expected to have, named explicitly. A build that ignores these will read as off-vertical.]
+
+**Conventions:**
+- [Convention 1]
+- [Convention 2]
+- [Convention 3]
+- ...
+
+---
+
+## Gaps (the positioning opportunity)
+
+[Where even the leaders fall short. The recurring weakness across the field. This is the wedge a new build's positioning can exploit. Observable, not speculative.]
+
+- **[Gap 1]:** [The weakness the field shares; how it shows up across N of the N leaders; what a build that fixes it would look like.]
+- **[Gap 2]:**
+- **[Gap 3]:**
+
+---
+
+## The experience bar (the build standard)
+
+A credible build in this vertical, against this field, must:
+
+- [Bar item 1 - usually maps to a recurring convention from dimension 7]
+- [Bar item 2]
+- [Bar item 3]
+- ...
+
+Optional positioning move:
+
+- [The build's wedge - exploit one or more of the gaps above]
+
+Hand this bar to `creative-direction`, `design-standards`, `information-architecture`, and the relevant build skill so they read as the standard to meet, not as suggestions.
+
+---
+
+## Not assessable
+
+[Dimensions or sites that could not be judged honestly. Common reasons: site not renderable, motion not capturable, brand voice not derivable from a single page, depth of the category surface only visible after authentication.]
+
+- **[Dimension or site]:** [Why it cannot be judged from the evidence available. What evidence would be needed to assess it.]
+- **[Dimension or site]:** 
+- ...
+
+---
+
+## Generalized version (for showcase / public use)
+
+If this audit will feed a public showcase workup or a published critique, copy the sections above into a generalized form that drops the named-competitor column and the Outliers callouts. Patterns and gaps are publishable; named-and-rated competitor breakdowns are not. The named version stays operated-side.

--- a/skills/competitor-experience-audit/references/experience-dimensions-checklist.md
+++ b/skills/competitor-experience-audit/references/experience-dimensions-checklist.md
@@ -1,0 +1,134 @@
+# Experience Dimensions Checklist
+
+Score each leading site on each dimension using the observable questions below. Mark `not_assessable` whenever the evidence does not support a judgment; do not guess. The audit's value rests on honest observation.
+
+The rule for every dimension: name what is observably true across the field, not whether you like it. If you cannot point at a specific observable thing, you are giving taste, not a pattern.
+
+---
+
+## 1. Primary-task prominence
+
+The visitor arrives with a primary job. The leading sites either lead with that job or bury it.
+
+- [ ] What is the largest, earliest interactive element on the first viewport?
+- [ ] Does that element correspond to the visitor's primary task in the vertical? (Auto-parts: a fitment selector. Hospitality-food: a menu or reservation entry. Inventory-listing: a search or filter. Local-service-booking: a "book now" or service picker.)
+- [ ] How many clicks or scrolls from arrival to completing the core task?
+- [ ] How many competing CTAs share the hero with the primary task?
+- [ ] Is the primary task reachable from a sticky element on scroll?
+
+Rendered required: **partial.** The primary task can usually be identified from a static fetch (it is in the markup), but its visual dominance and protection from competitors requires the rendered view.
+
+---
+
+## 2. Layout register and density
+
+Storefront, editorial, marketing-airy, hybrid. Cross-reference `creative-direction` aesthetic positions (editorial-restrained, polished-standard, controlled-maximalist, expressive-maximalist) for vocabulary.
+
+- [ ] How many distinct modules appear above the fold on a standard desktop viewport?
+- [ ] How many on a mobile viewport?
+- [ ] What is the content-per-viewport ratio: dense (a catalog or storefront), calm (an editorial), generous (a landing page or brochure)?
+- [ ] Where does the page read as a storefront vs a marketing page?
+- [ ] Does the whitespace ratio match a retail or a publication register?
+
+Rendered required: **yes.** Static HTML cannot tell you what users see in the first viewport.
+
+---
+
+## 3. Merchandising and category surface
+
+How much of the catalog or offering is surfaced at once, and in what shape.
+
+- [ ] How many category, collection, or entry-point modules appear before scroll?
+- [ ] How is depth signaled (mega-menu hover, fly-out, side rail, faceted search, breadcrumb expansion)?
+- [ ] Is the surface flat (one tier visible) or hierarchical (parent plus child)?
+- [ ] Are the categories shown as text, icon, image, or hybrid?
+- [ ] Is a search-first path offered alongside the category-first path?
+
+Rendered required: **partial.** Counts and structure show up in static markup; visual emphasis and reveal patterns need rendering.
+
+---
+
+## 4. Primary navigation and search paths
+
+The know-what-I-want path and the browse path. Both, or only one.
+
+- [ ] Is a search input prominent (in the header, large input), secondary (small, in a side panel), or absent?
+- [ ] Which paths does the primary nav offer (by category, by brand, by attribute, by vehicle, by location, by occasion, by audience)?
+- [ ] Score each available path: primary / secondary / absent.
+- [ ] Where does the primary nav sit (top bar, side drawer, mega-menu, sticky)?
+- [ ] On mobile, does the primary nav collapse into a hamburger or stay flat?
+
+Rendered required: **partial.** Path inventory is in the static markup; visual prominence and primary-vs-secondary judgment needs the rendered view.
+
+---
+
+## 5. Brand register and conviction
+
+The posture the leading sites take and whether they hold it across the page.
+
+- [ ] Color palette: muted / saturated; warm / cool; monochrome / multi-hue.
+- [ ] Typography: humanist / geometric / serif-led / display-led; one face or paired.
+- [ ] Imagery: photographic (studio, lifestyle, editorial); illustrated; abstract; none.
+- [ ] Voice in headings: direct, persuasive, technical, warm, plain, institutional.
+- [ ] Voice in microcopy and CTAs: matches the heading voice or breaks from it.
+- [ ] Brand posture: utilitarian / premium / friendly / institutional / technical / expressive.
+
+Cross-reference `creative-direction` and `brand-archetype-system` for the controlled vocabulary; use those terms rather than inventing new ones.
+
+Rendered required: **yes.** Brand register is a visual judgment; static HTML alone cannot support it.
+
+---
+
+## 6. Trust and conversion signals
+
+The recurring conventions a credible commercial page in this vertical carries.
+
+- [ ] Reviews / ratings present (where, how prominent, count or average shown).
+- [ ] Guarantees (return policy, money-back, warranty) surfaced or hidden.
+- [ ] Pricing transparency: price visible without interaction; total cost surfaced before checkout; "starting at" or full?
+- [ ] Stock or availability signals (in stock, low stock, lead time).
+- [ ] Fitment, sizing, eligibility, or compatibility confirmation (where the vertical requires it).
+- [ ] Shipping or service-level promises (ETA, free over $X, same-day).
+- [ ] Institutional trust signals (years in business, association badges, certifications).
+- [ ] Social proof (logos of customers, press mentions, testimonials).
+
+Rendered required: **partial.** Many trust signals are visible in markup; placement and emphasis are rendered judgments.
+
+---
+
+## 7. Recurring vertical conventions (synthesis)
+
+The patterns that recur across the field define what a credible site in this vertical is expected to have. This is not a new measurement; it is the synthesis of dimensions 1 through 6.
+
+- [ ] Which conventions appear on 3 of N or more of the leaders?
+- [ ] Which appear on fewer than 3 (single-site moves, not conventions)?
+- [ ] Which are absent across the field (the gap a positioning opportunity exploits)?
+
+The output of this dimension is a short list: "If your build does not do X, Y, Z, it will read as off-vertical." That list is what goes into the experience bar.
+
+---
+
+## Scoring rubric
+
+For each dimension, score the field (not a single site):
+
+- **Pattern present.** 3 of N or more leaders converge on a recognizable convention. Name it.
+- **Mixed.** The field splits across two or three distinct approaches. Name each, and note which the new build should adopt.
+- **Gap.** No convention emerges, or every leader misses the dimension. Often this is the positioning opportunity.
+- **Not assessable.** The evidence does not support a judgment. Name what evidence would be needed.
+
+For each site (operated-side only; the public version drops named scores):
+
+- Mark each dimension `pattern-aligned`, `outlier`, or `not assessable`.
+
+---
+
+## What this checklist will not do
+
+- Rate a single site's design taste. Use `design-standards` for production design review.
+- Tell you which vertical your build belongs in. The vertical and field are inputs to this skill, not outputs.
+- Replace user research. Use `ux-research` and `usability-testing` for real-user assessment.
+- Generate creative direction from scratch. Use `creative-direction` and `brand-discovery` for that.
+- Produce a SERP or backlink competitive analysis. Use `seo-competitor`.
+
+This checklist names patterns and gaps so a downstream build has a real bar to meet. Everything else is out of scope.


### PR DESCRIPTION
## Summary

Adds a new catalog skill `competitor-experience-audit` that audits the brand, UX, and site design of the leading sites in a vertical as a set of observable cross-site patterns. The output is the experience bar a new build must meet or beat. It is the brand / UX / design counterpart to `seo-onpage` and `accessibility-audit`.

**Category:** `research`, `display_order: 6` (after `user-feedback-aggregation`).
**Path:** `skills/competitor-experience-audit/`.

Catalog count after this PR: **100 skills**, **429 reference files**. README regenerated via `scripts/generate_readme_catalog.py --write`. Crosslink pass clean.

## Why this skill

Technical findings are objective (a missing canonical is missing). Design is more subjective, and if a catalog audit skill starts emitting confident aesthetic opinions, it erodes the honesty that makes its verdict worth anything. So the skill is deliberately written to make the subjective assessable: every dimension is judged by observable questions about what the leading sites actually do, reported as cross-site patterns and gaps, and marked `not_assessable` whenever the evidence does not support a judgment.

The need surfaced when an existing competitor audit captured SEO and accessibility cleanly but never named the brand, UX, or design conventions of the vertical. The build downstream came out technically clean but read off-vertical because no bar was set against the field's experience. This skill is the bar.

## The seven dimensions (all framed as observable patterns, not taste)

1. **Primary-task prominence.** Largest earliest interactive element; clicks to the core task; competing CTAs in the hero. Observable: what the layout actually privileges as the primary job.
2. **Layout register and density.** Modules per viewport; storefront vs editorial vs marketing-airy. Cross-references `creative-direction` aesthetic positions for vocabulary.
3. **Merchandising and category surface.** Count and shape of category entry points; navigation depth (mega-menu vs grid vs side rail).
4. **Primary navigation and search paths.** Which paths the field offers (by-category, by-brand, by-attribute, by-vehicle, by-location), scored primary / secondary / absent.
5. **Brand register and conviction.** The posture the leaders take (utilitarian, premium, friendly, institutional, technical, expressive). Cross-references `creative-direction` and `brand-archetype-system` so the skill uses the controlled vocabulary rather than reinventing it.
6. **Trust and conversion signals.** Reviews, guarantees, pricing transparency, stock signals, fitment / sizing / eligibility confirmation, service-level promises.
7. **Recurring vertical conventions (synthesis).** Patterns that recur across the leaders and define what a credible site in this vertical is expected to have.

Each dimension scores the field (`Pattern present` / `Mixed` / `Gap` / `Not assessable`), names the cross-site pattern, and names the gap where even the leaders fall short.

## Honesty guardrail (load-bearing, explicit in the skill)

The skill states these rules in plain prose:

- Report what the leading sites observably do and where they observably fall short, as cross-site patterns. Do not render personal aesthetic judgments ("this is ugly", "good design", "clean typography"). Aesthetic verdicts belong in `art-direction` or `design-standards`, not here.
- When the evidence does not support a judgment, say so plainly and mark the dimension `not_assessable`. Common cases: layout and density cannot be judged from un-rendered static HTML; motion cannot be judged from a screenshot; brand voice cannot be judged from a single page.
- A pattern is a recurrence across the field (3 of N or more leaders). One site doing something distinctive is a single-site observation, not a convention.
- The output is a grounded experience bar, not an opinion piece.

The skill's `Failure patterns` section names the common ways an audit slides into taste and how to redirect each one ("Rate the design of these sites" -> redirect to observable patterns; aesthetic verbs without observable signal -> flag as taste, not finding; etc.).

## Static vs rendered

The skill says explicitly which dimensions can be partially assessed from static HTML and which require the rendered page. Layout density, brand register, motion, and rendered hierarchy all need the rendered view; the skill instructs marking those `not_assessable` for any site you cannot render rather than guessing. This is the hook the deferred rendered-capture path will satisfy when it lands.

## Output format and scrub for showcase use

Output is a markdown experience bar (`experience-audit-[vertical-slug].md`) with cross-site patterns, gaps, and the synthesized bar. Under 1500 words; appendices link deeper if needed.

If the audit will feed a public showcase workup, the skill instructs scrubbing for named competitors so the public version is pattern-level only. The named version stays operated-side. This mirrors how the catalog's existing `basanoCompetitorReview` shape already handles named sites.

## Reference files

- `references/audit-template.md` — fillable experience-audit template. Includes a section for the named version (operated-side) and a generalized version (for public / showcase use). Each dimension has a Pattern + Outliers slot; the synthesis builds the bar.
- `references/experience-dimensions-checklist.md` — observable questions per dimension, in scoring order, with a "rendered required" flag on each (full / partial / no). Scoring rubric inline. Closes with what the checklist will NOT do (rate single-site taste, replace user research, etc.) so it is not misused.

## Cross-references

The skill points at adjacent skills rather than duplicating them:

- `creative-direction` and `brand-archetype-system` for brand vocabulary (dimensions 2 and 5).
- `design-standards`, `art-direction`, `brand-style-guide` for production design decisions on a known build (the "when NOT to use" path).
- `seo-onpage`, `accessibility-audit`, `seo-competitor` as the technical-audit counterparts (the "when NOT to use" path).
- `ux-research`, `usability-testing` as the real-user-participant counterparts.
- `information-architecture`, `landing-page-copy`, `frontend-component-build` as the build skills the bar feeds into.

## Linter / catalog

- `python scripts/generate_readme_catalog.py --check`: clean (after `--write`).
- `python scripts/crosslink_pass.py`: clean (0 replacements across 100 files and 429 references).
- Skill count badge, table of contents, "What you get" counts, and CATALOG block in README.md all regenerated to 100.
- Skill follows the established frontmatter shape (`name`, trigger-rich `description`, `category`, `catalog_summary`, `display_order`) verified against `seo-onpage` as the read reference.

## Report

- **Skill path:** `skills/competitor-experience-audit/`. Reference files at `references/audit-template.md` and `references/experience-dimensions-checklist.md`.
- **Category:** `research`. Lands at `display_order: 6` after the existing five research skills (`ux-research`, `usability-testing`, `journey-mapping`, `discovery-research-synthesis`, `user-feedback-aggregation`).
- **Seven dimensions defined.** Each framed as observable questions and cross-site pattern scoring; no aesthetic verdicts in any of them.
- **Honesty guardrail explicit.** A standalone "The honesty guardrail (load-bearing)" section names the rule, the `not_assessable` discipline, the 3-of-N pattern threshold, and the redirect for taste questions.
- **Linter / catalog regeneration:** both passes clean; catalog count updated to 100.
- **Vertical-agnostic.** Works for any `SiteShape`. Auto-parts catalogs are the first test case named in the skill, not the only target.
