### PR TITLE
chore(reference-bank): specialty-coffee-subscription combination

### DIFF
--- a/skills/creative-brief-selector/references/reference-bank/editorial-restrained-documentary-honest-specialty-coffee-subscription.md
+++ b/skills/creative-brief-selector/references/reference-bank/editorial-restrained-documentary-honest-specialty-coffee-subscription.md
@@ -1,0 +1,22 @@
+# Editorial-restrained, documentary-honest, specialty coffee subscription
+
+- **Archetype**: `editorial-restrained` with `documentary-honest` as the composition secondary. The lead is editorial type-led restraint (low-saturation, generous whitespace, considered typography); the secondary is documentary farm and bean photography that grounds the single-origin claim. Premium but approachable; not luxury, not mass-market.
+- **Vertical**: DTC food and beverage (specifically specialty coffee subscriptions; the references generalise to tea and other consumable single-origin subscriptions in adjacent registers).
+- **Position summary**: A specialty single-origin coffee subscription in the editorial-restrained register. Subscriber-first commerce (cadence picker, pause and swap surfaced as features, not buried in account settings). Named farms, named processes, named roast dates. Documentary farm photography supports the type rather than leads.
+
+## Positive references
+
+- [drinktrade.com](https://drinktrade.com) - Subscriber-first commerce explicit: cadence picker on the home, match-quiz to find your roast, pause and swap surfaced as features rather than buried in account settings. Editorial-restrained type-led layout with documentary product photography.
+- [counterculturecoffee.com](https://counterculturecoffee.com) - Specialty roaster with subscription surfaced; documentary photography of farms and farmers carries the page; editorial type. The canonical reference for "farm-direct specialty roaster with a subscription option."
+- [onyxcoffeelab.com](https://onyxcoffeelab.com) - Editorial-restrained register at its most refined: type-led, considered photography, premium-but-approachable. Useful as the type-system reference (small-caps, restrained tracking, editorial serifs).
+- [atlascoffeeclub.com](https://atlascoffeeclub.com) - Subscriber-first explicitly with a world-coffee-journey narrative. The closest match to the "one origin a month, named farm, named process" positioning. Useful for how to surface the rotation as the value prop.
+
+## Negative references
+
+- [starbucks.com](https://starbucks.com) - Mass-market grocery register; frappuccino lifestyle photography; promotional cadence dominates the homepage. The register a specialty roaster must not pull from.
+- [folgers.com](https://folgers.com) - Commodity grocery brand; blue-can heritage but no specialty register. The bottom of the grocery shelf, conceptually.
+- Generic lifestyle-influencer subscription boxes (BarkBox, FabFitFun, Allure Beauty Box and similar) - Lifestyle-spectacle subscription register where the unboxing is the product; the box itself is supposed to be a surprise. Wrong register entirely for a specialty-coffee subscription where the named farm and the roast date are the value, not the unboxing reveal.
+
+## Extension note
+
+- Seeded by the Northbound Coffee Co. brief (Phase 2 live pressure-test of the creative-brief-selector skill, rampstack/rampstackco-app PR #131). The brief was the first live invocation of the selector and discovered these references during step 3 because the bank had no seed for the specialty-coffee-subscription combination. Last updated: 2026-05-27.


### PR DESCRIPTION
## Summary

Adds a new bank file to the `creative-brief-selector` skill, seeding the `editorial-restrained-documentary-honest` archetype applied to specialty coffee subscriptions in the DTC food and beverage vertical.

New file: `skills/creative-brief-selector/references/reference-bank/editorial-restrained-documentary-honest-specialty-coffee-subscription.md`

## Context

The bank had no seed for this archetype-and-vertical combination. The Northbound Coffee Co. brief (Phase 2 live pressure-test of the selector, rampstack/rampstackco-app PR #131) discovered the references during step 3 of the skill's process and commits them back to the bank here per the hybrid model documented in `reference-bank/README.md`:

> A build that uses this skill on a sparse combination is expected to commit the discovered references back to the bank as part of its build PR (one-line PR rider).

This PR is that commit-back.

## Contents

**Positive references** (4):
- [drinktrade.com](https://drinktrade.com) - subscriber-first commerce explicit; cadence picker, match-quiz, pause/swap surfaced
- [counterculturecoffee.com](https://counterculturecoffee.com) - canonical farm-direct specialty roaster with a subscription option; documentary farm photography
- [onyxcoffeelab.com](https://onyxcoffeelab.com) - editorial-restrained register at its most refined; the type-system reference
- [atlascoffeeclub.com](https://atlascoffeeclub.com) - subscriber-first with world-coffee-journey narrative; closest to "one origin a month, named farm"

**Negative references** (3):
- [starbucks.com](https://starbucks.com) - mass-market grocery
- [folgers.com](https://folgers.com) - commodity grocery
- Generic lifestyle-influencer subscription boxes (BarkBox, FabFitFun, Allure Beauty Box and similar) - lifestyle-spectacle register where unboxing is the product

## Lint

- CI lint (`.github/scripts/lint_skills.py`) passes locally with 102 skills validated, 1 warning (the pre-existing `documentation-strategy` line-count, unrelated).
- README catalog count unchanged at 102 skills, 445 reference files. Reference-bank files are nested (sub-subdirectory of `references/`) and the catalog counter iterates only top-level files under each skill's `references/`. This matches the convention from the three Phase 1 seed reference-bank files.

## File format

Mirrors the three Phase 1 seeds (`premium-dtc-maker-western-boots.md`, `heritage-local-service-barbershop.md`, `hospitality-experience-balloon-ride.md`):

- Header with archetype, vertical, and one-line position summary
- Positive references with one-line whys
- Negative references with one-line whys
- Extension note pointing back to the build that seeded the entry

## Companion PR

The brief that drove this discovery: rampstack/rampstackco-app PR #131 (private repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)