### PR TITLE
feat(creative-brief-selector): section shapes as first-class brief output [HOLD]

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
 - **102 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
-- **445 reference files** (templates, checklists, decision matrices, worked examples)
+- **446 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.

--- a/skills/creative-brief-selector/SKILL.md
+++ b/skills/creative-brief-selector/SKILL.md
@@ -12,9 +12,9 @@ A starting-point selector for brand and microsite builds. Given a business spec 
 
 1. An archetype position from `brand-archetype-system`, picked or composed to be deliberately distinct from the shipped demos.
 2. A small set of live reference sites for that archetype-and-vertical combination, drawn from a curated bank plus optional per-build discovery.
-3. A divergence check against the shipped demos that flags palette, voice, or structural overlap before the brief is handed off.
+3. A divergence check against the shipped demos that flags palette, voice, structural pattern, and section-shape overlap before the brief is handed off.
 
-The brief output is concrete tokens, not abstract families. It is meant to be loaded by downstream build skills as the single creative artifact for the build.
+The brief output is concrete tokens, not abstract families, including explicit section-shape choices (hero shape and footer shape) as first-class outputs alongside palette and voice. It is meant to be loaded by downstream build skills as the single creative artifact for the build.
 
 ---
 
@@ -71,21 +71,26 @@ When a build draws from a sparse combination, the build is expected to commit th
 
 ## The divergence schema
 
-Each shipped demo carries a signature with four fields:
+Each shipped demo carries a signature with seven fields:
 
 - `slug`
 - `archetype` (the canonical archetype name from `brand-archetype-system`)
 - `dominant_hue_family` (the recognizable colour family, e.g. leather-bone-saddle, dawn-navy-coral, dark-linen-amber)
 - `voice_register` (e.g. story-forward third-person, atmospheric second-person, fitment-first technical)
 - `primary_structural_pattern` (e.g. shoppable-grid-product-forward, arc-timeline-hero, fitment-selector-then-rails)
+- `hero_shape` (e.g. dual-column-image-and-text, wide-photograph-with-band-below, full-bleed-image-with-overlay; canonical vocabulary in `references/05-section-shapes-vocabulary.md`)
+- `footer_shape` (e.g. single-line-strip, multi-column-sitemap, type-only-no-links; same vocabulary file)
 
-Overlap rules:
+Overlap rules (full set in [`references/03-divergence-check.md`](references/03-divergence-check.md)):
 
 - Two demos share archetype AND share dominant_hue_family => **SIBLING (block)**.
 - Two demos share archetype AND share voice_register AND share primary_structural_pattern => **SIBLING (block)**.
-- Two demos share only dominant_hue_family across different archetypes => **WARN** (a recurring palette across the portfolio is the most common drift signal).
+- Two demos share only dominant_hue_family across different archetypes => **WARN**.
+- The candidate's hero_shape matches the hero_shape of two or more shipped demos => **WARN**.
+- The candidate's hero_shape matches three or more shipped demos AND any share an archetype family => **BLOCK**.
+- The candidate's footer_shape matches three or more shipped demos => **WARN**.
 
-Full schema and procedure in [`references/03-divergence-check.md`](references/03-divergence-check.md). A worked example file of seven signatures lives at [`references/04-shipped-demos-signatures-example.md`](references/04-shipped-demos-signatures-example.md) for illustration; the live signatures file for any consuming project lives in that project, not in this skill.
+A worked example file of seven signatures lives at [`references/04-shipped-demos-signatures-example.md`](references/04-shipped-demos-signatures-example.md) for illustration; the live signatures file for any consuming project lives in that project, not in this skill.
 
 ---
 
@@ -102,5 +107,6 @@ Archetypes are NAMED for aesthetic families, NOT for brands, following the conve
 - [`references/02-brief-template.md`](references/02-brief-template.md) - The fillable brief template with section-by-section guidance.
 - [`references/03-divergence-check.md`](references/03-divergence-check.md) - The signature schema and the overlap rules.
 - [`references/04-shipped-demos-signatures-example.md`](references/04-shipped-demos-signatures-example.md) - Worked example signatures file with seven demos.
