### PR TITLE
feat(reference-bank): local-trades directory-marketplace entry [HOLD]

### DIFF
--- a/skills/creative-brief-selector/references/reference-bank/README.md
+++ b/skills/creative-brief-selector/references/reference-bank/README.md
@@ -97,7 +97,7 @@ Retirement is a normal part of bank maintenance. The bank reflects what is curre
 
 ## Seeded combinations
 
-Nine combinations live in the bank:
+Ten combinations live in the bank:
 
 - [`premium-dtc-maker-western-boots.md`](premium-dtc-maker-western-boots.md) - Premium DTC maker register applied to a small-collection western-boot maker.
 - [`heritage-local-service-barbershop.md`](heritage-local-service-barbershop.md) - Heritage local-service register applied to a neighborhood barbershop.
@@ -108,5 +108,6 @@ Nine combinations live in the bank:
 - [`luxe-considered-editorial-restrained-residential-architectural-brokerage.md`](luxe-considered-editorial-restrained-residential-architectural-brokerage.md) - Luxe-considered-editorial-restrained inventory-listing register applied to a residential brokerage of architecturally significant homes (the first same-shape divergence test against the rugged-utilitarian regional-used-vehicle-marketplace entry).
 - [`bold-confident-editorial-restrained-aaa-game-studio.md`](bold-confident-editorial-restrained-aaa-game-studio.md) - Bold-confident-editorial-restrained corporate-portfolio register applied to a AAA-adjacent action game studio (the first portfolio entry in Bold Confident; the gentler entry into the bold register before a game-title demo).
 - [`bold-confident-vibrant-saturated-single-ip-game-title.md`](bold-confident-vibrant-saturated-single-ip-game-title.md) - Bold-confident-vibrant-saturated single-IP marketing register applied to a post-launch AAA action game title (the first single-IP marketing entry; the title side of the game-studio pair, claiming the saturated leap the studio brief reserved).
+- [`minimal-essentialist-documentary-honest-trades-directory.md`](minimal-essentialist-documentary-honest-trades-directory.md) - Minimal-essentialist-documentary-honest directory-marketplace register applied to a homeowner-facing local-trades directory (the first directory-marketplace shape and the first multi-provider entry; encodes the multi-provider conventions and the no-fabricated-reviews resolution).
 
 Each seed file was built against a real shipped demo or shipped brief and reflects the references that build drew from. As the portfolio grows, the bank grows with it.

