### PR TITLE
feat(creative-brief-selector): add rugged-utilitarian regional used-vehicle marketplace bank entry [HOLD]

### DIFF
--- a/skills/creative-brief-selector/references/reference-bank/README.md
+++ b/skills/creative-brief-selector/references/reference-bank/README.md
@@ -97,10 +97,12 @@ Retirement is a normal part of bank maintenance. The bank reflects what is curre
 
 ## Seeded combinations
 
-Three combinations ship with the skill:
+Five combinations live in the bank:
 
 - [`premium-dtc-maker-western-boots.md`](premium-dtc-maker-western-boots.md) - Premium DTC maker register applied to a small-collection western-boot maker.
 - [`heritage-local-service-barbershop.md`](heritage-local-service-barbershop.md) - Heritage local-service register applied to a neighborhood barbershop.
 - [`hospitality-experience-balloon-ride.md`](hospitality-experience-balloon-ride.md) - Documentary-honest hospitality-experience register applied to a scenic-flight operator.
+- [`editorial-restrained-documentary-honest-specialty-coffee-subscription.md`](editorial-restrained-documentary-honest-specialty-coffee-subscription.md) - Editorial-restrained subscription-app register applied to a single-origin specialty coffee subscription.
+- [`rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md`](rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md) - Rugged-utilitarian inventory-listing register applied to a regional used-truck-and-SUV marketplace.
 
-Each seed file was built against a real shipped demo and reflects the references that demo's build drew from. As the portfolio grows, the bank grows with it.
+Each seed file was built against a real shipped demo or shipped brief and reflects the references that build drew from. As the portfolio grows, the bank grows with it.

--- a/skills/creative-brief-selector/references/reference-bank/rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md
+++ b/skills/creative-brief-selector/references/reference-bank/rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md
@@ -1,0 +1,24 @@
+# Rugged-utilitarian-documentary-honest, regional used-vehicle marketplace
+
+- **Archetype**: `rugged-utilitarian` with `documentary-honest` as the composition secondary. The lead is workwear-and-craft (Mountain West heritage utility register); the secondary is data-forward documentary (transparency-first listings, real photography, real source attribution).
+- **Vertical**: Inventory-listing (specifically regional used-truck-and-SUV marketplace serving working-vehicle buyers, not full passenger-car market).
+- **Position summary**: A regional working-vehicle specialist marketplace, transparency-first on every listing, documentary photography of vehicles in working context, plain-direct voice that speaks with familiarity of the terrain its audience drives. Specialist, not generalist; transparent, not promotional; regional, not national.
+
+## Positive references
+
+- [bringatrailer.com](https://bringatrailer.com) - The canonical listing-detail transparency reference: full ownership history, mileage timeline, photograph density (forty to one hundred photographs per lot is typical), a comments thread that adds provenance. Inherit the listing-detail anatomy and the source-attributed transparency posture. Diverge from the auction format; a fixed-price marketplace borrows the transparency without the closing-clock.
+- [icon4x4.com](https://icon4x4.com) - Editorial documentary register applied to working vehicles. Inherit the photography direction (vehicles photographed in landscape and at work, not glamour shots on a studio seamless), the considered editorial type, and the absence of promotional banners.
+- [filson.com](https://filson.com) - Mountain West heritage workwear register. Inherit the palette tendency (granite, evergreen, oxblood, aspen gold; cool ground with restrained accents), the documentary photography that supports the type rather than fighting it, and the plain-direct voice.
+- [patagonia.com](https://patagonia.com) - The adjacent outdoor-utility register, useful as the second positive on voice (plain-direct, no marketing inflation, the audience treated as competent).
+
+## Negative references
+
+- [cargurus.com](https://cargurus.com) - Mass-market national passenger-car register; price-anxiety scoring as the hero, financing-first conversion architecture. The register a specialist regional marketplace must avoid on conversion architecture, palette, and voice.
+- [cars.com](https://cars.com) - Same mass-market national register; promotional banner cadence, broad-inventory generalist posture.
+- [carvana.com](https://carvana.com) - DTC mass-market with vending-machine theatrics, financing-first. The register to avoid on theatrics and on conversion-flow priority.
+- [autotempest.com](https://autotempest.com) - Meta-aggregator with no editorial voice; utility-only search-across-the-others. A specialist marketplace must not read as utility-only.
+- [edmunds.com](https://edmunds.com) - Research-led advisory; content-heavy editorial sitting adjacent to a marketplace. A specialist marketplace must not read as a magazine pretending to be a marketplace.
+
+## Extension note
+
+- Seeded from the Treeline Motors inventory-listing brief (the second batch-two build using the creative-brief-selector skill end to end). The Bring a Trailer reference is dual-positioned: positive on listing-detail transparency, negative on format (auction vs fixed-price marketplace). Last updated: 2026-05-27.


### PR DESCRIPTION
## Summary

Fifth entry in the creative-brief-selector reference-bank. Seeded from the Treeline Motors inventory-listing brief in rampstack/rampstackco-app (parallel HOLD PR).

## What this adds

`skills/creative-brief-selector/references/reference-bank/rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md`

Four positive references:
- bringatrailer.com (canonical listing-detail transparency; dual-positioned positive on listing anatomy, negative on auction format)
- icon4x4.com (editorial documentary register for working vehicles)
- filson.com (Mountain West workwear palette and voice)
- patagonia.com (adjacent outdoor-utility voice register)

Five negative references (the mass-market national passenger-car register the brief must avoid):
- cargurus.com
- cars.com
- carvana.com
- autotempest.com
- edmunds.com

## README

Updated the seeded-combinations list from three (the original three at skill ship) to five (Northbound's specialty-coffee-subscription added during PR #77, Treeline's regional-used-vehicle-marketplace added by this PR).

## Lint

`.github/scripts/lint_skills.py` passes; 102 skills validated, 1 pre-existing line-length warning unrelated to this change.

## HOLD

Held pending the rampstack/rampstackco-app brief PR landing. After merge, the bank is ready for any future inventory-listing build in the working-vehicle or working-equipment register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)