### PR TITLE
feat(reference-bank): curated short-term-stays directory-marketplace entry [HOLD]

### DIFF
--- a/skills/creative-brief-selector/references/reference-bank/README.md
+++ b/skills/creative-brief-selector/references/reference-bank/README.md
@@ -97,7 +97,7 @@ Retirement is a normal part of bank maintenance. The bank reflects what is curre
 
 ## Seeded combinations
 
-Ten combinations live in the bank:
+Eleven combinations live in the bank:
 
 - [`premium-dtc-maker-western-boots.md`](premium-dtc-maker-western-boots.md) - Premium DTC maker register applied to a small-collection western-boot maker.
 - [`heritage-local-service-barbershop.md`](heritage-local-service-barbershop.md) - Heritage local-service register applied to a neighborhood barbershop.
@@ -109,5 +109,6 @@ Ten combinations live in the bank:
 - [`bold-confident-editorial-restrained-aaa-game-studio.md`](bold-confident-editorial-restrained-aaa-game-studio.md) - Bold-confident-editorial-restrained corporate-portfolio register applied to a AAA-adjacent action game studio (the first portfolio entry in Bold Confident; the gentler entry into the bold register before a game-title demo).
 - [`bold-confident-vibrant-saturated-single-ip-game-title.md`](bold-confident-vibrant-saturated-single-ip-game-title.md) - Bold-confident-vibrant-saturated single-IP marketing register applied to a post-launch AAA action game title (the first single-IP marketing entry; the title side of the game-studio pair, claiming the saturated leap the studio brief reserved).
 - [`minimal-essentialist-documentary-honest-trades-directory.md`](minimal-essentialist-documentary-honest-trades-directory.md) - Minimal-essentialist-documentary-honest directory-marketplace register applied to a homeowner-facing local-trades directory (the first directory-marketplace shape and the first multi-provider entry; encodes the multi-provider conventions and the no-fabricated-reviews resolution).
+- [`luxe-considered-curated-stays-directory.md`](luxe-considered-curated-stays-directory.md) - Pure-luxe-considered directory-marketplace register applied to an aspirational curated short-term-stays marketplace (the second directory-marketplace entry; the same-shape divergence partner to the trades directory, showing the shape across two opposite registers; reframes the multi-provider conventions for hosts and stays).
 
 Each seed file was built against a real shipped demo or shipped brief and reflects the references that build drew from. As the portfolio grows, the bank grows with it.