+- [`references/05-section-shapes-vocabulary.md`](references/05-section-shapes-vocabulary.md) - Canonical open vocabulary of hero and footer section shapes plus archetype affinities.
 
 The curated reference bank lives in a `reference-bank/` subdirectory under `references/`. The bank ships with a README plus three seed archetype-and-vertical files: `premium-dtc-maker-western-boots.md`, `heritage-local-service-barbershop.md`, and `hospitality-experience-balloon-ride.md`. The bank's purpose and extension procedure are documented in its README; the seed files each carry three to four positive live references and one to two negative references for the chosen position. Load the bank file matching the build's archetype-and-vertical at step 3 of the process.

--- a/skills/creative-brief-selector/references/01-process.md
+++ b/skills/creative-brief-selector/references/01-process.md
@@ -91,6 +91,7 @@ Take the chosen archetype's defaults from `brand-archetype-system` (palette, typ
 - **Type system.** Pick the display family (often a serif from the archetype), the body family (often Inter or similar), and the micro-label treatment (tracking, casing, weight). Document the explicit differentiators from shipped demos (e.g. "tight uppercase tracking 0.04em on micro-labels, distinct from the loose 0.18em tracking the hospitality-experience build uses").
 - **Voice.** Pick the voice register (e.g. story-forward third-person; atmospheric second-person; fitment-first technical). Write five to ten voice samples in this voice using the brand name.
 - **Layout.** Pick the structural pattern (e.g. shoppable-grid-product-forward; arc-timeline-hero; fitment-selector-then-rails). Describe the spine moves the homepage will run (four to six numbered moves).
+- **Section shapes.** Pick a `hero_shape` and a `footer_shape` from the vocabulary in [`05-section-shapes-vocabulary.md`](05-section-shapes-vocabulary.md). The hero shape carries the most visual weight on the page; pick it deliberately based on archetype, audience, and the shapes already shipped in the portfolio. Document the rejected shapes in the brief with one-line reasons. Skipping this step means the engine inherits the most recently built hero shape regardless of brief specification, which is the drift signal this skill exists to catch.
 - **CTA grammar.** Pick the verb register (e.g. "Shop the collection," "Book a dawn," "See the morning"). Verb-first, shape-appropriate.
 - **Imagery direction.** Describe the shoot's register (e.g. "warm-bone studio seamless, three-quarter angle, soft overhead, products fill 70 percent of frame"). Specify aspect ratios per page slot.
 
@@ -112,8 +113,10 @@ After rendering, compute the brief's own signature and run output-side divergenc
 - `dominant_hue_family`: derived from the palette tokens
 - `voice_register`: from the voice section
 - `primary_structural_pattern`: from the spine moves
+- `hero_shape`: from the section-shapes choice in step 4
+- `footer_shape`: from the section-shapes choice in step 4
 
-Compare this signature against every shipped demo using the same rules from step 2.
+Compare this signature against every shipped demo using the full rule set in [`03-divergence-check.md`](03-divergence-check.md). The check now runs seven rules: the original three pairwise rules (archetype/hue, archetype/voice/pattern, recurring hue across archetypes) plus the three aggregate shape rules (hero shape collision warn at two matches, hero shape archetype-collision block at three matches with shared family, footer shape warn at three matches).
 
 **Possible outcomes:**
 

--- a/skills/creative-brief-selector/references/02-brief-template.md
+++ b/skills/creative-brief-selector/references/02-brief-template.md
@@ -49,6 +49,27 @@ Negative references (do NOT pull from):
 
 - [<URL>] - <one-line why this register is the wrong one>
 
+## Section shapes (hero and footer; first-class brief outputs)
+
+Pick a `hero_shape` and a `footer_shape` from [`05-section-shapes-vocabulary.md`](05-section-shapes-vocabulary.md). Document the choice with rationale; the choice is not optional and a brief without these fields does not pass the divergence check.
+
+### `hero_shape`: <chosen shape label, e.g. `wide-photograph-with-band-below`>
+
+<One paragraph: why this shape, what the chosen shape signals to the visitor that the alternatives do not, what shapes were rejected and why. Reference the section-shapes vocabulary by label.>
+
+Rejected shapes:
+
+- `<rejected shape 1>` - <one-line why this shape was wrong for this brief>
+- `<rejected shape 2>` - <one-line why this shape was wrong for this brief>
+
+### `footer_shape`: <chosen shape label, e.g. `single-line-strip`>
+
+<One paragraph: why this footer shape, what it does for the page that alternatives do not.>
+
+Rejected shapes:
+
+- `<rejected shape>` - <one-line why>
+
 ## Palette token shape (specific to this brand; do not reuse across brands)
 
 | Token | Hex | Role |