--- a/skills/creative-brief-selector/references/reference-bank/minimal-essentialist-documentary-honest-trades-directory.md
+++ b/skills/creative-brief-selector/references/reference-bank/minimal-essentialist-documentary-honest-trades-directory.md
@@ -1,0 +1,34 @@
+# Minimal-essentialist-documentary-honest, local-trades directory
+
+- **Archetype**: `minimal-essentialist` with `documentary-honest` as the composition secondary. The lead is the functional-tool register (clean, organized, content-forward, reduced chrome; the page is the directory and the chrome recedes to let the listings carry). The secondary is honest-transparency trust (a stated verification claim, honest placeholders where reviews would render, real-context provider photography). The marketplace platform-versus-provider principle is the structural rationale: the directory brand must not compete with the provider identities, so restraint wins.
+- **Vertical**: Directory-marketplace (specifically a homeowner-facing local-trades directory of many independent providers across real trade categories: plumbing, electrical, HVAC, carpentry, painting, roofing). The first multi-provider entry in the bank.
+- **Position summary**: A clean, trustworthy directory tool the homeowner controls, light-mode-first, where the categories and the providers are the page. Discoverability is the spine, comparison is core, and the trust is built on honest transparency rather than on warmth or on clinical authority.
+
+## Positive references
+
+The references are cited NOMINATIVELY as register exemplars only. A build in this position inherits the register (search-first discovery, category browse, provider listings, a comparison surface, a verification claim) and pulls NO palette, trade dress, logo language, or conversion-funnel pattern from any specific real directory.
+
+- [angi.com](https://angi.com) - The modern consolidated home-services directory register: category-and-location search, provider listings, the lead-handoff conversion. Inherit the search-first discovery spine and the category structure; do NOT pull the orange-and-green palette, the match-now funnel, or any trade dress.
+- [thumbtack.com](https://thumbtack.com) - The matched-services register: structured by trade and location, provider profiles with comparable fields. Inherit the comparable-provider-profile anatomy; do NOT pull the blue palette or the get-matched interstitial funnel.
+- [houzz.com](https://houzz.com) - The visual-services-directory register: real work photography carrying the provider listings. Inherit the documentary work-in-context photography direction (a trade in progress, a finished job), not glamour shots; do NOT pull the green-and-orange palette or the social-feed product framing.
+
+## Negative references
+
+- Warm-conversational single-provider service brands (a neighbourhood barbershop, a single local shop's site; the heritage-local-service register). Wrong register and wrong count: that is a single provider speaking warmly about itself, not a directory of many providers in a functional-trust tool. A trades directory must not read as one warm shop with extras.
+- Magazine-editorial services-content sites (a home-improvement publication, a services-advice editorial). Wrong register: a directory is a functional tool, not a magazine pretending to be a directory; the editorial-publication register buries the listing density behind a narrative.
+- Bold-cinematic or saturated AAA visual registers (a cinematic full-bleed experiential hero). Wrong register entirely: a directory reads functional, not experiential; an image-and-overlay cinema-poster hero is the opposite of the page-is-the-directory discovery spine.
+
+## Multi-provider conventions (new ground; inherited by future directory-marketplace briefs)
+
+The directory-marketplace shape is the first multi-provider register in the portfolio. These conventions are first-class and carry forward:
+
+- **Brand versus provider voice.** The directory brand's voice is the site voice throughout; each provider has its own short voice only inside its listing card (a one-line how-we-work statement). The directory speaks as the trustworthy tool; the providers speak as themselves inside their cards. (Single-provider builds never had to navigate this distinction.)
+- **Discoverability is the spine.** The home page is a search-and-browse surface (category-and-location search, category tiles, provider cards), not a hero-and-essay narrative. A `grid-of-elements` hero fits naturally; a type-led or image-and-overlay hero does not.
+- **Listing density.** A meaningful directory reads as real only at sufficient density: roughly 4 to 6 categories with 4 to 8 providers each (16 to 48 total). Fewer reads as a single-provider demo with extras; more risks bloat.
+- **Comparison surface.** Providers within a category are comparable on a small honest set of dimensions (service area, specialties, years in business), not on an opaque ranking score. Comparison is core to the pattern.
+- **Reviews and ratings are the canonical fabrication risk, and the resolution is honest UX without fabricated content.** A directory conventionally shows aggregate ratings, review counts, and written reviews; a demo cannot fabricate any of them. The resolution: an explicit "Demo: no reviews shown" placeholder slot where review content and an aggregate rating would render, plus a demo-only "Verified Pro" badge (the directory's own badge, meaning stated, not a real accreditation) where earned. The directory's full trust UX is visible without a single fabricated review, rating, license number, or certification.
+- **Real categories, fictitious providers.** The trade categories are real; the providers within them are demo-fictitious, with names vetted against recognizable businesses (a proprietor-surname-plus-trade format), set in a fictitious city, with schematic service-area maps and no fabricated license numbers, certifications, or accreditation marks.
+
+## Extension note
+
+- Seeded from the Tradepost local-trades directory brief (the first directory-marketplace shape and the first multi-provider demo in the portfolio; the seventh selector-led build). The brand-archetype-system has no dedicated home-services, local-services, or trades vertical file; this build used `16-marketplace.md` (the two-sided-platform register) as the closest anchor, and the gap is flagged for a future skill-extension dispatch to add a dedicated local-services-and-trades vertical file. Tradepost runs maximal-distance mode; it is the same-shape divergence partner to a forthcoming vacation rental marketplace (the Browse-AI attended capstone), and the two diverge naturally because the verticals differ. The palette deliberately avoids the recognizable real-brand directory colours (Angi orange-and-green, Thumbtack blue, HomeAdvisor orange, Yelp red, Houzz green-and-orange, Yellow Pages yellow-and-black). Last updated: 2026-05-28.


### PR DESCRIPTION
Parallel to the rampstackco-app Tradepost brief PR. Adds the first directory-marketplace shape and the first multi-provider entry to the reference bank. Hold for review; do not merge.

## What this adds
- `minimal-essentialist-documentary-honest-trades-directory.md` — seeded from the Tradepost local-trades directory brief.
- README seeded-combinations list updated from nine to ten.

## Reference posture
Positive references (angi.com, thumbtack.com, houzz.com) are cited **nominatively as register exemplars only**, each with an explicit do-not-mimic note (no palette, trade dress, logo language, or conversion-funnel pattern pulled from any real directory). Negative references rule out warm-conversational single-provider service brands, magazine-editorial services-content sites, and bold-cinematic AAA registers.

## Multi-provider conventions (new ground, encoded for inheritance)
The entry encodes the conventions future directory-marketplace briefs inherit: the brand-vs-provider voice distinction, the discoverability spine, listing density (4–6 categories × 4–8 providers), the comparison surface, and the canonical reviews fabrication risk with its honest resolution (an honest no-reviews placeholder plus a demo-only Verified Pro badge). Also notes the absence of a dedicated home-services/trades vertical file (used `16-marketplace.md` as the closest anchor) and the maximal-distance pairing with the forthcoming vacation rental marketplace (the Browse-AI capstone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)