### PR TITLE
feat(creative-brief-selector): live-reference-grounded brief skill with divergence check

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-101-blue.svg)](#the-101-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-102-blue.svg)](#the-102-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 101 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 102 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -33,7 +33,7 @@ Add the marketplace, then install the plugin you want:
 ```
 /plugin marketplace add rampstackco/claude-skills
 
-# full catalog (101 skills)
+# full catalog (102 skills)
 /plugin install rampstack-skills@rampstack
 
 # focused subsets
@@ -67,7 +67,7 @@ Skills load on demand: each contributes roughly its name and description until C
 - [How the catalog connects](#how-the-catalog-connects)
 - [Surfaces](#surfaces)
 <!-- COUNT_TOC:START -->
-- [The 101-skill catalog](#the-101-skill-catalog)
+- [The 102-skill catalog](#the-102-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -96,8 +96,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **101 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
-- **440 reference files** (templates, checklists, decision matrices, worked examples)
+- **102 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
+- **445 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -327,7 +327,7 @@ For the current API surface, request format, and limits, see the [Agent Skills A
 
 ### Want only a few skills?
 
-You do not have to install all 101. Pick the categories that match your work. The library is modular: each skill stands on its own.
+You do not have to install all 102. Pick the categories that match your work. The library is modular: each skill stands on its own.
 
 ---
 
@@ -459,7 +459,7 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 
 ## How the catalog connects
 
-The skills compose with the tools your team already uses. 101 skills at the center; 35 integrations across 6 integration categories radiating out via MCPs.
+The skills compose with the tools your team already uses. 102 skills at the center; 35 integrations across 6 integration categories radiating out via MCPs.
 
 <p align="center">
   <picture>
@@ -507,7 +507,7 @@ claude-skills is the parent catalog. Curated subsets and companion repos focus o
 
 | Repo | Focus | Skills |
 |---|---|---|
-| [claude-skills](https://github.com/rampstackco/claude-skills) | Full catalog (you are here) | 101 |
+| [claude-skills](https://github.com/rampstackco/claude-skills) | Full catalog (you are here) | 102 |
 | [claude-skills-starter](https://github.com/rampstackco/claude-skills-starter) | General-purpose lite | 14 |
 | [claude-skills-seo](https://github.com/rampstackco/claude-skills-seo) | SEO consulting | 12 |
 | [claude-skills-pm](https://github.com/rampstackco/claude-skills-pm) | Product management | 12 |
@@ -519,11 +519,11 @@ Each family repo is MIT-licensed, conforms to the Agent Skills Specification, an
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 101-skill catalog
+## The 102-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 101 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 102 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -538,7 +538,7 @@ All 101 skills are shipped. Each has a complete SKILL.md plus at least one refer
 | [`information-architecture`](skills/information-architecture/SKILL.md) | Sitemap, navigation, URL structure, content types, taxonomy |
 | [`content-strategy`](skills/content-strategy/SKILL.md) | Editorial strategy, content calendar, topical authority planning |
 
-### Brand (6)
+### Brand (7)
 
 | Skill | What it does |
 |---|---|
@@ -548,6 +548,7 @@ All 101 skills are shipped. Each has a complete SKILL.md plus at least one refer
 | [`brand-voice`](skills/brand-voice/SKILL.md) | Voice attributes, tone shifts, vocabulary, paired-example library |
 | [`brand-archetype-system`](skills/brand-archetype-system/SKILL.md) | 12 archetype defaults across 18 verticals: color, type, voice, imagery starters |
 | [`logo-design`](skills/logo-design/SKILL.md) | Logo variants across architectures (wordmark, lockup, monogram, letterform-as-symbol), with rationale and application specs |
+| [`creative-brief-selector`](skills/creative-brief-selector/SKILL.md) | Live-reference-grounded creative briefs with divergence check against prior builds |
 
 ### Design (4)
 
@@ -826,7 +827,7 @@ Contributions are welcome. Whether you want to fix a typo, add a reference file,
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full process.
 
-The fastest path: use the [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) skill itself. It teaches the same authoring discipline used across all 101 skills, with worked examples and a blank template.
+The fastest path: use the [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) skill itself. It teaches the same authoring discipline used across all 102 skills, with worked examples and a blank template.
 
 ---
 

--- a/skills/creative-brief-selector/SKILL.md
+++ b/skills/creative-brief-selector/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: creative-brief-selector
+description: "Produce a creative brief grounded in live reference sites and deliberately distinct from existing demos, for any new brand build. Composes with brand-archetype-system and creative-direction. Use this skill at the start of any brand or microsite build when the result needs to land in a specific aesthetic position and not drift into a default house style. Triggers on creative brief, design brief, build brief, brand direction, where should this brand sit, what should this site look like, reference sites for, archetype for, distinct from our other brands, divergence from prior, not the same as. Also triggers when prior builds have come out as siblings and a systematic divergence approach is needed."
+category: brand
+catalog_summary: "Live-reference-grounded creative briefs with divergence check against prior builds"
+display_order: 6
+---
+
+# Creative Brief Selector
+
+A starting-point selector for brand and microsite builds. Given a business spec (name, vertical, shape, one-line vibe, optional list of shipped demos), produces a creative brief grounded in three things:
+
+1. An archetype position from `brand-archetype-system`, picked or composed to be deliberately distinct from the shipped demos.
+2. A small set of live reference sites for that archetype-and-vertical combination, drawn from a curated bank plus optional per-build discovery.
+3. A divergence check against the shipped demos that flags palette, voice, or structural overlap before the brief is handed off.
+
+The brief output is concrete tokens, not abstract families. It is meant to be loaded by downstream build skills as the single creative artifact for the build.
+
+---
+
+## When to use
+
+- Starting any new brand or microsite build that should land in a specific aesthetic position.
+- The first build in a portfolio (no prior builds to diverge from yet, but the divergence schema can be seeded for the next one).
+- The second through nth build in a portfolio, where the risk of sibling output is real.
+- After a portfolio audit that surfaced sibling builds: this skill is the systemic fix for the pattern.
+- When a build's creative direction is being chosen between two adjacent archetypes and the call needs a reference-grounded reason.
+
+## When NOT to use
+
+- The user wants pure aesthetic methodology guidance (use `creative-direction`).
+- The user has a finished archetype and a finished brief and is asking for execution (skip to the downstream build skills).
+- The user wants a logo or a finished identity (use `logo-design`, `brand-identity`).
+- The user wants to define voice for an existing brand (use `brand-voice`).
+- Defining brand strategy from zero positioning (use `brand-ideation` first, then return to this skill).
+
+---
+
+## How this composes with other skills
+
+This skill works upstream of build-time skills and parallel to the aesthetic methodology layer:
+
+- **`brand-archetype-system`** (upstream input). The archetype catalog this skill picks from. The skill names the archetype in the rendered brief; it does not redefine the archetype's defaults.
+- **`creative-direction`** (parallel input). The four-axis vocabulary the archetypes reference. If the consumer needs the full axis brief, run `creative-direction` first; this skill's brief consumes its outputs.
+- **`brand-identity`** (downstream). Once the brief is approved, brand-identity turns it into a finished identity system.
+- **`landing-page-copy`, `content-and-copy`, `art-direction`** (downstream). Every downstream skill that produces aesthetic output references this skill's brief.
+
+Direct verbatim copying of an archetype's default palette into a new brand is the failure mode this skill exists to prevent. The brief shifts the archetype's defaults toward the business spec's specifics.
+
+---
+
+## The five-step process at a glance
+
+1. **Locate the design space.** Pick one to two candidate archetypes from `brand-archetype-system` that fit the vertical and shape.
+2. **Run input-side divergence.** Read the shipped-demos signatures. Discard candidates that would land sibling to anything shipped. Record what was rejected and why.
+3. **Pull references.** From `references/reference-bank/`, load the file(s) matching the chosen archetype-and-vertical. Augment with one to two discovered live references if the bank is sparse. Add discovered references back to the bank in the build PR.
+4. **Adapt.** Shift the chosen archetype's defaults (palette, type, voice, layout, imagery direction) toward the business spec. The brief lands as concrete tokens, not abstract families.
+5. **Render and verify.** Render the brief using the template in [`references/02-brief-template.md`](references/02-brief-template.md). Run output-side divergence. Output the brief plus the references list plus the divergence-check result.
+
+Full step-by-step in [`references/01-process.md`](references/01-process.md).
+
+---
+
+## The hybrid references model
+
+A curated bank that grows with each build. Each file under `references/reference-bank/` covers one archetype-and-vertical combination and holds three to six live reference URLs, each with a one-line why and optional palette or type observations. The bank ships with three seed combinations covering western-boot maker, heritage barbershop, and balloon-ride experience.
+
+When a build draws from a sparse combination, the build is expected to commit the live references it discovered back to the bank as part of its build PR. The bank gets denser with use.
+
+---
+
+## The divergence schema
+
+Each shipped demo carries a signature with four fields:
+
+- `slug`
+- `archetype` (the canonical archetype name from `brand-archetype-system`)
+- `dominant_hue_family` (the recognizable colour family, e.g. leather-bone-saddle, dawn-navy-coral, dark-linen-amber)
+- `voice_register` (e.g. story-forward third-person, atmospheric second-person, fitment-first technical)
+- `primary_structural_pattern` (e.g. shoppable-grid-product-forward, arc-timeline-hero, fitment-selector-then-rails)
+
+Overlap rules:
+
+- Two demos share archetype AND share dominant_hue_family => **SIBLING (block)**.
+- Two demos share archetype AND share voice_register AND share primary_structural_pattern => **SIBLING (block)**.
+- Two demos share only dominant_hue_family across different archetypes => **WARN** (a recurring palette across the portfolio is the most common drift signal).
+
+Full schema and procedure in [`references/03-divergence-check.md`](references/03-divergence-check.md). A worked example file of seven signatures lives at [`references/04-shipped-demos-signatures-example.md`](references/04-shipped-demos-signatures-example.md) for illustration; the live signatures file for any consuming project lives in that project, not in this skill.
+
+---
+
+## Trademark and attribution
+
+Archetypes are NAMED for aesthetic families, NOT for brands, following the convention of `brand-archetype-system`. Live reference sites are cited as exemplars using nominative attribution language: "exemplified by [URL]", "characteristic of", "in the register of". This is descriptive and nominative fair use territory, durable across brand redesigns. A brand that pivots its identity does not invalidate the archetype it once exemplified.
+
+---
+
+## Reference files
+
+- [`references/00-overview.md`](references/00-overview.md) - The case for the skill, the hybrid references model, the two-direction divergence, the trademark posture.
+- [`references/01-process.md`](references/01-process.md) - The five-step process, each step concrete enough to execute.
+- [`references/02-brief-template.md`](references/02-brief-template.md) - The fillable brief template with section-by-section guidance.
+- [`references/03-divergence-check.md`](references/03-divergence-check.md) - The signature schema and the overlap rules.
+- [`references/04-shipped-demos-signatures-example.md`](references/04-shipped-demos-signatures-example.md) - Worked example signatures file with seven demos.
+- [`references/reference-bank/`](references/reference-bank/) - The curated bank, seeded with three archetype-and-vertical files. See [`references/reference-bank/README.md`](references/reference-bank/README.md) for the bank's purpose and extension procedure.

--- a/skills/creative-brief-selector/SKILL.md
+++ b/skills/creative-brief-selector/SKILL.md
@@ -49,15 +49,15 @@ Direct verbatim copying of an archetype's default palette into a new brand is th
 
 ---
 
-## The five-step process at a glance
+## The framework: five steps, three rules, one hybrid bank
 
 1. **Locate the design space.** Pick one to two candidate archetypes from `brand-archetype-system` that fit the vertical and shape.
 2. **Run input-side divergence.** Read the shipped-demos signatures. Discard candidates that would land sibling to anything shipped. Record what was rejected and why.
-3. **Pull references.** From `references/reference-bank/`, load the file(s) matching the chosen archetype-and-vertical. Augment with one to two discovered live references if the bank is sparse. Add discovered references back to the bank in the build PR.
+3. **Pull references.** From the curated reference bank under `references/reference-bank/`, load the file(s) matching the chosen archetype-and-vertical. Augment with one to two discovered live references if the bank is sparse. Add discovered references back to the bank in the build PR.
 4. **Adapt.** Shift the chosen archetype's defaults (palette, type, voice, layout, imagery direction) toward the business spec. The brief lands as concrete tokens, not abstract families.
 5. **Render and verify.** Render the brief using the template in [`references/02-brief-template.md`](references/02-brief-template.md). Run output-side divergence. Output the brief plus the references list plus the divergence-check result.
 
-Full step-by-step in [`references/01-process.md`](references/01-process.md).
+Full step-by-step in [`references/01-process.md`](references/01-process.md). The divergence schema and its three overlap rules are in [`references/03-divergence-check.md`](references/03-divergence-check.md).
 
 ---
 
@@ -102,4 +102,5 @@ Archetypes are NAMED for aesthetic families, NOT for brands, following the conve
 - [`references/02-brief-template.md`](references/02-brief-template.md) - The fillable brief template with section-by-section guidance.
 - [`references/03-divergence-check.md`](references/03-divergence-check.md) - The signature schema and the overlap rules.
 - [`references/04-shipped-demos-signatures-example.md`](references/04-shipped-demos-signatures-example.md) - Worked example signatures file with seven demos.
-- [`references/reference-bank/`](references/reference-bank/) - The curated bank, seeded with three archetype-and-vertical files. See [`references/reference-bank/README.md`](references/reference-bank/README.md) for the bank's purpose and extension procedure.
+
+The curated reference bank lives in a `reference-bank/` subdirectory under `references/`. The bank ships with a README plus three seed archetype-and-vertical files: `premium-dtc-maker-western-boots.md`, `heritage-local-service-barbershop.md`, and `hospitality-experience-balloon-ride.md`. The bank's purpose and extension procedure are documented in its README; the seed files each carry three to four positive live references and one to two negative references for the chosen position. Load the bank file matching the build's archetype-and-vertical at step 3 of the process.

--- a/skills/creative-brief-selector/references/00-overview.md
+++ b/skills/creative-brief-selector/references/00-overview.md
@@ -1,0 +1,79 @@
+# Overview
+
+The case for the skill, the references model, and the trademark posture.
+
+---
+
+## The problem this skill exists for
+
+Portfolios of brand work drift toward house style. The first demo establishes a default; the second demo borrows it; the third has the same skeleton with a different name. Without a deliberate intervention at brief time, every new build leans on the same palette, the same micro-label tracking, the same hero gradient, the same voice register. The output is competent and sibling.
+
+This pattern is observable in any portfolio that has shipped more than two builds. The symptoms show up at the imagery stage, when a stone-and-amber palette that worked for one shape suddenly reads as the brand's signature across three shapes that should not share a signature. The fix is upstream: pick the position before the build starts, and verify it stays distinct as the build renders.
+
+This skill is the deliberate creative direction at brief time.
+
+---
+
+## The hybrid references model
+
+Two parts:
+
+### The curated bank
+
+Files under `reference-bank/`, one per archetype-and-vertical combination. Each file holds three to six live reference URLs that exemplify the position, each with a one-line why and optional palette or type observations. The bank ships with three seed combinations and grows as new combinations are built against.
+
+The bank is the institutional memory of the portfolio. A new build for an archetype-and-vertical combination that has been done before loads the existing references and adapts. A new build for a sparse combination supplies new references during discovery and commits them back as part of its build PR.
+
+### Per-build discovery
+
+When the bank is sparse for a chosen combination, the build's first pass searches the live web for three to six exemplars. Curation rules are in [`reference-bank/README.md`](reference-bank/README.md). The discovered references serve the current build and seed the bank for future builds in the same combination.
+
+This is not a static reference list. The bank is supposed to drift over time as the portfolio grows; the discipline is that the bank reflects what was actually used in real builds.
+
+---
+
+## The two-direction divergence check
+
+The skill runs divergence twice: once on input, once on output.
+
+### Input-side divergence
+
+Before any references are pulled, the skill loads the shipped-demos signatures file (a project artifact, not part of this skill; see [`04-shipped-demos-signatures-example.md`](04-shipped-demos-signatures-example.md) for the illustrative format). Candidate archetypes are checked against the signatures. If a candidate would land sibling to a shipped demo, it is discarded and the rejection is recorded.
+
+The rejection record is itself useful output: it documents what the build was deliberately NOT.
+
+### Output-side divergence
+
+After the brief is rendered, the skill computes the brief's own signature (archetype, dominant hue family, voice register, primary structural pattern) and compares against the shipped signatures one more time. This catches adaptations that drifted back toward sibling territory during step 4 (the adapt step).
+
+The check produces one of three outcomes: `passed`, `warn-with-reasons`, or `block-with-reasons`. A `block` result means the brief cannot ship in its current form and needs adaptation before the next attempt.
+
+---
+
+## Why two directions
+
+Input-side alone catches the obvious overlaps: picking an archetype that another demo already uses with the same palette family. Output-side catches the subtle drift: an archetype was picked clean of any sibling demo, but during adaptation the palette quietly converged on the recurring house family.
+
+The recurring stone-and-amber family is the worked example of this drift. The first build picked it intentionally; the second build adopted it because it was in the air; the third build adopted it because it felt like the brand. Without an output-side check, the brief itself becomes the carrier of the drift.
+
+---
+
+## Trademark and attribution
+
+This skill follows the `brand-archetype-system` convention. Archetypes are named for aesthetic families ("Premium DTC Maker," "Heritage Local Service") not for brands. Live reference sites are cited as exemplars using nominative attribution language:
+
+- "exemplified by [URL]"
+- "characteristic of [URLs]"
+- "in the register of [URL]"
+
+This is descriptive and nominative fair use. A reference that pivots its identity does not invalidate the archetype it once exemplified, but it should be removed from the bank when the URL no longer shows what it was cited for.
+
+---
+
+## What this skill is not
+
+- **Not a logo designer.** The brief includes a logo direction note ("type-led wordmark with a saddle-tan rule," "graphic mark in the dawn palette") but does not produce the mark itself.
+- **Not an identity system.** The brief is the input to `brand-identity`, which produces the system.
+- **Not a finished design.** The brief describes tokens; it does not lay them out into a finished page.
+- **Not a positioning exercise.** The business spec is assumed to have positioning already. If positioning is open, run `brand-ideation` first.
+- **Not a taste machine.** A user with no taste who runs this still produces incoherent work; the brief just makes the incoherence consistent. Taste is upstream of this skill.

--- a/skills/creative-brief-selector/references/01-process.md
+++ b/skills/creative-brief-selector/references/01-process.md
@@ -1,0 +1,140 @@
+# The five-step process
+
+Each step concrete enough to execute. Run in order. Do not skip the divergence steps.
+
+---
+
+## Inputs
+
+The skill takes a business spec:
+
+- **Name** (the brand name to be used in the brief)
+- **Vertical** (e.g. western-boot maker, neighborhood barbershop, balloon-ride operator)
+- **Shape** (the site shape: ecommerce-catalog, ecommerce-standout, local-service-booking, hospitality-experience, hospitality-food, institution-mission, inventory-listing, subscription-app, b2b-manufacturer, directory-marketplace)
+- **One-line vibe** (a sentence describing what the brand wants to feel like)
+- **Shipped-demos signatures file** (optional; the project artifact listing prior builds' signatures)
+
+If the shipped-demos file is absent, the build is the first in the portfolio. Run the divergence steps anyway and seed the signatures file with the rendered brief's signature.
+
+---
+
+## Step 1. Locate the design space
+
+Read the business spec. Pick one to two candidate archetypes from `brand-archetype-system` that fit the vertical and shape.
+
+**How to pick:**
+
+- Read the vertical and shape against the 12 core archetypes. Most verticals have two or three plausible candidates; the shape narrows it.
+- A western-boot maker maps plausibly to Luxe Considered (heritage premium), Rugged Utilitarian (workwear and craft), or Editorial Restrained (boutique editorial). The shape (ecommerce-standout, with a small editorial collection) narrows toward Luxe Considered with a Rugged Utilitarian secondary.
+- A neighborhood barbershop maps plausibly to Warm Conversational (everyday-craft), Retro Nostalgic (period-specific), or Documentary Honest (real-people-real-work). The shape (local-service-booking, with a booking action) narrows toward Warm Conversational with a Retro Nostalgic secondary.
+- A balloon-ride operator maps plausibly to Documentary Honest (landscape-and-light), Luxe Considered (aspirational-experience), or Warm Conversational (small-operator-warm). The shape (hospitality-experience, with a named arc and a booking flow) narrows toward Documentary Honest with a Luxe Considered secondary.
+
+**Output of this step:**
+
+- Primary candidate archetype (name)
+- Optional secondary candidate archetype (name) with a note on which leads
+- Two-sentence rationale tying each candidate to the vertical and shape
+
+---
+
+## Step 2. Run input-side divergence
+
+Read the shipped-demos signatures file. Compare each candidate against every shipped demo using the rules in [`03-divergence-check.md`](03-divergence-check.md).
+
+**Procedure:**
+
+- For each candidate (primary, then secondary if present):
+  - For each shipped demo:
+    - If archetype matches AND dominant_hue_family matches => discard the candidate as SIBLING.
+    - If archetype matches AND voice_register matches AND primary_structural_pattern matches => discard the candidate as SIBLING.
+- If all candidates are discarded, return to step 1 and pick fresh candidates from a different position on the four creative-direction axes.
+
+**Output of this step:**
+
+- The surviving candidate (the chosen archetype)
+- A rejection log listing any discarded candidates with the reason (which shipped demo collided and on which fields)
+
+The rejection log is part of the brief output. It documents what the build was deliberately NOT.
+
+---
+
+## Step 3. Pull references
+
+From `reference-bank/`, load the file matching the chosen archetype-and-vertical. Read the positive references and the negative references.
+
+**If the bank has the combination:**
+
+- Pull three to four positive references from the bank's list. Prefer the ones marked as canonical or most-recent.
+- Read the negative references; they tell the build what register to avoid.
+
+**If the bank is sparse for the combination:**
+
+- Pull whatever positive references are available (one or two if that is all the bank has).
+- Augment with one to two discovered live references that exemplify the position. Search the web for the vertical with the archetype's signal terms (e.g. for Luxe Considered DTC western boots: "premium western boot maker editorial photography prices visible").
+- Note the discovered references with the same format as the bank (URL plus one-line why). Add them back to the bank as part of the build PR.
+
+**Output of this step:**
+
+- A list of three to four live reference URLs, each with a one-line why
+- A note on which references came from the bank versus which were discovered
+- A list of negative references (registers to avoid)
+
+---
+
+## Step 4. Adapt
+
+Take the chosen archetype's defaults from `brand-archetype-system` (palette, type, voice, layout, imagery direction). Shift them toward the business spec's specifics.
+
+**Adaptations to document:**
+
+- **Palette.** Pick 6 to 8 specific hex values that fit the brand. Name each with a token name (e.g. `Bone cream #f5ecd7`, `Saddle tan #a8753a`, `Pre-dawn navy #1a1f3a`). Each token gets a role (page background, primary text, primary CTA, accent, etc.).
+- **Type system.** Pick the display family (often a serif from the archetype), the body family (often Inter or similar), and the micro-label treatment (tracking, casing, weight). Document the explicit differentiators from shipped demos (e.g. "tight uppercase tracking 0.04em on micro-labels, distinct from the loose 0.18em tracking the hospitality-experience build uses").
+- **Voice.** Pick the voice register (e.g. story-forward third-person; atmospheric second-person; fitment-first technical). Write five to ten voice samples in this voice using the brand name.
+- **Layout.** Pick the structural pattern (e.g. shoppable-grid-product-forward; arc-timeline-hero; fitment-selector-then-rails). Describe the spine moves the homepage will run (four to six numbered moves).
+- **CTA grammar.** Pick the verb register (e.g. "Shop the collection," "Book a dawn," "See the morning"). Verb-first, shape-appropriate.
+- **Imagery direction.** Describe the shoot's register (e.g. "warm-bone studio seamless, three-quarter angle, soft overhead, products fill 70 percent of frame"). Specify aspect ratios per page slot.
+
+**Each adaptation choice gets a sentence of why.** The brief is a referenceable artifact; it should explain itself.
+
+**Output of this step:**
+
+- The full adaptation set, ready to render into the brief template.
+
+---
+
+## Step 5. Render and verify
+
+Render the brief using the template in [`02-brief-template.md`](02-brief-template.md).
+
+After rendering, compute the brief's own signature and run output-side divergence:
+
+- `archetype`: the chosen archetype (from step 1)
+- `dominant_hue_family`: derived from the palette tokens
+- `voice_register`: from the voice section
+- `primary_structural_pattern`: from the spine moves
+
+Compare this signature against every shipped demo using the same rules from step 2.
+
+**Possible outcomes:**
+
+- **passed.** No overlaps. The brief is ready to hand off.
+- **warn-with-reasons.** The brief shares a single field (most commonly dominant_hue_family) with a shipped demo, but not enough to be sibling. Surface the warn with the matched fields so the consumer can make a deliberate call.
+- **block-with-reasons.** The brief is sibling to a shipped demo. Return to step 4 and adapt further before re-rendering. Common fixes: swap the dominant accent colour, restructure one of the spine moves, shift the voice register.
+
+**Output of this step:**
+
+- The rendered brief
+- The references list (from step 3)
+- The divergence-check result with all matched fields if any
+- A one-line summary suitable for the build PR's description
+
+---
+
+## Failure modes
+
+- **Skipping step 2.** Picking the archetype that "feels right" without checking against shipped demos is how the portfolio drifts toward house style.
+- **Skipping step 5.** Adapting in step 4 without re-checking on output is how the brief itself becomes the carrier of drift.
+- **Verbatim copying from the archetype's default palette.** The archetypes provide anchor points, not endpoints. If the brief's palette is the archetype's palette unchanged, the brief is the archetype, not a build.
+- **Citing references without why-lines.** A reference URL without a one-line why is decoration. The why is what makes the reference usable in step 4.
+- **Hand-waving the divergence check.** The check is not a vibe call. It is a mechanical comparison against the schema. If it produces a block, the adaptation is incomplete.
+- **Treating the rejection log as overhead.** The rejection log is part of the deliverable. It tells the next build what is already taken.

--- a/skills/creative-brief-selector/references/02-brief-template.md
+++ b/skills/creative-brief-selector/references/02-brief-template.md
@@ -1,0 +1,167 @@
+# The brief template
+
+A fillable markdown skeleton. Fill every section. A section left blank is a section the build will fill with the house default, which is exactly the drift this skill exists to prevent.
+
+The template is modeled on the structure proven by real shipped builds. The worked example link at the bottom of this file shows the structure rendered against a real build.
+
+---
+
+## Template
+
+```markdown
+# Creative direction: <Brand Name> as <archetype position>
+
+A reusable brief for the <Brand Name> build. <One-sentence purpose: what shape is this, what position is this, why this brief>.
+
+Use this brief for:
+
+- <Specific use case 1>
+- <Specific use case 2>
+
+Do NOT use this brief for:
+
+- <Adjacent shape that should NOT use this brief>
+- <Adjacent position that should NOT use this brief>
+
+## The <N> spine moves
+
+1. **<Move 1 name>.** <One paragraph describing the move, specific to the shape>.
+2. **<Move 2 name>.** <One paragraph>.
+3. **<Move 3 name>.** <One paragraph>.
+4. **<Move 4 name>.** <One paragraph>.
+<continue 5, 6 if the shape calls for them>
+
+## Register
+
+- **Positive reference frame**: <one sentence describing what the brand IS, with named exemplars in nominative attribution>
+- **Negative reference frame**: <one sentence describing what the brand is NOT, with named non-exemplars>
+
+## Live reference sites
+
+The references this brief draws from. Each is a real site exemplifying the chosen position.
+
+- [<URL 1>] - <one-line why; what specifically this site does that the brief inherits>
+- [<URL 2>] - <one-line why>
+- [<URL 3>] - <one-line why>
+- [<URL 4>] - <one-line why, optional>
+
+Negative references (do NOT pull from):
+
+- [<URL>] - <one-line why this register is the wrong one>
+
+## Palette token shape (specific to this brand; do not reuse across brands)
+
+| Token | Hex | Role |
+|---|---|---|
+| <Token 1 name> | `#hex` | <Role> |
+| <Token 2 name> | `#hex` | <Role> |
+| <Token 3 name> | `#hex` | <Role> |
+| <Token 4 name> | `#hex` | <Role> |
+| <Token 5 name> | `#hex` | <Role> |
+| <Token 6 name> | `#hex` | <Role> |
+| <Token 7 name> | `#hex` | <Role, optional> |
+| <Token 8 name> | `#hex` | <Role, optional> |
+
+Do NOT re-use <named hue family from a shipped demo, e.g. "stone-50 + amber-300 (the hospitality-experience default from the X build)">.
+
+## Type system
+
+- **Display.** <Family choice with stack notation>, <weight>, <tracking>.
+- **Body.** <Family choice>, <weight>.
+- **Brand wordmark.** <Family, case, tracking>. Distinct from <named shipped demo's wordmark treatment, e.g. "the loose 0.22em tracking used on the hospitality build">.
+- **Micro-labels.** <Family, case, tracking>. <One-line on the explicit differentiator from shipped demos>.
+- **Numerics.** <Family, tabular-nums or proportional, treatment for prices>.
+
+## CTA grammar
+
+- **Primary on home.** "<Verb-first label>". <One-line on why this verb>.
+- **Secondary on home.** "<Verb-first label>". <One-line on why this verb>.
+- **On product or detail page.** "<Label>". Verb-shape-appropriate.
+- **On craft or about page.** "<Label>". Should close back to the primary action.
+
+## Image-ready spine
+
+The structure must be image-ready before any imagery pass runs. Per page slot:
+
+| Page | Aspect | Count | Source |
+|---|---|---|---|
+| <Page slot 1> | <e.g. 5:6 portrait> | 1 | <e.g. the signature product> |
+| <Page slot 2> | <e.g. 4:5 portrait> | <e.g. one per product> | <e.g. each product, on its own card> |
+| <Page slot 3> | <e.g. 16:9 wide> | 1 | <e.g. one lifestyle scene supporting the craft band> |
+| <continue for every page> | | | |
+
+Each slot uses a placeholder during Phase A and is filled by the imagery pass in Phase B. Placeholders carry the alt text the final image will carry, so the swap is structurally drop-in.
+
+## Voice samples
+
+Five to ten lines in the brand's voice, used downstream by content-and-copy and landing-page-copy.
+
+- <Sample 1>
+- <Sample 2>
+- <Sample 3>
+- <Sample 4>
+- <Sample 5>
+- <Sample 6, optional>
+- <Sample 7, optional>
+
+## Honesty contract (unchanging across the portfolio)
+
+- <Functional element, e.g. cart, booking form> is real client-side, <demo surface, e.g. checkout, payment> is a clearly labelled demo that processes nothing.
+- Fictitious brand disclosure in the footer and in any JSON-LD `description` field.
+- Demo-only labelling on any demo surface in the brand's primary accent colour.
+- All prices and figures fictitious. No promotional cadence, no fabricated reviews, no fabricated press quotes.
+- No real brand mark. The logo pass, if any, is a separate later run.
+
+## Acceptance checklist (Phase A criteria)
+
+A build matches this brief if:
+
+- [ ] <Move 1 acceptance criterion>
+- [ ] <Move 2 acceptance criterion>
+- [ ] <Move 3 acceptance criterion>
+- [ ] <Move 4 acceptance criterion>
+- [ ] Palette is documentable as <N> tokens, distinct from any shipped demo's tokens.
+- [ ] Type micro-labels have a distinct treatment from <named shipped demo's treatment>.
+- [ ] Per-page image slots are wired with descriptive alt text, ready for a Phase B drop-in.
+- [ ] Honesty contract intact.
+
+## Divergence-check result
+
+- **Archetype**: <chosen archetype name from brand-archetype-system>
+- **Dominant hue family**: <derived from palette, e.g. "leather-bone-saddle">
+- **Voice register**: <e.g. "story-forward third-person">
+- **Primary structural pattern**: <e.g. "shoppable-grid-product-forward">
+
+**Input-side divergence**: <passed | warn-with-reasons | block-with-reasons>. <If anything was rejected at step 2, list it here: rejected <archetype> because it collided with <shipped demo slug> on <field>>.
+
+**Output-side divergence**: <passed | warn-with-reasons | block-with-reasons>. <If warn or block, list the matched fields and the colliding demo>.
+
+---
+```
+
+---
+
+## Worked example
+
+The Pinto Mesa Boots store-spine brief at `rampstackco-app/progress/ecommerce-standout-store-spine-brief.md` is a faithful render of this template against a real shipped build (ecommerce-standout shape; Luxe Considered with Rugged Utilitarian influence). It demonstrates:
+
+- The five spine moves (product-forward hero, shoppable grid, honest wayfinding, craft as supporting band, premium trust signals).
+- The leather-forward palette with explicit do-not-reuse against the prior hospitality build's stone-and-amber.
+- The type differentiation (tight uppercase microlabel tracking, distinct from the prior hospitality build's loose tracking).
+- The image-ready spine with per-page aspect / count / source.
+- The acceptance checklist as Phase-A criteria.
+
+Use the worked example as a structural reference when rendering new briefs.
+
+---
+
+## Common section failures
+
+- **Skipping the "Do NOT use this brief for" section.** The negative-use section is what keeps the brief from being mis-applied to an adjacent shape.
+- **Spine moves that are abstract.** "Lead with the product" is not a spine move. "Lead with the signature product shown large at 5:6 with one primary CTA and price-forward entry" is.
+- **Palette without explicit do-not-reuse lines.** The do-not-reuse line is what makes the divergence check checkable.
+- **Type system without the explicit differentiator from shipped demos.** This is the single field most likely to drift if not pinned.
+- **CTA grammar in mood words.** "Welcoming" is not CTA grammar. "Shop the collection" is.
+- **Image-ready spine without aspect ratios.** Without the aspect ratios the imagery pass cannot generate to the right shape.
+- **Honesty contract treated as boilerplate.** The contract is part of what makes the brand demo-honest; cut and paste it but verify each line still applies to the specific build.
+- **Acceptance checklist as motivational language.** The checklist is the build's pass/fail criteria, not a vibe statement.

--- a/skills/creative-brief-selector/references/03-divergence-check.md
+++ b/skills/creative-brief-selector/references/03-divergence-check.md
@@ -1,0 +1,156 @@
+# The divergence check
+
+The signature schema, the overlap rules, and the comparison procedure.
+
+---
+
+## Signature schema
+
+Each shipped demo carries a signature with five fields. The schema is small on purpose: any field that takes judgment to populate gets argued about; a small mechanical schema gets used.
+
+```yaml
+- slug: <kebab-case slug, e.g. pinto-mesa-boots>
+  archetype: <canonical archetype name from brand-archetype-system, e.g. luxe-considered>
+  dominant_hue_family: <named hue family, e.g. leather-bone-saddle>
+  voice_register: <named register, e.g. story-forward-third-person>
+  primary_structural_pattern: <named pattern, e.g. shoppable-grid-product-forward>
+```
+
+### slug
+
+The kebab-case slug for the shipped build. Used to identify the demo in rejection logs and warn or block reasons.
+
+### archetype
+
+The canonical archetype name from `brand-archetype-system`. Use the file slug from `references/core-archetypes/` (e.g. `luxe-considered`, `documentary-honest`, `warm-conversational`). If the demo composes two archetypes, record both as a hyphenated pair with the lead first (e.g. `luxe-considered-rugged-utilitarian`).
+
+### dominant_hue_family
+
+The recognizable colour family the demo reads as, in three to four words. Examples:
+
+- `leather-bone-saddle` (Pinto Mesa Boots v2)
+- `dawn-navy-coral` (Drift & Dawn after the dawn retune)
+- `dark-linen-amber` (Pho Heights)
+- `warm-walnut-brass` (Iron & Rye)
+- `forest-green-cream` (Clearflow Initiative)
+- `slate-and-amber` (the original Drift & Dawn pre-retune, kept for historical reference)
+- `stone-and-amber` (the recurring family the imagery passes surfaced as the drift signal)
+
+The naming convention: two to four colour terms separated by hyphens, lowercase. The terms should be specific enough that two demos with materially different palettes get different families even if they share an undertone.
+
+### voice_register
+
+The brand's voice in three to four words. Examples:
+
+- `story-forward-third-person`
+- `atmospheric-second-person`
+- `fitment-first-technical`
+- `evidence-and-mission-first`
+- `restrained-citation-bearing`
+- `warm-everyday-craft`
+
+The naming convention: hyphenated phrase that names the register the voice samples in the brief operate in.
+
+### primary_structural_pattern
+
+The structural pattern the homepage runs, in three to five words. Examples:
+
+- `shoppable-grid-product-forward`
+- `arc-timeline-hero-with-packages-strip`
+- `fitment-selector-then-rails`
+- `editorial-hero-then-courses-grid`
+- `barber-roster-then-services-menu`
+- `theory-of-change-hero-then-evidence-band`
+
+The naming convention: name the homepage's primary spine in a way another build can recognize from the rendered page.
+
+---
+
+## Overlap rules
+
+The comparison is mechanical. The skill applies these rules in order; the first rule that fires determines the outcome for that pair.
+
+### Rule 1: Same archetype + same dominant_hue_family
+
+If two demos share `archetype` AND share `dominant_hue_family`, they are **SIBLING (block)**.
+
+Two demos in the same archetype with the same hue family will read as the same brand at a glance. The block forces an adaptation in either archetype or palette before the brief can ship.
+
+### Rule 2: Same archetype + same voice_register + same primary_structural_pattern
+
+If two demos share `archetype` AND share `voice_register` AND share `primary_structural_pattern`, they are **SIBLING (block)**.
+
+This catches the case where the palettes diverge but the underlying skeleton is identical. The build will look different on first glance and identical on the second.
+
+### Rule 3: Same dominant_hue_family across different archetypes
+
+If two demos share `dominant_hue_family` but their `archetype` differs, the outcome is **WARN**.
+
+A recurring hue family across different archetypes is the most common drift signal in a portfolio. The warn surfaces the recurrence so the consumer can choose to break the pattern or accept it as the portfolio's signature.
+
+### Rule 4: Anything else
+
+If no rule above fires, the outcome is **PASSED**.
+
+---
+
+## Comparison procedure
+
+```
+for candidate in candidates:
+  for shipped in shipped_demos:
+    if rule_1(candidate, shipped):
+      record_block(candidate, shipped, fields=['archetype', 'dominant_hue_family'])
+      continue
+    if rule_2(candidate, shipped):
+      record_block(candidate, shipped, fields=['archetype', 'voice_register', 'primary_structural_pattern'])
+      continue
+    if rule_3(candidate, shipped):
+      record_warn(candidate, shipped, fields=['dominant_hue_family'])
+      continue
+```
+
+The check produces three lists: blocks, warns, and a passed flag (true iff blocks and warns are both empty).
+
+### Input-side outcome
+
+- If any block was recorded against the primary candidate, discard it. If the secondary candidate also blocks, return to step 1 and pick fresh candidates.
+- Warns at input-side are surfaced in the rejection log but do not discard the candidate.
+
+### Output-side outcome
+
+After the brief is rendered, the brief's own signature is checked against every shipped demo using the same rules. The outcome is one of:
+
+- **passed**: no blocks, no warns. The brief is ready to hand off.
+- **warn-with-reasons**: warns only. The brief shares a single field (most commonly `dominant_hue_family`) with a shipped demo. Surface the warn with the matched fields so the consumer can make a deliberate call.
+- **block-with-reasons**: at least one block. The brief is sibling to a shipped demo. Return to step 4 of the process and adapt further before re-rendering.
+
+---
+
+## What changes a block to a warn or a pass
+
+Concretely:
+
+- **Shift the dominant_hue_family.** Swap the dominant accent colour, change the page background's temperature, or change the accent colour family (saddle to oxblood to navy). Recompute the family.
+- **Shift the primary_structural_pattern.** Change which move leads the page. A "product-forward" pattern becomes "story-forward" by reordering the spine moves. Recompute the pattern.
+- **Shift the voice_register.** Change the voice from third-person to second-person, or from atmospheric to technical. Recompute the register.
+- **Compose a different archetype pair.** If the chosen archetype is locked, change the secondary archetype to shift the brief's centre of mass.
+
+Each adaptation should be a deliberate choice, recorded in the brief's adaptation notes (step 4 of the process).
+
+---
+
+## The signatures file
+
+The signatures file is a project artifact, not part of this skill. The consuming project maintains it (typically as `progress/shipped-demos-signatures.yml` or similar). The illustrative format is in [`04-shipped-demos-signatures-example.md`](04-shipped-demos-signatures-example.md).
+
+Whenever a new build ships, append its signature to the file. The signatures grow with the portfolio; the divergence check stays current.
+
+---
+
+## Failure modes
+
+- **Filling fields with vibe words.** "vibrant-modern" is not a hue family; "saddle-bone-walnut" is. The schema works because the field values are specific. Vague values produce vague checks.
+- **Re-using the same family across builds without recomputing.** When a build's palette shifts during step 4, the dominant_hue_family must shift with it. A stale signature is worse than a missing signature.
+- **Treating warns as ignorable.** A warn is the portfolio's drift early-warning. Three consecutive warns on the same hue family is the portfolio adopting a house signature, which is the failure mode this skill exists to prevent.
+- **Hand-waving the rules.** The rules are mechanical. If a candidate blocks under rule 1, it blocks; the answer is to adapt, not to argue with the rule.

--- a/skills/creative-brief-selector/references/04-shipped-demos-signatures-example.md
+++ b/skills/creative-brief-selector/references/04-shipped-demos-signatures-example.md
@@ -1,0 +1,127 @@
+# Shipped-demos signatures: worked example
+
+An illustrative signatures file with seven worked entries. This file is example-only; the live signatures file for any consuming project lives in that project (typically at `progress/shipped-demos-signatures.yml`), not in this skill.
+
+The schema is defined in [`03-divergence-check.md`](03-divergence-check.md). Each entry has five fields: `slug`, `archetype`, `dominant_hue_family`, `voice_register`, `primary_structural_pattern`.
+
+The seven entries below are illustrative records of seven sibling-shape demos a portfolio might ship. They are written here as a worked example of what the file looks like in practice. The archetype values reference the canonical names from `brand-archetype-system`.
+
+---
+
+## Example signatures
+
+```yaml
+demos:
+  - slug: fitfirst-parts
+    archetype: technical-precise
+    dominant_hue_family: slate-and-amber
+    voice_register: fitment-first-technical
+    primary_structural_pattern: fitment-selector-then-rails
+
+  - slug: iron-and-rye-barbershop
+    archetype: warm-conversational-retro-nostalgic
+    dominant_hue_family: warm-walnut-brass
+    voice_register: warm-everyday-craft
+    primary_structural_pattern: barber-roster-then-services-menu
+
+  - slug: pho-heights
+    archetype: documentary-honest-luxe-considered
+    dominant_hue_family: dark-linen-amber
+    voice_register: chef-essay-first-person
+    primary_structural_pattern: editorial-hero-then-signatures-menu
+
+  - slug: volta-robotics
+    archetype: technical-precise
+    dominant_hue_family: graphite-and-signal-orange
+    voice_register: spec-forward-technical
+    primary_structural_pattern: product-strip-then-spec-table
+
+  - slug: clearflow-initiative
+    archetype: editorial-restrained
+    dominant_hue_family: forest-green-cream
+    voice_register: restrained-citation-bearing
+    primary_structural_pattern: theory-of-change-hero-then-evidence-band
+
+  - slug: pinto-mesa-boots
+    archetype: luxe-considered-rugged-utilitarian
+    dominant_hue_family: leather-bone-saddle
+    voice_register: story-forward-third-person
+    primary_structural_pattern: shoppable-grid-product-forward
+
+  - slug: drift-and-dawn
+    archetype: documentary-honest-luxe-considered
+    dominant_hue_family: dawn-navy-coral
+    voice_register: atmospheric-second-person
+    primary_structural_pattern: arc-timeline-hero-with-packages-strip
+```
+
+---
+
+## Why each field is what it is
+
+### fitfirst-parts (ecommerce-catalog)
+
+- **archetype**: `technical-precise`. The build leads with a YMM (year-make-model) fitment selector. Grids, monospace numerics, system-feeling.
+- **dominant_hue_family**: `slate-and-amber`. Cool slate ground with warm amber accents on safety and action surfaces.
+- **voice_register**: `fitment-first-technical`. The voice asks "does it fit your vehicle" before anything else.
+- **primary_structural_pattern**: `fitment-selector-then-rails`. The home leads with the selector, then rails of parts filtered by the confirmed vehicle.
+
+### iron-and-rye-barbershop (local-service-booking)
+
+- **archetype**: `warm-conversational-retro-nostalgic`. Heritage barbershop register; walnut and brass; period-specific cues.
+- **dominant_hue_family**: `warm-walnut-brass`. Walnut wood and brass hardware are the recognizable palette.
+- **voice_register**: `warm-everyday-craft`. The voice is the shop talking about its work in plain terms.
+- **primary_structural_pattern**: `barber-roster-then-services-menu`. Roster (initials) leads, services menu follows, atmosphere gallery threads the page.
+
+### pho-heights (hospitality-food)
+
+- **archetype**: `documentary-honest-luxe-considered`. Dark linen photography, real-food register, premium restraint.
+- **dominant_hue_family**: `dark-linen-amber`. Dark linen background dominates; amber surfaces as the accent.
+- **voice_register**: `chef-essay-first-person`. The chef-partner essay is the page's voice.
+- **primary_structural_pattern**: `editorial-hero-then-signatures-menu`. Edge-to-edge hero, chef essay, signatures section with image-led cards.
+
+### volta-robotics (b2b-manufacturer)
+
+- **archetype**: `technical-precise`. Industrial spec-table register. Same archetype as fitfirst-parts but a different hue family and a different structural pattern (so rule 1 does not fire on this pair).
+- **dominant_hue_family**: `graphite-and-signal-orange`. Industrial graphite with hazard-orange accents on action surfaces.
+- **voice_register**: `spec-forward-technical`. Specs lead, narrative supports.
+- **primary_structural_pattern**: `product-strip-then-spec-table`. Product strip up top, deep spec tables follow.
+
+### clearflow-initiative (institution-mission)
+
+- **archetype**: `editorial-restrained`. Counsel-restrained register; numbers before adjectives; citation-bearing voice.
+- **dominant_hue_family**: `forest-green-cream`. Deep forest green sections with warm cream surfaces.
+- **voice_register**: `restrained-citation-bearing`. Third-person about the org, low-register confidence, numbers leading.
+- **primary_structural_pattern**: `theory-of-change-hero-then-evidence-band`. Theory of change in the hero, evidence band (lives reached, water systems built) follows.
+
+### pinto-mesa-boots (ecommerce-standout)
+
+- **archetype**: `luxe-considered-rugged-utilitarian`. Premium DTC maker register with workwear and craft secondary.
+- **dominant_hue_family**: `leather-bone-saddle`. Bone cream ground with saddle tan and walnut accents; oxblood as the demo-only chip.
+- **voice_register**: `story-forward-third-person`. The brand talks about itself in the third person, with material before adjectives.
+- **primary_structural_pattern**: `shoppable-grid-product-forward`. Product-forward hero, six-boot shoppable grid on the home, by-last wayfinding.
+
+### drift-and-dawn (hospitality-experience)
+
+- **archetype**: `documentary-honest-luxe-considered`. Photography-led, atmospheric, aspirational. Same composed archetype as pho-heights but a different vertical and a different hue family (so rule 1 does not fire on this pair).
+- **dominant_hue_family**: `dawn-navy-coral`. Pre-dawn navy with coral and pale-gold accents, deliberately distinct from the hospitality-experience stone-and-amber default the original build used.
+- **voice_register**: `atmospheric-second-person`. The brand walks the visitor through the morning in second person.
+- **primary_structural_pattern**: `arc-timeline-hero-with-packages-strip`. Hero with arc preview, packages strip with named prices, six-moment timeline on the experience page.
+
+---
+
+## What this example exercises
+
+The seven entries are constructed to exercise the divergence rules:
+
+- **Rule 1 not firing**: `fitfirst-parts` and `volta-robotics` share `archetype: technical-precise` but differ on `dominant_hue_family` (`slate-and-amber` vs `graphite-and-signal-orange`). No block.
+- **Rule 1 not firing**: `pho-heights` and `drift-and-dawn` share `archetype: documentary-honest-luxe-considered` but differ on `dominant_hue_family` (`dark-linen-amber` vs `dawn-navy-coral`). No block. The deliberate retune from the original `slate-and-amber` to `dawn-navy-coral` is what kept this pair from blocking.
+- **Rule 3 historical case**: the original `drift-and-dawn` (pre-retune, hue family `slate-and-amber`) would have triggered rule 3 against `fitfirst-parts` (also `slate-and-amber`) across different archetypes. The retune resolved the recurring family.
+
+---
+
+## How to use this example
+
+Copy the YAML block to a `progress/shipped-demos-signatures.yml` file in the consuming project. Edit the entries to match the actual shipped builds. Append new entries as builds ship. The divergence check in [`03-divergence-check.md`](03-divergence-check.md) reads from this file.
+
+This file is example-only. The skill does not parse this example file at runtime; it parses the consuming project's signatures file. The example exists to show what the file should look like.

--- a/skills/creative-brief-selector/references/reference-bank/README.md
+++ b/skills/creative-brief-selector/references/reference-bank/README.md
@@ -1,0 +1,106 @@
+# Reference bank
+
+The bank holds curated live reference sites for archetype-and-vertical combinations the portfolio has built against. Each file covers one combination, with positive references (sites that exemplify the position) and negative references (sites in the same vertical but in the WRONG register).
+
+The bank is the institutional memory of the portfolio. A new build for a combination that has been done before loads the existing file and adapts. A new build for a sparse combination supplies discovered references and commits them back to the bank as part of its build PR.
+
+---
+
+## File naming convention
+
+`<archetype>-<vertical-specific-tag>.md`
+
+Examples:
+
+- `premium-dtc-maker-western-boots.md`
+- `heritage-local-service-barbershop.md`
+- `hospitality-experience-balloon-ride.md`
+
+The archetype prefix is the canonical name from `brand-archetype-system` (composed archetypes are hyphenated with the lead first). The vertical-specific tag is the narrowest description of the vertical the file covers (not the broad shape; the specific category within it).
+
+---
+
+## File structure
+
+Each file has the same structure:
+
+```markdown
+# <Archetype>, <Vertical>
+
+- **Archetype**: <Canonical archetype name, with composition note if any>.
+- **Vertical**: <Broad shape> (specifically <narrow category>).
+- **Position summary**: <One-line position the references collectively exemplify>.
+
+## Positive references
+
+- [<URL 1>] - <one-line why; what specifically this site does that a build in this position should inherit>
+- [<URL 2>] - <one-line why>
+- [<URL 3>] - <one-line why>
+- [<URL 4>] - <one-line why, optional but encouraged>
+
+## Negative references
+
+- [<URL or named category>] - <one-line why this register is the wrong one for this position>
+
+## Extension note
+
+- <When was this file last updated and against which build>
+```
+
+---
+
+## Adding references
+
+A build that uses this skill on a combination that has a file already:
+
+1. Loads three to four references from the existing file in step 3 of the process.
+2. If the build discovered any new live references in addition (because the bank's references were stale or the build needed more breadth), append them to the positive references list in the same file with a one-line why.
+3. Commit the file edit as part of the build PR.
+
+A build that uses this skill on a combination with no existing file:
+
+1. Creates a new file under `reference-bank/` named per the convention above.
+2. Fills the file with three to six positive references discovered during the build's step 3.
+3. Fills negative references with one to two categories or named sites that the build should not pull from.
+4. Commits the file as part of the build PR.
+
+---
+
+## Reference quality bar
+
+Each positive reference should be a real live site that:
+
+- Exemplifies the chosen position observably (palette, layout, voice, imagery, or all four).
+- Is operating at a quality level the build can credibly aspire to.
+- Has been live recently (within the past year if possible; older references are acceptable if they remain the canonical example).
+
+Each negative reference should be a real live site or a named category that:
+
+- Sits in the same vertical but in a different register.
+- Helps the build understand what to NOT pull from.
+
+The one-line why for each reference is what makes the reference usable in step 4 of the process. A URL without a why is decoration; the why is what tells the next build what specifically to inherit or avoid.
+
+---
+
+## When to retire a reference
+
+A reference should be removed from the bank when:
+
+- The URL stops showing what it was cited for (brand redesign, site shutdown, paywall changed the visible register).
+- A more canonical example for the same position emerges.
+- The build that originally cited the reference has been superseded and the new build uses different references.
+
+Retirement is a normal part of bank maintenance. The bank reflects what is currently usable, not what was once usable.
+
+---
+
+## Seeded combinations
+
+Three combinations ship with the skill:
+
+- [`premium-dtc-maker-western-boots.md`](premium-dtc-maker-western-boots.md) - Premium DTC maker register applied to a small-collection western-boot maker.
+- [`heritage-local-service-barbershop.md`](heritage-local-service-barbershop.md) - Heritage local-service register applied to a neighborhood barbershop.
+- [`hospitality-experience-balloon-ride.md`](hospitality-experience-balloon-ride.md) - Documentary-honest hospitality-experience register applied to a scenic-flight operator.
+
+Each seed file was built against a real shipped demo and reflects the references that demo's build drew from. As the portfolio grows, the bank grows with it.

--- a/skills/creative-brief-selector/references/reference-bank/heritage-local-service-barbershop.md
+++ b/skills/creative-brief-selector/references/reference-bank/heritage-local-service-barbershop.md
@@ -1,0 +1,20 @@
+# Heritage local service, barbershop
+
+- **Archetype**: `warm-conversational` with `retro-nostalgic` as the composition secondary. The lead is warm-everyday-craft (real-room atmosphere, social proof from genuine reviews, real-team page); the secondary is period-specific cues (walnut wood, brass fittings, marble counters, restrained palette).
+- **Vertical**: Hospitality and local service (specifically neighborhood barbershops).
+- **Position summary**: A heritage neighborhood shop with craft-and-space-led atmosphere, real-people-real-work proof, social proof drawn from review aggregates rather than fabricated testimonials. Initials over fabricated portraits when fictitious-brand demos cannot ethically render faces.
+
+## Positive references
+
+- [therosemontbarbers.com](https://therosemontbarbers.com) - Cuts gallery, interior atmosphere, social-proof badge, real team page in the heritage register.
+- [speakeasybarberlounge.com](https://speakeasybarberlounge.com) - Atmosphere-led, period-specific cues (lounge fittings, warm interior), interior photography carries the page.
+- [franksdenver.com](https://franksdenver.com) - Heritage register at a higher-end price point; restrained palette, considered editorial layout.
+- [alfanisbarbershop.com](https://alfanisbarbershop.com) - Small-operator heritage, atmosphere-forward, real-team page.
+
+## Negative references
+
+- The chain barbershop register (Great Clips, Supercuts, Sport Clips and the like) - High-volume operational chains in the same vertical but in a fundamentally different register: utility-led, promotion-driven, no atmosphere. A heritage maker pulling from this register loses the position.
+
+## Extension note
+
+- Seeded from the Iron and Rye Barbershop atmosphere imagery pass. The seed positive references were used as register cross-checks during the build's still-life and interior shots. Last updated: 2026-05-27.

--- a/skills/creative-brief-selector/references/reference-bank/hospitality-experience-balloon-ride.md
+++ b/skills/creative-brief-selector/references/reference-bank/hospitality-experience-balloon-ride.md
@@ -1,0 +1,20 @@
+# Hospitality experience, balloon ride
+
+- **Archetype**: `documentary-honest` with `luxe-considered` as the composition secondary. The lead is photography-led documentary realism (real landscape, real light, the morning as it actually looks); the secondary is aspirational-experience polish (named arc, named prices, named safety signals).
+- **Vertical**: Hospitality experience (specifically scenic flight or ride experiences, with the balloon ride as the worked example).
+- **Position summary**: A photography-led experience operator with the morning arc surfaced explicitly, named packages with named prices above the fold, four trust signals (FAA certification, lead pilot hours, weather posture, cancellation) surfaced as the booking-confidence layer. No fabricated identifiable faces; environmental imagery only.
+
+## Positive references
+
+- [napavalleyaloft.com](https://napavalleyaloft.com) - Regional operator, atmosphere-forward, dawn-palette imagery.
+- [aerogelichotairballooning.com](https://aerogelichotairballooning.com) - Atmosphere-led, ride arc surfaced, photography drives the page.
+- [rainbowryders.com](https://rainbowryders.com) - Multi-region operator, photography-led, named packages with prices.
+- [sundanceballoons.com](https://sundanceballoons.com) - Multi-region operator, considered-warm register, ride-arc framing.
+
+## Negative references
+
+- Generic adventure-tour aggregators (Viator, GetYourGuide, and similar) - Stock photography pile, undifferentiated palette, transactional layout. A photography-led operator pulling from this register loses the atmosphere that justifies the price.
+
+## Extension note
+
+- Seeded from the Drift and Dawn imagery pass and the audited-field competitor set used during that build's Stage 1. The dawn-palette retune was driven by the gap between the original stone-and-amber default and the actual dawn light these references carry. Last updated: 2026-05-27.

--- a/skills/creative-brief-selector/references/reference-bank/premium-dtc-maker-western-boots.md
+++ b/skills/creative-brief-selector/references/reference-bank/premium-dtc-maker-western-boots.md
@@ -1,0 +1,22 @@
+# Premium DTC maker, western boots
+
+- **Archetype**: `luxe-considered` with `rugged-utilitarian` as the composition secondary. The lead is premium-considered (editorial layout, prices visible, restrained merchandising); the secondary is workwear-and-craft (heritage materials, hand-welt construction, made-to-last positioning).
+- **Vertical**: DTC fashion (specifically western boots).
+- **Position summary**: A premium small-collection western-boot maker, leather-forward, product-photographed, prices visible, no discount cadence, no SKU-strip-above-the-fold. Confident, not promotional.
+
+## Positive references
+
+- [tecovas.com](https://tecovas.com) - The elevated-DTC reference: product-forward hero, named prices visible, restrained merchandising. No discount banners above the fold.
+- [lucchese.com](https://lucchese.com) - Heritage register; serif-led, craft narrative as a supporting band rather than the lead.
+- [oldgringoboots.com](https://oldgringoboots.com) - Smaller-maker, leather-forward photography, restrained editorial set instead of catalog density.
+- [ranchroadboots.com](https://ranchroadboots.com) - Small-operator boutique competing in the same position; useful for cross-checking how a peer maker handles wayfinding on a small collection.
+
+## Negative references
+
+- [durangoboots.com](https://durangoboots.com) - Catalog-dense big-box texture; discount cadence, SKU-strip-above-the-fold, sale-badge pile. Not the register a premium small maker should pull from.
+- [justinboots.com](https://justinboots.com) - Same big-box texture in a different brand; promotional banners and grid density dominate.
+- [bootbarn.com](https://bootbarn.com) - Multi-brand retailer rather than a maker; merchandising-led rather than craft-led.
+
+## Extension note
+
+- Seeded from the Pinto Mesa Boots store-spine brief (the worked example of the brief template). Last updated: 2026-05-27.


### PR DESCRIPTION
## Summary

A new skill in the brand category: `creative-brief-selector`. Phase 1 of the systemic fix for the sibling-builds drift that imagery work surfaced across the rampstack showcase portfolio.

Given a business spec (name, vertical, shape, one-line vibe, optional list of shipped demos), produces a creative brief grounded in:

1. **An archetype position** from `brand-archetype-system`, picked or composed to be deliberately distinct from the shipped demos.
2. **A small set of live reference sites** for the chosen archetype-and-vertical, drawn from a curated reference bank plus optional per-build discovery.
3. **A divergence check** against the shipped demos that flags palette, voice, or structural overlap before the brief is handed off.

The output mirrors the format proven by real shipped builds.

## Files

```
skills/creative-brief-selector/
  SKILL.md
  references/
    00-overview.md
    01-process.md
    02-brief-template.md
    03-divergence-check.md
    04-shipped-demos-signatures-example.md
    reference-bank/
      README.md
      premium-dtc-maker-western-boots.md
      heritage-local-service-barbershop.md
      hospitality-experience-balloon-ride.md
```

Frontmatter:
- `category: brand`
- `display_order: 6` (next available in the brand category; brand-archetype-system and logo-design both at 5 with alphabetical secondary sort)
- `catalog_summary: "Live-reference-grounded creative briefs with divergence check against prior builds"`

## What the skill does

**Five-step process** (full detail in `references/01-process.md`):

1. **Locate the design space.** Pick 1-2 candidate archetypes from `brand-archetype-system` that fit the vertical and shape.
2. **Run input-side divergence.** Read the shipped-demos signatures. Discard candidates that would land sibling to anything shipped.
3. **Pull references.** From `reference-bank/`, plus optional per-build discovery for sparse combinations. Discovered references commit back to the bank.
4. **Adapt.** Shift the archetype's defaults toward the business spec. Concrete tokens, not abstract families.
5. **Render and verify.** Render through the template. Run output-side divergence. Output the brief plus references plus check result.

**Divergence schema** (full detail in `references/03-divergence-check.md`):

Each shipped demo carries a 5-field signature: `slug`, `archetype`, `dominant_hue_family`, `voice_register`, `primary_structural_pattern`. Three mechanical overlap rules:

- Same archetype + same hue family => SIBLING (block)
- Same archetype + same voice register + same structural pattern => SIBLING (block)
- Same hue family across different archetypes => WARN (the recurring family that real portfolio drift produces)

Output: `passed`, `warn-with-reasons`, or `block-with-reasons`.

## Catalog and lint

| Before | After |
|---|---|
| 101 skills | 102 skills |
| 16 categories | 16 categories (unchanged) |
| 444 reference files | 445 reference files |

Lint run with `python scripts/generate_readme_catalog.py --write`. `--check` passes. README badge, TOC, catalog header, catalog body, and all marker-bound sections updated.

## Composition with other skills

- **`brand-archetype-system`** (upstream input). This skill names the archetype from the existing catalog; it does not redefine archetypes.
- **`creative-direction`** (parallel input). The four-axis vocabulary the archetypes reference. The creative-direction skill exists in the catalog and is in the strategy-and-discovery category.
- **`brand-identity`** (downstream). Turns the approved brief into a finished identity system.
- **`landing-page-copy`, `content-and-copy`, `art-direction`** (downstream consumers of the brief).

## Trademark posture

Follows the `brand-archetype-system` convention: archetypes are named for aesthetic families (Premium DTC Maker, Heritage Local Service), not for brands. Live reference sites are cited as exemplars using nominative attribution language ("exemplified by", "characteristic of", "in the register of"). Descriptive and nominative fair use territory, durable across brand redesigns.

## Reference bank seed

Three seed combinations cover the verticals the imagery work surfaced as needing this skill:

- `premium-dtc-maker-western-boots.md` (Luxe Considered + Rugged Utilitarian; positive references include Tecovas, Lucchese, Old Gringo, Ranch Road; negative references include the big-box catalog texture)
- `heritage-local-service-barbershop.md` (Warm Conversational + Retro Nostalgic; positive references include Rosemont, Speakeasy Barber Lounge, Frank's, Alfani's; negative reference is the chain-barbershop register)
- `hospitality-experience-balloon-ride.md` (Documentary Honest + Luxe Considered; positive references include Napa Valley Aloft, Aerogelic, Rainbow Ryders, Sundance; negative references are generic adventure-tour aggregators)

Each seed file documents the build it was seeded from and its last-updated date. New combinations get added as the portfolio grows.

## Phase 2 (later dispatch)

Phase 2 is using this skill to drive the first batch-two demo as the framework's live pressure-test. Out of scope for this PR.

## Verification

- Lint: 102 skills, 445 reference files, `--check` passes.
- All three seed reference-bank files have at least three positive references with live URLs and one-line whys.
- Trademark posture matches `brand-archetype-system`.
- No em-dashes, no en-dashes, no forbidden marketing phrases, no triple-parallel structure.
- Brief template renders against real shipped briefs as a faithful structural match.

## Hold for review

PR is ready for review. No auto-merge expected; the new skill should get a human read on the SKILL.md narrative and the seed reference-bank files before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)