@@ -131,10 +152,12 @@ A build matches this brief if:
 - **Dominant hue family**: <derived from palette, e.g. "leather-bone-saddle">
 - **Voice register**: <e.g. "story-forward third-person">
 - **Primary structural pattern**: <e.g. "shoppable-grid-product-forward">
+- **Hero shape**: <chosen label from 05-section-shapes-vocabulary.md>
+- **Footer shape**: <chosen label from 05-section-shapes-vocabulary.md>
 
 **Input-side divergence**: <passed | warn-with-reasons | block-with-reasons>. <If anything was rejected at step 2, list it here: rejected <archetype> because it collided with <shipped demo slug> on <field>>.
 
-**Output-side divergence**: <passed | warn-with-reasons | block-with-reasons>. <If warn or block, list the matched fields and the colliding demo>.
+**Output-side divergence**: <passed | warn-with-reasons | block-with-reasons>. <If warn or block, list the matched fields and the colliding demo. Rules 4 and 6 surface as warns; Rule 5 surfaces as a block; Rules 1, 2, 3 surface per their definitions in 03-divergence-check.md.>
 
 ---
 ```

--- a/skills/creative-brief-selector/references/03-divergence-check.md
+++ b/skills/creative-brief-selector/references/03-divergence-check.md
@@ -6,7 +6,7 @@ The signature schema, the overlap rules, and the comparison procedure.
 
 ## Signature schema
 
-Each shipped demo carries a signature with five fields. The schema is small on purpose: any field that takes judgment to populate gets argued about; a small mechanical schema gets used.
+Each shipped demo carries a signature with seven fields. The schema is small on purpose: any field that takes judgment to populate gets argued about; a small mechanical schema gets used.
 
 ```yaml
 - slug: <kebab-case slug, e.g. pinto-mesa-boots>
@@ -14,7 +14,11 @@ Each shipped demo carries a signature with five fields. The schema is small on p
   dominant_hue_family: <named hue family, e.g. leather-bone-saddle>
   voice_register: <named register, e.g. story-forward-third-person>
   primary_structural_pattern: <named pattern, e.g. shoppable-grid-product-forward>
