### PR TITLE
fix(evidence-based-reviews): yield to teaching skills for instructional how-tos

### DIFF
--- a/SKILLS.lock
+++ b/SKILLS.lock
@@ -346,7 +346,7 @@
     "references/subject-line-patterns.md": "ccb7daafdea47a5dfc632cab458b319a5ded21fc499a74da2aa305ed1a7c01d5"
   },
   "evidence-based-reviews": {
-    "SKILL.md": "26d1f567153d92601d58749afed86b03905db703f88b393c1c09b03dbae7465e",
+    "SKILL.md": "44bd22df772d09e8f8fc98cbb3355ff398c5d38c1cb066b709f67391211857ae",
     "references/evidence-tiers.md": "fee3b0f7ec78ad8cf9f0f15325679972db4180eafdd3419b257e92b98bfe4fda",
     "references/methodology-block-template.md": "74ec061cf5befb94a4db24479df918f1ed8c1dfa35721daaf3476a64e4082ef4"
   },

--- a/skills/evidence-based-reviews/SKILL.md
+++ b/skills/evidence-based-reviews/SKILL.md
@@ -29,6 +29,7 @@ Most review sites fail this rule quietly. "We tested" appears above content asse
 - Defining how the brand sounds (use `brand-voice`)
 - Optimizing the review page itself for search (use `seo-onpage`)
 - Per-piece editorial briefs (use `content-brief-authoring`)
+- Instructional how-to content that teaches a procedure or concept to a first-time reader, such as a tutorial or an explainer: a teaching piece of this kind is owned by its writing, its structure, and its search craft, with the evidence discipline riding alongside as a constraint on its claims, so this skill is one input among several rather than the single choice for it
 
 If genuine hands-on testing at scale exists, with instrumentation and protocols, this skill still applies: the tiers do not change, the methodology block simply states tier 4 and the testing protocol becomes the disclosed basis.
 


### PR DESCRIPTION
## What and why

For an instructional how-to (for example "how to measure your draw length"), the substrate selected only `evidence-based-reviews` and cleared `content-and-copy`, `brand-voice`, `seo-onpage`, and `content-brief-authoring`. That is correct for a product review or buying guide, where this skill owns the piece. It is too wide for a how-to, which teaches a procedure and needs the brief, the voice, and the on-page work running alongside the evidence discipline. This is a scope correction: the boundary was drawn wider than what the skill actually owns.

## What changed

One bullet added to the skill's "When NOT to use": instructional how-to content is declared not this skill's to own. `SKILLS.lock` updated for the new SKILL.md hash only. No skills added or removed; catalog count unchanged.

## Why this is the edit the engine actually reads

The substrate's de-confliction (`tholo-engine-app` `src/select/select.ts`) keys off backtick skill refs in `whenNotToUse`, and it skips a winning skill's drops when that winner's own boundary fired on the task (a flagged skill is the catalog saying it may be the wrong fit). Reworded prose scoping alone is invisible to the engine. The new bullet is rich in how-to vocabulary (instructional, teaches, tutorial, explainer) and free of product-review vocabulary, so:

- on a how-to goal it trips this skill's boundary, the four drops are skipped, and the teaching skills survive alongside it;
- on a review goal it stays quiet, the drops fire, and this skill stays the single winner.

## Caveat

The boundary heuristic is a two-shared-token cluster, so the review-versus-how-to separation is approximate and rests on vocabulary overlap, not goal type. A review goal that explicitly names brand voice or briefs could still trip it. A goal-type-aware de-confliction in the engine would be the cleaner long-term fix; this scope correction is the catalog-side half.

Held draft. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)