### PR TITLE
feat(creative-brief-selector): add luxe-considered residential architectural brokerage bank entry [HOLD]

### DIFF
--- a/skills/creative-brief-selector/references/reference-bank/README.md
+++ b/skills/creative-brief-selector/references/reference-bank/README.md
@@ -97,7 +97,7 @@ Retirement is a normal part of bank maintenance. The bank reflects what is curre
 
 ## Seeded combinations
 
-Six combinations live in the bank:
+Seven combinations live in the bank:
 
 - [`premium-dtc-maker-western-boots.md`](premium-dtc-maker-western-boots.md) - Premium DTC maker register applied to a small-collection western-boot maker.
 - [`heritage-local-service-barbershop.md`](heritage-local-service-barbershop.md) - Heritage local-service register applied to a neighborhood barbershop.
@@ -105,5 +105,6 @@ Six combinations live in the bank:
 - [`editorial-restrained-documentary-honest-specialty-coffee-subscription.md`](editorial-restrained-documentary-honest-specialty-coffee-subscription.md) - Editorial-restrained subscription-app register applied to a single-origin specialty coffee subscription.
 - [`rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md`](rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md) - Rugged-utilitarian inventory-listing register applied to a regional used-truck-and-SUV marketplace.
 - [`editorial-restrained-literary-quarterly.md`](editorial-restrained-literary-quarterly.md) - Editorial-restrained editorial-publication register applied to a themed literary and ideas quarterly.
+- [`luxe-considered-editorial-restrained-residential-architectural-brokerage.md`](luxe-considered-editorial-restrained-residential-architectural-brokerage.md) - Luxe-considered-editorial-restrained inventory-listing register applied to a residential brokerage of architecturally significant homes (the first same-shape divergence test against the rugged-utilitarian regional-used-vehicle-marketplace entry).
 
 Each seed file was built against a real shipped demo or shipped brief and reflects the references that build drew from. As the portfolio grows, the bank grows with it.

--- a/skills/creative-brief-selector/references/reference-bank/luxe-considered-editorial-restrained-residential-architectural-brokerage.md
+++ b/skills/creative-brief-selector/references/reference-bank/luxe-considered-editorial-restrained-residential-architectural-brokerage.md
@@ -1,0 +1,23 @@
+# Luxe-considered-editorial-restrained, residential architectural brokerage
+
+- **Archetype**: `luxe-considered` with `editorial-restrained` as the composition secondary. The lead is the gallery-monograph register: premium, considered, type-and-photography-led, design-literate. The secondary is design-publication restraint: listings rendered as small monographs, the architect-and-year credit at byline weight, the brokerage represented as a practice rather than as a roster of agents.
+- **Vertical**: Inventory-listing (specifically residential brokerage of architecturally significant homes: modernist, mid-century, architect-designed new builds, design-forward renovations).
+- **Position summary**: A luxe residential brokerage that treats each architecturally significant home as a small monograph. The architect, the design year, the materials, the siting, and the light are first-class fields on every listing. The brokerage speaks as a design-literate practice rather than as a roster of individual agents.
+
+## Positive references
+
+- [themodernhouse.com](https://themodernhouse.com) - The canonical reference for the design-led residential brokerage register at editorial-restrained tier. Each listing reads as a small monograph; the architect is named in the listing card; the photography is disciplined. Inherit the listing-as-monograph anatomy and the considered-restraint voice. (Cited as a register anchor, not for trade dress copy; the negative-reference frame governs which brokerages a build must not pull trade dress from.)
+- [phillips.com](https://phillips.com/design) - Phillips's design auction catalog register. The monograph treatment per lot (designer, year, materials, provenance) transfers cleanly to a residential listing. Inherit the per-lot monograph anatomy.
+- [dezeen.com](https://dezeen.com) - The architectural press register. Listing-style architecture coverage with architect credits, year, materials, photography. Inherit the architecture-press literacy and the credit-line convention.
+- [architecturaldigest.com](https://architecturaldigest.com) - The design-publication register with residential homes covered as design objects. Inherit the photography sensibility and the design-publication restraint.
+
+## Negative references
+
+- [zillow.com](https://zillow.com) - Mass-market portal; algorithmic listing presentation, estimated-value overlays, financing-first conversion. The register a luxe-considered brokerage must avoid on conversion architecture, palette, and voice.
+- [realtor.com](https://realtor.com) - Same mass-market portal register; broker-listing-syndication shape, generic photography presentation.
+- [redfin.com](https://redfin.com) - Mass-market portal with light brokerage layer; price-anxiety scoring, financing partnerships surfaced as primary CTAs.
+- High-volume luxury brokerages whose primary surface is personality-led agent funnels. The architectural-monograph register is a practice, not a personal brand; the no-fabricated-agent-headshots line in the honesty contract is the structural rationale.
+
+## Extension note
+
+- Seeded from the Datum residential-brokerage brief (the first portfolio entry in luxe-residential-architectural-brokerage and the first same-shape divergence test in the portfolio; second inventory-listing build, the first being the rugged-utilitarian Treeline Motors marketplace). The brief documents the Section Shapes Rule 5 block on the two obvious luxe-architectural defaults (full-bleed-image-with-overlay and dual-column-image-and-text) and the resulting selection of asymmetric-large-image-small-text as the hero shape. Last updated: 2026-05-27.


### PR DESCRIPTION
## Summary

Seventh entry in the creative-brief-selector reference-bank. Seeded from the Datum residential-brokerage brief in rampstack/rampstackco-app (parallel HOLD PR).

This is the first same-shape entry in the bank: both this and the prior `rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace` entry are inventory-listing builds. The Datum brief documents the Section Shapes Rule 5 block on the two obvious luxe-architectural defaults and the resulting selection of `asymmetric-large-image-small-text` as the hero shape.

## What this adds

`skills/creative-brief-selector/references/reference-bank/luxe-considered-editorial-restrained-residential-architectural-brokerage.md`

Four positive references (cited as register anchors, not for trade-dress copy):
- themodernhouse.com (canonical design-led residential brokerage register)
- phillips.com/design (design auction catalog per-lot monograph treatment)
- dezeen.com (architectural press listing register)
- architecturaldigest.com (design-publication restraint)

Four negative references named (zillow.com, realtor.com, redfin.com, and the high-volume luxury brokerage personality-led agent-funnel register).

## README

Updated the seeded-combinations list from six to seven.

## Lint

`.github/scripts/lint_skills.py` passes; 102 skills validated, 1 pre-existing line-length warning unrelated to this change.

## HOLD

Held pending the rampstack/rampstackco-app brief PR landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)