### PR TITLE
docs: add pointer to rampstackco/plugins marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Add the marketplace, then install the plugin you want:
 /plugin install rampstack-pm@rampstack
 ```
 
+Prefer a lighter marketplace that lists only the curated subsets (no full catalog)? Add `rampstackco/plugins` instead and install the same three plugins from there:
+
+```
+/plugin marketplace add rampstackco/plugins
+/plugin install rampstack-starter@rampstack
+```
+
 Skills load on demand: each contributes roughly its name and description until Claude needs it.
 
 ---


### PR DESCRIPTION
## Summary

Adds a short alternate-install note in the README pointing readers to the new [rampstackco/plugins](https://github.com/rampstackco/plugins) marketplace. That marketplace catalogs only the curated subset plugins (starter, SEO, PM) without the full 101-skill catalog, so users who only want a subset do not have to clone this larger repo to read marketplace.json.

The note sits outside any generator-managed marker region and does not match any inline-count regex anchor, so the readme catalog generator's `--check` still passes.

## Test plan

- [x] \`python scripts/generate_readme_catalog.py --check\` exits 0
- [x] No em-dashes in the new prose
- [ ] CI: lint workflow passes on this PR