+  hero_shape: <named shape from 05-section-shapes-vocabulary.md, e.g. dual-column-image-and-text>
+  footer_shape: <named shape from 05-section-shapes-vocabulary.md, e.g. single-line-strip>
 ```
+
+The last two fields (`hero_shape` and `footer_shape`) are the latest schema additions. The canonical vocabulary for both lives in [`05-section-shapes-vocabulary.md`](05-section-shapes-vocabulary.md).
 
 ### slug
 
@@ -64,6 +68,32 @@ The structural pattern the homepage runs, in three to five words. Examples:
 
 The naming convention: name the homepage's primary spine in a way another build can recognize from the rendered page.
 
+### hero_shape
+
+The shape of the hero section, drawn from the vocabulary in [`05-section-shapes-vocabulary.md`](05-section-shapes-vocabulary.md). Examples:
+
+- `dual-column-image-and-text`
+- `wide-photograph-with-band-below`
+- `full-bleed-image-with-overlay`
+- `type-led-prose`
+- `centered-single-column`
+- `asymmetric-large-image-small-text`
+- `grid-of-elements`
+- `data-table-or-spec-led`
+
+A build that needs a shape not in the vocabulary documents and proposes a new label per the extension procedure in `05-section-shapes-vocabulary.md`.
+
+### footer_shape
+
+The shape of the footer section, drawn from the vocabulary in [`05-section-shapes-vocabulary.md`](05-section-shapes-vocabulary.md). Examples:
+
+- `single-line-strip`
+- `multi-column-sitemap`
+- `type-only-no-links`
+- `editorial-colophon-with-masthead`
+- `newsletter-band-with-credits`
+- `dark-cta-then-credits`
+
 ---
 
 ## Overlap rules
@@ -88,15 +118,46 @@ If two demos share `dominant_hue_family` but their `archetype` differs, the outc
 
 A recurring hue family across different archetypes is the most common drift signal in a portfolio. The warn surfaces the recurrence so the consumer can choose to break the pattern or accept it as the portfolio's signature.
 
-### Rule 4: Anything else
+### Rule 4: Hero shape collision (warn)
+
+If the candidate's proposed `hero_shape` matches the `hero_shape` of two or more shipped demos, the outcome is **WARN**.
+
+The warn surfaces a deliberation note listing every shipped demo using the same shape. The brief author either justifies the repeat (and records that justification in the brief's section-shapes rationale) or picks a different shape from the vocabulary. Two demos sharing a hero shape is acceptable for a portfolio of nine to twelve demos; three or more is the point where the shape starts reading as the engine's house default.
+
+### Rule 5: Hero shape archetype-collision (block)
+
+If the candidate's proposed `hero_shape` matches the `hero_shape` of three or more shipped demos AND any of those matching demos share an archetype family with the proposed brief, the outcome is **BLOCK**.
+
+This catches the case where the brief is heading toward the strongest sibling result possible: the same hero shape AND a related archetype. The block forces the brief to choose differently on at least one dimension (a different hero shape, or a different archetype lead, or a documented justification that escalates to the deliberation notes with explicit reasoning).
+
+Archetype-family overlap is computed by comparing the lead archetype tokens. Composed archetypes share a family if either of their tokens matches. For example, `editorial-restrained` and `editorial-restrained-documentary-honest` share the `editorial-restrained` family; `documentary-honest-luxe-considered` and `rugged-utilitarian-documentary-honest` share the `documentary-honest` family.
+
+### Rule 6: Footer shape collision (warn)
+
+If the candidate's proposed `footer_shape` matches the `footer_shape` of three or more shipped demos, the outcome is **WARN**.
+
+Footers tolerate more repetition than heroes since they carry less visual weight and are more functional than expressive. The threshold (three matching demos for a warn, not two) is correspondingly higher. There is no block-level rule for footer shapes at this scope; if a portfolio-wide footer shape emerges as the house default, it becomes part of the portfolio's signature rather than a per-build distinctness failure.
+
+### Rule 7: Anything else
 
 If no rule above fires, the outcome is **PASSED**.
+
+---
+
+## Why shapes carry weight
+
+Heroes carry the most visual weight on a page and the most signal to the visitor. Hero-shape repetition across a portfolio compresses the perceived distance between builds even when palette, voice, and structural pattern diverge. The early showcase portfolio surfaced this drift signal: most builds shipped a `dual-column-image-and-text` or `full-bleed-image-with-overlay` hero regardless of brief specification, because the engine pattern-matched the most recently built shape.
+
+Footers carry less weight and are typically more functional than expressive. They tolerate more repetition before the repetition becomes a distinctness cost.
+
+Rules 4, 5, and 6 exist to make hero-shape and footer-shape choice an explicit selection at brief time rather than an implicit inheritance from the most recently built demo.
 
 ---
 
 ## Comparison procedure
 
 ```
+# Pairwise rules (run on every candidate-shipped pair):
 for candidate in candidates:
   for shipped in shipped_demos:
     if rule_1(candidate, shipped):
@@ -108,6 +169,18 @@ for candidate in candidates:
     if rule_3(candidate, shipped):
       record_warn(candidate, shipped, fields=['dominant_hue_family'])
       continue
