### PR TITLE
Tighten ecommerce-catalog density conventions (stacked on #70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-100-blue.svg)](#the-100-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-101-blue.svg)](#the-101-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 100 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 101 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -60,7 +60,7 @@ Skills load on demand: each contributes roughly its name and description until C
 - [How the catalog connects](#how-the-catalog-connects)
 - [Surfaces](#surfaces)
 <!-- COUNT_TOC:START -->
-- [The 100-skill catalog](#the-100-skill-catalog)
+- [The 101-skill catalog](#the-101-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -89,8 +89,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **100 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
-- **429 reference files** (templates, checklists, decision matrices, worked examples)
+- **101 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
+- **440 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -513,11 +513,11 @@ Each family repo is MIT-licensed, conforms to the Agent Skills Specification, an
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 100-skill catalog
+## The 101-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 100 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 101 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -543,13 +543,14 @@ All 100 skills are shipped. Each has a complete SKILL.md plus at least one refer
 | [`brand-archetype-system`](skills/brand-archetype-system/SKILL.md) | 12 archetype defaults across 18 verticals: color, type, voice, imagery starters |
 | [`logo-design`](skills/logo-design/SKILL.md) | Logo variants across architectures (wordmark, lockup, monogram, letterform-as-symbol), with rationale and application specs |
 
-### Design (3)
+### Design (4)
 
 | Skill | What it does |
 |---|---|
 | [`design-system`](skills/design-system/SKILL.md) | Component library, design tokens, design system documentation |
 | [`design-standards`](skills/design-standards/SKILL.md) | Production-grade page and component design standards |
 | [`art-direction`](skills/art-direction/SKILL.md) | Photography, illustration, and visual direction for campaigns |
+| [`vertical-site-conventions`](skills/vertical-site-conventions/SKILL.md) | Vertical page and site composition built to the experience bar |
 
 ### Content (12)
 

--- a/skills/vertical-site-conventions/SKILL.md
+++ b/skills/vertical-site-conventions/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: vertical-site-conventions
+description: "Compose pages and sites that read as their vertical: ecommerce-catalog storefronts that look like storefronts, hospitality-food sites that look like restaurants, b2b-manufacturer sites that look industrial. Use this skill whenever the user wants to build a site that looks like the vertical it serves, fix a build that reads as generic or off-vertical, build to an experience bar produced by competitor-experience-audit, or compose pages with the merchandising, density, and layout conventions a credible site in the category is expected to carry. Triggers on vertical conventions, storefront layout, ecommerce layout, retail conventions, merchandising layout, category page composition, site composition, build to the experience bar, make it look like the vertical, off-vertical, looks generic, build conventions for a vertical, site grammar. Also triggers when a build that is technically clean reads wrong for its category, and the cause is composition, not visual taste."
+category: design
+catalog_summary: "Vertical page and site composition built to the experience bar"
+display_order: 4
+---
+
+# Vertical Site Conventions
+
+Compose pages and whole sites to the layout, density, and merchandising conventions that make a build read as a credible member of its vertical. Stack-agnostic. Works on any framework that can express server-rendered pages and component composition.
+
+This skill owns vertical-level composition: which modules go where, how dense the page is, how much of the catalog or offering is surfaced, and which paths the navigation serves. It routes the day-to-day visual decisions to `design-standards`, the aesthetic register to `creative-direction`, the site-structure modeling to `information-architecture`, and the component implementation to `frontend-component-build`. It does not duplicate any of them; it composes their outputs into a vertical-correct site.
+
+It is the build-side counterpart to `competitor-experience-audit`. The audit measures the field on seven dimensions; this skill builds to those same seven, dimension by dimension. The two are deliberately structured as two sides of one standard so an experience bar produced by the audit maps one-to-one onto what this skill builds.
+
+---
+
+## When to use
+
+- Building a new site in a vertical you have not built in before
+- Fixing a build that reads as generic or off-vertical even though it is technically clean (the SEO, accessibility, and component implementation are correct, but the page does not read like its category)
+- Building to an experience bar produced by `competitor-experience-audit` (the audit-fed path is the intended use)
+- Adding the merchandising, density, and navigation conventions a site in this category is expected to carry
+- Building a showcase or demo where the build must read as its vertical, not as a generic SaaS landing page
+
+## When NOT to use
+
+- Day-to-day visual decisions on a known build (use `design-standards`)
+- Defining the brand register or aesthetic from scratch (use `creative-direction`, `brand-archetype-system`, `brand-discovery`)
+- Building one component well (use `frontend-component-build`)
+- Modeling site structure and navigation hierarchy from scratch (use `information-architecture`)
+- Building a formal design system or token system (use `design-system`)
+- Auditing the competitive field for what conventions exist (use `competitor-experience-audit`; this skill consumes that audit's output, it does not produce it)
+
+---
+
+## Required inputs
+
+- The site shape the build is for, from the controlled list: `ecommerce-catalog`, `inventory-listing`, `directory-marketplace`, `local-service-booking`, `subscription-app`, `hospitality-food`, `institution-mission`, `b2b-manufacturer`, `ecommerce-standout`, `hospitality-experience`.
+- An experience bar from `competitor-experience-audit` (the cross-site patterns and gaps for the vertical). If absent, the skill falls back to the per-shape default conventions in the references; the audit-fed path is stronger and is the intended use.
+- The brand register and aesthetic decisions (from `creative-direction` or already settled). This skill does not redefine them.
+- The framework or technical context the build will use (the skill is stack-agnostic but the consumer needs to know).
+
+If the site shape is unclear, ask. Building to the wrong shape's conventions produces a build that reads off-vertical, which is the exact failure this skill exists to prevent.
+
+---
+
+## The framework: build to the seven dimensions
+
+The framework mirrors the seven dimensions `competitor-experience-audit` measures. Each is expressed here as build guidance (what to do) rather than audit questions (what to observe). Run them in order; the synthesis in dimension 7 is the composition checklist that catches what the earlier six missed.
+
+### 1. Build the primary task as the dominant, earliest element
+
+The visitor arrives with a primary job. The leaders in the vertical lead with that job; off-vertical builds bury it behind marketing copy or competing CTAs.
+
+- Identify the vertical's primary task from the experience bar or the per-shape reference. (Ecommerce-catalog: a fitment, search, or category-entry interaction. Hospitality-food: a menu or reservation entry. Inventory-listing: a search-and-filter. Local-service-booking: a "book now" or service-picker.)
+- Give that task the largest, earliest interactive treatment in the hero.
+- Demote competing CTAs. The hero gets one primary action; secondary actions live below the fold or in the chrome.
+- Reach the core task without scrolling on the device class the vertical's visitors use.
+- For commercial pages, sticky a compact version of the primary task to the chrome so it stays reachable on scroll.
+
+If the primary task cannot be the hero (a constraint from a stakeholder, a regulated vertical), surface the closest equivalent and document the compromise. Do not silently push the primary task below the fold.
+
+### 2. Build to the vertical's layout register and density
+
+Most off-vertical builds default to a generic SaaS-airy landing page. Retail and catalog verticals are denser; editorial verticals are calmer; hospitality is image-led. Build to the field's density, not to a default.
+
+- Identify the register from the experience bar or the per-shape reference (storefront-dense, editorial-calm, marketing-airy, image-led).
+- Match the field's content-per-viewport: a catalog vertical surfaces more modules above the fold than a SaaS landing page.
+- Choose the module count above the fold deliberately. State the count in the build notes.
+- Route the actual color, type, and aesthetic choice to `creative-direction` and `design-standards`. This skill owns the density and module-count decision, not the visual register itself.
+
+Composition decision lives here. Visual register lives there. Do not redefine either; route to the right skill.
+
+### 3. Build the merchandising and category surface the vertical uses
+
+How much of the catalog or offering is surfaced at once, and in what shape, is a per-vertical decision the build must own.
+
+- Surface the catalog the way the vertical does: how many category, collection, or entry-point modules appear before scroll.
+- Signal depth the way the vertical signals it: mega-menu hover, grid of category cards, faceted-search side rail, breadcrumb-driven hierarchy. Pick one and commit; do not stack three.
+- Choose flat (one tier visible) or hierarchical (parent plus child categories shown together) per the vertical's convention.
+- Use icon / image / text / hybrid category presentation per the vertical.
+
+Cross-reference `information-architecture` for the structural modeling of the nav tree. This skill owns the compositional surface; that skill owns the structural model.
+
+### 4. Build both the know-what-I-want and the browse path the vertical expects
+
+Verticals differ on which path is primary. A catalog vertical needs both search and category browse, with search often primary. A hospitality-food site rarely needs search but always needs a menu and a reservation entry. Build to the paths the field actually offers, in the prominence the field gives them.
+
+- List the paths the experience bar names (by category, by brand, by attribute, by vehicle, by location, by occasion, by audience).
+- Score each path as primary, secondary, or absent per the vertical.
+- Build the primary paths into the hero or primary nav. Build the secondary paths into the chrome or below the fold. Drop the paths the field does not use.
+- Search input prominence is a per-vertical decision: header-primary, secondary in a side rail, or absent. Match the field.
+
+Route the structural nav modeling to `information-architecture`; route the search UX patterns to that skill or to the project's existing search component. This skill owns which paths exist and how prominent each is.
+
+### 5. Build the brand posture consistently across the page
+
+The brand register is set by `creative-direction` and `brand-archetype-system`. This skill does not redefine it. But composition decides whether the posture holds across the page or only in the hero.
+
+- Carry the brand register from the hero into the nav, the cards, the empty states, the trust signals, and the footer. A premium-utilitarian register that disappears below the hero is a composition failure, not a brand failure.
+- Apply the voice consistently in headings, microcopy, CTAs, and empty states. Do not let the empty states default to generic copy.
+- Hold the imagery posture across the page: a vertical that uses studio product photography in the hero does not switch to abstract illustration in the trust section.
+
+Route the actual register choice and the voice attributes to `creative-direction` and `brand-voice`. Own the consistency requirement here.
+
+### 6. Build the trust and conversion signals the vertical requires
+
+Each vertical has a different set of trust signals it is expected to carry. A build that ships without them reads as not-yet-credible. Build them in.
+
+- Identify the required signals from the experience bar or the per-shape reference. (Ecommerce-catalog: reviews, guarantees, pricing transparency, stock signals, fitment confirmation, shipping promises. Hospitality-food: hours, location, reservation availability, menu price range. B2b-manufacturer: certifications, customer logos, spec sheets. Local-service-booking: licensing, insurance, service-area, response time.)
+- Surface them where the field surfaces them. Reviews near the buying action; service-area in the hero; certifications in the chrome.
+- Honor the functional-vs-demo line for showcase builds: real where touchable (real reviews if they exist, real cart state), honestly demo where it needs a backend (clearly labeled demo checkout modal, no fake payment).
+
+### 7. Run the synthesis as a composition checklist
+
+The seventh dimension is the synthesis: the specific conventions a credible build in this vertical must have, named explicitly. Run this as a pre-ship checklist before declaring the composition done.
+
+- Pull the conventions from the experience bar's dimension 7, or from the per-shape reference's recurring-conventions section.
+- For each, confirm the build does it. Mark each item present, absent, or routed elsewhere (with a link to the routing decision).
+- If three or more conventions are absent, the build is off-vertical. Go back to the earlier dimensions; this is not a polish-pass fix.
+- If one or two are absent, name the reason: deliberate positioning (the wedge the build is exploiting from the audit's gaps section), constraint (stakeholder, technical), or oversight (fix before ship).
+
+The synthesis is what catches builds that pass dimensions 1 through 6 individually but compose into something off-vertical anyway. Run it.
+
+---
+
+## How the skill consumes an experience bar
+
+When `competitor-experience-audit` has run for the vertical, its output is the input to this skill. The audit's seven dimensions map directly onto this skill's seven, in order. Concretely:
+
+- The audit's `Primary-task prominence` pattern names what to build in this skill's dimension 1.
+- The audit's `Layout register and density` pattern names the density target for dimension 2.
+- The audit's `Merchandising and category surface` pattern names the surface shape for dimension 3.
+- The audit's `Primary navigation and search paths` pattern names the path inventory for dimension 4.
+- The audit's `Brand register and conviction` pattern names the register `creative-direction` should be working from, which this skill carries across the page in dimension 5.
+- The audit's `Trust and conversion signals` pattern names the required signals for dimension 6.
+- The audit's `Recurring vertical conventions` are the checklist for dimension 7.
+- The audit's `Gaps` section names the positioning opportunity the build can exploit as its wedge.
+
+If no audit has been run, fall back to the per-shape reference files in `references/`. The default conventions there are derived from observable cross-site patterns and are honest, but a vertical-specific audit is stronger and is the intended path.
+
+---
+
+## Stays in its lane (load-bearing)
+
+This skill owns one thing: vertical-level page and site composition. It routes everything else, and that routing discipline is what keeps it useful and what keeps the catalog clean.
+
+- Visual tokens, color, type, contrast, spacing scale: route to `design-standards`.
+- Aesthetic register, archetype, voice attributes: route to `creative-direction` and `brand-archetype-system`.
+- Site structure, nav hierarchy, URL design: route to `information-architecture`.
+- Component API, states, accessibility implementation: route to `frontend-component-build`.
+- Formal design system, token library, component documentation: route to `design-system`.
+- The audit that produces the experience bar: route to `competitor-experience-audit`.
+- On-page SEO and accessibility audits: route to `seo-onpage` and `accessibility-audit`.
+
+If a build decision sits inside one of those skills, do not restate the standard here. Link to the skill and let it own its territory.
+
+---
+
+## Workflow
+
+1. **Confirm the site shape and the experience bar.** Site shape from the controlled list. Experience bar from `competitor-experience-audit` if run; the per-shape reference otherwise.
+2. **Run dimensions 1 through 6 in order.** For each, name the build decision and which other skill it routes to (for the parts that route elsewhere).
+3. **Run dimension 7 as a checklist.** Confirm every recurring convention from the vertical is present, absent for a stated reason, or routed elsewhere.
+4. **Write the composition notes.** Use the template in [`references/shape-conventions-checklist.md`](references/shape-conventions-checklist.md). The notes are what `frontend-component-build` and `design-standards` read as the spec to implement against.
+5. **Hand off to the implementation skills.** This skill's output is composition decisions, not finished components. The build is done when those decisions have been implemented through `frontend-component-build`, `design-standards`, and the project's component library.
+
+---
+
+## Failure patterns
+
+When you spot one of these, push back before delivering.
+
+- **"Make it look modern."** Vague. Ask which vertical, which experience bar, which conventions. "Modern" without a vertical produces the generic SaaS-airy build this skill exists to prevent.
+- **Building to a generic / SaaS-airy default when the vertical wants a denser storefront.** Retail and catalog verticals surface more per viewport than a marketing page. If the build looks calm and roomy, check the density against the field.
+- **Burying the primary task.** A hero stuffed with marketing copy and three competing CTAs is the most common off-vertical failure. Dimension 1 is not optional.
+- **Redefining aesthetic vocabulary instead of routing to `creative-direction`.** This skill does not coin new register names or invent new voice attributes. If the question is what posture the brand takes, that is `creative-direction`'s call.
+- **Treating the experience bar as optional when it is available.** If `competitor-experience-audit` has run for the vertical, the bar is the spec. Building to the per-shape default while ignoring the audit's bar is half a build.
+- **Producing a template instead of building to the field's actual conventions.** Per-shape references are starting points, not finished templates. They name the patterns the field shares; the build still has to land them in this brand and this brief.
+- **Skipping dimension 7.** A build that passes dimensions 1 through 6 individually can still compose off-vertical. The synthesis check is the one that catches it.
+- **Calling implementation detail "composition".** Button radius, font size, color contrast are `design-standards` decisions. Module count, primary-task prominence, category-surface depth are this skill's decisions. Do not bleed across the line.
+
+---
+
+## Output format
+
+Default output is a markdown set of composition notes at `composition-[site-shape]-[brand-slug].md` in the project root. Structure:
+
+1. The site shape and the experience bar consulted (or "no audit available; per-shape reference used")
+2. Dimension-by-dimension build decisions (1 through 6)
+3. The synthesis checklist (dimension 7), each convention marked present / absent / routed
+4. The wedge (which gap from the audit's gaps section this build is exploiting, if any)
+5. The hand-off list: what `frontend-component-build`, `design-standards`, and `creative-direction` need from these notes to implement
+
+Keep notes under 1500 words. The notes are a spec for the implementation skills; if they need more detail, that is a sign one of those skills should own the deeper specification.
+
+---
+
+## Reference files
+
+- [`references/shape-conventions-checklist.md`](references/shape-conventions-checklist.md) - The per-dimension build checklist applied as a pre-ship review. Mirror of the audit's dimension checklist on the build side.
+- [`references/shape-ecommerce-catalog.md`](references/shape-ecommerce-catalog.md) - Default conventions for the ecommerce-catalog shape (first test case; auto-parts and similar dense storefronts).
+- [`references/shape-inventory-listing.md`](references/shape-inventory-listing.md) - Stub; fill when the first inventory-listing demo is built.
+- [`references/shape-directory-marketplace.md`](references/shape-directory-marketplace.md) - Stub.
+- [`references/shape-local-service-booking.md`](references/shape-local-service-booking.md) - Stub.
+- [`references/shape-subscription-app.md`](references/shape-subscription-app.md) - Stub.
+- [`references/shape-hospitality-food.md`](references/shape-hospitality-food.md) - Stub.
+- [`references/shape-institution-mission.md`](references/shape-institution-mission.md) - Stub.
+- [`references/shape-b2b-manufacturer.md`](references/shape-b2b-manufacturer.md) - Stub.
+- [`references/shape-ecommerce-standout.md`](references/shape-ecommerce-standout.md) - Stub.
+- [`references/shape-hospitality-experience.md`](references/shape-hospitality-experience.md) - Stub.

--- a/skills/vertical-site-conventions/references/shape-b2b-manufacturer.md
+++ b/skills/vertical-site-conventions/references/shape-b2b-manufacturer.md
@@ -1,0 +1,19 @@
+# Shape: b2b-manufacturer
+
+Industrial manufacturers, robotics, machine tools, components, OEMs. The reader arrives as a buying engineer, a procurement specialist, or a partnership lead, wanting specs, references, and a path to a salesperson.
+
+## Status
+
+Stub. Fill when the first b2b-manufacturer demo is built, or when a `competitor-experience-audit` for one has produced an experience bar.
+
+## Provisional conventions (until filled from a real audit)
+
+- **Primary task:** browse products / capabilities and reach a specialist. The hero is more often a capability statement than a CTA; the CTA path is "request a quote", "talk to engineering", "download spec sheet".
+- **Layout register:** technical-considered. Denser than a SaaS marketing page; less dense than a catalog. Photography is industrial, often factory floor or product close-ups.
+- **Merchandising:** product lines, capabilities, case studies, and spec sheets. Catalog depth varies; many manufacturers do not surface SKU-level prices on the public site.
+- **Paths:** by product line primary; by industry served primary; by capability or service secondary; resources / spec library secondary but conventional.
+- **Brand register:** technical-authoritative, premium-utilitarian, institutional. Cross-reference `creative-direction`.
+- **Trust signals:** certifications (ISO, AS9100, UL), named customers (logos), case studies with measurable outcomes, years in business, made-in-X if relevant, spec sheets downloadable.
+- **Synthesis (provisional):** capability statement in the hero, product-line surface in the first or second viewport, named customer logos somewhere visible, certifications surfaced, a clear engineering / sales contact path, downloadable spec sheets where the product warrants them.
+
+Until this shape is built into a demo, treat the above as observation defaults to verify against an audit, not as ship-ready conventions.

--- a/skills/vertical-site-conventions/references/shape-conventions-checklist.md
+++ b/skills/vertical-site-conventions/references/shape-conventions-checklist.md
@@ -62,9 +62,16 @@ Pull the conventions from the experience bar's dimension 7 (or the per-shape ref
 - [ ] Convention 5:
 - [ ] Convention 6:
 - [ ] Convention 7:
+- [ ] Convention 8:
+- [ ] Convention 9:
+- [ ] Convention 10:
 - [ ] (Add rows as needed for the vertical's full convention list.)
 
-**Synthesis rule:** if three or more conventions are absent and not deliberately positioned-against, the build is off-vertical. Go back to dimensions 1 through 6.
+**Density-bearing items.** Some conventions are density-bearing: their absence makes a checklist-passing build still read airy or brochure-like instead of storefront-dense. For the ecommerce-catalog shape, conventions 2 (category surface band above the fold at 1280x800), 9 (a promotional or deal surface near the top), and 10 (an inventory or catalog-depth signal a first-time visitor sees) are the density-bearing trio. Each shape's per-shape reference names its own density-bearing items.
+
+Mark the density-bearing items explicitly in the list above. Missing any one density-bearing item is sufficient to fail the synthesis on its own, regardless of how many other conventions hit. This rule comes from a real build hitting 6 of 8 conventions in an earlier (pre-density-bearing) form of this reference and still reading off-vertical because the density-bearing items it missed were the load-bearing ones.
+
+**Threshold:** a build hitting 8 of 10 (or the equivalent ratio for shapes with a different convention count) is at the experience bar for the shape; the wedge is what the build does beyond that. A build missing 3 or more conventions, OR any density-bearing item, is off-vertical and needs composition work, not a polish pass. Go back to dimensions 1 through 6.
 
 ---
 

--- a/skills/vertical-site-conventions/references/shape-conventions-checklist.md
+++ b/skills/vertical-site-conventions/references/shape-conventions-checklist.md
@@ -1,0 +1,90 @@
+# Vertical Site Conventions Checklist
+
+Run this checklist as the composition pre-ship review. It mirrors the seven dimensions `competitor-experience-audit` measures, on the build side. Mark each item present, absent for a stated reason, or routed elsewhere (with a link).
+
+Three or more absences across the seven dimensions means the build is off-vertical and needs composition work, not a polish pass.
+
+---
+
+## 1. Primary-task prominence
+
+- [ ] The vertical's primary task is named (from the experience bar or per-shape reference).
+- [ ] The primary task is the largest, earliest interactive element in the hero.
+- [ ] No competing CTA is louder than the primary task in the hero.
+- [ ] The primary task is reachable without scroll on the device class the vertical's visitors use.
+- [ ] A compact version of the primary task is sticky to the chrome on scroll (for commercial pages).
+- [ ] If the primary task is not the hero, the compromise is documented and the closest equivalent is surfaced.
+
+## 2. Layout register and density
+
+- [ ] The vertical's register is named (storefront-dense, editorial-calm, marketing-airy, image-led).
+- [ ] The module count above the fold is decided deliberately, not by default, and matches the field's content-per-viewport.
+- [ ] The visual register (color, type, aesthetic) is routed to `creative-direction` and `design-standards`, not redefined here.
+- [ ] The page does not default to a generic SaaS-airy layout when the field uses a denser register.
+
+## 3. Merchandising and category surface
+
+- [ ] The number of category, collection, or entry-point modules above the fold matches the field.
+- [ ] The depth signaling pattern is chosen and committed to (mega-menu, grid, faceted side rail, breadcrumb hierarchy). Not stacked.
+- [ ] Flat or hierarchical category presentation matches the vertical.
+- [ ] Category presentation style (icon, image, text, hybrid) matches the field.
+- [ ] The nav tree structural modeling is routed to `information-architecture`, not redefined here.
+
+## 4. Navigation and search paths
+
+- [ ] The paths the field offers are inventoried (by category, brand, attribute, vehicle, location, occasion, audience).
+- [ ] Each path is scored primary, secondary, or absent against the vertical.
+- [ ] Primary paths land in the hero or primary nav; secondary paths land in chrome or below the fold.
+- [ ] Search input prominence matches the vertical (header-primary, secondary side-rail, or absent).
+- [ ] Paths the field does not use are not surfaced (do not invent paths the vertical does not carry).
+
+## 5. Brand register and conviction
+
+- [ ] The brand register is set by `creative-direction` and `brand-archetype-system`, not by this skill.
+- [ ] The register carries from the hero into the nav, cards, empty states, trust signals, and footer.
+- [ ] Voice is applied consistently in headings, microcopy, CTAs, and empty states. Empty states do not fall back to generic copy.
+- [ ] Imagery posture is consistent across the page (no switch from studio photography to abstract illustration mid-page without a reason).
+
+## 6. Trust and conversion signals
+
+- [ ] The vertical's required signals are inventoried from the experience bar or per-shape reference.
+- [ ] Each required signal is built into the page where the field places it (reviews near the buying action, service-area in the hero, certifications in the chrome, etc.).
+- [ ] For showcase or demo builds, the functional-vs-demo line is honored: real where touchable, honestly demo where it needs a backend (clearly labeled demo modals, no fake payment, no real account creation).
+
+## 7. The synthesis: recurring vertical conventions
+
+Pull the conventions from the experience bar's dimension 7 (or the per-shape reference's "recurring conventions" section). For each:
+
+- [ ] Convention 1: __________________ — [present / absent (reason) / routed to ____]
+- [ ] Convention 2:
+- [ ] Convention 3:
+- [ ] Convention 4:
+- [ ] Convention 5:
+- [ ] Convention 6:
+- [ ] Convention 7:
+- [ ] (Add rows as needed for the vertical's full convention list.)
+
+**Synthesis rule:** if three or more conventions are absent and not deliberately positioned-against, the build is off-vertical. Go back to dimensions 1 through 6.
+
+---
+
+## The wedge
+
+If the experience bar named a recurring gap across the field, the build can exploit it as positioning. State which gap is being exploited and how the build addresses it.
+
+- **Gap exploited:** [from the audit's gaps section]
+- **How the build addresses it:**
+- **What that buys the build:**
+
+If the build is not exploiting a gap, that is fine; the build hits the experience bar and competes on execution. Say so explicitly.
+
+---
+
+## Hand-off list
+
+- [ ] `frontend-component-build`: the components the build needs and the states each must support.
+- [ ] `design-standards`: the tokens, contrast, and spacing the composition assumes.
+- [ ] `creative-direction`: the register and voice the composition carries.
+- [ ] `information-architecture`: the nav tree and URL structure the composition expects.
+
+The hand-off list is what makes this skill's output a real spec for the implementation skills, not a wish list. Each item should be specific enough that the implementation skill can read it and start.

--- a/skills/vertical-site-conventions/references/shape-directory-marketplace.md
+++ b/skills/vertical-site-conventions/references/shape-directory-marketplace.md
@@ -1,0 +1,19 @@
+# Shape: directory-marketplace
+
+Service-provider directories, home services marketplaces, freelance / contractor matching. The reader arrives wanting to find a provider for a need they can name.
+
+## Status
+
+Stub. Fill when the first directory-marketplace demo is built, or when a `competitor-experience-audit` for one has produced an experience bar.
+
+## Provisional conventions (until filled from a real audit)
+
+- **Primary task:** describe the need (service, location, urgency) and surface ranked providers. Often a wizard pattern (service picker, then ZIP, then refine).
+- **Layout register:** trust-led and service-led. Photos of providers, ratings, and quoted response time carry the page.
+- **Merchandising:** the provider list is the merchandising. Hero often carries a service-picker plus a band of top categories.
+- **Paths:** by service category primary; by location primary; by provider (named) secondary.
+- **Brand register:** marketplace-neutral or strongly opinionated (premium-curated vs widest-net). Cross-reference `creative-direction`.
+- **Trust signals:** verified, licensed, insured, response time, ratings with review count, dispute resolution promise.
+- **Synthesis (provisional):** service picker as the first interaction, location capture early, provider ratings with substantive review counts, response-time signal, clarity on what is curated vs open.
+
+Until this shape is built into a demo, treat the above as observation defaults to verify against an audit, not as ship-ready conventions.

--- a/skills/vertical-site-conventions/references/shape-ecommerce-catalog.md
+++ b/skills/vertical-site-conventions/references/shape-ecommerce-catalog.md
@@ -1,0 +1,102 @@
+# Shape: ecommerce-catalog
+
+Dense catalog storefronts. Auto-parts, hardware, industrial supply, mass-merchant retail. The reader arrives with a part to find or a category to browse. The build leads with the path that gets them to the part.
+
+This file is a default set of composition conventions for the shape. When `competitor-experience-audit` has been run for the specific vertical (auto-parts, hardware, tooling), the audit's experience bar overrides these defaults. Use these when no audit has been run, or as a sanity check on an audit's output.
+
+---
+
+## 1. Primary-task prominence
+
+**Primary task:** the path to a part. For verticals where compatibility matters (auto-parts, electronics), this is a fitment / compatibility selector. For undifferentiated catalogs (hardware, office supply), this is a search input. For mass merchants, this is category-entry-grid.
+
+**Build conventions:**
+- The primary task is the largest, earliest interactive element. Not a sidebar widget; not a modal triggered by a marketing CTA.
+- Competing CTAs (newsletter, account, brand pitch) live below the fold or in the chrome.
+- The primary task is sticky to the chrome on scroll. A visitor mid-page who realizes the fitment is wrong can change it without scrolling back to the hero.
+- For fitment-led verticals: setting the vehicle / compatibility once carries to every subsequent page. The selection is the global context, surfaced visibly.
+
+## 2. Layout register and density
+
+**Register:** storefront-dense. Not editorial; not marketing-airy. The page is a working surface, not a brand brochure.
+
+**Build conventions:**
+- More than four modules above the fold on desktop is normal for this shape. Two-module heros are off-vertical.
+- The first viewport carries: the primary task, a band of category or featured-collection entry points, and at least one trust or merchandising signal.
+- Whitespace is functional, not generous. The leaders in this shape are dense; an airy build reads as not-a-real-store.
+- Route color, type, and aesthetic to `creative-direction` and `design-standards`. This shape's register can be utilitarian, premium-utilitarian, or technical; not flowery or expressive.
+
+## 3. Merchandising and category surface
+
+**Conventions:**
+- A category surface band is present in the first or second viewport. Eight to twelve category entry points is typical for a wide catalog; four to six for a focused one.
+- Depth signaling is one of: mega-menu hover (broad catalogs), grid of category cards on the home (narrow catalogs), faceted-search side rail on category pages. Pick one; do not stack.
+- Category cards carry an icon, an image, or a tight text-only treatment. Hybrid icon-plus-text reads as catalog; image-only reads as marketing.
+- Hierarchical surface (parent plus child categories) is conventional for broad catalogs. Flat surface fits focused catalogs.
+- Featured / promoted collections appear below the category surface, not above; categories carry the navigation load.
+
+## 4. Navigation and search paths
+
+**Paths the shape carries:**
+- By category: primary. Always present.
+- By search: primary. Always present, in the header.
+- By brand or manufacturer: secondary to primary for broad catalogs (often a band in the chrome or a top-level page).
+- By attribute (price, size, color, condition): primary on category pages via the faceted side rail.
+- By vehicle / compatibility / fitment: primary for compatibility-led verticals; absent for undifferentiated catalogs.
+- Newsletter, account, cart: chrome-level secondary affordances.
+
+**Build conventions:**
+- Search input is in the header, not in a side panel. Visible width meaningful (not collapsed to an icon).
+- Faceted filtering on the listing page is conventional; flat lists are off-vertical for broad catalogs.
+- Sort options (price asc, price desc, name, relevance) are visible on the listing.
+- Search and category browse coexist; one is not gated behind the other.
+
+## 5. Brand register and conviction
+
+**Typical postures:** utilitarian, premium-utilitarian, technical, value-led. Cross-reference `creative-direction` and `brand-archetype-system` for the controlled vocabulary; do not invent new register names here.
+
+**Build conventions (consistency, not register choice):**
+- The register carries into the empty states, the cart, the demo modals, and the trust signals. A premium-utilitarian register that dissolves into generic copy below the fold is a composition failure.
+- Voice consistency in headings, microcopy, CTAs, and empty states.
+- Product imagery posture is consistent: studio product photography across listing and detail; lifestyle imagery in the hero or category headers, if used at all.
+
+## 6. Trust and conversion signals
+
+**Signals this shape carries:**
+- Reviews / ratings: average plus count on listing cards and at the top of the detail page. If reviews are absent, surface an alternative (warranty, return policy, brand reputation).
+- Pricing transparency: price visible on the listing card; total cost (price plus shipping plus tax) surfaced before checkout, not after.
+- Stock signals: in stock, low stock, lead time, backorder. Surfaced on the listing and detail.
+- Fitment / compatibility confirmation: required for fitment-led verticals. The confirmation badge ("confirmed to fit your {vehicle}") on the detail page is conventional.
+- Shipping promises: free over $X, same-day, two-day. Surfaced in the chrome or hero.
+- Return policy: linked from the cart and the detail page. The exact text is in `terms` or `returns`.
+- Brand or store badges: certifications, "X years in business", authorized-dealer, where relevant.
+
+For showcase or demo builds, the functional-vs-demo line: real where touchable (real cart state, real fitment filtering), honestly demo where it needs a backend (clearly labeled demo checkout modal, no fake payment, no real account creation).
+
+## 7. Recurring vertical conventions (the synthesis)
+
+A credible ecommerce-catalog storefront, against the field of leaders, carries:
+
+1. A primary task that owns the hero (fitment, search, or category-grid; not a brand pitch).
+2. A category surface band in the first or second viewport, not buried in a menu.
+3. Working faceted filtering on category pages.
+4. A persistent global context indicator if the vertical is fitment-led (the confirmed vehicle, the selected compatibility, the active filter set).
+5. Visible price on every listing card, with no "click to reveal".
+6. Reviews or an explicit substitute (warranty, return policy) near the buying action.
+7. A working cart with real client-side state across pages.
+8. A clearly labeled checkout flow (real in production; honestly demo in showcase builds).
+
+A build missing three or more of these is off-vertical. A build hitting all eight is at the experience bar for the shape; the wedge is what the build does beyond that.
+
+---
+
+## Common positioning wedges in this shape
+
+From the gaps the audited fields tend to share:
+
+- **Fitment-first as the entire navigation pattern.** Most catalogs treat fitment as a sidebar widget. A build that makes fitment the primary, persistent, single-source-of-truth navigation owns the "wrong-fit return is impossible" position.
+- **Pricing transparency to the dollar.** Most catalogs hide total cost until checkout. A build that surfaces shipping plus tax on the listing card owns the "no surprises" position.
+- **Honest stock and lead-time signals.** Most catalogs use "low stock" theatrically. A build that names actual lead time owns the "we tell you when it ships, not what we want you to feel" position.
+- **Real reviews vs review theater.** Most catalogs surface 4.7-star aggregates that no one trusts. A build that surfaces verified-buyer reviews with the bad ones visible owns the trust position.
+
+Pick one wedge per build. Two wedges dilute the positioning; zero wedges hits the bar without a reason to remember.

--- a/skills/vertical-site-conventions/references/shape-ecommerce-catalog.md
+++ b/skills/vertical-site-conventions/references/shape-ecommerce-catalog.md
@@ -22,18 +22,20 @@ This file is a default set of composition conventions for the shape. When `compe
 
 **Build conventions:**
 - More than four modules above the fold on desktop is normal for this shape. Two-module heros are off-vertical.
-- The first viewport carries: the primary task, a band of category or featured-collection entry points, and at least one trust or merchandising signal.
+- **Above the fold at a 1280x800 desktop viewport** (not "the first or second viewport"; the assertion is hard) the page carries: the primary task, the category surface band, AND at least one merchandising or trust signal. A category band that requires any scroll to reach reads as airy and off-vertical for this shape; a real build verifies this against a rendered capture, not in prose.
 - Whitespace is functional, not generous. The leaders in this shape are dense; an airy build reads as not-a-real-store.
 - Route color, type, and aesthetic to `creative-direction` and `design-standards`. This shape's register can be utilitarian, premium-utilitarian, or technical; not flowery or expressive.
 
 ## 3. Merchandising and category surface
 
 **Conventions:**
-- A category surface band is present in the first or second viewport. Eight to twelve category entry points is typical for a wide catalog; four to six for a focused one.
+- A category surface band sits **above the fold at a 1280x800 desktop viewport.** Eight to twelve category entry points is typical for a wide catalog; four to six for a focused one. ("First or second viewport" is too loose; a real build hit that and still read airy because the band slipped below the fold.)
 - Depth signaling is one of: mega-menu hover (broad catalogs), grid of category cards on the home (narrow catalogs), faceted-search side rail on category pages. Pick one; do not stack.
 - Category cards carry an icon, an image, or a tight text-only treatment. Hybrid icon-plus-text reads as catalog; image-only reads as marketing.
 - Hierarchical surface (parent plus child categories) is conventional for broad catalogs. Flat surface fits focused catalogs.
-- Featured / promoted collections appear below the category surface, not above; categories carry the navigation load.
+- A **promotional or deal surface** lives near the top: a deal-of-the-week strip, a promo band, a featured-offer row. The field carries it to signal "this is an active store with offers." Its absence reads as brochure-like rather than storefront-like. The promo can be a single strip with one or two offers; it does not have to be a full module.
+- An **inventory or catalog-depth signal** appears somewhere a first-time visitor will see it: a part count, "12,000+ parts in stock," a category-count figure, or a near-equivalent that establishes the catalog has real depth. The field carries it as a credibility move; its absence reads as a thin or demo catalog. The figure can be approximate, can be in the hero, the trust band, or the chrome.
+- Featured / promoted collections appear below the category surface, not above; categories carry the navigation load. (The promotional surface above is distinct from featured collections; one is a deal band, the other is a curation grid.)
 
 ## 4. Navigation and search paths
 
@@ -75,18 +77,22 @@ For showcase or demo builds, the functional-vs-demo line: real where touchable (
 
 ## 7. Recurring vertical conventions (the synthesis)
 
-A credible ecommerce-catalog storefront, against the field of leaders, carries:
+A credible ecommerce-catalog storefront, against the field of leaders, carries ten conventions:
 
 1. A primary task that owns the hero (fitment, search, or category-grid; not a brand pitch).
-2. A category surface band in the first or second viewport, not buried in a menu.
+2. **(Density-bearing)** A category surface band **above the fold at a 1280x800 desktop viewport**, not buried in a menu and not requiring scroll to reach.
 3. Working faceted filtering on category pages.
 4. A persistent global context indicator if the vertical is fitment-led (the confirmed vehicle, the selected compatibility, the active filter set).
 5. Visible price on every listing card, with no "click to reveal".
 6. Reviews or an explicit substitute (warranty, return policy) near the buying action.
 7. A working cart with real client-side state across pages.
 8. A clearly labeled checkout flow (real in production; honestly demo in showcase builds).
+9. **(Density-bearing, new)** A promotional or deal surface near the top: a deal-of-the-week strip, a promo band, or a featured-offer row.
+10. **(Density-bearing, new)** An inventory or catalog-depth signal a first-time visitor will see (a part count, an SKU total, a category count, or a near-equivalent).
 
-A build missing three or more of these is off-vertical. A build hitting all eight is at the experience bar for the shape; the wedge is what the build does beyond that.
+**Threshold and density-bearing items.** A build hitting 8 or more of these is at the experience bar for the shape; the wedge is what the build does beyond that. A build missing 3 or more is off-vertical and needs composition work, not a polish pass.
+
+Conventions **2, 9, and 10 are the density-bearing ones**, the items whose absence makes a checklist-passing build still read airy or brochure-like instead of storefront-dense. A build can miss a nice-to-have (a strong substitute for reviews, for example) and still read as the vertical; missing any of conventions 2, 9, or 10 is the failure mode the first real auto-parts build exposed. Treat the density-bearing items as non-skippable: if any one is missing, the build will read off-vertical regardless of how many other conventions it hits.
 
 ---
 

--- a/skills/vertical-site-conventions/references/shape-ecommerce-standout.md
+++ b/skills/vertical-site-conventions/references/shape-ecommerce-standout.md
@@ -1,0 +1,19 @@
+# Shape: ecommerce-standout
+
+Single-product or narrow-line ecommerce where the brand and the object carry the page. Premium boots, designer goods, single-product subscriptions, expressive consumer brands. The reader arrives because of the brand, not because of a category need.
+
+## Status
+
+Stub. Fill when the first ecommerce-standout demo is built, or when a `competitor-experience-audit` for one has produced an experience bar.
+
+## Provisional conventions (until filled from a real audit)
+
+- **Primary task:** see the product (image-led), see the story (brand-led), buy. Hero often carries large product photography or a brand statement.
+- **Layout register:** expressive or premium-considered. The opposite of a dense catalog; air and image carry the load.
+- **Merchandising:** one product line, surfaced as a few SKUs or one product with options. The product story is the merchandising; spec lists are short.
+- **Paths:** by SKU or by product secondary (the catalog is small); by story / about primary; press or recognition often surfaced; size / fit guides important.
+- **Brand register:** expressive-maximalist or premium-considered. Cross-reference `creative-direction`; this shape is where strong register choices land.
+- **Trust signals:** materials, where-made, founder story, press, reviews focused on quality and longevity, return policy generous and visible.
+- **Synthesis (provisional):** large product photography in the hero, brand story or founding line surfaced early, size / fit / materials guide reachable, press logos if they exist, reviews emphasizing quality and longevity (not quantity), generous and clearly stated return policy.
+
+Until this shape is built into a demo, treat the above as observation defaults to verify against an audit, not as ship-ready conventions.

--- a/skills/vertical-site-conventions/references/shape-hospitality-experience.md
+++ b/skills/vertical-site-conventions/references/shape-hospitality-experience.md
@@ -1,0 +1,19 @@
+# Shape: hospitality-experience
+
+Tours, balloon rides, escape rooms, adventure outfitters, immersive experiences. The reader arrives wanting to understand what the experience is, see real photos, and book.
+
+## Status
+
+Stub. Fill when the first hospitality-experience demo is built, or when a `competitor-experience-audit` for one has produced an experience bar.
+
+## Provisional conventions (until filled from a real audit)
+
+- **Primary task:** book a date and time. The hero CTA is "book" or "check availability"; secondary is "what to expect" for first-timers.
+- **Layout register:** image-led, atmosphere-heavy. The hero is the experience itself, in photography or video.
+- **Merchandising:** experiences as packages with dates, durations, and prices. What-to-expect content carries the trust load.
+- **Paths:** by experience or package primary; by date / availability primary; private events or group secondary.
+- **Brand register:** expressive, premium-considered, or warm-considered. Often regionally-anchored (place-led brand).
+- **Trust signals:** what-to-expect, what-to-bring, age and accessibility constraints, cancellation policy, weather policy (for outdoor experiences), safety briefing, real customer photos, recent reviews on a trusted platform.
+- **Synthesis (provisional):** book or check-availability in the hero, what-to-expect content surfaced before the booking choice, constraints (age, accessibility, weather) clearly stated, cancellation and weather policies visible, recent real photography and reviews, no stock imagery that does not match the actual experience.
+
+Until this shape is built into a demo, treat the above as observation defaults to verify against an audit, not as ship-ready conventions.

--- a/skills/vertical-site-conventions/references/shape-hospitality-food.md
+++ b/skills/vertical-site-conventions/references/shape-hospitality-food.md
@@ -1,0 +1,19 @@
+# Shape: hospitality-food
+
+Restaurants, cafes, bars, food trucks. The reader arrives wanting to know what kind of place this is, see the menu, and either reserve or stop in.
+
+## Status
+
+Stub. Fill when the first hospitality-food demo is built, or when a `competitor-experience-audit` for one has produced an experience bar.
+
+## Provisional conventions (until filled from a real audit)
+
+- **Primary task:** menu, reservation, or hours / location. The hero often carries all three as parallel entry points.
+- **Layout register:** image-led. Hero photography of food, room, or owner does the most work. Density is moderate; photos need room.
+- **Merchandising:** the menu is the merchandising. Surface it on the site, not behind a PDF.
+- **Paths:** menu primary; reservation primary; hours / location primary; private events or catering secondary.
+- **Brand register:** wide range. Neighborhood-casual, fine-dining, fast-casual, ethnic-specific. Cross-reference `creative-direction`.
+- **Trust signals:** address (with map), hours, phone, reservation availability, recent reviews on a trusted platform, photos that match the actual room and plates.
+- **Synthesis (provisional):** menu reachable in the hero (not behind a PDF), reservation entry or a clear "we do not take reservations" statement, hours in the chrome, address with a map, recent photography that matches the room, no stock food images that read as off-brand.
+
+Until this shape is built into a demo, treat the above as observation defaults to verify against an audit, not as ship-ready conventions.

--- a/skills/vertical-site-conventions/references/shape-institution-mission.md
+++ b/skills/vertical-site-conventions/references/shape-institution-mission.md
@@ -1,0 +1,19 @@
+# Shape: institution-mission
+
+Nonprofits, museums, foundations, public-interest organizations. The reader arrives wanting to understand what the institution does and decide whether to give, attend, volunteer, or read further.
+
+## Status
+
+Stub. Fill when the first institution-mission demo is built, or when a `competitor-experience-audit` for one has produced an experience bar.
+
+## Provisional conventions (until filled from a real audit)
+
+- **Primary task:** depends on the moment. Donate during a campaign; visit / attend for an institution with a physical presence; sign up or read for a research or advocacy group. The hero CTA matches the institution's primary ask.
+- **Layout register:** editorial-considered. More text than a catalog, less than a long-form publication. Trust load is heavy; expressive maximalism is rare in this shape.
+- **Merchandising:** the cause or mission is the merchandising. Programs, impact, and recent work carry the page.
+- **Paths:** by program primary; by impact / outcomes primary for established institutions; news / press / blog secondary; financials / 990 secondary but conventional for nonprofits.
+- **Brand register:** institutional, considered, mission-led. Premium-considered for arts and culture; restrained-authoritative for advocacy.
+- **Trust signals:** mission statement, board / leadership, financial transparency (for nonprofits, the 990 or audit), accreditations, named donors or partners, recent impact numbers with sources.
+- **Synthesis (provisional):** mission statement above the fold, a clear primary ask (donate, attend, sign up), program or impact surface, leadership and governance reachable from the chrome, financial transparency linked (for nonprofits), no over-emotive imagery that reads as manipulative.
+
+Until this shape is built into a demo, treat the above as observation defaults to verify against an audit, not as ship-ready conventions.

--- a/skills/vertical-site-conventions/references/shape-inventory-listing.md
+++ b/skills/vertical-site-conventions/references/shape-inventory-listing.md
@@ -1,0 +1,19 @@
+# Shape: inventory-listing
+
+Used-car lots, real estate, equipment rental, marketplace listings. The reader arrives wanting to filter a finite inventory down to the right item.
+
+## Status
+
+Stub. Fill when the first inventory-listing demo is built, or when a `competitor-experience-audit` for an inventory-listing vertical has produced an experience bar.
+
+## Provisional conventions (until filled from a real audit)
+
+- **Primary task:** filtered search with high-fidelity facets (price range, location, condition, year, make, model, beds, square feet). Search and faceted filtering are co-primary.
+- **Layout register:** dense, but more grid-led than catalog-led. Each listing carries multiple attributes that need room to read.
+- **Merchandising:** the listing is the merchandising. Hero carries a search-and-filter entry plus a few featured items.
+- **Paths:** search-and-filter primary; saved-search and favorites secondary (account-gated); browse-by-attribute primary on category pages.
+- **Brand register:** transactional, trust-led. Premium-led for high-ticket inventory (real estate, luxury cars).
+- **Trust signals:** verified seller, listing freshness, photos count, condition reports, response time.
+- **Synthesis (provisional):** persistent filter chip row, listing freshness indicators, photo count signal, save-this-listing affordance, contact-the-seller path.
+
+Until this shape is built into a demo, treat the above as observation defaults to verify against an audit, not as ship-ready conventions.

--- a/skills/vertical-site-conventions/references/shape-local-service-booking.md
+++ b/skills/vertical-site-conventions/references/shape-local-service-booking.md
@@ -1,0 +1,19 @@
+# Shape: local-service-booking
+
+Barber shops, salons, gyms, BJJ schools, dental practices, repair shops. The reader arrives wanting to book a time, get prices, or confirm the place exists.
+
+## Status
+
+Stub. Fill when the first local-service-booking demo is built, or when a `competitor-experience-audit` for one has produced an experience bar.
+
+## Provisional conventions (until filled from a real audit)
+
+- **Primary task:** book an appointment, or call. The book-now button is the hero CTA. For unbookable services, the contact path is the equivalent.
+- **Layout register:** image-led and warm; less dense than a catalog, more dense than a marketing page.
+- **Merchandising:** services list with prices is conventional. "About us" content carries the trust load.
+- **Paths:** by service primary; by staff member secondary (for places where the picked stylist matters).
+- **Brand register:** warm, considered, premium-friendly for service businesses; institutional-professional for medical and legal.
+- **Trust signals:** address, hours, phone number, licensing or certifications, reviews, "we have been here X years".
+- **Synthesis (provisional):** book-now or call-now in the hero, services list with prices, address and hours in the chrome, reviews near the booking action, photos of the space, named staff if they are the draw.
+
+Until this shape is built into a demo, treat the above as observation defaults to verify against an audit, not as ship-ready conventions.

--- a/skills/vertical-site-conventions/references/shape-subscription-app.md
+++ b/skills/vertical-site-conventions/references/shape-subscription-app.md
@@ -1,0 +1,19 @@
+# Shape: subscription-app
+
+Weather apps, productivity tools, news readers, fitness trackers, language learning. The reader arrives wanting to understand the app and decide whether to install or subscribe.
+
+## Status
+
+Stub. Fill when the first subscription-app demo is built, or when a `competitor-experience-audit` for one has produced an experience bar.
+
+## Provisional conventions (until filled from a real audit)
+
+- **Primary task:** install (App Store / Play Store buttons) or start trial. The download or trial CTA is the hero.
+- **Layout register:** marketing-led with strong product imagery (device frames, screen captures). Editorial-airy is common.
+- **Merchandising:** features as a vertical scroll of capability sections; not a catalog grid.
+- **Paths:** by feature primary (scroll); pricing secondary (navigable but not first); blog / support tertiary.
+- **Brand register:** wide range. Consumer apps lean expressive or playful; productivity leans considered or technical.
+- **Trust signals:** App Store rating, install count, press logos, customer testimonials, screenshots that read as the actual product.
+- **Synthesis (provisional):** install CTAs (real store buttons) in the hero and chrome, feature-by-feature scroll with real product imagery, pricing surfaced clearly with the free / paid line drawn, App Store rating and review count surfaced, no fake screenshots.
+
+Until this shape is built into a demo, treat the above as observation defaults to verify against an audit, not as ship-ready conventions.


### PR DESCRIPTION
## Summary

Surgical edit to the `ecommerce-catalog` shape reference in `vertical-site-conventions`, with a matching sync to the shared `shape-conventions-checklist.md`. Makes "storefront-dense" enforceable as discrete, observable conventions instead of leaving it as prose.

**Stacked on PR #70** (vertical-site-conventions). The base branch is `vertical-site-conventions`; this PR shows only the two-file diff that tightens the density conventions. Once #70 merges, this rebases onto main.

## Why

A real build (the auto-parts re-run) hit **6 of the 8 conventions** in the old synthesis and still read SaaS-onboarding-ish, not storefront-dense. The model's grounded findings named exactly the three conventions the reference was silent on:

> "Category surface band falls below the fold on 1280x800 capture."
>
> "Auto-parts storefronts uniformly carry a promotional band or deal-of-the-week strip near the top; no such element appears anywhere."
>
> "Leading auto-parts sites display part counts to establish catalog depth; no such signal appears."

Three cross-field patterns the field observably carries, that the reference was permitting builds to skip. This PR folds them in as enforceable conventions, not prose suggestions.

The flywheel point: these were the unstated assumptions the first real build revealed as load-bearing. The conventions skill could not write them from theory; it needed a build to hit the old checklist and still read wrong before the missing items were visible. That is the cycle each build that pioneers a shape will harden the reference further.

## Dimensions edited

### Dimension 2 (layout register and density): above-fold is hard now

Old: "The first viewport carries: the primary task, a band of category or featured-collection entry points, and at least one trust or merchandising signal."

New: "**Above the fold at a 1280x800 desktop viewport** (not 'the first or second viewport'; the assertion is hard) the page carries: the primary task, the category surface band, AND at least one merchandising or trust signal. A category band that requires any scroll to reach reads as airy and off-vertical for this shape; a real build verifies this against a rendered capture, not in prose."

The 1280x800 viewport target matches the Fork A rendered-capture default, so a Stage 5 verify can check it mechanically.

### Dimension 3 (merchandising and category surface): two new conventions added

Old text retained, with three substantive additions:

1. **Category band above the fold at 1280x800** (tightened from "first or second viewport"). With the explicit note that the auto-parts re-run hit "first or second viewport" and still read airy because the band slipped below the fold.
2. **A promotional or deal surface near the top.** Deal-of-the-week strip, promo band, or featured-offer row. Field signal that "this is an active store with offers."
3. **An inventory or catalog-depth signal.** Part count, "12,000+ parts in stock," category-count figure, or near-equivalent. Field credibility move; absence reads as thin or demo.

Both new conventions are stated as observable: the figure can be approximate, the promo can be a single strip, neither has to be a full module. These are patterns to build, not templates to copy.

### Dimension 7 (the synthesis): grows from 8 to 10 with density-bearing items marked

The synthesis is now ten conventions:

1. A primary task that owns the hero
2. **(Density-bearing)** Category surface band **above the fold at 1280x800**
3. Working faceted filtering on category pages
4. Persistent global context indicator if fitment-led
5. Visible price on every listing card
6. Reviews or an explicit substitute near the buying action
7. Working cart with real client-side state
8. Clearly labeled checkout flow
9. **(Density-bearing, new)** A promotional or deal surface near the top
10. **(Density-bearing, new)** An inventory or catalog-depth signal a first-time visitor sees

**Conventions 2, 9, and 10 are the density-bearing items**, the trio whose absence makes a checklist-passing build still read airy. The reference now states explicitly: missing any one density-bearing item fails the synthesis on its own, regardless of how many other conventions hit.

**Threshold recalibration:**
- Old (8 conventions): 8 of 8 at the bar; 3 or more missing = off-vertical.
- New (10 conventions): 8 of 10 at the bar; 3 or more missing OR any density-bearing item missing = off-vertical.

The change preserves the spirit (a build can miss a couple of nice-to-haves) while making the density-bearing items non-skippable. This is the part that closes the seam the auto-parts re-run exposed: a build cannot hit 6 of 8 with the wrong 2 missing and still call itself convention-correct.

## Checklist sync (`shape-conventions-checklist.md`)

The shared checklist serves all shapes (it ships with placeholder rows the user fills from the per-shape reference's synthesis). Two changes to stay in sync:

1. Placeholder rows extended from 7 to 10 (still with the "Add rows as needed" line for shapes with a different count).
2. **Density-bearing items** called out explicitly with a note that missing any density-bearing item fails the synthesis on its own, naming the auto-parts re-run precedent as the why.
3. Threshold language updated to match the per-shape reference's new wording: 8 of 10 at the bar; 3 or more missing OR any density-bearing item off-vertical.

The checklist remains shape-agnostic; the ecommerce-catalog reference is the one that names which conventions in this shape are density-bearing. Other shapes will name their own as they fill in.

## Linter / catalog

- `python scripts/generate_readme_catalog.py --check`: clean (exit 0). No regeneration needed; file count and skill count are unchanged.
- `python scripts/crosslink_pass.py`: clean (0 replacements across 101 files and 440 references).

Catalog count remains at 101 skills, 440 reference files (no files added or removed).

## Report

- **Dimensions edited:** 2 (layout register and density), 3 (merchandising and category surface), 7 (the synthesis). Dimension 2 hardens the above-fold assertion to 1280x800; dimension 3 adds promotional-surface and inventory-depth-signal as observable conventions; dimension 7 grows from 8 to 10 with the recalibrated threshold.
- **Density-bearing items confirmed:** conventions **2, 9, 10** in the synthesis, marked explicitly with `(Density-bearing)` in the list and named in the threshold paragraph as the non-skippable trio.
- **Checklist in sync:** the shared `shape-conventions-checklist.md` has its synthesis rows extended to 10 and its threshold language updated to match.
- **Linter and README:** `generate_readme_catalog.py --check` exits clean; `crosslink_pass.py` clean; catalog count unchanged (101 skills, 440 references).

The auto-parts re-run's specific failure mode (hit the checklist, still read airy) cannot recur with this reference: missing any one of the density-bearing trio fails the synthesis directly.
