### PR TITLE
Tighten ecommerce-catalog density conventions

### DIFF
--- a/skills/vertical-site-conventions/references/shape-conventions-checklist.md
+++ b/skills/vertical-site-conventions/references/shape-conventions-checklist.md
@@ -62,9 +62,16 @@ Pull the conventions from the experience bar's dimension 7 (or the per-shape ref
 - [ ] Convention 5:
 - [ ] Convention 6:
 - [ ] Convention 7:
+- [ ] Convention 8:
+- [ ] Convention 9:
+- [ ] Convention 10:
 - [ ] (Add rows as needed for the vertical's full convention list.)
 
-**Synthesis rule:** if three or more conventions are absent and not deliberately positioned-against, the build is off-vertical. Go back to dimensions 1 through 6.
+**Density-bearing items.** Some conventions are density-bearing: their absence makes a checklist-passing build still read airy or brochure-like instead of storefront-dense. For the ecommerce-catalog shape, conventions 2 (category surface band above the fold at 1280x800), 9 (a promotional or deal surface near the top), and 10 (an inventory or catalog-depth signal a first-time visitor sees) are the density-bearing trio. Each shape's per-shape reference names its own density-bearing items.
+
+Mark the density-bearing items explicitly in the list above. Missing any one density-bearing item is sufficient to fail the synthesis on its own, regardless of how many other conventions hit. This rule comes from a real build hitting 6 of 8 conventions in an earlier (pre-density-bearing) form of this reference and still reading off-vertical because the density-bearing items it missed were the load-bearing ones.
+
+**Threshold:** a build hitting 8 of 10 (or the equivalent ratio for shapes with a different convention count) is at the experience bar for the shape; the wedge is what the build does beyond that. A build missing 3 or more conventions, OR any density-bearing item, is off-vertical and needs composition work, not a polish pass. Go back to dimensions 1 through 6.
 
 ---
 

--- a/skills/vertical-site-conventions/references/shape-ecommerce-catalog.md
+++ b/skills/vertical-site-conventions/references/shape-ecommerce-catalog.md
@@ -22,18 +22,20 @@ This file is a default set of composition conventions for the shape. When `compe
 
 **Build conventions:**
 - More than four modules above the fold on desktop is normal for this shape. Two-module heros are off-vertical.
-- The first viewport carries: the primary task, a band of category or featured-collection entry points, and at least one trust or merchandising signal.
+- **Above the fold at a 1280x800 desktop viewport** (not "the first or second viewport"; the assertion is hard) the page carries: the primary task, the category surface band, AND at least one merchandising or trust signal. A category band that requires any scroll to reach reads as airy and off-vertical for this shape; a real build verifies this against a rendered capture, not in prose.
 - Whitespace is functional, not generous. The leaders in this shape are dense; an airy build reads as not-a-real-store.
 - Route color, type, and aesthetic to `creative-direction` and `design-standards`. This shape's register can be utilitarian, premium-utilitarian, or technical; not flowery or expressive.
 
 ## 3. Merchandising and category surface
 
 **Conventions:**
-- A category surface band is present in the first or second viewport. Eight to twelve category entry points is typical for a wide catalog; four to six for a focused one.
+- A category surface band sits **above the fold at a 1280x800 desktop viewport.** Eight to twelve category entry points is typical for a wide catalog; four to six for a focused one. ("First or second viewport" is too loose; a real build hit that and still read airy because the band slipped below the fold.)
 - Depth signaling is one of: mega-menu hover (broad catalogs), grid of category cards on the home (narrow catalogs), faceted-search side rail on category pages. Pick one; do not stack.
 - Category cards carry an icon, an image, or a tight text-only treatment. Hybrid icon-plus-text reads as catalog; image-only reads as marketing.
 - Hierarchical surface (parent plus child categories) is conventional for broad catalogs. Flat surface fits focused catalogs.
-- Featured / promoted collections appear below the category surface, not above; categories carry the navigation load.
+- A **promotional or deal surface** lives near the top: a deal-of-the-week strip, a promo band, a featured-offer row. The field carries it to signal "this is an active store with offers." Its absence reads as brochure-like rather than storefront-like. The promo can be a single strip with one or two offers; it does not have to be a full module.
+- An **inventory or catalog-depth signal** appears somewhere a first-time visitor will see it: a part count, "12,000+ parts in stock," a category-count figure, or a near-equivalent that establishes the catalog has real depth. The field carries it as a credibility move; its absence reads as a thin or demo catalog. The figure can be approximate, can be in the hero, the trust band, or the chrome.
+- Featured / promoted collections appear below the category surface, not above; categories carry the navigation load. (The promotional surface above is distinct from featured collections; one is a deal band, the other is a curation grid.)
 
 ## 4. Navigation and search paths
 
@@ -75,18 +77,22 @@ For showcase or demo builds, the functional-vs-demo line: real where touchable (
 
 ## 7. Recurring vertical conventions (the synthesis)
 
-A credible ecommerce-catalog storefront, against the field of leaders, carries:
+A credible ecommerce-catalog storefront, against the field of leaders, carries ten conventions:
 
 1. A primary task that owns the hero (fitment, search, or category-grid; not a brand pitch).
-2. A category surface band in the first or second viewport, not buried in a menu.
+2. **(Density-bearing)** A category surface band **above the fold at a 1280x800 desktop viewport**, not buried in a menu and not requiring scroll to reach.
 3. Working faceted filtering on category pages.
 4. A persistent global context indicator if the vertical is fitment-led (the confirmed vehicle, the selected compatibility, the active filter set).
 5. Visible price on every listing card, with no "click to reveal".
 6. Reviews or an explicit substitute (warranty, return policy) near the buying action.
 7. A working cart with real client-side state across pages.
 8. A clearly labeled checkout flow (real in production; honestly demo in showcase builds).
+9. **(Density-bearing, new)** A promotional or deal surface near the top: a deal-of-the-week strip, a promo band, or a featured-offer row.
+10. **(Density-bearing, new)** An inventory or catalog-depth signal a first-time visitor will see (a part count, an SKU total, a category count, or a near-equivalent).
 
-A build missing three or more of these is off-vertical. A build hitting all eight is at the experience bar for the shape; the wedge is what the build does beyond that.
+**Threshold and density-bearing items.** A build hitting 8 or more of these is at the experience bar for the shape; the wedge is what the build does beyond that. A build missing 3 or more is off-vertical and needs composition work, not a polish pass.
+
+Conventions **2, 9, and 10 are the density-bearing ones**, the items whose absence makes a checklist-passing build still read airy or brochure-like instead of storefront-dense. A build can miss a nice-to-have (a strong substitute for reviews, for example) and still read as the vertical; missing any of conventions 2, 9, or 10 is the failure mode the first real auto-parts build exposed. Treat the density-bearing items as non-skippable: if any one is missing, the build will read off-vertical regardless of how many other conventions it hits.
 
 ---
 


### PR DESCRIPTION
## Summary

Surgical edit to the `ecommerce-catalog` shape reference in `vertical-site-conventions`, with a matching sync to the shared `shape-conventions-checklist.md`. Makes "storefront-dense" enforceable as discrete, observable conventions instead of leaving it as prose.

Reopened from #71 after PR #70 squash-merged to main. Rebased onto main; no force-push needed. The diff is the same single commit (two files, 20 insertions, 7 deletions); the body below is unchanged from #71. Closing #71 in favor of this PR.

**Stacked on PR #70** (vertical-site-conventions). The base branch is `vertical-site-conventions`; this PR shows only the two-file diff that tightens the density conventions. Once #70 merges, this rebases onto main.

## Why

A real build (the auto-parts re-run) hit **6 of the 8 conventions** in the old synthesis and still read SaaS-onboarding-ish, not storefront-dense. The model's grounded findings named exactly the three conventions the reference was silent on:

> "Category surface band falls below the fold on 1280x800 capture."
>
> "Auto-parts storefronts uniformly carry a promotional band or deal-of-the-week strip near the top; no such element appears anywhere."
>
> "Leading auto-parts sites display part counts to establish catalog depth; no such signal appears."

Three cross-field patterns the field observably carries, that the reference was permitting builds to skip. This PR folds them in as enforceable conventions, not prose suggestions.

The flywheel point: these were the unstated assumptions the first real build revealed as load-bearing. The conventions skill could not write them from theory; it needed a build to hit the old checklist and still read wrong before the missing items were visible. That is the cycle each build that pioneers a shape will harden the reference further.

## Dimensions edited

### Dimension 2 (layout register and density): above-fold is hard now

Old: "The first viewport carries: the primary task, a band of category or featured-collection entry points, and at least one trust or merchandising signal."

New: "**Above the fold at a 1280x800 desktop viewport** (not 'the first or second viewport'; the assertion is hard) the page carries: the primary task, the category surface band, AND at least one merchandising or trust signal. A category band that requires any scroll to reach reads as airy and off-vertical for this shape; a real build verifies this against a rendered capture, not in prose."

The 1280x800 viewport target matches the Fork A rendered-capture default, so a Stage 5 verify can check it mechanically.

### Dimension 3 (merchandising and category surface): two new conventions added

Old text retained, with three substantive additions:

1. **Category band above the fold at 1280x800** (tightened from "first or second viewport"). With the explicit note that the auto-parts re-run hit "first or second viewport" and still read airy because the band slipped below the fold.
2. **A promotional or deal surface near the top.** Deal-of-the-week strip, promo band, or featured-offer row. Field signal that "this is an active store with offers."
3. **An inventory or catalog-depth signal.** Part count, "12,000+ parts in stock," category-count figure, or near-equivalent. Field credibility move; absence reads as thin or demo.

Both new conventions are stated as observable: the figure can be approximate, the promo can be a single strip, neither has to be a full module. These are patterns to build, not templates to copy.

### Dimension 7 (the synthesis): grows from 8 to 10 with density-bearing items marked

The synthesis is now ten conventions:

1. A primary task that owns the hero
2. **(Density-bearing)** Category surface band **above the fold at 1280x800**
3. Working faceted filtering on category pages
4. Persistent global context indicator if fitment-led
5. Visible price on every listing card
6. Reviews or an explicit substitute near the buying action
7. Working cart with real client-side state
8. Clearly labeled checkout flow
9. **(Density-bearing, new)** A promotional or deal surface near the top
10. **(Density-bearing, new)** An inventory or catalog-depth signal a first-time visitor sees

**Conventions 2, 9, and 10 are the density-bearing items**, the trio whose absence makes a checklist-passing build still read airy. The reference now states explicitly: missing any one density-bearing item fails the synthesis on its own, regardless of how many other conventions hit.

**Threshold recalibration:**
- Old (8 conventions): 8 of 8 at the bar; 3 or more missing = off-vertical.
- New (10 conventions): 8 of 10 at the bar; 3 or more missing OR any density-bearing item missing = off-vertical.

The change preserves the spirit (a build can miss a couple of nice-to-haves) while making the density-bearing items non-skippable. This is the part that closes the seam the auto-parts re-run exposed: a build cannot hit 6 of 8 with the wrong 2 missing and still call itself convention-correct.

## Checklist sync (`shape-conventions-checklist.md`)

The shared checklist serves all shapes (it ships with placeholder rows the user fills from the per-shape reference's synthesis). Two changes to stay in sync:

1. Placeholder rows extended from 7 to 10 (still with the "Add rows as needed" line for shapes with a different count).
2. **Density-bearing items** called out explicitly with a note that missing any density-bearing item fails the synthesis on its own, naming the auto-parts re-run precedent as the why.
3. Threshold language updated to match the per-shape reference's new wording: 8 of 10 at the bar; 3 or more missing OR any density-bearing item off-vertical.

The checklist remains shape-agnostic; the ecommerce-catalog reference is the one that names which conventions in this shape are density-bearing. Other shapes will name their own as they fill in.

## Linter / catalog

- `python scripts/generate_readme_catalog.py --check`: clean (exit 0). No regeneration needed; file count and skill count are unchanged.
- `python scripts/crosslink_pass.py`: clean (0 replacements across 101 files and 440 references).

Catalog count remains at 101 skills, 440 reference files (no files added or removed).

## Report

- **Dimensions edited:** 2 (layout register and density), 3 (merchandising and category surface), 7 (the synthesis). Dimension 2 hardens the above-fold assertion to 1280x800; dimension 3 adds promotional-surface and inventory-depth-signal as observable conventions; dimension 7 grows from 8 to 10 with the recalibrated threshold.
- **Density-bearing items confirmed:** conventions **2, 9, 10** in the synthesis, marked explicitly with `(Density-bearing)` in the list and named in the threshold paragraph as the non-skippable trio.
- **Checklist in sync:** the shared `shape-conventions-checklist.md` has its synthesis rows extended to 10 and its threshold language updated to match.
- **Linter and README:** `generate_readme_catalog.py --check` exits clean; `crosslink_pass.py` clean; catalog count unchanged (101 skills, 440 references).

The auto-parts re-run's specific failure mode (hit the checklist, still read airy) cannot recur with this reference: missing any one of the density-bearing trio fails the synthesis directly.