--- a/skills/creative-brief-selector/references/reference-bank/luxe-considered-curated-stays-directory.md
+++ b/skills/creative-brief-selector/references/reference-bank/luxe-considered-curated-stays-directory.md
@@ -1,0 +1,33 @@
+# Luxe-considered, curated short-term-stays directory-marketplace
+
+- **Archetype**: `luxe-considered` (pure; no composition secondary). The aspirational curated-stays register the hospitality vertical file names as Aman and Four Seasons: serif-led, understated authority, image-forward, the stay as a designed object. The escapist warmth is carried by a warm palette and a host-voice convention, not by a second archetype. Documentary Honest (the mass-market Airbnb register and a recurring portfolio secondary), Editorial Restrained (another build's exact luxe composition string), and Warm Conversational (the review-platform register) were each considered and rejected as secondaries; pure Luxe is the fit.
+- **Vertical**: Directory-marketplace (specifically an aspirational curated short-term-rental marketplace of many independent hosts' standout stays). The second directory-marketplace entry in the bank; with the trades-directory entry it shows the shape across two opposite registers (functional-tool versus escapist-aspirational).
+- **Position summary**: A small, curated marketplace a traveler dreams through, where the property photography carries the page and the stay is the product. Image-forward, escapist, design-forward; inventory grouped into curated collections; trust built on a stated verification claim rather than a fabricated-metric arms race.
+
+## Positive references
+
+The references are cited NOMINATIVELY as register exemplars only. A build in this position inherits the register (curated collections, image-forward discovery, the property-as-monograph, restrained booking affordances) and pulls NO palette, type, trade dress, photography style, or grid treatment from any specific real platform.
+
+- [plumguide.com](https://plumguide.com) - The curated-design short-term-stay register: a small vetted collection rather than the long tail, each stay presented with editorial care. Inherit the curated-collection posture and the property-as-monograph anatomy; do NOT pull the palette, type, or the specific listing-grid treatment.
+- [boutique-homes.com](https://boutique-homes.com) - The design-led curated-stays register: architecturally distinctive properties grouped by design feeling. Inherit the design-forward collection grouping and the generous property gallery; do NOT pull the trade dress.
+- [onefinestay.com](https://onefinestay.com) - The upper-curated hospitality register: a small set of standout homes with a hotel-grade presentation. Inherit the restrained-confident chrome and the aspirational photo direction; do NOT pull the palette or the brand identity.
+
+## Negative references
+
+- Functional-tool consumer directories (the trustworthy-direct-functional trades-directory neighbourhood; the same directory-marketplace shape in the opposite register). The functional tool a user controls is the deliberate opposite of the escapist marketplace a traveler dreams through; the shape and the multi-provider conventions are shared, the register is inverted.
+- Single-operator hospitality-experience brands (one operator selling its own arc). The count axis differs: a curated-stays marketplace lists many independent hosts, not one operator's owned experience.
+- Mass-market transactional rental platforms (the high-volume long-tail booking engines with urgency banners, opaque ranking, and dense result grids). Wrong register: a curated marketplace presents a small standout set as a publication, not the whole inventory as a funnel.
+
+## Multi-provider conventions (reframed for hosts and stays)
+
+The directory-marketplace shape's multi-provider conventions (first encoded by the trades-directory entry) carry forward, reframed from providers to hosts and stays:
+
+- **Brand versus host voice.** The marketplace brand's voice is the site voice throughout; each property carries a short host voice (a one-line note on why the place is worth the trip) only inside its card and detail, set with a typographic voice-shift. The brand never speaks as a host; hosts never speak as the brand.
+- **Discoverability is the spine, image-forward.** The home is a search-and-browse surface where the property photography carries the page (the aspirational counterpart to the functional-categorical discovery of a trades directory). The hero is image-forward, not a functional tile grid.
+- **Listing density, organized as collections.** Curated themed collections (coastal escapes, design landmarks, mountain retreats) rather than flat categories; roughly 4 to 6 collections with 4 to 8 properties each (24 to 40 properties). The collection is itself an editorial act.
+- **Comparison surface.** Properties comparable within a collection on a small honest set (location, sleeps, stay-type, a demo-only rate band), with a within-collection compare view.
+- **Reviews-and-ratings honesty resolution.** A demo-only Verified Host badge with its meaning stated plainly, plus an explicit "Demo: no reviews shown" placeholder slot and an aggregate-rating placeholder. The full trust UX is visible without fabricating a single review, rating, or superhost-style metric. Hosts are represented by their properties and a one-line voice, NOT by fabricated headshots; properties are set in fictitious locations; no real platform is named, even in negation.
+
+## Extension note
+
+- Seeded from the Lodestar curated-stays marketplace brief (the fifteenth and final showcase demo; the second directory-marketplace shape and the same-shape divergence partner to the trades-directory entry, running maximal-distance mode within the shape). Anchored to the hospitality and travel vertical file (`12-hospitality-travel.md`), which names pure Luxe Considered as the aspirational-hospitality register and Documentary Honest as the mass-market Airbnb register. The styled-aspirational property photography carries a real drift profile for the imagery pass: real-listing-platform aesthetic mimicry and fabricated-location-resemblance, both flagged for the build's NEGATIVE_GUARDRAILS, plus no real brand marks in any property image. The palette must read warm-aspirational (a design-hotel sandstone-clay-brass family) and must not reuse the trades-directory's cool functional family or any shipped warm-hospitality family. Last updated: 2026-05-29.


### PR DESCRIPTION
Parallel to the rampstackco-app Lodestar brief PR. Adds the second directory-marketplace entry to the reference bank, completing the same-shape pair. Hold for review; do not merge.

## What this adds
- `luxe-considered-curated-stays-directory.md` — seeded from the Lodestar curated-stays marketplace brief.
- README seeded-combinations list updated from ten to eleven.

## The pair
With the trades-directory entry, this shows the **directory-marketplace shape across two opposite registers**: functional-tool (minimal-essentialist) vs escapist-aspirational (pure luxe-considered). The shared layer is the multi-provider conventions, reframed here for hosts and stays.

## Reference posture
Pure `luxe-considered` (the aspirational-hospitality register the hospitality vertical file names as Aman). Positive references (plumguide.com, boutique-homes.com, onefinestay.com) cited **nominatively as register exemplars only**, each with a do-not-mimic note (no palette, type, trade dress, photography style, or grid treatment pulled from any real platform). Negative references rule out functional-tool directories, single-operator hospitality-experience brands, and mass-market transactional platforms.

## Multi-provider conventions (reframed for hosts/stays)
Brand-vs-host voice, image-forward discoverability, curated collections, within-collection comparison, and the no-fabricated-reviews resolution (demo-only Verified Host badge + "Demo: no reviews shown" slot; no fabricated host faces; fictitious locations; no real platform named even in negation). Notes the styled-aspirational property-photography drift profile (real-listing-platform mimicry, fabricated-location-resemblance) for the imagery pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)