### PR TITLE
feat(creative-brief-selector): add editorial-restrained literary quarterly bank entry [HOLD]

### DIFF
--- a/skills/creative-brief-selector/references/reference-bank/README.md
+++ b/skills/creative-brief-selector/references/reference-bank/README.md
@@ -97,12 +97,13 @@ Retirement is a normal part of bank maintenance. The bank reflects what is curre
 
 ## Seeded combinations
 
-Five combinations live in the bank:
+Six combinations live in the bank:
 
 - [`premium-dtc-maker-western-boots.md`](premium-dtc-maker-western-boots.md) - Premium DTC maker register applied to a small-collection western-boot maker.
 - [`heritage-local-service-barbershop.md`](heritage-local-service-barbershop.md) - Heritage local-service register applied to a neighborhood barbershop.
 - [`hospitality-experience-balloon-ride.md`](hospitality-experience-balloon-ride.md) - Documentary-honest hospitality-experience register applied to a scenic-flight operator.
 - [`editorial-restrained-documentary-honest-specialty-coffee-subscription.md`](editorial-restrained-documentary-honest-specialty-coffee-subscription.md) - Editorial-restrained subscription-app register applied to a single-origin specialty coffee subscription.
 - [`rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md`](rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md) - Rugged-utilitarian inventory-listing register applied to a regional used-truck-and-SUV marketplace.
+- [`editorial-restrained-literary-quarterly.md`](editorial-restrained-literary-quarterly.md) - Editorial-restrained editorial-publication register applied to a themed literary and ideas quarterly.
 
 Each seed file was built against a real shipped demo or shipped brief and reflects the references that build drew from. As the portfolio grows, the bank grows with it.

--- a/skills/creative-brief-selector/references/reference-bank/editorial-restrained-literary-quarterly.md
+++ b/skills/creative-brief-selector/references/reference-bank/editorial-restrained-literary-quarterly.md
@@ -1,0 +1,25 @@
+# Editorial-restrained, literary quarterly
+
+- **Archetype**: `editorial-restrained` (pure, no composition secondary). The lead is the literary quarterly tradition: typography carries the page, the considered editorial register, the restrained accent, and the absence of marketing inflation.
+- **Vertical**: Editorial publication (specifically themed literary and ideas quarterly with multi-author masthead, each issue organized around a single question or theme).
+- **Position summary**: A themed literary quarterly where each issue is a single question, the table of contents reads as variations on the question across disciplines, the design is restrained-considered with one literary accent colour. Not politically situated, not generationally branded, not topical, not single-author. The audience is literary readers across disciplines.
+
+## Positive references
+
+- [aeon.co](https://aeon.co) - Multidisciplinary ideas register. Considered design, restrained palette (warm-grey ground with deep type and a single accent), essays at substantial length, multiple disciplines per surface. Inherit the ideas-led register, the considered-but-not-luxe typography, the absence of marketing inflation.
+- [thepointmag.com](https://thepointmag.com) - Themed multi-author essay structure at length. The closest peer on the audience axis (broadly literary readers across disciplines). Inherit the multi-author themed-issue treatment and the essay-length expectation.
+- [cabinetmagazine.org](https://cabinetmagazine.org) - The closest structural anchor in the field: each issue is organized around a single thematic question rendered with editorial restraint. Inherit the single-theme-per-issue structure and the question-as-masthead treatment.
+- [canopycanopycanopy.com](https://canopycanopycanopy.com) - Triple Canopy. Themed digital-first sequenced issues with editorial restraint. Inherit the digital-first design discipline and the sequenced-issue numbering.
+
+## Negative references
+
+- [thedriftmag.com](https://thedriftmag.com) - Politically situated, generationally branded, identity-forward. A considered quarterly must avoid the political-statement register on conversion architecture, palette, and voice.
+- [nplusonemag.com](https://nplusonemag.com) - Institutional NY cultural authority register. A considered quarterly should not borrow the geographic or generational positioning.
+- [laphamsquarterly.org](https://laphamsquarterly.org) - Historical-source-driven format (passages from historical writing assembled around a theme). A different format entirely; canonical to that publication and not transferable.
+- [believermag.com](https://believermag.com) - McSweeney's-adjacent geometric illustration identity. A type-led quarterly should not borrow the illustration-led visual treatment.
+- [atavist.com](https://atavist.com) - Single-essay-per-issue reportage register. A multi-essay themed quarterly is a different shape.
+- [themarginalian.org](https://themarginalian.org) - Single-author blog register. A multi-author themed quarterly is a different shape.
+
+## Extension note
+
+- Seeded from the Caesura editorial-publication brief (the first portfolio entry in the editorial-publication shape, using the extended creative-brief-selector framework with hero_shape and footer_shape as first-class outputs). The pure `editorial-restrained` archetype combined with the type-led-prose hero and editorial-colophon-with-masthead footer renders as the natural literary-publication fit; the framework's extended rules align with the register's tradition rather than fighting it. Last updated: 2026-05-27.


### PR DESCRIPTION
## Summary

Sixth entry in the creative-brief-selector reference-bank. Seeded from the Caesura editorial-publication brief in rampstack/rampstackco-app (parallel HOLD PR).

First entry under the extended creative-brief-selector framework (with hero_shape and footer_shape as first-class outputs).

## What this adds

`skills/creative-brief-selector/references/reference-bank/editorial-restrained-literary-quarterly.md`

Four positive references:
- aeon.co (multidisciplinary ideas register)
- thepointmag.com (themed multi-author essay structure at length)
- cabinetmagazine.org (single-theme-per-issue structural anchor; closest peer in field)
- canopycanopycanopy.com (Triple Canopy; digital-first sequenced-issue structure)

Six negative references (the literary-quarterly registers the brief deliberately differentiates from):
- thedriftmag.com
- nplusonemag.com
- laphamsquarterly.org
- believermag.com
- atavist.com
- themarginalian.org

## README

Updated the seeded-combinations list from five to six.

## Lint

`.github/scripts/lint_skills.py` passes; 102 skills validated, 1 pre-existing line-length warning unrelated to this change.

## HOLD

Held pending the rampstack/rampstackco-app brief PR landing. After merge, the bank is ready for any future editorial-publication build in the considered-literary register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)