### PR TITLE
readme: bring 5 inline skill counts under generator control

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the marketplace, then install the plugin you want:
 ```
 /plugin marketplace add rampstackco/claude-skills
 
-# full catalog (99 skills)
+# full catalog (101 skills)
 /plugin install rampstack-skills@rampstack
 
 # focused subsets
@@ -320,8 +320,7 @@ For the current API surface, request format, and limits, see the [Agent Skills A
 
 ### Want only a few skills?
 
-<!-- TODO: refresh hardcoded count below when catalog crosses next round number -->
-You do not have to install all 99. Pick the categories that match your work. The library is modular: each skill stands on its own.
+You do not have to install all 101. Pick the categories that match your work. The library is modular: each skill stands on its own.
 
 ---
 
@@ -453,7 +452,7 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 
 ## How the catalog connects
 
-The skills compose with the tools your team already uses. 99 skills at the center; 35 integrations across 6 integration categories radiating out via MCPs.
+The skills compose with the tools your team already uses. 101 skills at the center; 35 integrations across 6 integration categories radiating out via MCPs.
 
 <p align="center">
   <picture>
@@ -501,7 +500,7 @@ claude-skills is the parent catalog. Curated subsets and companion repos focus o
 
 | Repo | Focus | Skills |
 |---|---|---|
-| [claude-skills](https://github.com/rampstackco/claude-skills) | Full catalog (you are here) | 99 |
+| [claude-skills](https://github.com/rampstackco/claude-skills) | Full catalog (you are here) | 101 |
 | [claude-skills-starter](https://github.com/rampstackco/claude-skills-starter) | General-purpose lite | 14 |
 | [claude-skills-seo](https://github.com/rampstackco/claude-skills-seo) | SEO consulting | 12 |
 | [claude-skills-pm](https://github.com/rampstackco/claude-skills-pm) | Product management | 12 |
@@ -820,8 +819,7 @@ Contributions are welcome. Whether you want to fix a typo, add a reference file,
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full process.
 
-<!-- TODO: refresh hardcoded count below when catalog crosses next round number -->
-The fastest path: use the [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) skill itself. It teaches the same authoring discipline used across all 99 skills, with worked examples and a blank template.
+The fastest path: use the [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) skill itself. It teaches the same authoring discipline used across all 101 skills, with worked examples and a blank template.
 
 ---
 

--- a/scripts/generate_readme_catalog.py
+++ b/scripts/generate_readme_catalog.py
@@ -5,7 +5,10 @@ Walks ``skills/`` and parses each ``SKILL.md`` frontmatter for the fields
 ``name``, ``description``, ``category``, ``catalog_summary``, and
 ``display_order``. Produces the README catalog section, the skill count
 badge, the subtitle blockquote, the "What you get" counts, the catalog
-header, the table-of-contents anchor, and the catalog intro line.
+header, the table-of-contents anchor, the catalog intro line, and a
+handful of inline skill counts (install block, install-all paragraph,
+hub paragraph, family-table claude-skills row, contributing paragraph)
+that are substituted via anchored regex rather than marker pairs.
 
 Two operating modes:
 
@@ -408,6 +411,23 @@ def replace_badge_count(text: str, total: int) -> str:
     return badge_pattern.sub(replacement, text, count=1)
 
 
+def replace_inline_count(text: str, pattern: str, total: int, label: str) -> str:
+    """Substitute a skill count embedded in prose or a code fence.
+
+    The pattern must capture the text before the count as group 1 and the
+    text after as group 2, with the digits ungrouped between them. Asserts
+    the pattern matches exactly once so a drifted or duplicated anchor fails
+    loudly rather than silently mis-substituting.
+    """
+    rx = re.compile(pattern)
+    matches = list(rx.finditer(text))
+    if not matches:
+        raise ValueError(f"{label}: count pattern not found in README.md")
+    if len(matches) > 1:
+        raise ValueError(f"{label}: count pattern appears more than once in README.md")
+    return rx.sub(rf"\g<1>{total}\g<2>", text, count=1)
+
+
 def render_readme(text: str, skills: list[Skill]) -> str:
     """Apply all marker replacements and return the updated README content."""
     grouped = group_by_category(skills)
@@ -416,6 +436,11 @@ def render_readme(text: str, skills: list[Skill]) -> str:
     ref_total = count_reference_files()
     cat_total = len(CATEGORIES)
     text = replace_badge_count(text, total)
+    text = replace_inline_count(text, r"(# full catalog \()\d+( skills\))", total, "install-block count")
+    text = replace_inline_count(text, r"(You do not have to install all )\d+(\.)", total, "install-all count")
+    text = replace_inline_count(text, r"(already uses\. )\d+( skills at the center)", total, "hub count")
+    text = replace_inline_count(text, r"(Full catalog \(you are here\) \| )\d+( \|)", total, "family-table count")
+    text = replace_inline_count(text, r"(authoring discipline used across all )\d+( skills)", total, "contributing count")
     text = replace_block(text, "COUNT_INTRO", generate_intro_blockquote(total))
     text = replace_block(
         text, "COUNT_WHATYOUGET", generate_whatyouget(total, ref_total, cat_total)


### PR DESCRIPTION
## Summary

Brings the five remaining hardcoded README skill counts under the generator the same way the badge already is, single-sourced from `skills/` and enforced by CI. Fixes the visible 99 vs 101 contradiction (badge/CATALOG/markers said 101; five hardcoded prose/table/code-fence spots still said 99) and removes the two now-false `<!-- TODO: refresh hardcoded count below ... -->` comments.

Approach mirrors the existing `replace_badge_count` precedent rather than introducing a new pattern.

## Changes

- `scripts/generate_readme_catalog.py`
  - Add `replace_inline_count(text, pattern, total, label)` helper. Each call's anchored regex must match exactly once (group 1 + ungrouped `\d+` + group 2); drift or duplication fails loudly.
  - Wire it into `render_readme` for the five remaining inline count spots: install-block code fence, "install all" paragraph, "How the catalog connects" hub paragraph, the `claude-skills` row of the Family repos table (other rows are not touched), and the Contributing fastest-path paragraph.
  - Docstring updated to mention the inline-count spots alongside the existing marker-bounded regions.
- `README.md` (generated)
  - Five `99` to `101` substitutions in the spots above.
  - Two stale `<!-- TODO: refresh hardcoded count below when catalog crosses next round number -->` comments removed.

## Verification

Run from repo root, in order:

- `python scripts/generate_readme_catalog.py --check` (after wiring, before regenerating) intentionally fails with the diff of the five expected substitutions, confirming new ownership is active.
- `python scripts/generate_readme_catalog.py --write` updates exactly those five spots.
- `python scripts/generate_readme_catalog.py --check` passes.
- `python scripts/generate_readme_catalog.py --write` is idempotent (second run produces no further changes).
- `python .github/scripts/lint_skills.py` passes (one pre-existing unrelated line-length warning).

`docs/architecture-wide.jpg` was inspected; it shows only integration counts, no baked-in skill count, so no diagram regeneration is needed.

## Test plan

- [x] Generator `--check` fail-then-pass behaves as designed.
- [x] Second `--write` is a no-op (idempotent).
- [x] `lint_skills.py` green.
- [x] Em-dash scan clean (CI gate).
- [x] Family-repos table: only the `claude-skills` row touched; other repos' counts preserved.
- [x] Integration counts (35 / 6) untouched.