### PR TITLE
feat(creative-brief-selector): add bold-confident AAA game studio bank entry [HOLD]

### DIFF
--- a/skills/creative-brief-selector/references/reference-bank/README.md
+++ b/skills/creative-brief-selector/references/reference-bank/README.md
@@ -97,7 +97,7 @@ Retirement is a normal part of bank maintenance. The bank reflects what is curre
 
 ## Seeded combinations
 
-Seven combinations live in the bank:
+Eight combinations live in the bank:
 
 - [`premium-dtc-maker-western-boots.md`](premium-dtc-maker-western-boots.md) - Premium DTC maker register applied to a small-collection western-boot maker.
 - [`heritage-local-service-barbershop.md`](heritage-local-service-barbershop.md) - Heritage local-service register applied to a neighborhood barbershop.
@@ -106,5 +106,6 @@ Seven combinations live in the bank:
 - [`rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md`](rugged-utilitarian-documentary-honest-regional-used-vehicle-marketplace.md) - Rugged-utilitarian inventory-listing register applied to a regional used-truck-and-SUV marketplace.
 - [`editorial-restrained-literary-quarterly.md`](editorial-restrained-literary-quarterly.md) - Editorial-restrained editorial-publication register applied to a themed literary and ideas quarterly.
 - [`luxe-considered-editorial-restrained-residential-architectural-brokerage.md`](luxe-considered-editorial-restrained-residential-architectural-brokerage.md) - Luxe-considered-editorial-restrained inventory-listing register applied to a residential brokerage of architecturally significant homes (the first same-shape divergence test against the rugged-utilitarian regional-used-vehicle-marketplace entry).
+- [`bold-confident-editorial-restrained-aaa-game-studio.md`](bold-confident-editorial-restrained-aaa-game-studio.md) - Bold-confident-editorial-restrained corporate-portfolio register applied to a AAA-adjacent action game studio (the first portfolio entry in Bold Confident; the gentler entry into the bold register before a game-title demo).
 
 Each seed file was built against a real shipped demo or shipped brief and reflects the references that build drew from. As the portfolio grows, the bank grows with it.

