### PR TITLE
feat(workflows): launch forward-deployed workflows tier, wave one

### DIFF
--- a/.github/workflows/workflows-manifest.yml
+++ b/.github/workflows/workflows-manifest.yml
@@ -1,0 +1,56 @@
+name: Workflows manifest
+
+on:
+  pull_request:
+    paths:
+      - "workflows/**"
+      - "SKILLS.lock"
+      - "tools/gen_workflows_lock.py"
+      - "tools/check_workflow_drift.py"
+      - ".github/workflows/workflows-manifest.yml"
+
+jobs:
+  verify-lock:
+    name: WORKFLOWS.lock is current
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Verify WORKFLOWS.lock
+        run: python tools/gen_workflows_lock.py --check
+
+  drift-check:
+    name: Bound skills exist in SKILLS.lock
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Check workflow-to-catalog drift
+        run: python tools/check_workflow_drift.py
+
+  fence-test:
+    name: SKILLS.lock untouched by the workflows tier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Assert the fence
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          touches_workflows=$(git diff --name-only "$BASE_SHA" HEAD -- \
+            workflows/ tools/gen_workflows_lock.py tools/check_workflow_drift.py)
+          skills_lock_changed=$(git diff --name-only "$BASE_SHA" HEAD -- SKILLS.lock)
+          if [ -n "$touches_workflows" ] && [ -n "$skills_lock_changed" ]; then
+            echo "FENCE BREACH: this PR changes both the workflows tier and SKILLS.lock."
+            echo "The workflows tier lives outside the skills source tree and must not"
+            echo "perturb the skills manifest. Split the skill change into its own PR."
+            git diff --stat "$BASE_SHA" HEAD -- SKILLS.lock
+            exit 1
+          fi
+          echo "Fence holds: SKILLS.lock is byte-identical to base for this workflows-tier PR."

--- a/WORKFLOWS.lock
+++ b/WORKFLOWS.lock
@@ -1,0 +1,27 @@
+{
+  "content-pipeline-prove-gates": {
+    "file": "content-pipeline-prove-gates.md",
+    "sha256": "e0c6569472fb2dad5a385f4ccf7816d292f204fc787ad0d4c909538dff692557",
+    "status": "template"
+  },
+  "conversion-by-source-diagnosis": {
+    "file": "conversion-by-source-diagnosis.md",
+    "sha256": "56c2965d1612f152365fac22fae68b41d0e8f9a7c2016fbaaaf95d2e1c8e9908",
+    "status": "template"
+  },
+  "corpus-integrity-and-correction": {
+    "file": "corpus-integrity-and-correction.md",
+    "sha256": "8073203de6c8e46126ec2c82bcb2d0d734456a5ff5370af34bb35919765ecc9f",
+    "status": "template"
+  },
+  "post-deploy-live-verification": {
+    "file": "post-deploy-live-verification.md",
+    "sha256": "944d20aa8740eb54f12fba5457b3f897b4f66cbed7a20e09dc89341e11bea90c",
+    "status": "template"
+  },
+  "traffic-drop-triage": {
+    "file": "traffic-drop-triage.md",
+    "sha256": "2f00f2c4f2d08e0df0699d057b5061300254a2adb0b9f7344eee2d9cf5cf8569",
+    "status": "template"
+  }
+}

