### PR TITLE
New skill: evidence-based-reviews (content)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Skills](https://img.shields.io/badge/Skills-102-blue.svg)](#the-102-skill-catalog)
+[![Skills](https://img.shields.io/badge/Skills-103-blue.svg)](#the-103-skill-catalog)
 [![Made for Claude](https://img.shields.io/badge/Made%20for-Claude-orange.svg)](https://claude.ai)
 
 [![Website](https://img.shields.io/badge/rampstack.co-FF6B35?style=for-the-badge&logo=googlechrome&logoColor=white)](https://rampstack.co)
@@ -19,7 +19,7 @@
 </div>
 
 <!-- COUNT_INTRO:START -->
-> 102 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
+> 103 stack-agnostic skills covering brand, design, content, SEO, dev, ops, growth, and research. Includes an Ahrefs MCP-powered SEO audit suite. Use them on Next.js, WordPress, Shopify, Webflow, plain HTML, or anything else.
 <!-- COUNT_INTRO:END -->
 
 *Featured in [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) under Business & Marketing.*
@@ -33,7 +33,7 @@ Add the marketplace, then install the plugin you want:
 ```
 /plugin marketplace add rampstackco/claude-skills
 
-# full catalog (102 skills)
+# full catalog (103 skills)
 /plugin install rampstack-skills@rampstack
 
 # focused subsets
@@ -67,7 +67,7 @@ Skills load on demand: each contributes roughly its name and description until C
 - [How the catalog connects](#how-the-catalog-connects)
 - [Surfaces](#surfaces)
 <!-- COUNT_TOC:START -->
-- [The 102-skill catalog](#the-102-skill-catalog)
+- [The 103-skill catalog](#the-103-skill-catalog)
 <!-- COUNT_TOC:END -->
 - [Recommended MCPs](#recommended-mcps)
 - [Authoring conventions](#authoring-conventions)
@@ -97,8 +97,8 @@ This is not a curated list of other people's skills. It is a single, opinionated
 What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
-- **102 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
-- **446 reference files** (templates, checklists, decision matrices, worked examples)
+- **103 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
+- **448 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.
@@ -328,7 +328,7 @@ For the current API surface, request format, and limits, see the [Agent Skills A
 
 ### Want only a few skills?
 
-You do not have to install all 102. Pick the categories that match your work. The library is modular: each skill stands on its own.
+You do not have to install all 103. Pick the categories that match your work. The library is modular: each skill stands on its own.
 
 ---
 
@@ -460,7 +460,7 @@ You can also pull individual skills for one-off work. Need just a backlink audit
 
 ## How the catalog connects
 
-The skills compose with the tools your team already uses. 102 skills at the center; 35 integrations across 6 integration categories radiating out via MCPs.
+The skills compose with the tools your team already uses. 103 skills at the center; 35 integrations across 6 integration categories radiating out via MCPs.
 
 <p align="center">
   <picture>
@@ -508,7 +508,7 @@ claude-skills is the parent catalog. Curated subsets and companion repos focus o
 
 | Repo | Focus | Skills |
 |---|---|---|
-| [claude-skills](https://github.com/rampstackco/claude-skills) | Full catalog (you are here) | 102 |
+| [claude-skills](https://github.com/rampstackco/claude-skills) | Full catalog (you are here) | 103 |
 | [claude-skills-starter](https://github.com/rampstackco/claude-skills-starter) | General-purpose lite | 14 |
 | [claude-skills-seo](https://github.com/rampstackco/claude-skills-seo) | SEO consulting | 12 |
 | [claude-skills-pm](https://github.com/rampstackco/claude-skills-pm) | Product management | 12 |
@@ -520,11 +520,11 @@ Each family repo is MIT-licensed, conforms to the Agent Skills Specification, an
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->
-## The 102-skill catalog
+## The 103-skill catalog
 <!-- COUNT_CATALOG_HEADER:END -->
 
 <!-- COUNT_CATALOG_INTRO:START -->
-All 102 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
+All 103 skills are shipped. Each has a complete SKILL.md plus at least one reference file (template, checklist, or playbook).
 <!-- COUNT_CATALOG_INTRO:END -->
 
 <!-- AUTO-GENERATED CATALOG: do not edit by hand. Run scripts/generate_readme_catalog.py --write -->
@@ -560,7 +560,7 @@ All 102 skills are shipped. Each has a complete SKILL.md plus at least one refer
 | [`art-direction`](skills/art-direction/SKILL.md) | Photography, illustration, and visual direction for campaigns |
 | [`vertical-site-conventions`](skills/vertical-site-conventions/SKILL.md) | Vertical page and site composition built to the experience bar |
 
-### Content (12)
+### Content (13)
 
 | Skill | What it does |
 |---|---|
@@ -576,6 +576,7 @@ All 102 skills are shipped. Each has a complete SKILL.md plus at least one refer
 | [`content-refresh-system`](skills/content-refresh-system/SKILL.md) | Systematic content refresh: quarterly audits, refresh prioritization, refresh-vs-merge-vs-delete decisions, the lifecycle discipline that distinguishes intentional programs from set-and-forget decay |
 | [`content-repurposing`](skills/content-repurposing/SKILL.md) | Cross-format content adaptation: one piece becomes many (blog series, email, social, webinar, podcast, video) with per-format adaptation rather than mass-blast that ignores medium constraints |
 | [`content-distribution`](skills/content-distribution/SKILL.md) | Content distribution discipline: owned, earned, and paid channels matched to audience and content type. Channel-fit decisions, distribution cadence, the strategic alternative to spam-everywhere or hope-and-pray |
+| [`evidence-based-reviews`](skills/evidence-based-reviews/SKILL.md) | Evidence tiers, methodology disclosure, honest review claims |
 
 ### SEO foundation (7)
 
@@ -843,7 +844,7 @@ Contributions are welcome. Whether you want to fix a typo, add a reference file,
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full process.
 
-The fastest path: use the [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) skill itself. It teaches the same authoring discipline used across all 102 skills, with worked examples and a blank template.
+The fastest path: use the [`skill-creation-walkthrough`](skills/skill-creation-walkthrough/SKILL.md) skill itself. It teaches the same authoring discipline used across all 103 skills, with worked examples and a blank template.
 
 ---
 

--- a/SKILLS.lock
+++ b/SKILLS.lock
@@ -345,6 +345,11 @@
     "references/sequence-templates.md": "01278eb7b4a30fe73bd609d3f11f641860b45b243520efc7da4393cd08a9f002",
     "references/subject-line-patterns.md": "ccb7daafdea47a5dfc632cab458b319a5ded21fc499a74da2aa305ed1a7c01d5"
   },
+  "evidence-based-reviews": {
+    "SKILL.md": "26d1f567153d92601d58749afed86b03905db703f88b393c1c09b03dbae7465e",
+    "references/evidence-tiers.md": "fee3b0f7ec78ad8cf9f0f15325679972db4180eafdd3419b257e92b98bfe4fda",
+    "references/methodology-block-template.md": "74ec061cf5befb94a4db24479df918f1ed8c1dfa35721daaf3476a64e4082ef4"
+  },
   "experiment-design": {
     "SKILL.md": "10e8c08d666170badc5eecc7880be137263a9533620f83ffa6f6f4d430c4ba15",
     "references/common-failures.md": "0c059512ada9af9831dbd6351c752fd77aa91e5e86b814268aa3a18d3d954a5c",

--- a/skills/evidence-based-reviews/SKILL.md
+++ b/skills/evidence-based-reviews/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: evidence-based-reviews
+description: "Produce honest product reviews and buying guides without fabricated first-hand experience, using disclosed evidence tiers: verified specs, owner-experience synthesis at scale, expert triangulation, and hands-on only when true. Use this skill whenever the user wants to write product reviews or buying guides without hands-on access, set up a review methodology, add evidence disclosure to review content, align reviews with Google's reviews system or FTC affiliate disclosure expectations, or decide when Review and Product schema are honest to use. Triggers on product review, buying guide, best-of list, review methodology, evidence basis, hands-on testing, we tested, affiliate review site, review disclosure, methodology block, original research, reviews system. Also triggers when review content claims testing that did not happen, or when an affiliate site needs a trust mechanism that survives scrutiny."
+category: content
+catalog_summary: "Evidence tiers, methodology disclosure, honest review claims"
+display_order: 13
+---
+
+# Evidence-Based Reviews
+
+Produce product reviews and buying guides whose claims match their evidence. The method is evidence synthesis with a disclosed basis, and one rule anchors everything: never claim hands-on time that did not happen.
+
+Most review sites fail this rule quietly. "We tested" appears above content assembled from spec sheets, and readers have learned to smell it. The honest alternative is stronger, not weaker: synthesis of owner experience at scale, verified specifications, and triangulated expert sources is demonstrable original analysis, and disclosing it builds the trust that fabricated testing destroys.
+
+---
+
+## When to use
+
+- Writing product reviews or buying guides when hands-on access is partial or absent
+- Setting up the review methodology for a new review or affiliate site
+- Adding evidence disclosure to existing review content
+- Auditing review content for claims its evidence cannot support
+- Deciding whether Review or Product schema is honest for a given piece
+- Aligning review content with Google's reviews system and FTC disclosure expectations
+
+## When NOT to use
+
+- General content writing and editing (use `content-and-copy`; this skill governs the evidence and claims layer of review content specifically)
+- Defining how the brand sounds (use `brand-voice`)
+- Optimizing the review page itself for search (use `seo-onpage`)
+- Per-piece editorial briefs (use `content-brief-authoring`)
+
+If genuine hands-on testing at scale exists, with instrumentation and protocols, this skill still applies: the tiers do not change, the methodology block simply states tier 4 and the testing protocol becomes the disclosed basis.
+
+---
+
+## Required inputs
+
+- The product category and the pieces planned (reviews, buying guides, or both)
+- Access to evidence sources: manufacturer pages, retailer review corpora, forums or owner communities, expert publications
+- The brand's disclosure language, if one exists (this skill supplies a template if not)
+- An honest inventory of what hands-on experience genuinely exists, if any
+
+---
+
+## The framework: one rule, four evidence tiers
+
+The anchor rule: never claim hands-on time that did not happen. Every other part of the method exists to make honest content strong enough that the lie is unnecessary.
+
+### Tier 1: verified manufacturer specs
+
+Specifications cited to the maker's own page, not to aggregator copies that drift. The verification step is the work: cross-check the spec against the manufacturer's current listing, note the date, and flag discrepancies between sources instead of picking one silently. A spec table built this way is a fact layer; a spec table pasted from another review site is a rumor layer.
+
+When it suffices: factual comparisons, fit and compatibility answers, price-tier groupings. It never supports a quality verdict on its own.
+
+### Tier 2: owner-experience synthesis at scale
+
+Retailer review corpora, forum threads, warranty and return patterns, read across sources and summarized honestly. Honest synthesis means:
+
+- Recurring complaints and recurring praise, not the loudest single anecdote
+- Sample-size candor: "across roughly 1,400 owner reviews" reads differently from "owners say," and the reader deserves the number
+- No cherry-picking: if owners split, the split is the finding
+- Source naming: which corpora, which communities, over what period
+
+When it suffices: durability and reliability verdicts, real-world quirks specs never show, satisfaction patterns by use case. This tier is the workhorse of honest no-hands-on reviewing, and it is genuine original analysis when done at scale.
+
+### Tier 3: expert-source triangulation
+
+Named expert sources compared against each other. Triangulation means surfacing agreement and disagreement, not averaging verdicts into mush. When two credible testers reach opposite conclusions, the honest move is to say so and explain the conditions that might account for it. Anonymous "experts agree" is not a tier; it is decoration.
+
+When it suffices: performance claims that require instrumentation the site lacks, technique-dependent judgments, category context.
+
+### Tier 4: hands-on, only when true
+
+Stated only when it happened, flagged as such, with the extent quantified: what was done, how much, under what conditions. When hands-on experience arrives later for a piece published on tiers 1 to 3, the piece is upgraded and the update is marked with what changed. Never backfilled to look like it was always hands-on; the upgrade trail is itself a trust signal.
+
+---
+
+## The methodology block
+
+Every review and buying guide carries a short disclosure block naming its evidence basis, placed with the criteria, written for readers rather than lawyers. The fillable template and a worked example live in [`references/methodology-block-template.md`](references/methodology-block-template.md).
+
+The block names: the criteria in the order they were weighted, the tiers actually used (specifically, with sources), what was done hands-on or the words "none claimed," and the update line. A block that claims a tier the piece did not use is the same lie the anchor rule bans, in smaller type.
+
+---
+
+## Structure discipline the method implies
+
+- **Criteria stated and ordered before picks.** A verdict the reader cannot trace to a stated criterion is an opinion wearing a methodology costume.
+- **A named drawback per recommended pick.** Every product has one; a review that finds none has not looked. Consistent placement makes the honesty visible.
+- **Update transparency.** Dated updates with what changed. Stale best-of content silently rotting is one of the most common failures in the category, and a dated what-changed line beats the field.
+
+---
+
+## Google reviews-system alignment
+
+The guidance asks for demonstrated first-hand experience OR demonstrable original research and analysis. The second branch is this skill's lane, and "original analysis" means concrete work product:
+
+- The synthesis itself: owner-experience patterns no single source contains
+- Comparative tables built from verified data, structured around the stated criteria
+- Decision frameworks: who each pick fits and who it does not
+- What paraphrased spec sheets are not: rearranging a manufacturer's bullet points is neither experience nor analysis, and ranks accordingly
+
+A site that does tier 2 and 3 work honestly is doing original analysis by the guidance's own definition. The methodology block is how the work shows.
+
+---
+
+## FTC alignment
+
+Affiliate relationships are disclosed in plain language, placed where the recommendation is, not in a footer. The disclosure travels with the monetized content: near the picks, in body-size text, before or beside the first affiliate link a reader can act on. "Plain language" means a reader who has never heard the word affiliate understands that the site earns a commission and that the price they pay does not change. Euphemisms ("partner links," "support the site") fail the plain-language test.
+
+---
+
+## Schema judgment
+
+Markup is a claim. Apply the same honesty to structured data as to prose:
+
+- **Review and Product markup** only when the piece's claims support what the markup asserts. Review markup asserts an evaluative review of an item the reviewer assessed; a tier 1-to-3 buying guide asserting hands-on style review markup is making a machine-readable version of the banned claim.
+- **Buying guides without hands-on** use guide-shaped markup: ItemList for the picks, Article for the piece.
+- When tier 4 is real and stated, Review markup becomes honest; add it then, per piece, not as a template default.
+
+---
+
+## Workflow
+
+1. **Inventory the evidence honestly.** What tiers are actually available for this category? What hands-on exists, if any?
+2. **Set the criteria first.** Ordered, before any product is examined, so the criteria cannot quietly bend toward a favored pick.
+3. **Gather per tier.** Verify specs at the source. Pull owner corpora at scale and note sample sizes. Collect named expert sources, including the disagreements.
+4. **Synthesize.** Findings per criterion, drawbacks per pick, splits surfaced.
+5. **Write the methodology block** from what was actually done, not from what sounds good.
+6. **Match the markup to the claims.** ItemList and Article by default; Review only where tier 4 is true.
+7. **Maintain.** Date updates, state what changed, upgrade pieces when hands-on arrives, and mark the upgrade.
+
+---
+
+## Failure patterns
+
+- **"We tested" inflation.** The anchor-rule violation. It is also unnecessary: honest synthesis outperforms fake testing once readers compare the work.
+- **Aggregator specs.** Spec tables copied from other reviews, drift included. Verify at the maker's page or do not publish the number.
+- **Anecdote dressed as synthesis.** Three forum posts is not owner experience at scale. State the sample or downgrade the claim.
+- **Averaged experts.** Splitting the difference between conflicting expert verdicts erases the most useful information: that credible testers disagree, and why.
+- **The drawback-free pick.** A recommendation with no named drawback reads as advertising because it is structured like advertising.
+- **Backfilled hands-on.** Quietly rewriting an old synthesis piece as if it had been tested all along. The upgrade-and-mark pattern exists so this never has to happen.
+- **Footer disclosure.** An affiliate disclosure the reader has to hunt for fails both the FTC's placement expectations and the trust purpose it exists to serve.
+- **Schema overreach.** Review markup on synthesis content. The piece's prose is honest and its markup lies.
+
+---
+
+## Output format
+
+For a methodology setup: a short methodology standard the site adopts (the tiers, the block template filled with the site's sources, the schema policy), suitable for docs or an editorial guide.
+
+For a piece-level engagement: the methodology block for that piece, the criteria list, the evidence file (sources gathered per tier with sample sizes), and the claims audit if the piece existed before this skill did.
+
+---
+
+## Reference files
+
+- [`references/evidence-tiers.md`](references/evidence-tiers.md) - The four tiers in depth: verification steps, synthesis honesty, triangulation practice, and the upgrade-and-mark pattern.
+- [`references/methodology-block-template.md`](references/methodology-block-template.md) - The fillable per-piece disclosure block, a worked example, and placement rules.

--- a/skills/evidence-based-reviews/references/evidence-tiers.md
+++ b/skills/evidence-based-reviews/references/evidence-tiers.md
@@ -1,0 +1,46 @@
+# The four evidence tiers, in depth
+
+The tiers are not a ladder of prestige; they are different kinds of knowledge with different verification work and different claims they can support. A strong piece usually combines two or three, and says which.
+
+## Tier 1: verified manufacturer specs
+
+**The verification step.** Cite the specification to the manufacturer's own current product page. Aggregators, retailer listings, and other reviews drift: units get converted wrong, superseded model years linger, and one site's typo becomes the category's consensus number. When the manufacturer's page and a retailer listing disagree, note the discrepancy in the piece; the disagreement is information.
+
+**Date the pull.** Specs change across model years. A spec table that says when its numbers were verified survives the next revision; one that does not becomes silently wrong.
+
+**What tier 1 supports:** factual comparison (weights, dimensions, capacities, materials), compatibility and fit answers, price-tier groupings. **What it cannot support:** any quality verdict. A spec sheet cannot tell you the thing rattles.
+
+## Tier 2: owner-experience synthesis at scale
+
+The workhorse tier for review work without hands-on access, and the one most often done dishonestly. The honest version:
+
+**Scale and candor.** Read across sources: retailer review corpora, owner forums, warranty and return discussions. State the scale in the piece ("across roughly 1,400 retailer reviews and two seasons of forum threads"). If the sample is small, say so and weaken the claim to match.
+
+**Recurrence over volume.** The finding is the pattern that recurs across independent sources, not the most dramatic single report. One catastrophic failure post is an anecdote; the same failure described by unrelated owners across two sites is a finding.
+
+**Splits are findings.** When owners divide (half love the trigger, half send it back), the split is the most useful thing the piece can report, usually with the variable that explains it (hand size, draw weight, use case).
+
+**No cherry-picking.** Deciding the verdict first and quoting only supporting owners is fabrication with extra steps. The synthesis is written from the pattern, not toward a pick.
+
+**Name the corpora.** Which retailers, which communities, what period. This is what makes the synthesis auditable and what makes it original analysis rather than vibes.
+
+## Tier 3: expert-source triangulation
+
+**Named sources only.** "Experts agree" without names is decoration. Name the publication or tester, and link where possible.
+
+**Triangulate, never average.** Three credible sources agreeing is strong signal; two credible sources disagreeing is stronger content. Surface the disagreement and look for the condition that explains it: different test protocols, different units, different use assumptions. Averaging opposite verdicts into "mixed reviews" throws away exactly what the reader came for.
+
+**Independence check.** Three reviews that all trace to the same press kit are one source wearing three hats.
+
+## Tier 4: hands-on, only when true
+
+**Quantify the experience.** "We shot it" hides more than it tells. The honest form states extent and conditions: how many arrows or hours or miles, over what period, in what setting, with what comparison points. The quantification is what separates a real claim from a vibe.
+
+**Flag it.** On a site where synthesis is the norm, hands-on time is the exception worth marking. Flagging it does double duty: it strengthens the piece that has it and keeps every other piece honest by contrast.
+
+**The upgrade-and-mark pattern.** When hands-on experience arrives for a piece originally published on tiers 1 to 3:
+
+1. Update the piece with the hands-on findings.
+2. Update the methodology block: the hands-on line changes from "none claimed" to the quantified statement.
+3. Mark the update with the date and what changed ("Updated [date]: added hands-on findings after six weeks with the production unit; the durability verdict held, the comfort note changed").
+4. Never rewrite history. The piece does not pretend it was always hands-on; the visible upgrade is itself evidence the site's claims mean something.

--- a/skills/evidence-based-reviews/references/methodology-block-template.md
+++ b/skills/evidence-based-reviews/references/methodology-block-template.md
@@ -1,0 +1,33 @@
+# The methodology block: template, example, placement
+
+The per-piece disclosure block. Short, placed with the criteria, written for readers. It names what the piece's verdicts rest on, and it never claims a tier the piece did not use.
+
+## The template
+
+> **How we reviewed this**
+> **Criteria:** [the 3 to 5 criteria, in the order they were weighted, stated before the picks].
+> **Evidence:** [the tiers actually used, specifically: verified manufacturer specs (noting where and when); owner-experience synthesis at scale (name the corpora and the rough sample size); expert-source triangulation (name the sources)].
+> **Hands-on:** [what was physically done, quantified, or the words "none claimed for this piece"].
+> **Updated:** [date]: [what changed and why].
+
+## A worked example (generic category)
+
+> **How we reviewed this**
+> **Criteria:** noise under load, durability across a season, build quality, price against the field, in that order.
+> **Evidence:** manufacturer specs verified against each maker's current product page (May 2026); owner-experience synthesis across roughly 1,400 retailer reviews and two seasons of forum threads from three owner communities; expert triangulation across two named publications, whose durability verdicts disagreed (the disagreement and the likely cause are discussed under pick 2).
+> **Hands-on:** none claimed for this piece.
+> **Updated:** June 2026: replaced the budget pick after recurring owner reports of a failed adjustment mechanism; previous pick moved to the skip-it section with the evidence.
+
+## Placement rules
+
+- The block sits with the criteria, before or immediately after the picks summary, never below the fold of a long piece and never in a footer.
+- Body-size text. A disclosure styled to be skipped is a disclosure in name only.
+- The hands-on line is mandatory even when the answer is "none claimed." The absence stated plainly is the trust mechanism; the absence omitted is the lie of implication.
+- The affiliate disclosure is a sibling, not a substitute: it travels with the recommendation per FTC expectations and says in plain language that the site earns a commission and that the reader's price does not change. The methodology block discloses the evidence; the affiliate block discloses the money. A piece with affiliate links carries both.
+
+## Anti-patterns
+
+- A block that lists every tier the site has ever used instead of the tiers this piece used.
+- "Extensive research" as the evidence line. Name the corpora or do not claim the scale.
+- A block written in legal register. The reader should finish it trusting the piece more, not feeling warned.
+- The block as template default with fields unfilled. An unfilled block is a claim generator; every line must be true per piece.


### PR DESCRIPTION
A generic, public method for honest product reviews and buying guides without fabricated first-hand experience. Content category, display_order 13.

## The skill
- The anchor rule: never claim hands-on time that did not happen. Everything else makes honest content strong enough that the lie is unnecessary.
- Four evidence tiers with the work each requires: verified manufacturer specs (cited to the maker's page with the verification step, not aggregator copies), owner-experience synthesis at scale (recurrence over volume, sample-size candor, splits as findings, no cherry-picking), expert triangulation (named sources, disagreements surfaced not averaged), and hands-on only when true with the upgrade-and-mark pattern (never backfilled).
- The per-piece methodology block: placed with the criteria, written for readers, with the mandatory hands-on line even when the answer is none claimed.
- Structure discipline: criteria before picks, a named drawback per pick, dated what-changed updates.
- Google reviews-system alignment: what demonstrable original analysis concretely means (the synthesis, comparative tables from verified data, decision frameworks; not paraphrased spec sheets).
- FTC alignment: plain-language disclosure traveling with the recommendation, never footer-buried.
- Schema judgment: markup is a claim; ItemList and Article for synthesis guides, Review only when tier 4 is true, per piece.
- Two reference files: the tiers in depth, and the fillable methodology block with a worked example and placement rules.

## Catalog discipline
- Structure matches the exemplars (content-and-copy, seo-onpage): same frontmatter shape, section order, when-not-to-use convention. Every when-not-to-use name resolves to a real skill (content-and-copy, brand-voice, seo-onpage, content-brief-authoring).
- Description: 910 characters, under the 1024 platform-port cap.
- README catalog regenerated via scripts/generate_readme_catalog.py --write (103 skills, 448 reference files; all counts derived, never hardcoded); the --check sync gate passes.
- SKILLS.lock regenerated via tools/gen_skills_lock.py; the lock diff is exactly the new skill's five-line entry and the local --check passes. CORRECTION: the first version of this PR body flagged gen_skills_lock.py and SKILLS.lock as missing from the repo; that was wrong (the check ran against a stale local main checkout before branching). A Windows hashing nuance surfaced while fixing it: the tool hashes raw bytes, so the lock must be generated from LF working files; this machine's checkout now uses repo-local core.autocrlf=false to keep regeneration CI-parity.
- Em-dash grep across the skill folder: zero. Generic method throughout; no Bowhunt America, RampStack-brand, or vertical specifics.
- Diff scoped to skills/evidence-based-reviews/, SKILLS.lock, and the generated README sections.

Held for Andy's squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)