### PR TITLE
fix(readme): count nested reference files (448 to 490)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ What you get:
 
 <!-- COUNT_WHATYOUGET:START -->
 - **103 skills** across 16 categories, every one with a complete `SKILL.md` and at least one reference file
-- **448 reference files** (templates, checklists, decision matrices, worked examples)
+- **490 reference files** (templates, checklists, decision matrices, worked examples)
 <!-- COUNT_WHATYOUGET:END -->
 - **Stack-agnostic.** Works on any web stack. The only named-tool exception is the SEO audit suite, which assumes the Ahrefs MCP.
 - **Future-proof.** Principles over tools. Stable concepts over trending techniques. References to durable specs (W3C, WHATWG, Schema.org, MDN, NN/g, WCAG) over content that ages with each algorithm update.

--- a/scripts/generate_readme_catalog.py
+++ b/scripts/generate_readme_catalog.py
@@ -273,7 +273,12 @@ def group_by_category(skills: list[Skill]) -> dict[str, list[Skill]]:
 
 
 def count_reference_files() -> int:
-    """Count files under any skills/*/references/ directory."""
+    """Count files under any skills/*/references/ directory, at any depth.
+
+    Recurses into nested reference subdirectories (for example
+    references/by-vertical/) so every shipped reference file is counted,
+    including the ones below the top level of references/.
+    """
     total = 0
     for entry in sorted(SKILLS_DIR.iterdir()):
         if not entry.is_dir():
@@ -281,7 +286,7 @@ def count_reference_files() -> int:
         ref_dir = entry / "references"
         if not ref_dir.exists():
             continue
-        for ref in ref_dir.iterdir():
+        for ref in ref_dir.rglob("*"):
             if ref.is_file():
                 total += 1
     return total
@@ -512,7 +517,9 @@ def main() -> int:
         )
         return 2
 
-    README.write_text(updated, encoding="utf-8")
+    # Write LF newlines explicitly so --write does not flip the file to
+    # CRLF on Windows, which would churn every line in the diff.
+    README.write_text(updated, encoding="utf-8", newline="\n")
     ref_total = count_reference_files()
     print(
         f"Updated {len(MARKERS)} sections in README.md, "


### PR DESCRIPTION
## Reference-file count: fix the generator to recurse (448 to 490)

Held draft for squash-merge. PR B of the public-surface audit; the site copy fixes ship separately on `rampstack/rampstackco-app` (PR #230).

### What was wrong
The README's "reference files" count is generated by `scripts/generate_readme_catalog.py`. `count_reference_files()` walked only the top level of each `skills/*/references/` directory (`iterdir`), so it skipped 42 real reference files living in nested subdirectories (`brand-archetype-system/references/by-vertical/*.md` and similar). The README was self-consistent with its generator (`--check` passed at 448), but the generator undercounted.

### The fix (number comes from the generator, not a hand-edit)
- `count_reference_files()` now recurses with `rglob("*")`, counting every reference file under each `references/` tree. The trees hold only `.md` files (zero non-reference assets at any depth), so the recursive walk counts genuine references only.
- Regenerated the README with `--write`: **448 to 490**.
- `--write` now writes explicit LF newlines. Without that, the generator flipped the LF README to CRLF on Windows and churned every line; with it, the diff is the single count line.

### Same-bug check on the other counts
A `SKILL.md` only ever lives at the top of a skill folder (`find skills -mindepth 3 -name SKILL.md` is 0), so `load_skills` (top-level `iterdir`) and `group_by_category` have no equivalent recursion gap. **103 skills** and the per-track sums are unchanged and correct; they were checked, not assumed.

### Before and after
| Count | Before | After |
|---|---|---|
| Reference files | 448 | 490 |
| Skills | 103 | 103 (unchanged) |
| Per-track sums | correct | correct (unchanged) |

### Verification
- `generate_readme_catalog.py --check`: passes at 490 (generator and README agree).
- README diff is the single count line; line endings stay LF.
- No other catalog content changed. No em-dashes, en-dashes, or banned phrases in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