+
+# Aggregate rules (run once per candidate against the full set):
+for candidate in candidates:
+  hero_matches = [s for s in shipped_demos if s.hero_shape == candidate.hero_shape]
+  if len(hero_matches) >= 3 and any(shares_archetype_family(candidate, s) for s in hero_matches):
+    record_block(candidate, hero_matches, fields=['hero_shape', 'archetype'])  # rule 5
+  elif len(hero_matches) >= 2:
+    record_warn(candidate, hero_matches, fields=['hero_shape'])  # rule 4
+
+  footer_matches = [s for s in shipped_demos if s.footer_shape == candidate.footer_shape]
+  if len(footer_matches) >= 3:
+    record_warn(candidate, footer_matches, fields=['footer_shape'])  # rule 6
 ```
 
 The check produces three lists: blocks, warns, and a passed flag (true iff blocks and warns are both empty).

--- a/skills/creative-brief-selector/references/04-shipped-demos-signatures-example.md
+++ b/skills/creative-brief-selector/references/04-shipped-demos-signatures-example.md
@@ -2,7 +2,7 @@
 
 An illustrative signatures file with seven worked entries. This file is example-only; the live signatures file for any consuming project lives in that project (typically at `progress/shipped-demos-signatures.yml`), not in this skill.
 
-The schema is defined in [`03-divergence-check.md`](03-divergence-check.md). Each entry has five fields: `slug`, `archetype`, `dominant_hue_family`, `voice_register`, `primary_structural_pattern`.
+The schema is defined in [`03-divergence-check.md`](03-divergence-check.md). Each entry has seven fields: `slug`, `archetype`, `dominant_hue_family`, `voice_register`, `primary_structural_pattern`, `hero_shape`, `footer_shape`. The last two (`hero_shape`, `footer_shape`) are the latest additions; their canonical vocabulary lives in [`05-section-shapes-vocabulary.md`](05-section-shapes-vocabulary.md).
 
 The seven entries below are illustrative records of seven sibling-shape demos a portfolio might ship. They are written here as a worked example of what the file looks like in practice. The archetype values reference the canonical names from `brand-archetype-system`.
 
@@ -17,42 +17,56 @@ demos:
     dominant_hue_family: slate-and-amber
     voice_register: fitment-first-technical
     primary_structural_pattern: fitment-selector-then-rails
+    hero_shape: dual-column-image-and-text
+    footer_shape: multi-column-sitemap
 
   - slug: iron-and-rye-barbershop
     archetype: warm-conversational-retro-nostalgic
     dominant_hue_family: warm-walnut-brass
     voice_register: warm-everyday-craft
     primary_structural_pattern: barber-roster-then-services-menu
+    hero_shape: dual-column-image-and-text
+    footer_shape: single-line-strip
 
   - slug: pho-heights
     archetype: documentary-honest-luxe-considered
     dominant_hue_family: dark-linen-amber
     voice_register: chef-essay-first-person
     primary_structural_pattern: editorial-hero-then-signatures-menu
+    hero_shape: full-bleed-image-with-overlay
+    footer_shape: single-line-strip
 
   - slug: volta-robotics
     archetype: technical-precise
     dominant_hue_family: graphite-and-signal-orange
     voice_register: spec-forward-technical
     primary_structural_pattern: product-strip-then-spec-table
+    hero_shape: full-bleed-image-with-overlay
+    footer_shape: single-line-strip
 
   - slug: clearflow-initiative
     archetype: editorial-restrained
     dominant_hue_family: forest-green-cream
     voice_register: restrained-citation-bearing
     primary_structural_pattern: theory-of-change-hero-then-evidence-band
+    hero_shape: full-bleed-image-with-overlay
+    footer_shape: single-line-strip
 
   - slug: pinto-mesa-boots
     archetype: luxe-considered-rugged-utilitarian
     dominant_hue_family: leather-bone-saddle
     voice_register: story-forward-third-person
     primary_structural_pattern: shoppable-grid-product-forward
+    hero_shape: dual-column-image-and-text
+    footer_shape: single-line-strip
 
   - slug: drift-and-dawn
     archetype: documentary-honest-luxe-considered
     dominant_hue_family: dawn-navy-coral
     voice_register: atmospheric-second-person
     primary_structural_pattern: arc-timeline-hero-with-packages-strip
+    hero_shape: full-bleed-image-with-overlay
+    footer_shape: single-line-strip
 ```
 
 ---