--- a/skills/creative-brief-selector/references/reference-bank/bold-confident-editorial-restrained-aaa-game-studio.md
+++ b/skills/creative-brief-selector/references/reference-bank/bold-confident-editorial-restrained-aaa-game-studio.md
@@ -1,0 +1,23 @@
+# Bold-confident-editorial-restrained, AAA-adjacent action game studio
+
+- **Archetype**: `bold-confident` with `editorial-restrained` as the composition secondary. The lead is the cinematic-confident register of AAA-adjacent action studios; the secondary is chrome restraint (the platform-versus-content distinction from the gaming and entertainment vertical file: a studio is the chrome around its games, so the chrome composes while the game key art carries the saturation). The composition is the explicit chrome-restraint dial: pure Bold Confident or composed-with-Vibrant-Saturated is reserved for single-game-title demos.
+- **Vertical**: Corporate-portfolio (specifically AAA-adjacent action game studio: a content-creator studio that builds large-scale action games and presents itself as a serious craft-and-scale shop).
+- **Position summary**: A studio whose chrome is composed and dark-mode-first, where each fictitious title's key art carries the saturation and energy. Cinematic full-bleed hero, titles portfolio strip, type-led studio band, careers band as the load-bearing conversion surface, dark CTA close.
+
+## Positive references
+
+- [bungie.net](https://bungie.net) - The canonical AAA-action studio chrome register: cinematic full-bleed key-art hero, dark-mode-first ground, restrained type chrome that lets the game art carry. Inherit the cinematic hero treatment, the dark ground, and the chrome restraint.
+- [insomniac.com](https://insomniac.com) - Insomniac Games. The studio chrome at composed-cinematic; the titles portfolio surfaced with care. Inherit the titles-portfolio anatomy and the craft-proud-without-arrogance voice.
+- [naughtydog.com](https://naughtydog.com) - Naughty Dog. The restrained-cinematic studio register; type-led studio band with the team presented at masthead density. Inherit the studio-band convention and the restrained-cinematic chrome.
+- [remedygames.com](https://remedygames.com) - Remedy Entertainment. The composed-cinematic register at the studio level, with a smaller portfolio presented with editorial discipline. Inherit the title-detail-page-as-small-monograph anatomy.
+
+## Negative references
+
+- [steampowered.com](https://steampowered.com) - Steam. Platform chrome that hosts third-party content. Wrong vertical (platform, not studio); the platform chrome reads totally different from a studio's content-creator brand.
+- [itch.io](https://itch.io) - Itch.io. Indie game platform; minimal chrome; wrong register and wrong vertical.
+- Mobile and casual free-to-play studio sites (the bright-saturated multi-hue cartoon register of casual-mobile studio brands). Wrong register; a AAA-adjacent action studio is not casual-mobile.
+- Streaming-service sites (netflix.com, hbomax.com). Adjacent Bold-Confident-leaning register but wrong vertical (streaming distribution vs studio creation). Netflix's content-as-hero treatment is a useful inheritance for the cinematic hero; the rest of Netflix's chrome is platform-distributor, not studio.
+
+## Extension note
+
+- Seeded from the Ironhold AAA-adjacent action studio brief (first portfolio entry in Bold Confident; first portfolio entry in the corporate-portfolio shape applied to a game studio). The brief is the gentler entry into Bold Confident in the showcase portfolio; the upcoming game-title demo is the leap into the saturated single-IP register. The studio composes with Editorial Restrained as the chrome-restraint dial so the title-demo can pull saturation further without colliding. The brief documents a Rule 4 WARN override on the full-bleed-image-with-overlay hero (the canonical AAA-studio cinematic treatment, four shipped matches but no archetype-family share so Rule 5 does not block; the override is justified by the new archetype carrying the shape into a completely different visual reading). Last updated: 2026-05-28.


### PR DESCRIPTION
## Summary

Eighth entry in the creative-brief-selector reference-bank. Seeded from the Ironhold AAA-adjacent action studio brief in rampstack/rampstackco-app (parallel HOLD PR).

The studio is the **first portfolio entry in Bold Confident**: every one of the 11 shipped demos sits outside the bold register. Ironhold is the deliberate, gentler entry; the upcoming game-title demo will be the leap into the saturated single-IP register.

## What this adds

`skills/creative-brief-selector/references/reference-bank/bold-confident-editorial-restrained-aaa-game-studio.md`

Four positive references (real AAA-adjacent action studios in the cinematic-confident chrome register; cited as register anchors):
- bungie.net (canonical AAA-studio chrome)
- insomniac.com (composed-cinematic studio chrome)
- naughtydog.com (restrained-cinematic studio register, type-led studio band)
- remedygames.com (smaller portfolio with editorial discipline)

Four negative references named (steampowered.com and itch.io as platform chrome, casual-mobile studio sites, streaming-service sites).

## Why composed with Editorial Restrained

The studio is the chrome around its games. Per the gaming and entertainment vertical file's platform-versus-content distinction, platform brands lean restrained to let content carry. A studio is not literally a platform but its site is the chrome that hosts its own content; the Editorial Restrained secondary pulls the studio chrome away from full Vibrant Saturated and toward composed-cinematic. The forward-divergence note is explicit: pure Bold Confident and Vibrant Saturated are reserved for the upcoming game-title demo so the two read as a studio-and-its-game pair.

## Rule 4 WARN override precedent

The brief takes a documented Rule 4 WARN override on the `full-bleed-image-with-overlay` hero (canonical AAA-studio cinematic treatment, four shipped matches but no archetype-family share so Rule 5 does not block). Override justified because the new archetype carries the shape into a completely different visual reading. **First Rule 4 WARN override precedent in the framework.**

## README

Updated the seeded-combinations list from seven to eight.

## Lint

`.github/scripts/lint_skills.py` passes; 102 skills validated, 1 pre-existing line-length warning unrelated to this change.

## HOLD

Held pending the rampstack/rampstackco-app brief PR landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