--- a/WORKFLOWS.lock
+++ b/WORKFLOWS.lock
@@ -11,7 +11,7 @@
   },
   "corpus-integrity-and-correction": {
     "file": "corpus-integrity-and-correction.md",
-    "sha256": "8073203de6c8e46126ec2c82bcb2d0d734456a5ff5370af34bb35919765ecc9f",
+    "sha256": "f700641957273b279a9656b5bb5b4675bfddc1a6db2759abea8fff4607e15832",
     "status": "template"
   },
   "post-deploy-live-verification": {

--- a/tools/check_workflow_drift.py
+++ b/tools/check_workflow_drift.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Drift check: every skill slug a workflow binds must exist in SKILLS.lock.
+
+The authoring contract binds skills by SLUG on each phase's `Skills:` line
+(the Run block then invokes those same slugs in prose). This check reads those
+lines, extracts the bound slugs, and asserts each is a real skill in
+SKILLS.lock. It is the operate-time twin of the catalog's authoring-time
+verification: a workflow that names a skill the catalog does not have would
+silently fail to run, so the reference is caught here instead.
+
+Two bare words appear on `Skills:` lines as authoring markers rather than
+slugs: `none` (a phase that is deliberately a human judgment stop) and
+`routing` (a phase that routes to other workflows). They are listed explicitly
+so a genuine typo is still caught rather than waved through.
+
+Usage:
+  python tools/check_workflow_drift.py     # exit 1 on any unknown slug
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = ROOT / "workflows"
+LOCK_PATH = ROOT / "SKILLS.lock"
+
+SKILLS_LINE = re.compile(r"^Skills:\s*(.*)$", re.MULTILINE)
+SLUG_SHAPE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# Bare words used on Skills: lines as authoring markers, not skill slugs.
+NON_SKILL_MARKERS = {"none", "routing"}
+
+
+def bound_slugs(text: str):
+    """Yield the skill slugs a workflow file binds on its Skills: lines."""
+    for m in SKILLS_LINE.finditer(text):
+        value = m.group(1)
+        # The slug list ends at the first parenthetical note or semicolon.
+        for cut in ("(", ";"):
+            idx = value.find(cut)
+            if idx != -1:
+                value = value[:idx]
+        for token in value.split(","):
+            token = token.strip()
+            if not token or " " in token:
+                continue
+            yield token
+
+
+def main() -> int:
+    if not LOCK_PATH.exists():
+        print("SKILLS.lock is missing; cannot run the drift check.")
+        return 1
+    known = set(json.loads(LOCK_PATH.read_text(encoding="utf-8")).keys())
+
+    checked = set()
+    unknown = []
+    for path in sorted(WORKFLOWS_DIR.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        for token in bound_slugs(text):
+            if token in NON_SKILL_MARKERS:
+                continue
+            if not SLUG_SHAPE.match(token):
+                unknown.append((path.name, token, "not slug-shaped"))
+                continue
+            checked.add(token)
+            if token not in known:
+                unknown.append((path.name, token, "not in SKILLS.lock"))
+
+    print(f"Checked {len(checked)} distinct slugs against SKILLS.lock:")
+    for slug in sorted(checked):
+        print(f"  {slug}")
+    if unknown:
+        print("\nDRIFT:")
+        for name, token, why in unknown:
+            print(f"  {name}: '{token}' {why}")
+        return 1
+    print("\nNo drift: every bound slug exists in SKILLS.lock.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gen_workflows_lock.py
+++ b/tools/gen_workflows_lock.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Generate or verify WORKFLOWS.lock, the canonical manifest of workflow files.
+
+A workflow file is any Markdown file in workflows/ whose opening fenced block
+declares both a slug and a status. The tier docs (README.md, CONNECTORS.md,
+AGREEMENT-LOG.md) have no such block and are skipped. WORKFLOWS.lock is the
+count source for the tier; no count is hand-typed anywhere.
+
+Usage:
+  python tools/gen_workflows_lock.py           # write WORKFLOWS.lock
+  python tools/gen_workflows_lock.py --check    # verify, exit 1 on drift
+"""
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = ROOT / "workflows"
+LOCK_PATH = ROOT / "WORKFLOWS.lock"
+
+FENCE = re.compile(r"```(.*?)```", re.DOTALL)
+SLUG = re.compile(r"^slug:\s*(\S+)\s*$", re.MULTILINE)
+STATUS = re.compile(r"^status:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def parse_workflow(path: Path):
+    """Return (slug, status) if the file is a workflow, else None."""
+    text = path.read_text(encoding="utf-8")
+    fence = FENCE.search(text)
+    if not fence:
+        return None
+    block = fence.group(1)
+    slug = SLUG.search(block)
+    status = STATUS.search(block)
+    if not slug or not status:
+        return None
+    return slug.group(1), status.group(1)
+
+
+def build_manifest() -> dict:
+    manifest = {}
+    for path in sorted(WORKFLOWS_DIR.glob("*.md")):
+        parsed = parse_workflow(path)
+        if parsed is None:
+            continue
+        slug, status = parsed
+        if slug != path.stem:
+            raise SystemExit(
+                f"{path.name}: declared slug '{slug}' does not match filename stem "
+                f"'{path.stem}'. Fix one so the manifest key is unambiguous."
+            )
+        manifest[slug] = {
+            "file": path.name,
+            "sha256": sha256(path.read_bytes()),
+            "status": status,
+        }
+    return manifest
+
+
+def main() -> int:
+    manifest = build_manifest()
+    serialized = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    # Compare and write as bytes with LF newlines so the lock is byte-stable
+    # across platforms; text mode on Windows would emit CRLF and break --check
+    # on a Linux runner.
+    payload = serialized.encode("utf-8")
+    if "--check" in sys.argv:
+        if not LOCK_PATH.exists():
+            print("WORKFLOWS.lock is missing. Run tools/gen_workflows_lock.py.")
+            return 1
+        if LOCK_PATH.read_bytes() != payload:
+            print("WORKFLOWS.lock is out of date. Regenerate and commit it.")
+            return 1
+        print(f"WORKFLOWS.lock is current ({len(manifest)} workflows).")
+        return 0
+    LOCK_PATH.write_bytes(payload)
+    print(f"Wrote WORKFLOWS.lock with {len(manifest)} workflows.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/AGREEMENT-LOG.md
+++ b/workflows/AGREEMENT-LOG.md
@@ -44,10 +44,12 @@ Retained from 0007 as-is:
 | Field | Type | Meaning |
 |---|---|---|
 | agreement | enum: true_pass, false_pass, true_fail, false_fail | the four-way agreement value, authored (see below), never derived from the verdict pair |
+| lane | text, not null | the autonomy lane, e.g. content_roadmap. Per-lane agreement rates are the unit the promotion thresholds apply to; without lane, false-pass-among-passes cannot be computed per lane |
 | risk_tier | text | the risk classification; per-tier thresholds govern promotion, and Tier 3 is permanently excluded |
 | guardrail_confidence | numeric, nullable | the graded score; null for purely deterministic checks. The confidence-cutoff promotion for graded lanes is impossible without it |
 | guardrail_checks | jsonb | which checks fired and their results, and the pointer to the proposal |
 | human_verdict | enum: merge, reject, revise (+ waive, added below) | what happened to the work; a separate axis from agreement, and neither maps from the other |
+| human_reason | text | the rationale, filled after human review; required on revise and waive in this tier |
 | proposal_to_merge_diff | jsonb | the proposal-to-merge diff or a pointer to it; the primary correction signal, and the cold-start recovery reads merged-versus-rejected diffs |
 | post_merge_outcome | text | null at merge, filled later by continuous verification; the second ground truth that demotion and the hardened rung read |
 
@@ -59,14 +61,13 @@ Added for this tier:
 | workflow_slug | text | which workflow produced the proposal |
 | phase | text | which phase of that workflow |
 | artifact_ref | text | pointer to the held artifact the row is about |
-| human_note | text, required on waive and revise | the rationale; generalizes 0007's `human_reason`, and carries whether a gate was too strict or a risk was knowingly accepted |
 | waive | value on human_verdict | a fourth human verdict alongside merge, reject, revise |
 
 ## Agreement is authored, never derived
 
 Agreement is AUTHORED by the human who saw the diff, never derived from the verdict pair. A guardrail pass that a human overrides to revise is a false_pass, and no naive rule produces that mapping; the human writes it. The verdict axis (what happened to the work) and the agreement axis (whether the guardrail was right) are independent, and neither is computed from the other.
 
-Waive rows carry an authored agreement value plus a required `human_note`, are excluded from false-pass and false-fail rate computations, and report as their own line in Autonomy Review. Waives stay visible without contaminating the promotion thresholds: a gate waived because it was too strict, and a risk waived because it was knowingly accepted, are both recorded and both kept out of the rates that earn a lane its autonomy.
+Waive rows carry an authored agreement value plus a required `human_reason`, are excluded from false-pass and false-fail rate computations, and report as their own line in Autonomy Review. Waives stay visible without contaminating the promotion thresholds: a gate waived because it was too strict, and a risk waived because it was knowingly accepted, are both recorded and both kept out of the rates that earn a lane its autonomy.
 
 ## The designation guard
 

--- a/workflows/AGREEMENT-LOG.md
+++ b/workflows/AGREEMENT-LOG.md
@@ -1,0 +1,81 @@
+# Agreement log: the schema spec
+
+The agreement log records what an engine proposed, what its guardrail said, what a human decided, and whether the two agreed. It is the substrate the autonomy doctrine reads: agreement rates per lane earn a gate class its auto-pass, and post-merge regressions revoke it. Autonomy Review reads this log; Incident Response and Lane Demotion reads its `post_merge_outcome`; nothing else mutates it.
+
+This file is the public schema, generalized from the krine agreement-rate table (migration 0007). The schema is what you get. The instance, its write path, the designation allowlist, and every promotion decision are operated, not published. A reader who implements this schema gets their own log; they do not get ours.
+
+The agreement log has no connector class, by design. It is operated substrate, not a connectable capability (see CONNECTORS.md). Workflow files that touch it split their done-when conditions into a public gate and an operated-log note, so a stranger running the workflow never depends on infrastructure that is not published.
+
+## Reference schema (migration 0007, quoted with types)
+
+The canonical source is the krine agreement-rate migration. Its columns and types, quoted as the reference:
+
+```sql
+create type human_verdict_kind as enum ('merge', 'reject', 'revise');
+create type agreement_kind as enum ('true_pass', 'false_pass', 'true_fail', 'false_fail');
+
+create table agreements (
+  id                    uuid primary key default gen_random_uuid(),
+  project_id            uuid references projects(id) on delete cascade,
+  decision_id           text not null,
+  pr_id                 text,
+  lane                  text not null,
+  risk_tier             text not null,
+  agent_id              text not null,
+  guardrail_verdict     text not null,        -- pass or fail
+  guardrail_confidence  numeric,              -- graded score; null for deterministic checks
+  guardrail_checks      jsonb,                -- which checks fired and their results, plus the proposal pointer
+  human_verdict         human_verdict_kind,   -- merge | reject | revise; filled after human review
+  human_reason          text,                 -- the rationale; filled after human review
+  proposal_to_merge_diff jsonb,               -- the proposal-to-merge diff or a pointer; filled after merge
+  human_review_latency  numeric,              -- seconds from PR open to human verdict
+  agreement             agreement_kind,       -- authored after human review
+  post_merge_outcome    text,                 -- null at merge, filled later by continuous verification
+  created_at            timestamptz not null default now()
+);
+```
+
+## The public spec
+
+The public schema carries the fields a reader implementing this tier needs. It converges with the reference above rather than restating it from memory.
+
+Retained from 0007 as-is:
+
+| Field | Type | Meaning |
+|---|---|---|
+| agreement | enum: true_pass, false_pass, true_fail, false_fail | the four-way agreement value, authored (see below), never derived from the verdict pair |
+| risk_tier | text | the risk classification; per-tier thresholds govern promotion, and Tier 3 is permanently excluded |
+| guardrail_confidence | numeric, nullable | the graded score; null for purely deterministic checks. The confidence-cutoff promotion for graded lanes is impossible without it |
+| guardrail_checks | jsonb | which checks fired and their results, and the pointer to the proposal |
+| human_verdict | enum: merge, reject, revise (+ waive, added below) | what happened to the work; a separate axis from agreement, and neither maps from the other |
+| proposal_to_merge_diff | jsonb | the proposal-to-merge diff or a pointer to it; the primary correction signal, and the cold-start recovery reads merged-versus-rejected diffs |
+| post_merge_outcome | text | null at merge, filled later by continuous verification; the second ground truth that demotion and the hardened rung read |
+
+Added for this tier:
+
+| Field | Type | Meaning |
+|---|---|---|
+| property | text, designation-guarded | the showcase property the row belongs to; the publish path enforces the allowlist against it |
+| workflow_slug | text | which workflow produced the proposal |
+| phase | text | which phase of that workflow |
+| artifact_ref | text | pointer to the held artifact the row is about |
+| human_note | text, required on waive and revise | the rationale; generalizes 0007's `human_reason`, and carries whether a gate was too strict or a risk was knowingly accepted |
+| waive | value on human_verdict | a fourth human verdict alongside merge, reject, revise |
+
+## Agreement is authored, never derived
+
+Agreement is AUTHORED by the human who saw the diff, never derived from the verdict pair. A guardrail pass that a human overrides to revise is a false_pass, and no naive rule produces that mapping; the human writes it. The verdict axis (what happened to the work) and the agreement axis (whether the guardrail was right) are independent, and neither is computed from the other.
+
+Waive rows carry an authored agreement value plus a required `human_note`, are excluded from false-pass and false-fail rate computations, and report as their own line in Autonomy Review. Waives stay visible without contaminating the promotion thresholds: a gate waived because it was too strict, and a risk waived because it was knowingly accepted, are both recorded and both kept out of the rates that earn a lane its autonomy.
+
+## The designation guard
+
+The publish path refuses any public row whose `property` is not on the maintained showcase allowlist. The guard sits at the write boundary, not only in authoring convention: a row for a non-designated property can never become public output, and its property name can never appear in published material. The allowlist is data, maintained in one place, not a per-row judgment.
+
+## Open versus operated
+
+The schema is public. The instance, the write path, the allowlist, and every promotion decision are operated. A reader who implements this schema gets their own log; they do not get ours. Forking the repo yields the gates and this spec, and a reader's own log if they build one; it does not yield RampStack's rows.
+
+## Storage
+
+One append-only table in an operational Postgres store. Autonomy Review reads it, Incident Response and Lane Demotion reads `post_merge_outcome`, and nothing else mutates it. Do not add a second table until there is a second writer.

--- a/workflows/CONNECTORS.md
+++ b/workflows/CONNECTORS.md
@@ -1,0 +1,23 @@
+# Connector capability classes
+
+Workflows in this tier declare the data access they need as capability CLASSES, never vendors. Your MCP server or integration binds the class; the workflow stays valid when your stack changes.
+
+Rules, in force across every workflow:
+- Read-only is the default. The only write mode is write-held: the action creates a draft or a held change that a human promotes. Publishing, merging, and platform actions are never agent actions under template status.
+- Every warehouse capability carries mandatory query bounds: a date range pushed down as a partition filter on every call. A call without bounds is rejected, not silently run.
+- Credentials live in environment, never in workflow files, tool output, or error messages.
+
+| Class | Access | What it serves | Binding today |
+|---|---|---|---|
+| warehouse.query | read | the metric warehouse all tracks read | managed warehouse MCP servers exist for the major warehouses; a thin domain layer encoding your query-correctness rules remains yours to build |
+| search-performance.read | read | search console class data | the bulk export lands this in the warehouse natively; direct-API access is a thin layer to build |
+| analytics.read | read | product/web analytics events | an official analytics MCP exists for the common stack; native warehouse export is the reference path |
+| cms.draft | write-held | content pipeline drafts | your CMS's draft state via its API; no universal server, a small adapter |
+| repo.change | write-held | code and config changes as held draft PRs | native to the code host |
+| crawl.read | read | live-page fetches for verification gates | plain HTTPS; no server needed |
+| experiment.read | read | experiment results and assignments | per-vendor adapter |
+| revenue.read | read | commerce/affiliate revenue events, reconciled against the warehouse | per-platform adapter |
+
+Deliberate absences: there is no index-submit class and no analytics-config-write class. Submitting sitemaps, requesting indexing, and changing analytics settings are state-changing human actions.
+
+The agreement log has NO connector class, deliberately. It is operated substrate, not a connectable capability: the schema is public (AGREEMENT-LOG.md), the instance and its write path are not. Workflow files that touch it carry a public-gate versus operated-log split in their done-when conditions.

--- a/workflows/GETTING-STARTED.md
+++ b/workflows/GETTING-STARTED.md
@@ -1,0 +1,12 @@
+# Running a workflow
+
+Each workflow in this directory is a runnable procedure, not an essay. The shape is identical across all of them:
+
+1. Install the catalog once: /plugin marketplace add rampstackco/claude-skills
+2. Open the workflow file. Check "when to use / when not to use" first; half the value of the tier is the routing between workflows.
+3. Work the prerequisites checklist. If it names a data export, enable it before anything else; the exports named here do not backfill.
+4. Run the phases in order. Each phase names the skills it invokes, the input it consumes, a Run block you copy and adapt, the output artifact it produces, and a binary done-when. Phases marked as declared gaps carry their procedure inline; the capability-class line tells you what to substitute if you are off-catalog.
+5. Respect the lanes. Divergent phases end at a human decision. Gate phases report and never fix. Nothing in any workflow publishes, merges, or changes platform state on its own.
+6. Record what happened. The minimum record is the per-phase artifacts and the human's merge note. The full schema, if you want to implement the operated version, is AGREEMENT-LOG.md.
+
+Statuses are honest and defined in the README: everything starts as a template, and a workflow is validated only when it has been executed as written on a real property with a linked run record. You can watch that happen in this repo's history.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,65 @@
+# Forward-deployed workflows
+
+Operating workflows for forward-deployed roles running the engines inside a real company's pipeline and data stack. The skills catalog covers building a site once; this tier covers operating a deployed content and growth pipeline continuously. Same authoring contract, extended with role, status, connectors, and autonomy.
+
+Install the catalog these workflows invoke:
+
+```
+/plugin marketplace add rampstackco/claude-skills
+```
+
+## Tracks
+
+Three tracks run the pipeline, and a cross-track pair spans them:
+
+- Forward-deployed engineer (FDE): stands the pipeline up and keeps its data and deploys honest.
+- Forward-deployed marketer (FDM): runs the content and experimentation loop through prove gates.
+- Forward-deployed analyst (FDA): owns the numbers, the attribution, and the diagnosis loops.
+- Cross-track: Incident Response and Lane Demotion, and Autonomy Review. These operate over every track, one on the event of a regression and one on a periodic cadence.
+
+## The status ladder
+
+The ladder is this tier's spine. A workflow's status says what has actually happened to it, not how good the document reads.
+
+- template: designed, not executed as written.
+- validated: executed as written, by the engines, on a showcase-designated property, with a PUBLIC linked run record; manual runs the workflow merely describes do not count.
+- hardened: validated plus failure modes documented from real incidents; explicitly the home of demotion and post_merge_outcome regression data, so hardened is earned by surviving events, not by prose.
+
+Every shipped file below enters at template. Content Pipeline with Prove Gates has a validation run in flight; its flip to validated lands as its own future commit with the linked run record, not as a claim made ahead of the evidence.
+
+## The merge doctrine
+
+Checks report and fail, engines propose and stop, a human merges; autonomy is earned per lane under the published doctrine, never asserted.
+
+## The set
+
+WORKFLOWS.lock is the canonical manifest and the source for any count. The table is the list. Shipped files link; the rest are defined here and publish in later waves.
+
+| Workflow | Track | Status |
+|---|---|---|
+| [Post-Deploy Live Verification](post-deploy-live-verification.md) | FDE | template |
+| Data Surface Integrity | FDE | defined, publishing |
+| Migration with Verification | FDE | defined, publishing |
+| CI Prove-Gate Wiring | FDE | defined, publishing |
+| Warehouse Data Plane Standup | FDE | defined, publishing |
+| [Content Pipeline with Prove Gates](content-pipeline-prove-gates.md) | FDM | template |
+| [Corpus Integrity and Correction](corpus-integrity-and-correction.md) | FDM | template |
+| Link Graph and Metadata Parity Audit | FDM | defined, publishing |
+| Regulated-Content Compliance Gate | FDM | defined, publishing |
+| Experiment Loop with Pre-Registered Gates | FDM | defined, publishing |
+| [Traffic-Drop Triage](traffic-drop-triage.md) | FDA | template |
+| [Conversion-by-Source Diagnosis](conversion-by-source-diagnosis.md) | FDA | template |
+| Revenue Tracking Integrity | FDA | defined, publishing |
+| Incident Response and Lane Demotion | cross | defined, publishing |
+| Autonomy Review | cross | defined, publishing |
+
+## Roadmap: named, not launched
+
+- AI-Surface Visibility Baseline (FDM): fails connector readiness honestly; ships when citation-measurement has real runs.
+- Attribution and Outcome Reporting (FDA): fails honest usability at template status; ships when the agreement log has real cross-property rows and post_merge_outcome data.
+- Forward-deployed product manager track (FDPM): named to hold the track; not launched, and carried with the same visible not-launched treatment so it cannot read as an empty shipped track.
+
+## The docs in this tier
+
+- CONNECTORS.md: the capability classes every workflow declares, the deliberate absences, and the operated-substrate boundary.
+- AGREEMENT-LOG.md: the public schema for the agreement log the operated deployment writes, generalized from the canonical agreement-rate table.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -2,6 +2,8 @@
 
 Operating workflows for forward-deployed roles running the engines inside a real company's pipeline and data stack. The skills catalog covers building a site once; this tier covers operating a deployed content and growth pipeline continuously. Same authoring contract, extended with role, status, connectors, and autonomy.
 
+New here? Start with GETTING-STARTED.md.
+
 Install the catalog these workflows invoke:
 
 ```

--- a/workflows/content-pipeline-prove-gates.md
+++ b/workflows/content-pipeline-prove-gates.md
@@ -1,0 +1,170 @@
+# Content Pipeline with Prove Gates
+
+```
+name:            Content Pipeline with Prove Gates
+slug:            content-pipeline-prove-gates
+tier:            forward-deployed (operations)
+role:            fdm
+status:          template
+score:           49 (demand 5, pain 4, differentiation 5, usability 4, connectors 4)
+intent:          run a content function as a delivery pipeline where every piece ships
+                 through verification gates and a human merge
+when to use:     a content property with real traffic stakes, where volume is
+                 agent-produced and trust cannot be
+when not to use: one-off content tasks (use the build-time Content Production module);
+                 site builds (use the Website Launch Pipeline); paid-media content
+                 (off-catalog)
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  warehouse.query
+    access:      read
+    bounds:      every query carries a date range pushed down as a partition filter
+  - capability:  search-performance.read
+    access:      read
+  - capability:  cms.draft          # for CMS-published properties
+    access:      write-held
+  - capability:  repo.change        # for git-published properties
+    access:      write-held
+  - capability:  crawl.read
+    access:      read
+```
+
+One of cms.draft or repo.change is required, matching how the property publishes. Write-held means every draft lands held; nothing in this workflow publishes on its own. The agreement log referenced below is operated substrate with no connector class; see the operated-layer notes.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- A demand source the ranking can read: a search-performance export, keyword data, or query logs. If using warehouse exports, enable them before anything else; they do not backfill.
+- A publishable target with a draft-and-hold mechanism (CMS drafts or PRs).
+- A claims-and-style standard file (STANDARDS.md or equivalent): voice rules, phrase rules, sourcing requirements.
+- A route list or sitemap the link checks can resolve against.
+
+## Phases
+
+### Phase 1: Rank the backlog from demand · lane: divergent (Krine)
+
+Skills: seo-keyword, seo-keyword-gap-audit, content-strategy
+Capability class: demand.rank (substitute equivalents if off-catalog)
+Input: the demand source (search-performance data, keyword exports) plus whatever outcome history exists; the current content inventory
+Run:
+
+    Invoke seo-keyword and seo-keyword-gap-audit against the demand data, and
+    content-strategy against the property's positioning. Rank the candidate
+    topics with named, auditable criteria (demand volume tiers, intent fit to
+    the property's priority pages, difficulty). Emit the top items as a ranked
+    queue with the evidence attached to each: the demand numbers, the intent
+    read, and why it outranks its neighbors. Do not pick the winner; present
+    the ranking and stop.
+
+Output artifact: a ranked brief queue with per-item evidence (the stop package)
+Done when: a human selects the go item from the ranking
+Operated-layer note: in an operated deployment, the ranking and the human's selection land as an agreement-log row (ranked-choice payload); the divergence between engine order and human pick is the calibration signal
+Fails look like: ranking by raw volume alone. Volume without intent fit sends the pipeline chasing traffic the property cannot convert or hold; the criteria exist to be argued with, which requires them to be named
+
+### Phase 2: Produce the held draft · lane: convergent (Tholo)
+
+Skills: content-brief-authoring, brand-voice, long-form-content-frameworks, seo-onpage
+Capability class: content.draft (write-held)
+Input: the selected brief from Phase 1; STANDARDS.md
+Run:
+
+    Invoke content-brief-authoring to expand the selected item into a full
+    brief, then draft against it using long-form-content-frameworks for
+    structure, brand-voice for voice, and seo-onpage for title, headers, meta,
+    and internal links. Every factual claim carries its source or derivation
+    inline. Land the result as a held draft (CMS draft or draft PR). Do not
+    publish, schedule, or merge.
+
+Output artifact: a held draft with sources inline, plus the brief it was written against
+Done when: the draft exists in held state and nothing has published
+Fails look like: the draft publishing directly because the target's draft mechanism was skipped. Write-held is the seam; a pipeline that can publish in this phase is a different and more dangerous machine
+
+### Phase 3: Pre-publish gate · lane: gate (Basano)
+
+Skills: editorial-qa, seo-onpage, seo-technical
+Capability class: content.pre-publish-gate (substitute equivalents if off-catalog)
+Input: the held draft from Phase 2 plus STANDARDS.md
+Run:
+
+    Invoke editorial-qa, seo-onpage, and seo-technical against the attached
+    draft. Using those skills' frameworks, check: every factual claim has a
+    source or derivation; style and phrase rules in STANDARDS.md pass; title,
+    meta description, and structured data are present and consistent; every
+    internal link resolves against the site's route list. Output a pass/fail
+    verdict per check with evidence. Do not fix anything; report only.
+
+Output artifact: a prove report (verdict per check, evidence attached), attached to the held draft
+Done when (public gate): every check passes, or a failure is waived in writing with a recorded rationale attached to the held draft
+Operated-layer note: in an operated deployment, the verdict and any waiver land as an agreement-log row; this is operated substrate, not part of the public package
+Fails look like: the gate passing on a claim citing a source that does not contain the number (source-shape checking, not source-presence checking)
+
+### Phase 4: Human review and merge · lane: divergent (human, structural)
+
+Skills: none; this phase is the point
+Input: the held draft and its prove report
+Run: a person reviews the draft the way they would review a contractor's work, reads the prove report, and merges or publishes, or sends it back with notes
+Output artifact: the published piece, or a revision note back to Phase 2
+Done when: a human has merged, published, or rejected; the pipeline never advances this phase on its own
+Operated-layer note: the human verdict (merge, reject, revise, waive) and, on revise, what changed between proposal and merge, land in the agreement log; the proposal-to-merge diff is the pipeline's primary correction signal
+Fails look like: rubber-stamping. If every draft merges untouched for weeks, either the pipeline has earned trust (the operated agreement record would show it) or the review has stopped happening; at template status, assume the second
+
+### Phase 5: Post-publish live audit · lane: gate (Basano)
+
+Skills: qa-testing (nearest anchor; the live-verification core is a DECLARED GAP, procedure inline)
+Capability class: deploy.live-verify (declared catalog gap; nearest-miss qa-testing)
+Input: the production URL of the published piece; the approved draft from Phase 4
+Run:
+
+    Fetch the live production URL (not a preview, not a staging domain, not a
+    cached copy). Verify: the rendered content matches what was approved at
+    merge; the canonical URL is self-referencing; title, meta description,
+    social-share metadata, and structured data are present on the live render
+    and match the approved values; every internal link on the live page
+    resolves. If the property fronts a CDN or uses incremental rendering,
+    confirm the render is current by checking a value known to have changed at
+    publish. Report verdict per check with the live evidence.
+
+Output artifact: a live-audit report tied to the production URL
+Done when: every check passes against the live render, or the discrepancy is filed as a defect with the live evidence attached
+Fails look like: verifying the preview. Merged is not live; a published piece can serve a stale render or the wrong metadata while the preview looks perfect, and only the production URL is ground truth
+
+### Phase 6: Outcomes and the refresh trigger · lane: convergent (Tholo)
+
+Skills: seo-rank-tracking, seo-content-audit, content-refresh-system
+Capability class: outcomes.read + content.decay-detect
+Input: search-performance and warehouse data for the published corpus, on a cadence (weekly or monthly)
+Run:
+
+    Invoke seo-rank-tracking against the published pieces' target queries and
+    seo-content-audit plus content-refresh-system against the corpus on the
+    set cadence. Flag pieces whose demand, position, or freshness has decayed
+    past the refresh thresholds. Emit decay flags as candidate items INTO the
+    Phase 1 ranking, carrying their evidence, where they compete with new
+    topics on the same criteria.
+
+Output artifact: outcome records per piece; decay flags entering the Phase 1 queue
+Done when: outcomes are queryable for the next ranking cycle and decay candidates are in the queue
+Fails look like: refresh running as its own separate pipeline. Decay is a demand source, not a second loop; the moment refreshes bypass the ranking, the pipeline has two front doors and the criteria govern only one of them
+
+## Failure modes
+
+- Gate theater: prove reports that always pass. A gate that never fails is either gating nothing or the drafts are being pre-sanitized to it; check by seeding a known-bad claim quarterly and confirming the gate catches it.
+- Source-shape blindness: claims citing real sources that do not contain the claimed number (Phase 3's inline failure, the most common one in practice).
+- Preview verification: Phase 5 run against anything but the production URL.
+- Volume chasing: Phase 1 criteria quietly reduced to demand volume.
+- Silent refresh edits: Phase 6 refreshes that change published claims without a visible note; corrections are visible or they are not corrections (see Corpus Integrity and Correction for the correction-note pattern).
+- Write-held erosion: any phase acquiring publish or merge authority. At template status the human merge is absolute; graduation exists only under the operated autonomy doctrine, per lane, revocably, and never for judgment-tier gates.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a showcase-designated property; the first scheduled run is a how-to piece on an outdoor-sports content property, entering at Phase 1 as a demand-ranked item and exiting Phase 5 with a live audit. Status flips to validated when that run record links here.
+
+## Boundaries
+
+- The build-time Content Production module owns one-off content tasks; this workflow owns the continuous loop. Each points here.
+- Corpus Integrity and Correction owns claim-truth across the published corpus and the correction-note pattern; Phase 6 hands decayed or wrong claims to it rather than editing silently.
+- Post-Deploy Live Verification owns the general deploy-verification procedure; Phase 5 is its content-shaped instance and shares its declared gap.

--- a/workflows/conversion-by-source-diagnosis.md
+++ b/workflows/conversion-by-source-diagnosis.md
@@ -1,0 +1,160 @@
+# Conversion-by-Source Diagnosis
+
+```
+name:            Conversion-by-Source Diagnosis
+slug:            conversion-by-source-diagnosis
+tier:            forward-deployed (operations)
+role:            fda
+status:          template
+score:           49 (demand 5, pain 5, differentiation 3, usability 4, connectors 5)
+intent:          find the conversion divergences worth money in the analytics export,
+                 verify they are behavior rather than measurement, and emit a ranked
+                 hypothesis list a human picks from
+when to use:     traffic is stable but the outcome number is not, or nobody has looked
+                 at conversion by segment in a quarter
+when not to use: traffic itself dropped (Traffic-Drop Triage); running the tests this
+                 workflow proposes (Experiment Loop with Pre-Registered Gates);
+                 verifying the tracking pipeline end to end (Revenue Tracking
+                 Integrity)
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  warehouse.query
+    access:      read
+    bounds:      every query carries a date range pushed down as a partition filter
+  - capability:  analytics.read
+    access:      read
+  - capability:  search-performance.read
+    access:      read           # intent context for landing pages
+  - capability:  crawl.read
+    access:      read           # measurement checks on live pages
+```
+
+Fully read-only. This workflow diagnoses and ranks; it changes nothing. Its output routes to the Experiment Loop or to held fixes owned elsewhere.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Conversion events landing in the warehouse or analytics store with source attribution (the native analytics export into the warehouse is the reference setup; enable exports before anything else, they do not backfill).
+- A defined conversion event set and, where it exists, a value per event; if value is unknown, the ranking uses volume and says so.
+- Enough history for a stable baseline per segment (thin segments produce loud noise; the workflow flags them rather than ranking them).
+
+## Phases
+
+### Phase 1: Frame the funnel and the baseline · lane: convergent (Tholo)
+
+Skills: analytics-strategy, product-analytics-setup
+Capability class: conversion.frame (substitute equivalents if off-catalog)
+Input: the conversion event definitions; the analytics export in the warehouse
+Run:
+
+    Invoke analytics-strategy to state, in writing: which events count as
+    conversions here, what a source is (source/medium granularity), which
+    segments matter (landing page template, device, country, intent class),
+    and the baseline window. Invoke product-analytics-setup to confirm the
+    events named actually exist in the export with the fields the analysis
+    needs. Produce the frame document. No analysis yet.
+
+Output artifact: the frame (events, segments, baseline window, known value per event or the stated absence)
+Done when: the frame names every dimension the sweep will cut by, and each named event is confirmed present in the data
+Fails look like: framing after looking. A frame written once the divergences are visible quietly becomes a justification for them; the frame comes first so the sweep cannot be steered
+
+### Phase 2: The divergence sweep · lane: convergent (Tholo)
+
+Skills: product-analytics-setup (nearest anchor; the divergence-detection core is a DECLARED GAP, procedure inline)
+Capability class: conversion.divergence-detect (declared catalog gap)
+Input: the frame; bounded warehouse queries per the frame's window
+Run:
+
+    Compute conversion rate by source x landing template x device against
+    the baseline, with volume attached to every cell. Surface the divergences
+    worth money, in three shapes: segments converting well below their peers
+    at meaningful volume (the fix candidates), sources whose conversion
+    quality shifted against their own history (the quality drifts), and pages
+    that earn traffic but not outcomes, cross-read with search-performance
+    intent data (the rank-without-reward set). Flag thin cells as
+    not-rankable instead of ranking their noise. Attach the numbers to every
+    finding.
+
+Output artifact: the divergence table (finding, segment, magnitude, volume, baseline)
+Done when: every finding carries its numbers and thin cells are marked not-rankable
+Fails look like: averaging across segments, the same failure that breaks traffic triage. A flat blended conversion rate can hide one template at half its peers; the cuts in the frame exist so the blend cannot
+
+### Phase 3: Measurement gate · lane: gate (Basano)
+
+Skills: product-analytics-setup (anchor; procedure inline)
+Capability class: measurement.verify (declared catalog gap)
+Input: the divergence table; the live pages of affected segments (crawl.read)
+Run:
+
+    Before any divergence is treated as behavior, test it as measurement.
+    Per finding, check: consent-flow differences by source or geography
+    (a consent-heavy source under-reports conversions, not visitors);
+    attribution parameters surviving the landing path (redirects and
+    canonicalization strip params); cross-domain or app boundaries in the
+    converting path; event firing verified on the live affected templates;
+    and whether the divergence's start date aligns with a tracking or
+    consent deploy rather than a demand or content change. Verdict per
+    finding: BEHAVIOR, MEASUREMENT, or MIXED, with evidence. Report only.
+
+Output artifact: the divergence table, annotated with measurement verdicts
+Done when: every finding carries a verdict; MEASUREMENT findings route to a tracking fix, not an optimization
+Fails look like: optimizing a consent artifact. A quarter spent lifting a segment whose conversions were merely unmeasured is the expensive version of this failure, and it is common
+
+### Phase 4: Hypothesis ranking · lane: divergent (Krine)
+
+Skills: none; this is the judgment stop
+Input: the BEHAVIOR and MIXED findings
+Run:
+
+    For each finding, state the hypothesis as mechanism, not aspiration:
+    what specifically about the page, offer, or match to intent would
+    explain the gap, and what change would test it. Rank by expected value
+    where value is known (volume x conversion delta x value per event) and
+    by volume-weighted delta where it is not, saying which basis each rank
+    uses. Present the ranked list with evidence. Recommend the top
+    candidates for testing; decide nothing. Stop for the human.
+
+Output artifact: the ranked hypothesis list (mechanism, evidence, expected-value basis)
+Done when: a human selects which hypotheses proceed
+Operated-layer note: in an operated deployment the ranking and the human's selection land as an agreement-log row; hypothesis hit-rate over time, fed back from experiment verdicts, is what calibrates this lane
+Fails look like: aspiration hypotheses ("improve the CTA") with no mechanism. A hypothesis that does not say why the gap exists cannot be falsified by a test, and the experiment it produces measures nothing
+
+### Phase 5: Route the winners · lane: convergent (Tholo)
+
+Skills: routing; the work lives in the owning workflows
+Input: the human-selected hypotheses
+Run:
+
+    Testable hypotheses route to the Experiment Loop with Pre-Registered
+    Gates, carrying their mechanism, expected effect size, and the segment
+    definition (the loop's pre-registration consumes exactly these).
+    Findings that are defects rather than hypotheses (a broken form, a
+    measurement fix) route as held changes to their owners. Record the
+    routing so experiment verdicts flow back against the original finding.
+
+Output artifact: routed work items, each tied to its finding and hypothesis
+Done when: every selected hypothesis is in the experiment queue or routed as a held fix, with the return path recorded
+Fails look like: the diagnosis running its own tests. The moment this workflow ships a variant, pre-registration is retrofitted to a change already believed in, and the experiment gate is theater
+
+## Failure modes
+
+- Segment blending (Phase 2's inline failure).
+- Measurement artifacts optimized as behavior (Phase 3's inline failure, the expensive one).
+- Expected-value theater: invented per-event values lending false precision to the ranking; the basis is stated or the rank is volume-weighted, never silently guessed.
+- Thin-cell confidence: ranking noise from segments too small to trust; not-rankable is a verdict, not an apology.
+- Mechanism-free hypotheses (Phase 4's inline failure).
+- Self-testing (Phase 5's inline failure).
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a showcase-designated property with conversion events; the intended first substrate is a designated property whose outbound pick-click events serve as the conversion set. Status flips to validated when that run record links here.
+
+## Boundaries
+
+- Experiment Loop with Pre-Registered Gates owns everything from pre-registration through verdict; this workflow supplies its intake and consumes its verdicts as calibration.
+- Revenue Tracking Integrity owns the money path end to end on a schedule; Phase 3 here is a per-finding spot check, not that audit.
+- Traffic-Drop Triage owns falling traffic; this workflow assumes traffic is roughly stable and the outcome is the question.

--- a/workflows/corpus-integrity-and-correction.md
+++ b/workflows/corpus-integrity-and-correction.md
@@ -58,8 +58,9 @@ Run:
     source. Classify each: DERIVED (rendered from a data source), RELAYED
     (typed from a source at authoring time), or DATED (true as of a stated
     date). Include claims living in titles, meta descriptions, and structured
-    data, not just body copy. Emit the claim register: claim, page(s), class,
-    source if stated, last-verified date if known.
+    data; body copy is the smallest part of the register. Emit the claim
+    register: claim, page(s), class, source if stated, last-verified date
+    if known.
 
 Output artifact: the claim register
 Done when: the register covers the corpus including metadata surfaces, and every claim carries a class

--- a/workflows/corpus-integrity-and-correction.md
+++ b/workflows/corpus-integrity-and-correction.md
@@ -1,0 +1,165 @@
+# Corpus Integrity and Correction
+
+```
+name:            Corpus Integrity and Correction
+slug:            corpus-integrity-and-correction
+tier:            forward-deployed (operations)
+role:            fdm
+status:          template
+score:           49 (demand 4, pain 5, differentiation 5, usability 4, connectors 4)
+intent:          keep a published corpus true over time: detect stale and wrong claims,
+                 enforce derived counters, and correct visibly instead of silently
+when to use:     any property whose published pages carry claims, numbers, or dated
+                 facts that age; any property where the same fact appears on more
+                 than one page
+when not to use: pre-publish checking of a new draft (Content Pipeline, Phase 3);
+                 refreshing a decayed piece for demand reasons (Content Pipeline,
+                 Phase 6); live data feeds like rates or prices (Data Surface
+                 Integrity owns machine-rendered series; this workflow owns
+                 authored claims)
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  crawl.read
+    access:      read
+  - capability:  warehouse.query
+    access:      read
+    bounds:      every query carries a date range pushed down as a partition filter
+  - capability:  search-performance.read
+    access:      read           # traffic-weights the triage
+  - capability:  cms.draft      # or repo.change, matching how the property publishes
+    access:      write-held
+```
+
+Read-only until Phase 4; corrections land held, a human merges.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- A crawlable corpus (the live site) and, for git-published properties, the content source tree.
+- The property's canonical data sources for checkable claims (the statistics pages, standards bodies, or datasets its content cites).
+- A decision, made once and recorded, of what counts as a visible correction on this property (the correction-note format and where it renders).
+
+## Phases
+
+### Phase 1: Claim inventory · lane: convergent (Tholo)
+
+Skills: seo-content-audit, editorial-qa
+Capability class: corpus.claim-extract (substitute equivalents if off-catalog)
+Input: the live corpus (crawl.read), plus the content source tree where one exists
+Run:
+
+    Invoke seo-content-audit across the corpus and editorial-qa's claim
+    framework per page. Extract every checkable claim: numbers, dates,
+    prices, counts, superlatives, cited facts, and every claim that names a
+    source. Classify each: DERIVED (rendered from a data source), RELAYED
+    (typed from a source at authoring time), or DATED (true as of a stated
+    date). Include claims living in titles, meta descriptions, and structured
+    data, not just body copy. Emit the claim register: claim, page(s), class,
+    source if stated, last-verified date if known.
+
+Output artifact: the claim register
+Done when: the register covers the corpus including metadata surfaces, and every claim carries a class
+Fails look like: inventorying body copy only. Claims rot fastest in the surfaces nobody rereads: meta descriptions, schema fields, comparison tables, and footer boilerplate
+
+### Phase 2: Truth check · lane: gate (Basano)
+
+Skills: editorial-qa, seo-content-audit (nearest anchors; the derived-counter and stale-claim detection cores are DECLARED GAPS, procedure inline)
+Capability class: corpus.truth-check (declared catalog gap; nearest-miss editorial-qa)
+Input: the claim register; the property's canonical sources
+Run:
+
+    For every RELAYED and DATED claim: check the source still exists, still
+    says what the page says, and whether the value has changed or the series
+    has been discontinued. For every count or total that a canonical source
+    could supply (a catalog size, an item count, an integration count): flag
+    any hand-typed literal as a defect regardless of whether it is currently
+    correct, because a correct literal is one release away from a wrong one.
+    For every fact appearing on more than one page: check the surfaces agree,
+    and flag any fact with two values or two sources as a defect even when
+    one of them is right. Output the discrepancy report with severity:
+    WRONG-NOW, STALE-BUT-WAS-RIGHT, HAND-TYPED-DERIVABLE, TWO-SURFACE-SPLIT,
+    UNVERIFIABLE (source gone). Verdict per claim, evidence attached. Do not
+    fix anything; report only.
+
+Output artifact: the discrepancy report
+Done when: every register entry has a verdict, including the clean ones
+Fails look like: source-presence checking. A claim citing a live source that no longer contains the claimed value passes a lazy check and fails a reader; the check is against the source's current content, not its existence
+
+### Phase 3: Triage and the correction plan · lane: divergent (Krine)
+
+Skills: none; this is the judgment stop
+Input: the discrepancy report; search-performance data for the affected pages
+Run:
+
+    Rank the defects by reader harm: traffic-weight the affected pages
+    (search-performance.read), weight claims readers act on (money, safety,
+    how-to steps) above color, and mark each defect's correction class:
+    SILENT-SAFE (typos, formatting, broken links) or VISIBLE-CORRECTION
+    (any claim a reader may have relied on). Present the ranked plan and
+    stop for the human.
+
+Output artifact: a ranked correction plan with per-item correction class
+Done when: a human approves the plan, including the correction classes
+Operated-layer note: in an operated deployment the ranking and the human's approval or reordering land as an agreement-log row
+Fails look like: severity by ease of fix. The cheap fixes migrate to the top because they close fast; the ranking's job is to hold reader harm above operator convenience
+
+### Phase 4: Corrections as held changes · lane: convergent (Tholo)
+
+Skills: editorial-qa, brand-voice
+Capability class: content.correct (write-held)
+Input: the approved plan; the property's correction-note format
+Run:
+
+    For each VISIBLE-CORRECTION item: fix the claim at its SOURCE (if the
+    value should derive, wire the derivation rather than retyping the number;
+    if the fact appears on several pages, fix the one source of truth and the
+    copies with it), and add the correction note in the property's format,
+    stating what was wrong, what it now says, and when it was corrected.
+    Original publish dates stay untouched. Removed claims are noted as
+    removed, not vanished. SILENT-SAFE items fix without notes. Everything
+    lands held: CMS drafts or a draft change, never a direct publish.
+
+Output artifact: held corrections, each tied to its plan item; correction notes in place
+Done when: every approved item has a held change and nothing has published
+Fails look like: silent edits to relied-upon claims. A correction a reader cannot see is indistinguishable from hoping nobody noticed, and on the day someone diffs the archive, it reads exactly that way
+
+### Phase 5: Verify live and install the guard · lane: gate (Basano)
+
+Skills: qa-testing (nearest anchor; live verification shares the deploy.live-verify DECLARED GAP)
+Input: the production URLs of corrected pages, post-merge
+Run:
+
+    After the human merges: fetch each corrected page's production URL and
+    verify the correction renders, the note renders where the format says it
+    should, and the corrected value matches the source. Then install the
+    guard: the Phase 1-2 pass recurs on a set cadence (quarterly fits most
+    corpora), and the property's authoring rule is recorded: every new
+    published number is derived or explicitly inventoried at publish time,
+    which is what keeps the next pass small.
+
+Output artifact: live verification per correction; the standing cadence and authoring rule, recorded
+Done when: every merged correction is verified on its production URL and the cadence is scheduled
+Fails look like: counting the fix as done at merge. Merged is not live; a correction that renders on the preview and not on production has corrected nothing
+
+## Failure modes
+
+- Silent edits (Phase 4's inline failure, and the workflow's reason to exist).
+- Fixing copies instead of sources: retyping the right number on four pages plants the next two-surface split.
+- Source-presence checking (Phase 2's inline failure).
+- Severity by ease (Phase 3's inline failure).
+- Metadata blindness: claims in meta descriptions, schema, and OG fields skipping the register.
+- One-shot integrity: running this once and never installing the cadence; a corpus is only as honest as its most recent pass.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a showcase-designated property. The pattern generalizes a real count-and-copy reconciliation on rampstack.co (hand-typed counts replaced with derived values, a listed-count mismatch corrected, a paragraph-length meta rebuilt from a derived count); the visible correction-note pattern additionally generalizes production incidents on an unnamed property. Status flips to validated when a run record links here.
+
+## Boundaries
+
+- Content Pipeline Phase 6 hands decayed or wrong claims here rather than editing silently; Phase 3 of the pipeline prevents new debt, this workflow retires existing debt.
+- Data Surface Integrity owns machine-rendered data series (rates, prices, live stats) and their freshness guards; this workflow owns authored claims about the world.
+- Regulated-Content Compliance Gate owns disclosure and claim rules at publish time in regulated verticals; corrections to regulated content route through both.

--- a/workflows/post-deploy-live-verification.md
+++ b/workflows/post-deploy-live-verification.md
@@ -1,0 +1,160 @@
+# Post-Deploy Live Verification
+
+```
+name:            Post-Deploy Live Verification
+slug:            post-deploy-live-verification
+tier:            forward-deployed (operations)
+role:            fde
+status:          template
+score:           53 (demand 5, pain 5, differentiation 4, usability 5, connectors 5)
+intent:          merged-is-not-live as a procedure: prove that what production serves
+                 is what was approved, on every route that matters, before the change
+                 is called done
+when to use:     after every merge that changes anything a user or crawler sees; as
+                 the standing final step of any pipeline that ships
+when not to use: pre-merge checking (that is CI Prove-Gate Wiring's territory);
+                 content-claim truth (Corpus Integrity and Correction); a live
+                 regression from an already-promoted lane (Incident Response and
+                 Lane Demotion, which this workflow's failures feed)
+gap note:        this workflow's core is the tier's largest DECLARED CATALOG GAP;
+                 most phases are inline procedure with qa-testing and seo-technical
+                 as the nearest anchors. It is written to be runnable anyway.
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  crawl.read
+    access:      read
+  - capability:  repo.change
+    access:      write-held     # only for fixes the verification surfaces
+```
+
+Verification is read-only. Fixes it surfaces land held; deploy-platform actions (promoting, purging, redeploying) are human actions on the platform, outside these connectors by design.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- The production domain, and the list of routes the change touched plus the routes that share templates or data with them.
+- A way to read which build produced a served page (a deployment id, build hash, or asset fingerprint in the rendered HTML; every modern host embeds one).
+- The approved state: the merged content, metadata, and values the pages are supposed to show.
+
+## Phases
+
+### Phase 1: Capture the expected state · lane: convergent (Tholo)
+
+Skills: qa-testing (nearest anchor; procedure inline)
+Capability class: deploy.expected-state (declared catalog gap)
+Input: the merged change; the route list
+Run:
+
+    From the merged change, record what production should now show, per
+    route: the content values that changed, titles and meta descriptions,
+    canonical URLs, structured data, and at least one DISCRIMINATOR VALUE
+    per route: something this deploy changed that the previous build could
+    not be showing (new copy, a new derived count, a version string). Add
+    the blast-radius routes: pages sharing the template, layout, nav, or
+    data source with the changed ones, because deploys regress neighbors.
+    Record the newest deployment or build identifier the platform reports.
+
+Output artifact: the expected-state sheet (route, expected values, discriminator value, expected build id)
+Done when: every touched and blast-radius route has expected values and a discriminator
+Fails look like: verifying only the changed route. The route you edited is the one you will look at anyway; the regression ships on the sibling route nobody listed
+
+### Phase 2: Production fetch and identity check · lane: gate (Basano)
+
+Skills: qa-testing, seo-technical (anchors; procedure inline)
+Capability class: deploy.live-verify (declared catalog gap)
+Input: the expected-state sheet
+Run:
+
+    Fetch each route's PRODUCTION URL: not a preview, not a staging domain,
+    not localhost, and not a browser with a warm cache. For each route,
+    record: the discriminator value present or absent; the build identifier
+    the served page embeds; title, meta description, canonical, social-share
+    metadata, and structured data against expected; and status codes on the
+    route and its internal links. Fetch twice with a short gap; a CDN can
+    serve different edges different builds, and one fetch is a sample, not
+    a verdict. Report per route: VERIFIED (discriminator present, build id
+    current, values match), STALE (old build id or missing discriminator),
+    or WRONG (current build, unexpected values).
+
+Output artifact: the live report (verdict, evidence, build id per route, both fetches)
+Done when: every route on the sheet has a verdict from production fetches
+Fails look like: trusting the deploy dashboard. The platform saying the deployment succeeded is a claim about the build, not about what a given route serves; tool-reported success is not verified state, and only the rendered production URL is ground truth
+
+### Phase 3: Discriminate the failure class · lane: convergent (Tholo)
+
+Skills: none; this is the decision table (procedure inline; the discriminator pattern generalizes production incidents on an unnamed property)
+Capability class: deploy.failure-discriminate (declared catalog gap)
+Input: the live report, when any route is STALE or WRONG
+Run:
+
+    Apply the decision table. ALL routes stale on the same old build id:
+    the deploy never promoted; the fix is platform-side promotion, not code.
+    SOME routes current and SOME stale: route-level cache or incremental
+    render staleness; the stale HTML was generated under the old build and
+    is being served past the new deploy; the fix is a targeted purge or
+    revalidation of those routes, and if a purged route goes stale again,
+    its background regeneration is failing and the platform's function logs
+    for that route are the next read. Routes CURRENT but WRONG: the defect
+    merged; the fix is code, as a held change. State which class the
+    evidence supports and what evidence would distinguish it further if
+    ambiguous.
+
+Output artifact: the failure-class finding with its evidence
+Done when: every non-verified route has a named failure class or a named ambiguity with the next check specified
+Fails look like: purge-and-hope. Purging a cache without knowing whether the deploy promoted treats two different diseases with one drug; when it happens to work, nothing was learned, and when it does not, the next hour is spent purging harder
+
+### Phase 4: Route the fix · lane: divergent (human)
+
+Skills: none; the actions here are deliberately human
+Input: the failure-class finding
+Run: promotion, purge, revalidation, and redeploy are performed by a person
+    on the platform (these are production state changes, and they stay
+    human). Code defects land as held changes (repo.change) for normal
+    review. The human records what action was taken and against which
+    failure class.
+Output artifact: the action taken, recorded against the finding
+Done when: the action for every non-verified route is taken or explicitly deferred
+Operated-layer note: in an operated deployment the finding and the action land as an agreement-log row; a promoted lane whose deploys repeatedly land STALE is exactly the post_merge_outcome signal Incident Response and Lane Demotion consumes
+Fails look like: the verification performing the platform action itself. The read side of this workflow can be trusted precisely because it cannot touch what it measures
+
+### Phase 5: Re-verify and close · lane: gate (Basano)
+
+Skills: qa-testing (anchor; procedure inline)
+Capability class: deploy.live-verify (declared catalog gap)
+Input: the expected-state sheet; the actions taken
+Run:
+
+    Re-run Phase 2 on every route that was not VERIFIED, same discipline:
+    production URL, discriminator, build id, two fetches. The change closes
+    only when every route on the sheet reads VERIFIED. Record the closure
+    with the final build id per route. If this workflow runs as a pipeline's
+    standing final step (it should), the closure record is the pipeline's
+    definition of done.
+
+Output artifact: the closure record (all routes VERIFIED, final build ids, timestamps)
+Done when: all routes VERIFIED on production, and the closure record exists
+Fails look like: closing at merge, or closing on the first good fetch after a purge. Done is a property of what production serves, held across both fetches, on every route on the sheet
+
+## Failure modes
+
+- Preview verification: any fetch that is not the production URL proves nothing about production.
+- Single-fetch verdicts: CDN edges disagree; two fetches minimum, and disagreement between them is itself a finding.
+- Dashboard trust: deploy success and served state are different facts (Phase 2's inline failure).
+- Sibling blindness: verifying only the edited route (Phase 1's inline failure).
+- Purge-and-hope (Phase 3's inline failure).
+- Missing discriminator: without a value only the new build can show, a stale page that happens to look right passes; the discriminator is what makes VERIFIED falsifiable.
+- Merge-time closure: the change is done when production says so, not when the repo does.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a showcase-designated property. The verification core generalizes real post-merge passes on rampstack.co (rendered-state checks, cross-link verification, build-identity reads across two merges in one day); the failure-class decision table additionally generalizes production incidents on an unnamed property, including a route serving a twelve-day-old render while its sibling served current data. Status flips to validated when a run record links here.
+
+## Boundaries
+
+- CI Prove-Gate Wiring owns pre-merge gates; this workflow begins where CI ends, because CI runs against the build and this runs against the world.
+- Incident Response and Lane Demotion consumes this workflow's repeated failures on promoted lanes; a STALE that recurs is an incident, not a verification note.
+- Content Pipeline Phase 5 and Corpus Integrity Phase 5 are this workflow's content-shaped instances; they share the declared gap and the doctrine.

--- a/workflows/traffic-drop-triage.md
+++ b/workflows/traffic-drop-triage.md
@@ -1,0 +1,193 @@
+# Traffic-Drop Triage
+
+```
+name:            Traffic-Drop Triage
+slug:            traffic-drop-triage
+tier:            forward-deployed (operations)
+role:            fda
+status:          template
+score:           51 (demand 5, pain 5, differentiation 4, usability 4, connectors 4)
+intent:          diagnose an organic traffic drop with a disciplined decision tree,
+                 evidence per branch, before anyone acts on it
+when to use:     organic traffic is down and the team is about to do something about it
+when not to use: routine performance review (use Conversion-by-Source Diagnosis);
+                 a known deploy broke something (use Incident Response and Lane
+                 Demotion); paid traffic changes (off-catalog)
+validation note: gated on a showcase-designated property experiencing a diagnosable
+                 drop; the pattern generalizes a real production diagnosis on an
+                 unnamed property
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  warehouse.query
+    access:      read
+    bounds:      every query carries a date range pushed down as a partition filter
+  - capability:  search-performance.read
+    access:      read
+  - capability:  analytics.read
+    access:      read
+  - capability:  crawl.read
+    access:      read
+  - capability:  repo.change
+    access:      write-held      # only if Phase 4 routes to a technical fix
+```
+
+This workflow is read-only until Phase 4, and Phase 4 only ever produces held changes. Nothing in the triage acts on production.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- At least one demand-side data source (search-performance export) AND one behavior-side source (analytics events), because the single most valuable discriminator in the tree is whether they disagree.
+- Enough history to compute a baseline: the same period last year if seasonality is plausible, or at minimum several stable weeks pre-drop.
+- The deploy log or release history for the drop window.
+
+## Phases
+
+### Phase 1: Pin the drop · lane: convergent (Tholo)
+
+Skills: seo-traffic-diagnosis
+Capability class: traffic.baseline (substitute equivalents if off-catalog)
+Input: search-performance and analytics data spanning the drop and the baseline window
+Run:
+
+    Invoke seo-traffic-diagnosis against the traffic data. Establish, with
+    numbers: when the drop started (day precision), its magnitude vs the
+    pre-drop baseline, and its shape across segments: which page templates,
+    which query classes, which devices, which countries, which traffic
+    sources. Do not explain the drop yet. Produce the drop profile only.
+
+Output artifact: a drop profile (start date, magnitude, segment breakdown)
+Done when: the profile states when, how much, and where, each with a number
+Fails look like: averaging over segments. A sitewide average of minus 30 percent can be one template at minus 90 and everything else flat, and those are different diagnoses; the segment breakdown is the whole point of this phase
+
+### Phase 2: Run the branches · lane: gate (Basano)
+
+Five branches, every one checked, none acted on. Each produces evidence for or against; skipping a branch because another already looks guilty is the failure this phase exists to prevent.
+
+**Branch A, tracking breakage.**
+Skills: product-analytics-setup (nearest anchor; the breakage-detection core is a DECLARED GAP, procedure inline)
+Run:
+
+    Cross-check the two data sources for the drop window: if search-performance
+    impressions and clicks are steady while analytics sessions dropped, the
+    traffic did not fall, the measurement did. Check: the analytics tag present
+    and firing on affected templates (crawl.read the live pages), consent-flow
+    changes in the window, filter or property configuration changes, and
+    whether the drop starts at a deploy boundary rather than a demand boundary.
+
+**Branch B, technical regression.**
+Skills: seo-site-health-audit, seo-technical
+Run:
+
+    Invoke seo-site-health-audit and seo-technical against the affected
+    segments. Check: robots directives and noindex on affected templates,
+    canonical correctness, status codes and redirect chains, sitemap presence,
+    render-blocking or hydration failures on the live pages, and whether any
+    of these changed at a deploy inside the drop window.
+
+**Branch C, algorithm-update timing.**
+Skills: seo-traffic-diagnosis
+Run:
+
+    Compare the drop start date against the published update timeline. Check
+    the drop's shape against the update class: sitewide vs template-scoped vs
+    query-class-scoped losses point at different update types. Timing
+    correlation alone is not a diagnosis; require shape agreement too.
+
+**Branch D, seasonality and demand shift.**
+Skills: seo-keyword
+Capability class: demand.trend
+Run:
+
+    Query the warehouse for the same period in prior years (bounded date
+    ranges). Invoke seo-keyword against the affected query classes: did the
+    demand itself fall? A drop that tracks the category's demand curve is not
+    a site problem, and treating it as one wastes a quarter.
+
+**Branch E, SERP displacement.**
+Skills: seo-rank-tracking, seo-competitor
+Run:
+
+    Invoke seo-rank-tracking on the affected queries: are positions held or
+    lost? Positions held with clicks down points at SERP-feature displacement
+    (check the affected queries' current result layout). Positions lost points
+    at a competitor or a relevance change; invoke seo-competitor to identify
+    who took them and with what.
+
+Output artifact: a branch evidence table: five branches, evidence for, evidence against, per-branch confidence
+Done when: all five branches have evidence recorded, including the branches that came back clean
+Fails look like: stopping at the first guilty-looking branch. Real drops are frequently compound (an update lands the same week a consent banner breaks measurement), and a one-branch diagnosis on a compound drop fixes half the problem while the other half compounds
+
+### Phase 3: Diagnosis · lane: divergent (Krine)
+
+Skills: none; this is the judgment stop
+Input: the drop profile and the branch evidence table
+Run:
+
+    Rank the candidate causes by evidence strength, stating per-branch
+    confidence and explicitly noting compound possibilities. Present the
+    ranked diagnosis with the evidence attached. Recommend nothing yet.
+    Stop for the human.
+
+Output artifact: a ranked diagnosis with per-cause confidence and the compound read
+Done when: a human has confirmed the diagnosis or sent specific branches back for deeper evidence
+Operated-layer note: in an operated deployment, the engine's ranked diagnosis and the human's confirmation or override land as an agreement-log row; diagnosis agreement over time is what earns this lane trust
+Fails look like: the diagnosis arriving pre-merged with the treatment. The moment the diagnosis says "and therefore we should," the human is reviewing a plan, not a finding, and anchoring does the rest
+
+### Phase 4: Route the response · lane: convergent (Tholo)
+
+Skills: routing per diagnosis; the responses live in their owning workflows
+Input: the confirmed diagnosis
+Run:
+
+    Route each confirmed cause to its owner: technical regression -> a held
+    change (repo.change) with the specific fix; tracking breakage -> a held
+    fix to the measurement path, plus an annotation on the drop window so
+    the record shows measurement loss, not traffic loss; update-class losses
+    -> the content-quality program (Corpus Integrity and Correction, Content
+    Pipeline refresh triggers), never a quick technical counterattack;
+    demand decline -> a strategy note, not a fix; SERP displacement ->
+    targeted format or coverage work through the Content Pipeline. Every
+    response lands held; nothing merges from inside the triage.
+
+Output artifact: held changes and routed work items, each tied to its diagnosed cause
+Done when: every confirmed cause has a routed response or an explicit decision to accept it
+Fails look like: fixing inside the triage. The triage's authority is diagnostic; the moment it merges its own fixes, the diagnosis and the treatment share an author and the verification story collapses
+
+### Phase 5: Recovery watch · lane: gate (Basano)
+
+Skills: seo-rank-tracking, seo-traffic-diagnosis
+Input: the pre-registered recovery metric (set it now, before watching: which segment, back to what level, measured how)
+Run:
+
+    On a fixed cadence, measure the affected segments against the
+    pre-registered recovery metric and the pre-drop baseline. Report
+    trajectory per diagnosed cause. Declare recovery only when the
+    pre-registered condition holds across the pre-registered window, not
+    on the first good week.
+
+Output artifact: recovery reports on cadence; a closure record when the pre-registered condition holds
+Done when: recovery is declared against the pre-registered condition, or the diagnosis is reopened because the trajectory contradicts it
+Fails look like: victory on one good week. Traffic is noisy; a recovery declared on a single datapoint reopens as a mystery a month later, now with the trail cold
+
+## Failure modes
+
+- First-plausible-branch tunnel vision (Phase 2's inline failure; the discipline is that clean branches get recorded too).
+- Measurement loss recorded as traffic loss: the record must say which it was, or every future baseline is quietly wrong.
+- Timing-only update attribution: correlation with an update date without shape agreement is a coin flip wearing a citation.
+- Treatment anchoring: diagnosis and recommendation delivered as one artifact (Phase 3's inline failure).
+- Unpre-registered recovery: the metric chosen after watching begins always finds recovery.
+- Compound drops resolved as single causes: fix half, and the remaining half now looks like the fix failed.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a showcase-designated property experiencing a diagnosable drop. The decision tree generalizes a real production diagnosis (a mass deindexation timed to a core update, root-caused to content quality rather than technical failure, on an unnamed property); that incident informs the branches but is not validation evidence.
+
+## Boundaries
+
+- Incident Response and Lane Demotion owns drops caused by the pipeline's own promoted changes (a post-merge regression is an incident with a known suspect, not a mystery).
+- Conversion-by-Source Diagnosis owns conversion problems on stable traffic; this workflow owns the traffic itself.
+- Corpus Integrity and Correction and the Content Pipeline own the content-quality responses this workflow routes to; the triage never edits content.


### PR DESCRIPTION
## What this ships

Wave one of the forward-deployed workflows tier at the repo root, all at **template** status:

- `workflows/` with the five pass-one files (placed verbatim), `README.md`, `CONNECTORS.md`, `AGREEMENT-LOG.md`.
- `WORKFLOWS.lock` plus its generator `tools/gen_workflows_lock.py` (the canonical count source).
- `tools/check_workflow_drift.py`.
- `.github/workflows/workflows-manifest.yml`: lock verify, the SKILLS.lock fence, and the workflow-to-catalog drift check.

The remaining ten workflows are defined in the README table and publish in later waves. This is a **held draft**. Do not merge; Andy squash-merges.

## How the skills manifest stays untouched

`tools/gen_skills_lock.py` globs `SKILLS_DIR = ROOT / "skills"` only: it iterates the subdirectories of `skills/` and hashes each file under them. `workflows/` is a sibling of `skills/` at the repo root, so it is never inside that glob, and `SKILLS.lock`'s content and its `len(manifest)` count cannot move because a workflow file was added. The existing `skills-lock.yml` CI triggers only on `skills/**` and `tools/gen_skills_lock.py`; this PR touches neither. `WORKFLOWS.lock` is produced by a separate generator that globs `workflows/*.md`; the two manifests never overlap.

## Acceptance evidence

**1. Five files byte-match their sources.** `diff` of each placed file against its source is empty:

```
content-pipeline-prove-gates    IDENTICAL
traffic-drop-triage             IDENTICAL
corpus-integrity-and-correction IDENTICAL
conversion-by-source-diagnosis  IDENTICAL
post-deploy-live-verification   IDENTICAL
```

**2. Drift check green.** Every skill slug bound on a `Skills:` line exists in `SKILLS.lock` (18 distinct slugs checked):

```
analytics-strategy, brand-voice, content-brief-authoring, content-refresh-system,
content-strategy, editorial-qa, long-form-content-frameworks, product-analytics-setup,
qa-testing, seo-competitor, seo-content-audit, seo-keyword, seo-keyword-gap-audit,
seo-onpage, seo-rank-tracking, seo-site-health-audit, seo-technical, seo-traffic-diagnosis
```

`No drift: every bound slug exists in SKILLS.lock.`

**3. Fence test green.** `git diff <base> -- SKILLS.lock` reports 0 changed files; `SKILLS.lock` is byte-identical to base. `python tools/gen_skills_lock.py --check` prints `SKILLS.lock is current.` and the built manifest still holds 103 skills, so the skills counts are unchanged in built output. The CI `fence-test` job asserts the same: a PR that touches the workflows tier must not also change `SKILLS.lock`.

**4. WORKFLOWS.lock generated, committed, CI-verified.** `python tools/gen_workflows_lock.py --check` prints `WORKFLOWS.lock is current (5 workflows).`; the `verify-lock` CI job runs it. The lock is written as LF bytes so `--check` is byte-stable on the Linux runner.

**5. AGREEMENT-LOG.md convergence with migration 0007.** The file quotes the real `0007_agreements.sql` column list with types as its reference schema, then presents the public spec as retain plus add. Reconciliation of every 0007 column below; nothing was silently dropped or invented.

Retained as-is (named by the dispatch, in the public spec):

| 0007 column / type | Disposition |
|---|---|
| `agreement` (agreement_kind: true_pass, false_pass, true_fail, false_fail) | retained; authored, never derived |
| `risk_tier` (text) | retained |
| `guardrail_confidence` (numeric) | retained |
| `guardrail_checks` (jsonb) | retained (proposal pointer) |
| `human_verdict` (human_verdict_kind: merge, reject, revise) | retained; extended with `waive` |
| `proposal_to_merge_diff` (jsonb) | retained |
| `post_merge_outcome` (text) | retained |

Added for this tier: `property` (designation-guarded), `workflow_slug`, `phase`, `artifact_ref`, and `waive` as a fourth human verdict.

**Flagged: 0007 columns the dispatch's retain/add lists do not account for.** Handled explicitly, none dropped in silence:

| 0007 column / type | Handling and recommendation |
|---|---|
| `human_reason` (text) | **Renamed / generalized** to the added `human_note` (required on waive and revise). Same field, tier-specific semantics. Confirm the rename is intended. |
| `lane` (text, not null) | **Needs a ruling.** The merge-authority doctrine is per-lane, yet the retain list omits `lane`. Kept out of the public-spec column body to honor the exact retain list; recommend adding `lane` to the public spec so per-lane autonomy has a home. |
| `guardrail_verdict` (text, pass/fail) | Kept out of the public column list: because `agreement` is authored (not derived from the verdict pair), the guardrail pass/fail detail lives inside `guardrail_checks`. Flagging so the omission is a decision, not an accident. |
| `id` (uuid PK) | Operated-internal row identity; not part of the public schema. |
| `project_id` (uuid FK to projects) | Operated-internal; ties to the krine projects table. |
| `decision_id` (text, not null) | Operated-internal logical id; the public identity is `workflow_slug` + `phase` + `artifact_ref`. |
| `pr_id` (text) | Operated-internal; `artifact_ref` is the public pointer. |
| `agent_id` (text, not null) | Operated-internal (which engine produced the proposal). |
| `human_review_latency` (numeric) | Operated-internal metric. |
| `created_at` (timestamptz, not null) | Operated-internal append-only ordering. |

Enums: `agreement_kind` retained verbatim; `human_verdict_kind` retained and extended with `waive`.

**6. README lists all fifteen.** The table carries name / track / status for all fifteen: the five shipped rows link to their files at `template`; the other ten read `defined, publishing`. No total count appears in prose; the table is the list and `WORKFLOWS.lock` is the count source.

**7. Style, hygiene, signing, LF.**
- Em-dash and en-dash grep across all added files: zero.
- Banned marketing phrases grep: zero.
- One `not just` occurrence exists in `workflows/corpus-integrity-and-correction.md` (line 61). It is inside a **verbatim** Andy-reviewed source file; per the dispatch it is placed as-is and flagged here rather than reworded. All authored prose (README, CONNECTORS, AGREEMENT-LOG) is clean.
- No watchlist property names in authored prose; the full repo lint (`lint_skills.py`) passes: em-dash, brand-leak, and README-catalog checks all OK, 103 skills validated.
- All added files are LF; commit is signed.

## Not in scope

The `rampstack.co/engines/deployment/workflows` page and the deployment-page rider are dispatch two, after this merges. The `content-pipeline-prove-gates` flip to `validated` lands as its own future commit with the linked run record.

---

## Update: pre-merge rulings applied (commit b8a8cbe)

Four Andy-ruled changes, one signed commit, still a held draft. Diff scope is exactly five files: `AGREEMENT-LOG.md`, `corpus-integrity-and-correction.md`, `WORKFLOWS.lock`, `GETTING-STARTED.md`, and one `README.md` line. Nothing else.

**1. `lane` added, retained from 0007.** Quoted from the migration (`lane text not null` / "the autonomy lane, e.g. content_roadmap"), placed with the promotion-math fields, with the rationale that per-lane agreement rates are the unit the promotion thresholds apply to, so false-pass-among-passes cannot be computed per lane without it.

**2. Converged on `human_reason` (no rename).** Every `human_note` replaced with 0007's `human_reason`; the added-fields list no longer implies a rename. `human_reason` now sits in the retained-from-0007 table. Grep: `human_note` appears **0** times repo-wide.

**3. Approved reword, corpus-integrity line 61.** Now reads "...and structured data; body copy is the smallest part of the register." Present exactly **once**. This is the only workflow-file content change; the other four files re-verified byte-identical to source.

**4. `GETTING-STARTED.md` disposition: ADDED.** It was not in the PR, so it was added verbatim from the ruling text, and `README.md` gained one line near the top linking it. The lock generator includes workflow files only (a file is a workflow when its opening fenced block declares both `slug` and `status`); `GETTING-STARTED.md` has no such block, so it is correctly excluded from `WORKFLOWS.lock`.

**Acceptance evidence.**
- CI green post-commit: `WORKFLOWS.lock is current`, drift (`No drift`), fence (`SKILLS.lock` byte-identical to base, 0 changed files), catalog lint unchanged at 103 skills.
- `WORKFLOWS.lock` regenerated: only the `corpus-integrity-and-correction` hash changed (`8073203…` to `f700641…`); the other four hashes are untouched; `WORKFLOWS.lock` still holds 5 workflows.
- Dashes, banned phrases, and watchlist names: zero across the changed prose. Commit signed; all files LF.