--- a/skills/creative-brief-selector/references/05-section-shapes-vocabulary.md
+++ b/skills/creative-brief-selector/references/05-section-shapes-vocabulary.md
@@ -1,0 +1,151 @@
+# Section shapes vocabulary
+
+A canonical, open vocabulary of section shapes the brief picks from for the hero and footer sections (with optional later extension to trust-strip, CTA-close, and how-it-works sections). The vocabulary is a starting point, not a closed enum. Builds can document and propose a new shape if none of the listed labels fits.
+
+Section shapes are first-class brief outputs. The brief picks a shape per section explicitly and records the rationale next to palette and voice rationale. Two new fields per signature record (`hero_shape` and `footer_shape`) let the divergence check fire against shape collision across shipped demos.
+
+The divergence rules for shapes are in [`03-divergence-check.md`](03-divergence-check.md) (Rules 4, 5, 6).
+
+---
+
+## Hero shapes (open list, starting set)
+
+### `dual-column-image-and-text`
+
+Image on one side of the hero, heading and lede and CTAs on the other. CSS grid with two columns (often around 1.1fr / 1fr). The engine's house default and the shape most prone to overuse in a portfolio that grows without explicit shape selection.
+
+- **When it fits**: brands where the photograph and the type carry roughly equal weight and the eye is meant to ricochet between them. Premium DTC product hero is the canonical fit; a single product on the image side and a price-and-CTA on the type side.
+- **References**: [allbirds.com](https://allbirds.com), [tecovas.com](https://tecovas.com).
+- **Archetype affinities**: Luxe Considered, Warm Conversational, Editorial Restrained (mild).
+
+### `wide-photograph-with-band-below`
+
+Single full-width hero photograph (aspect 16:9 or wider) spanning the content width, with structured content (search rail, CTA pair, lede, filter chips) stacked vertically below the photograph. The photograph carries the page; the band below carries the affordances.
+
+- **When it fits**: inventory marketplaces, regional specialists, sites where the photograph signals what the marketplace is for and the band carries the controls. Also fits magazine-style editorial registers where one strong image opens an article.
+- **References**: [bringatrailer.com](https://bringatrailer.com), [icon4x4.com](https://icon4x4.com).
+- **Archetype affinities**: Rugged Utilitarian, Documentary Honest, Editorial Restrained.
+
+### `full-bleed-image-with-overlay`
+
+Image fills the section (or near-fills, often at `object-cover` with `absolute inset-0`), with type overlaid via a gradient. Dramatic, cinema-poster register. Strongest visual signal of all hero shapes; correspondingly the easiest to over-saturate.
+
+- **When it fits**: hospitality experiences where the place is the product (balloon ride, restaurant, hotel), mission-driven nonprofits where the documentary photograph is the evidence, premium B2B where the product is photographed at scale. Atmospheric and cinematic.
+- **References**: [bombasses.com](https://bombasses.com) (hospitality), [charitywater.org](https://charitywater.org) (institution-mission).
+- **Archetype affinities**: Documentary Honest, Luxe Considered (composed with Documentary Honest), Editorial Restrained.
+
+### `type-led-prose`
+
+No image in the hero. The H1 and lede do the work; image (if any) appears below the hero as a supporting element. Editorial publication register. The whitespace and the type carry the page.
+
+- **When it fits**: editorial publications, ideas-led brands, B2B SaaS where the proposition is conceptual, premium consultancies, law and finance where understated credibility is the play.
+- **References**: [nytimes.com](https://nytimes.com), [stripe.com](https://stripe.com) (mild type-led, with type leading and a subtle product render below).
+- **Archetype affinities**: Editorial Restrained, Technical Precise (mild).
+
+### `centered-single-column`
+
+Narrow content column centered on the page, H1 and lede only, minimal. Often paired with atmospheric brand registers where the centered alignment signals "considered, not loud."
+
+- **When it fits**: portfolio brands, atmospheric or contemplative registers, single-product brands where the page is essentially a long-scroll story and the hero is just the opening line.
+- **References**: [linear.app](https://linear.app), [framer.com](https://framer.com) (both run centered single-column heroes at times).
+- **Archetype affinities**: Editorial Restrained, Luxe Considered.
+
+### `asymmetric-large-image-small-text`
+
+One element dominates the hero (usually an image at 70 to 80 percent of width), the other is caption-scale beside or below it. Distinct from `dual-column-image-and-text` by the imbalance: the dual-column is roughly balanced, the asymmetric leans heavily.
+
+- **When it fits**: magazine cover style, photography portfolios, single-product hero where the product carries everything and the type is a caption-scale credit line.
+- **References**: [magnum.com](https://magnum.com), [aesop.com](https://aesop.com) (varies; some pages use asymmetric layouts).
+- **Archetype affinities**: Luxe Considered, Documentary Honest, Editorial Restrained.
+
+### `grid-of-elements`
+
+The hero IS a grid: product tiles, listing cards, directory entries, no single anchor image. The inventory or directory itself is the hero. Distinct from `wide-photograph-with-band-below` by having no single dominant image; the grid carries the meaning.
+
+- **When it fits**: directory and marketplace shapes where the breadth of the catalog is the value, ecommerce catalog shapes where shoppability above the fold is the conversion lever.
+- **References**: [airbnb.com](https://airbnb.com) (search results hero is the grid), [unsplash.com](https://unsplash.com).
+- **Archetype affinities**: Technical Precise, Editorial Restrained (with restraint), Rugged Utilitarian (if the directory is the working catalog).
+
+### `data-table-or-spec-led`
+
+A data table or spec block is the hero element. The numbers and the comparison carry the page. Technical Precise register, B2B engineering context, comparison-led purchase decisions.
+
+- **When it fits**: B2B engineering procurement, hardware comparison sites, financial product comparison, anywhere the buyer is data-anchored before they care about photography.
+- **References**: [parametric-portfolios.com](https://parametric-portfolios.com), [substack.com/pricing](https://substack.com/pricing) (pricing-table-as-hero variants).
+- **Archetype affinities**: Technical Precise, Editorial Restrained.
+
+---
+
+## Footer shapes (open list, starting set)
+
+### `single-line-strip`
+
+One row carrying the brand disclosure paragraph and the footer nav, no multi-column structure. Mobile and desktop render the same content reflowed. The default across most demos in the showcase portfolio.
+
+- **When it fits**: small-collection brands, single-purpose microsites, demo and showcase contexts, brands where the footer is meant to be functional chrome rather than navigation in its own right.
+- **References**: most editorial brand sites with a small surface area.
+- **Archetype affinities**: any; this is the chrome default.
+
+### `multi-column-sitemap`
+
+Three to six columns of links plus brand info. Common on larger commerce sites where the footer carries category navigation, popular searches, account shortcuts, customer service, about-the-company, and resources.
+
+- **When it fits**: ecommerce catalog with deep category trees, multi-tenant marketplaces with seller-side and buyer-side links, B2B sites with documentation libraries.
+- **References**: [amazon.com](https://amazon.com), [shopify.com](https://shopify.com), most large retailers.
+- **Archetype affinities**: Technical Precise, Rugged Utilitarian (if functional), any commerce-heavy archetype.
+
+### `type-only-no-links`
+
+Minimal editorial footer, copyright and disclosure only, no nav. The footer is essentially a colophon.
+
+- **When it fits**: ideas-led brands, single-page narratives, publications where the nav lives in the top chrome and the bottom is just the credit line.
+- **References**: [pitchfork.com](https://pitchfork.com) (varies; minimal footer), portfolio sites.
+- **Archetype affinities**: Editorial Restrained, Luxe Considered.
+
+### `editorial-colophon-with-masthead`
+
+Masthead-style footer naming the editorial team or contributors. Fits publication register where the footer credits the people behind the work.
+
+- **When it fits**: publications, magazine sites, editorial collectives, organizations where the people are the brand.
+- **References**: [theatlantic.com](https://theatlantic.com), [theverge.com](https://theverge.com).
+- **Archetype affinities**: Editorial Restrained, Documentary Honest.
+
+### `newsletter-band-with-credits`
+
+Newsletter signup as the dominant footer element, with credits below. The newsletter is the conversion goal; the footer is the conversion surface.
+
+- **When it fits**: content sites, newsletter-first publications, brands where the newsletter is the customer-relationship channel.
+- **References**: [substack.com](https://substack.com), most content sites operating newsletter-led growth.
+- **Archetype affinities**: Editorial Restrained, Warm Conversational.
+
+### `dark-cta-then-credits`
+
+Two-row footer with a dark CTA band on top and a credits strip below. The CTA band acts as the page-bottom conversion surface; the credits strip is the actual footer.
+
+- **When it fits**: conversion-led sites where the bottom of the page is the second-most-attended surface (after the hero), marketing sites, B2B with a sign-up funnel.
+- **References**: [vercel.com](https://vercel.com), [linear.app](https://linear.app).
+- **Archetype affinities**: Technical Precise, any conversion-led register.
+
+---
+
+## Optional extensions (not formally checked at this dispatch's scope)
+
+The framework can grow to cover additional section shapes as the portfolio surfaces them. Currently documented loosely; not part of the divergence check fields.
+
+- **Trust-strip shapes**: four-signal block, two-paragraph narrative band, logo wall, citation row.
+- **CTA-close shapes**: dark band with single CTA, gradient band with pair of CTAs, image-backed close, newsletter close.
+- **How-it-works shapes**: three-card strip, numbered list with images, flow diagram, timeline.
+
+When a brief's shape choice for one of these sections proves load-bearing for the build's distinctness, a future framework dispatch can promote the section to a checked field.
+
+---
+
+## How to extend the vocabulary
+
+A build that discovers a section shape not present in the vocabulary:
+
+1. Documents the shape in the brief with a name (kebab-case), a one-paragraph description, and one or two real-world references.
+2. Adds the shape to this file under the appropriate section (hero or footer) with the same format the existing shapes use.
+3. Commits the vocabulary addition in the build PR.
+
+The vocabulary grows with the portfolio. Stale shapes (no demo uses them, no live references remain) can be retired in subsequent dispatches.


### PR DESCRIPTION
## Summary

Adds hero and footer section shapes as first-class brief outputs. Two new signature fields per shipped demo (`hero_shape` and `footer_shape`); three new divergence rules check shape collision across the portfolio.

**Background:** the rampstack/rampstackco-app showcase portfolio surfaced a drift signal where the engine reads palette, voice, type, and content as binding constraints from briefs but reads section shapes as house defaults regardless of brief specification. Treeline Motors' brief specified a wide-photograph-with-band-below hero; the build shipped dual-column-image-and-text. This dispatch makes shape selection explicit and checkable.

## New reference: `references/05-section-shapes-vocabulary.md`

**Eight hero shapes** (starting open vocabulary):

- `dual-column-image-and-text`
- `wide-photograph-with-band-below`
- `full-bleed-image-with-overlay`
- `type-led-prose`
- `centered-single-column`
- `asymmetric-large-image-small-text`
- `grid-of-elements`
- `data-table-or-spec-led`

**Six footer shapes:**

- `single-line-strip`
- `multi-column-sitemap`
- `type-only-no-links`
- `editorial-colophon-with-masthead`
- `newsletter-band-with-credits`
- `dark-cta-then-credits`

Each shape carries one paragraph of when-it-fits, one or two real-world references, and one or two archetype affinities. Optional extensions (trust-strip, CTA-close, how-it-works shapes) listed but not formally checked at this scope.

## Updated: `references/03-divergence-check.md`

Signature schema grown from five to seven fields. Three new aggregate rules:

| Rule | Trigger | Outcome |
|---|---|---|
| 4 | hero_shape matches two or more shipped | WARN |
| 5 | hero_shape matches three or more shipped AND any share archetype family | BLOCK |
| 6 | footer_shape matches three or more shipped | WARN |

Heroes carry the most visual weight on a page; the warn/block thresholds reflect that. Footers tolerate more repetition before the repetition becomes a distinctness cost.

## Updated: `references/02-brief-template.md`

New required Section Shapes section between Position and Spine of moves. The brief picks `hero_shape` and `footer_shape` from the vocabulary with rejected-shapes rationale. A brief without these fields does not pass the divergence check.

## Updated: `references/04-shipped-demos-signatures-example.md`

Schema example shows the seven-field record format. The seven worked entries now carry their characterized `hero_shape` and `footer_shape` values.

## Updated: `references/01-process.md`

- Step 4 (adapt): section-shape selection is part of the adaptation set.
- Step 5 (verify): full seven-rule check runs the three new shape rules alongside the original three pairwise rules.

## Updated: `SKILL.md`

Section shapes named in the skill description and in the schema summary; reference files index links to the new vocabulary doc.

## Companion PR

The live signatures backfill across the nine shipped demos lands in rampstack/rampstackco-app via a parallel PR. The two-PR sequence: this skill PR lands first so the schema exists, then the backfill PR populates the live file.

## Lint

`.github/scripts/lint_skills.py` passes; README catalog regenerated (446 reference files, was 445). 102 skills validated; 1 pre-existing line-length warning unrelated to this change.

## Test plan

- [ ] Vocabulary reads as canonical-but-open (the doc explicitly invites extension via build PRs)
- [ ] Divergence rules 4/5/6 are checkable in pseudocode (the procedure block in 03-divergence-check.md shows the aggregate-rule loop)
- [ ] Brief template's Section Shapes section is required (no opt-out path)
- [ ] HOLD: do not merge until the rampstackco-app backfill PR is ready to land second

🤖 Generated with [Claude Code](https://claude.com/claude-code)