### PR TITLE
feat(workflows): publish wave A, four FDE/FDM/FDA workflows

### DIFF
--- a/WORKFLOWS.lock
+++ b/WORKFLOWS.lock
@@ -1,4 +1,9 @@
 {
+  "ci-prove-gate-wiring": {
+    "file": "ci-prove-gate-wiring.md",
+    "sha256": "137d850bef7d84b4c0351e8b85a37c77aea8674dd93c9d2b7d5de9be8e75ac17",
+    "status": "template"
+  },
   "content-pipeline-prove-gates": {
     "file": "content-pipeline-prove-gates.md",
     "sha256": "e0c6569472fb2dad5a385f4ccf7816d292f204fc787ad0d4c909538dff692557",
@@ -14,14 +19,29 @@
     "sha256": "f700641957273b279a9656b5bb5b4675bfddc1a6db2759abea8fff4607e15832",
     "status": "template"
   },
+  "link-graph-and-metadata-parity-audit": {
+    "file": "link-graph-and-metadata-parity-audit.md",
+    "sha256": "b541c4f63c63a29191c913bc8f3620d365c2a4776694a4df1011c8f200ea5fe3",
+    "status": "template"
+  },
   "post-deploy-live-verification": {
     "file": "post-deploy-live-verification.md",
     "sha256": "944d20aa8740eb54f12fba5457b3f897b4f66cbed7a20e09dc89341e11bea90c",
     "status": "template"
   },
+  "revenue-tracking-integrity": {
+    "file": "revenue-tracking-integrity.md",
+    "sha256": "9a94e01de89e4a5e79c276ecee1618ce3a958ef2f40fa3bf6089e37d707f1ddd",
+    "status": "template"
+  },
   "traffic-drop-triage": {
     "file": "traffic-drop-triage.md",
     "sha256": "2f00f2c4f2d08e0df0699d057b5061300254a2adb0b9f7344eee2d9cf5cf8569",
+    "status": "template"
+  },
+  "warehouse-data-plane-standup": {
+    "file": "warehouse-data-plane-standup.md",
+    "sha256": "0d1b753d34023c8344b5f4bb5ecc9a74a644a7a1a8fff1ba80bb11eec413d303",
     "status": "template"
   }
 }

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -42,16 +42,16 @@ WORKFLOWS.lock is the canonical manifest and the source for any count. The table
 | [Post-Deploy Live Verification](post-deploy-live-verification.md) | FDE | template |
 | Data Surface Integrity | FDE | defined, publishing |
 | Migration with Verification | FDE | defined, publishing |
-| CI Prove-Gate Wiring | FDE | defined, publishing |
-| Warehouse Data Plane Standup | FDE | defined, publishing |
+| [CI Prove-Gate Wiring](ci-prove-gate-wiring.md) | FDE | template |
+| [Warehouse Data Plane Standup](warehouse-data-plane-standup.md) | FDE | template |
 | [Content Pipeline with Prove Gates](content-pipeline-prove-gates.md) | FDM | template |
 | [Corpus Integrity and Correction](corpus-integrity-and-correction.md) | FDM | template |
-| Link Graph and Metadata Parity Audit | FDM | defined, publishing |
+| [Link Graph and Metadata Parity Audit](link-graph-and-metadata-parity-audit.md) | FDM | template |
 | Regulated-Content Compliance Gate | FDM | defined, publishing |
 | Experiment Loop with Pre-Registered Gates | FDM | defined, publishing |
 | [Traffic-Drop Triage](traffic-drop-triage.md) | FDA | template |
 | [Conversion-by-Source Diagnosis](conversion-by-source-diagnosis.md) | FDA | template |
-| Revenue Tracking Integrity | FDA | defined, publishing |
+| [Revenue Tracking Integrity](revenue-tracking-integrity.md) | FDA | template |
 | Incident Response and Lane Demotion | cross | defined, publishing |
 | Autonomy Review | cross | defined, publishing |
 

--- a/workflows/ci-prove-gate-wiring.md
+++ b/workflows/ci-prove-gate-wiring.md
@@ -1,0 +1,162 @@
+# CI Prove-Gate Wiring
+
+```
+name:            CI Prove-Gate Wiring
+slug:            ci-prove-gate-wiring
+tier:            forward-deployed (operations)
+role:            fde
+status:          template
+score:           45 (demand 4, pain 4, differentiation 4, usability 4, connectors 5)
+intent:          install prove skills as required status checks so a failing verdict
+                 blocks a merge the way a failing test does
+when to use:     a repo where prove checks exist but run advisory, and a merge can pass
+                 without them
+when not to use: pre-publish content-claim checking (that is Content Pipeline with Prove
+                 Gates, Phase 3); verifying production after a merge (Post-Deploy Live
+                 Verification); one-off local linting
+gap note:        the CI-inventory and gate-implementation cores are DECLARED CATALOG
+                 GAPS; those phases are inline procedure with qa-testing and seo-technical
+                 as the nearest anchors. It is written to be runnable anyway.
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  repo.change
+    access:      write-held      # the wiring and every gate fix land as held PRs
+  - capability:  crawl.read
+    access:      read            # only if a gate fetches built output to check it
+```
+
+Everything this workflow changes lands held: the gate wiring and any fix a gate surfaces are proposed as PRs a human merges. Making the checks required and enabling branch protection are platform actions a person performs (Phase 5).
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- A repo with CI you can add status checks to, and the permission to make a check required.
+- The prove checks you intend to gate on, already runnable against the repo by hand.
+- A build command that produces the artifact production serves; a dev-flag build is a different artifact.
+- Branch protection you can configure, or the access to request it.
+
+## Phases
+
+### Phase 1: Inventory the pipeline and the gate candidates · lane: convergent (Tholo)
+
+Skills: qa-testing (nearest anchor; the CI-inventory core is a DECLARED GAP, procedure inline)
+Capability class: ci.inventory (declared catalog gap; nearest-miss qa-testing)
+Input: the repo, its CI configuration, and the list of prove checks that could become gates
+Run:
+
+    Invoke qa-testing's checklist discipline against the current pipeline.
+    Enumerate: what CI runs today and on which events, which checks are advisory
+    versus blocking, and which prove checks are run by hand but not wired. For
+    each candidate gate record what it needs to run (a build artifact, a route
+    list, a data source) and whether it reads source or built output. Produce the
+    inventory; propose nothing yet.
+
+Output artifact: the gate-candidate inventory (each candidate, its inputs, source-versus-built, current advisory or blocking state)
+Done when: every candidate has its inputs and current state recorded, including the checks that already block
+Fails look like: inventorying the CI config and missing the by-hand checks. The gate a team runs manually and trusts is the one worth wiring, and it never appears in the YAML.
+
+### Phase 2: Define the gate set and the report contract · lane: divergent (Krine)
+
+Skills: none; this is the judgment stop
+Input: the gate-candidate inventory
+Run:
+
+    Propose the gate set: which candidates become required checks, and for each,
+    the report contract every gate emits, one line per finding: file, check,
+    expected, found. The contract is report-only by construction, so a gate states
+    a pass or fail verdict with evidence and changes nothing. Rank candidates by
+    blocking value against false-positive cost. Present the proposed set and the
+    contract, and stop for the human.
+
+Output artifact: the proposed gate set and the per-finding report contract
+Done when: a human has approved the gate set and the report contract, or returned them with changes
+Operated-layer note: in an operated deployment the proposed set and the human's approval or edits land as an agreement-log row; the divergence between proposed and approved is the calibration signal (see AGREEMENT-LOG.md)
+Fails look like: a gate contract that lets a check fix and pass. The moment a gate rewrites the thing it judges, its green means nothing, because it is grading its own homework.
+
+### Phase 3: Implement the checks against built output · lane: convergent (Tholo)
+
+Skills: qa-testing, seo-technical (nearest anchors; the gate-implementation core is a DECLARED GAP, procedure inline)
+Capability class: ci.gate-implement (declared catalog gap; nearest-miss qa-testing, seo-technical)
+Input: the approved gate set; the production-equivalent build command
+Run:
+
+    Invoke qa-testing and seo-technical as the check frameworks, and implement
+    each approved gate to run against the BUILT output with production-equivalent
+    flags, not the dev server and not source. Each gate emits the Phase 2 report
+    contract and exits non-zero on any fail. Wire them to run on the pull-request
+    event against the branch build. Land the wiring as a held PR; merge nothing.
+
+Output artifact: the gate implementations and their CI wiring, as a held PR that emits the report contract
+Done when: each gate runs on the pull-request event against the built output and emits the report contract, in a held PR
+Fails look like: asserting against a dev-flag build. A gate that passes on the dev server while the real build serves something else has verified a machine no user visits.
+
+### Phase 4: Deliberate-failure demonstration · lane: gate (Basano)
+
+Skills: qa-testing (nearest anchor; procedure inline)
+Capability class: ci.gate-prove (declared catalog gap; nearest-miss qa-testing)
+Input: the wired gates from Phase 3
+Run:
+
+    Invoke qa-testing's adversarial discipline. For each gate, seed a known-bad
+    input it must catch (a missing title, a broken internal link, a failing prove
+    check), run the pipeline, and capture the red: the gate failing and blocking,
+    with its report contract naming the seeded fault. Then revert the seed and
+    capture the green. Retain both as the gate's evidence. Report only; the seed
+    is reverted, never merged.
+
+Output artifact: per-gate failure evidence (the seeded fault, the captured red with its report, the reverted green)
+Done when: every gate has a captured red on its seeded fault and a captured green after revert
+Fails look like: shipping a gate no one has seen fail. A gate that has only ever passed is indistinguishable from a gate that checks nothing, and the difference surfaces the day it should have caught something.
+
+### Phase 5: Install as required checks and branch protection · lane: divergent (human)
+
+Skills: none; the actions here are deliberately human
+Input: the proven gates and their evidence
+Run: a person sets the gates as REQUIRED status checks and enables branch
+    protection so a failing verdict blocks a merge the way a failing test does.
+    These are platform state changes (repository settings and protection rules),
+    and they stay human. The person records which gates were made required and on
+    which branches.
+Output artifact: the required-check and branch-protection configuration, recorded against the gate set
+Done when: the named gates are required on the protected branches and a failing gate blocks the merge, confirmed by the human
+Fails look like: gates that run but are not required. An advisory gate is a suggestion, and a pipeline under deadline merges past suggestions.
+
+### Phase 6: Drift watch · lane: convergent (Tholo)
+
+Skills: qa-testing, seo-technical (nearest anchors; procedure inline)
+Capability class: ci.gate-drift (declared catalog gap; nearest-miss qa-testing, seo-technical)
+Input: the installed gates; the canon each gate encodes (the prove checks, the report contract, the route list)
+Run:
+
+    Invoke qa-testing and seo-technical to re-verify each gate when its canon
+    moves: a gate that encodes a check's rules is re-proven (a Phase 4 rerun) when
+    that check updates, and a gate reading a route list is re-checked when routes
+    change. Flag any gate whose canon moved without a re-proof as stale. Land
+    re-proofs and updates as held changes.
+
+Output artifact: a drift record per gate (the canon version proven against, the last re-proof) and held updates for any stale gate
+Done when: every gate names the canon version it was last proven against, and no gate is enforcing against moved canon unproven
+Fails look like: a gate frozen against last quarter's rules. It still passes and still blocks, and it is now enforcing a standard the team no longer holds.
+
+## Failure modes
+
+- Gate theater: gates that never fail. The Phase 4 deliberate-failure demonstration is the antidote; a gate with no captured red is not installed.
+- Hooks tripping on pre-existing debt: a gate that fails on unrelated legacy files in every PR gets bypassed, and a bypassed gate is a pipeline defect. Scope gates to the staged or changed set.
+- Gates that fix instead of report: any gate that mutates what it judges. Report-only is the contract; a self-fixing gate grades its own work.
+- Dev-flag assertion: gating against a non-production build, so the gate verifies an artifact production never serves.
+- Advisory installation: wiring gates but never making them required (Phase 5's failure); a gate that does not block is documentation.
+- Stale canon: gates enforcing rules that have since moved (Phase 6's failure).
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a showcase-designated property; the scheduled occasion is installing this tier's prove gates as required status checks on an outdoor-sports content property, with the seeded-failure evidence retained per gate. Status flips to validated when that run record links here.
+
+## Boundaries
+
+- Post-Deploy Live Verification begins where these gates end: CI runs against the build, that workflow runs against the world, and a green pipeline is not a verified deploy.
+- Content Pipeline with Prove Gates owns the content pre-publish gate (its Phase 3); this workflow is the wiring that makes any such gate a required, report-only, non-bypassable check.
+- Warehouse Data Plane Standup stands up the bounded data access a data-reading gate would query; a gate needing warehouse access consumes that contract.

--- a/workflows/link-graph-and-metadata-parity-audit.md
+++ b/workflows/link-graph-and-metadata-parity-audit.md
@@ -1,0 +1,131 @@
+# Link Graph and Metadata Parity Audit
+
+```
+name:            Link Graph and Metadata Parity Audit
+slug:            link-graph-and-metadata-parity-audit
+tier:            forward-deployed (operations)
+role:            fdm
+status:          template
+score:           45 (demand 5, pain 3, differentiation 3, usability 5, connectors 5)
+intent:          audit a site's link graph and per-route share metadata: find orphans and
+                 dead ends, and hold every route to unique, self-referencing metadata
+when to use:     a site large enough that routes get orphaned or inherit the homepage's
+                 metadata by default; a periodic structural pass
+when not to use: per-deploy verification of the routes a change touched (Post-Deploy Live
+                 Verification); whether a claim is true (Corpus Integrity and Correction)
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  crawl.read
+    access:      read
+  - capability:  repo.change
+    access:      write-held      # only in Phase 4, and only as held changes
+```
+
+Read-only until Phase 4; fixes land held, a human merges. Nothing in the audit acts on production.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- The production site, crawlable, and the route registry or sitemap to reconcile the crawl against.
+- The templates behind the routes, for fixes that belong at the template rather than the page.
+- The list of money or conversion surfaces the graph is expected to feed.
+
+## Phases
+
+### Phase 1: Build the link graph · lane: convergent (Tholo)
+
+Skills: seo-technical, seo-site-health-audit
+Capability class: linkgraph.build (substitute equivalents if off-catalog)
+Input: the live site (crawl.read) and the route registry or sitemap
+Run:
+
+    Invoke seo-technical and seo-site-health-audit against a crawl of the live
+    site, reconciled with the route registry or sitemap. Build the directed link
+    graph: every route a node, every internal link an edge, with each route's
+    templates and its share metadata (title, description, canonical, OG, Twitter)
+    attached. Reconcile crawl against registry so that routes which exist but are
+    unlinked, and links that point at routes which do not exist, are both visible.
+    Produce the graph; judge nothing yet.
+
+Output artifact: the link graph (routes, edges, per-route metadata) reconciled against the route registry
+Done when: every registry route is a node and every internal link is an edge, with crawl-versus-registry discrepancies marked
+Fails look like: crawling the preview. A staging crawl maps a link graph no user traverses, and the orphan on production is the page staging linked fine.
+
+### Phase 2: Orphan and dead-end detection · lane: gate (Basano)
+
+Skills: seo-site-health-audit
+Capability class: linkgraph.orphan-detect (substitute equivalents if off-catalog)
+Input: the link graph
+Run:
+
+    Invoke seo-site-health-audit against the graph and flag two classes, fixing
+    nothing. Orphans: routes with zero inbound internal links, reachable only by
+    direct URL. Dead ends toward outcomes: routes with zero outbound links to the
+    money or conversion surfaces they should feed. Weight each by the route's
+    value (traffic or commercial intent) so the ranking holds business harm above
+    raw count. Report each with its graph evidence: the node, its inbound and
+    outbound degree, and the path that is missing.
+
+Output artifact: the orphan-and-dead-end report (each flagged route, its degrees, the missing path, its weight)
+Done when: every route with zero inbound, or zero outbound to an outcome surface, is flagged with evidence, including the clean high-value routes confirmed reachable
+Fails look like: counting orphans without weighting them. A thousand orphaned tag pages and one orphaned money page are not the same finding, and an unweighted list buries the one that pays.
+
+### Phase 3: Metadata parity per route · lane: gate (Basano)
+
+Skills: seo-onpage, seo-technical
+Capability class: metadata.parity (substitute equivalents if off-catalog)
+Input: the link graph's per-route metadata
+Run:
+
+    Invoke seo-onpage and seo-technical against every route's metadata. Check:
+    title and description are unique per route, not the homepage's defaults; OG
+    and Twitter tags are per-route, not the site-wide fallback; the canonical is
+    self-referencing; and no title template is doubling its suffix (the
+    "Page | Site | Site" class). Verdict per route per check, with the rendered
+    metadata as evidence. Report only.
+
+Output artifact: the metadata-parity report (verdict per route per check, rendered metadata attached)
+Done when: every route carries a verdict for uniqueness, per-route OG and Twitter, self-canonical, and suffix dedup
+Fails look like: checking presence, not uniqueness. Every page carrying the homepage's OG image passes a presence check and fails a reader who sees the same card for forty different links.
+
+### Phase 4: Triage and held fixes · lane: divergent (Krine) then convergent (Tholo)
+
+Skills: seo-onpage, seo-technical
+Capability class: metadata.correct (write-held)
+Input: the orphan-and-dead-end report and the metadata-parity report
+Run:
+
+    Invoke seo-onpage and seo-technical to rank the findings by value-weighted
+    harm and present the plan for a human to approve (the divergent stop). On
+    approval, use those skills to fix at the TEMPLATE, not the page: a doubled
+    suffix or a fallback-OG defect is one
+    template change that clears every route it governs, and a per-page patch
+    plants the next drift. Orphans are fixed by adding the missing inbound links
+    at their source. Everything lands held: a draft change, never a direct push.
+
+Output artifact: a ranked plan, then held fixes at the template level, each tied to its finding
+Done when (public gate): a human has approved the plan, and every approved fix is a held change with nothing published
+Operated-layer note: in an operated deployment the ranking and the human's approval or reordering land as an agreement-log row (see AGREEMENT-LOG.md)
+Fails look like: fixing template symptoms per page. Retyping the right title on forty routes leaves the template that mis-set them in place, and the forty-first route ships wrong next week.
+
+## Failure modes
+
+- Presence-not-uniqueness checking (Phase 3's failure): every page sharing the homepage OG passes a presence check.
+- Crawling the preview (Phase 1's failure): a link graph no user traverses.
+- Per-page template fixes (Phase 4's failure): treating a template defect one route at a time.
+- Unweighted orphan lists: a money page and a tag page counted the same.
+- Registry-crawl blindness: trusting one source, so a route that exists but is unlinked, or a link to a route that does not exist, never surfaces.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a showcase-designated property; a full-graph pass on rampstack.co is schedulable as written in the near term. Status flips to validated when that run record links here.
+
+## Boundaries
+
+- Corpus Integrity and Correction owns whether a claim is true; this workflow owns whether the structure around it (links, canonicals, share metadata) is sound.
+- Post-Deploy Live Verification owns the per-deploy check of the routes a change touched; this is the periodic full-graph pass across every route.
+- Content Pipeline with Prove Gates checks a single draft's metadata and links at publish (its Phase 3); this audits the whole graph after the fact.

--- a/workflows/revenue-tracking-integrity.md
+++ b/workflows/revenue-tracking-integrity.md
@@ -1,0 +1,163 @@
+# Revenue Tracking Integrity
+
+```
+name:            Revenue Tracking Integrity
+slug:            revenue-tracking-integrity
+tier:            forward-deployed (operations)
+role:            fda
+status:          template
+score:           47 (demand 4, pain 5, differentiation 5, usability 3, connectors 4)
+intent:          a scheduled prove pass over the money path: params surviving redirects,
+                 consent not zeroing attribution, platform and warehouse reconciled, and
+                 monetized links live
+when to use:     any property that earns through tracked links or events, on a schedule
+when not to use: diagnosing a conversion divergence on stable traffic (Conversion-by-Source
+                 Diagnosis); a falling-traffic mystery (Traffic-Drop Triage)
+gap note:        the money-path map, the consent matrix, and the reconciliation cores are
+                 DECLARED CATALOG GAPS; those phases are inline procedure with
+                 product-analytics-setup as the nearest anchor. It is written to be
+                 runnable anyway.
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  crawl.read
+    access:      read
+  - capability:  analytics.read
+    access:      read
+  - capability:  warehouse.query
+    access:      read
+    bounds:      every query carries a date range pushed down as a partition filter
+  - capability:  revenue.read
+    access:      read
+```
+
+Fully read-only until Phase 5, and Phase 5 only ever produces held changes and a schedule. Platform and merchant changes stay human; nothing in the audit acts on the money path.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- The list of monetized link and event classes the property runs (affiliate links, checkout events, lead events).
+- Read access to the platform that reports revenue or clicks, and to the analytics and warehouse stores the events land in.
+- Enough accrued revenue or click data for a reconciliation window to be meaningful.
+- The attribution parameter set: which parameters must survive the redirect chain.
+
+## Phases
+
+### Phase 1: Map the money path · lane: convergent (Tholo)
+
+Skills: product-analytics-setup (nearest anchor; the money-path-mapping core is a DECLARED GAP, procedure inline)
+Capability class: revenue.path-map (declared catalog gap; nearest-miss product-analytics-setup)
+Input: the site (crawl.read), the platform records (revenue.read), and the event definitions
+Run:
+
+    Invoke product-analytics-setup's instrumentation discipline. Enumerate every
+    monetized link and event CLASS, not instance: each affiliate or outbound money
+    link type, its full redirect chain, the attribution parameters it must carry,
+    the event it fires, and the platform record that event should become. Map each
+    class end to end, from the on-page link to the reconciled revenue row. Produce
+    the money-path map; test nothing yet.
+
+Output artifact: the money-path map (each class: link, redirect chain, required params, event, platform record)
+Done when: every monetized class is mapped from on-page link to platform record, with its required attribution parameters named
+Fails look like: mapping link instances instead of classes. Ten thousand affiliate links share a handful of classes, and a map keyed to instances misses the class-wide break while drowning in duplicates.
+
+### Phase 2: Liveness and parameter survival · lane: gate (Basano)
+
+Skills: product-analytics-setup (nearest anchor; procedure inline)
+Capability class: revenue.liveness-check (declared catalog gap; nearest-miss product-analytics-setup)
+Input: the money-path map
+Run:
+
+    Invoke product-analytics-setup's verification discipline as a gate. Per link
+    class, fetch a live instance (crawl.read), follow the full redirect chain to
+    its destination, and assert two things: the link resolves to a live endpoint
+    (no dead redirect, no parking page, no 404 at the merchant), and the required
+    attribution parameters arrive intact at the end of the chain, not stripped by
+    a redirect hop or a canonicalization. Test every class, including the ones
+    that look fine. Report liveness and parameter survival per class with the
+    chain as evidence. Report only.
+
+Output artifact: a liveness-and-survival report per class (resolves live, params arrived, the chain)
+Done when: every link class has a liveness verdict and a parameter-survival verdict with its redirect chain recorded
+Fails look like: testing one link and trusting the class. One affiliate link resolving does not prove the class resolves, and the broken subset earns nothing while the test stays green.
+
+### Phase 3: Consent-state matrix · lane: gate (Basano)
+
+Skills: product-analytics-setup (nearest anchor; the consent-matrix core is a DECLARED GAP, procedure inline)
+Capability class: measurement.consent-matrix (declared catalog gap; nearest-miss product-analytics-setup)
+Input: the money-path map; the property's consent states
+Run:
+
+    Invoke product-analytics-setup's measurement discipline. Build the matrix:
+    each money event against each consent state the property can be in (granted,
+    denied, not-yet-decided, and any regional variant). For each cell, confirm
+    whether the event fires and whether attribution survives. The failure this
+    catches: a consent state that silently zeroes attribution, so revenue is
+    earned but recorded as unattributed or not at all. Report the matrix with the
+    fired-and-attributed verdict per cell. Report only.
+
+Output artifact: the consent matrix (event by consent state, fired and attributed verdict per cell)
+Done when: every money event has a verdict under every consent state the property supports
+Fails look like: testing only the granted state. Consent-denied and undecided states are where attribution quietly zeroes, and a matrix that skips them certifies a path that loses money in the states most users are actually in.
+
+### Phase 4: Reconciliation · lane: gate (Basano)
+
+Skills: product-analytics-setup (nearest anchor; procedure inline)
+Capability class: revenue.reconcile (declared catalog gap; nearest-miss product-analytics-setup)
+Input: the platform-reported events and revenue (revenue.read); the warehouse-landed events (warehouse.query, bounded)
+Run:
+
+    Invoke product-analytics-setup's reconciliation discipline as a gate. For a
+    bounded window, pull platform-reported events and revenue and the
+    warehouse-landed equivalents, and reconcile them within a stated tolerance,
+    per source, not only in total. Flag any per-source row that drifts past
+    tolerance even when the totals happen to match, because offsetting errors hide
+    in the total. Every warehouse query carries its date range as a partition
+    filter. Report the reconciliation per source with the variance. Report only.
+
+Output artifact: the reconciliation report (platform versus warehouse per source, variance, tolerance verdict)
+Done when: every source is reconciled within tolerance for the window, or the per-source variance is flagged with evidence
+Fails look like: reconciling totals while per-source rows drift. A matching grand total made of two offsetting errors reads as healthy and is two broken sources wearing a coincidence.
+
+### Phase 5: Findings triage, held fixes, and the standing cadence · lane: divergent (Krine) then convergent (Tholo)
+
+Skills: product-analytics-setup (nearest anchor; procedure inline)
+Capability class: revenue.correct (write-held)
+Input: the liveness, consent, and reconciliation reports
+Run:
+
+    Invoke product-analytics-setup to rank the findings by revenue at risk and
+    present the plan for a human to approve (the divergent stop). On approval,
+    land fixes held: a dead link class routed to its owner, a consent-zeroing path
+    routed to a measurement fix, a reconciliation drift routed to the
+    instrumentation. Then set the standing cadence: this pass recurs on a schedule
+    (monthly fits most money paths), so a dead class is caught by the pass, not by
+    a quarter of missing revenue. Nothing here publishes; platform and merchant
+    changes stay human.
+
+Output artifact: a ranked plan, held fixes tied to findings, and the recorded recurring cadence
+Done when (public gate): a human has approved the plan, every approved fix is held, and the recurring cadence is scheduled
+Operated-layer note: in an operated deployment the ranking and the human's approval land as an agreement-log row (see AGREEMENT-LOG.md)
+Fails look like: running this once. A money path is only as sound as its last pass, and the dead link that appears the week after a one-time audit earns nothing until someone notices the gap in the revenue.
+
+## Failure modes
+
+- Instance-not-class testing (Phase 2's failure): one link checked, the class assumed.
+- Granted-only consent testing (Phase 3's failure): the states where attribution zeroes go unchecked.
+- Total-level reconciliation (Phase 4's failure): per-source drift hidden by a matching total.
+- One-shot auditing (Phase 5's failure): a dead monetized link discovered by its revenue's absence months later.
+- Unbounded reconciliation queries: a warehouse pull with no partition filter, a cost incident on the money path.
+- Parameter survival assumed from presence: a parameter present on the link but stripped mid-chain, so the click lands unattributed.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a showcase-designated property; the scheduled occasion is a prove pass over the affiliate money path on an outdoor-sports content property once its first affiliate data accrues. Status flips to validated when that run record links here.
+
+## Boundaries
+
+- Conversion-by-Source Diagnosis assumes this path passes: its Phase 3 is a per-finding spot-check of measurement, and this is the scheduled end-to-end audit of the money path.
+- Experiment Loop with Pre-Registered Gates (design v2, publishing later) reads verdicts only as trustworthy as this path; a revenue experiment on a broken money path measures noise.
+- Warehouse Data Plane Standup wires the bounded warehouse access this workflow's reconciliation reads through.

--- a/workflows/warehouse-data-plane-standup.md
+++ b/workflows/warehouse-data-plane-standup.md
@@ -1,0 +1,176 @@
+# Warehouse Data Plane Standup
+
+```
+name:            Warehouse Data Plane Standup
+slug:            warehouse-data-plane-standup
+tier:            forward-deployed (operations)
+role:            fde
+status:          template
+score:           43 (demand 4, pain 4, differentiation 3, usability 4, connectors 5)
+intent:          stand up the data plane the tier reads from: exports first, two stores,
+                 read-only bounded access, cost governance, and an always-on sensing layer
+when to use:     day zero of a forward-deployed engagement, before any workflow that
+                 reads metrics
+when not to use: a stack whose warehouse, exports, and governance already exist (start
+                 with the workflow that needs the data); a one-off query (this is the
+                 standing plane, not a query)
+validation note: the occasion is the search-console bulk-export and warehouse enablement
+                 session on a showcase-designated property, already on the critical path
+gap note:        the two-store standup, the access-wiring, and the verification cores are
+                 DECLARED CATALOG GAPS; those phases are inline procedure with
+                 data-warehouse-experimentation as the nearest anchor. It is written to be
+                 runnable anyway.
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  warehouse.query
+    access:      read
+    bounds:      every query carries a date range pushed down as a partition filter
+  - capability:  search-performance.read
+    access:      read
+  - capability:  analytics.read
+    access:      read
+```
+
+This workflow stands up read-only access and wires no write path. Enabling the exports and provisioning the stores are platform actions a person performs; the engines never gain a write tool on this plane.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- A warehouse you can create datasets in, with a billing project.
+- Admin access to the search-console and analytics properties whose exports you will enable.
+- An operational store separate from the warehouse, or the ability to provision one.
+- The access controls to grant a scoped, read-only service identity.
+
+## Phases
+
+### Phase 1: Enable the exports · lane: divergent (human)
+
+Skills: none; the actions here are deliberately human
+Input: the list of properties in scope; the search-console and analytics accounts
+Run: a person enables the search-console bulk export and the analytics
+    warehouse export (the native daily-table exports) on every property in
+    scope, and records the enablement date per property. This is the one
+    time-sensitive action in the standup: the exports do not backfill, so the
+    history starts the day the export is enabled and the clock only runs
+    forward. Turn them on before any other step.
+Output artifact: the exports enabled per property, with the enablement date recorded
+Done when: every in-scope property has both exports enabled with a recorded start date, confirmed in the source consoles
+Fails look like: doing this last. Every day the exports are off is a day of history that will never exist, and no later step can recover it.
+
+### Phase 2: Separate the two stores · lane: convergent (Tholo)
+
+Skills: data-warehouse-experimentation (nearest anchor; the two-store standup core is a DECLARED GAP, procedure inline)
+Capability class: warehouse.standup (declared catalog gap; nearest-miss data-warehouse-experimentation)
+Input: the enabled exports; the provisioned warehouse and operational store
+Run:
+
+    Invoke data-warehouse-experimentation's warehouse-shape discipline. Stand up
+    two stores with one boundary rule: the metric warehouse holds metric history
+    (the export tables and their derivations), the operational store holds run
+    records, decisions, and the agreement log. Pick the warehouse region once and
+    match it across both exports, because it cannot be changed later without a
+    migration. Nothing that answers "what did the engines and humans decide" goes
+    in the warehouse; nothing that answers "what happened to the numbers" goes in
+    the operational store. Record the boundary as written policy.
+
+Output artifact: the two stores stood up, the region fixed, and the store-boundary policy recorded
+Done when: both stores exist, the region matches across exports, and the boundary policy names which data lives where
+Fails look like: one store doing both jobs. A single store for metrics and decisions couples query cost to operational writes and loses the separation the whole plane depends on.
+
+### Phase 3: Wire read-only access with mandatory bounds · lane: convergent (Tholo)
+
+Skills: data-warehouse-experimentation (nearest anchor; the access-wiring core is a DECLARED GAP, procedure inline)
+Capability class: warehouse.mcp-wire (declared catalog gap; nearest-miss data-warehouse-experimentation)
+Input: the metric warehouse; the identity and access controls
+Run:
+
+    Invoke data-warehouse-experimentation's access discipline. Wire the engines'
+    read path through a read-only interface (a managed warehouse MCP server plus a
+    thin domain layer) under a scoped service identity with dataset-scoped read
+    and deny-by-default elsewhere. Encode the query-correctness rules the raw
+    tools lack: the mandatory date range pushed down as a partition filter on
+    every call, and any source-specific offset (search-console positions are
+    zero-based, so average position is computed with the offset). A call without a
+    date range is rejected, not run. No write tool is present on this path.
+
+Output artifact: the read-only access layer, the scoped identity, and the bounds-and-offset rules encoded in the domain layer
+Done when: every warehouse call goes through the bounded read path, an unbounded call is rejected, and the identity carries no write scope
+Fails look like: bounds enforced by convention instead of code. A partition filter that is supposed to be there is absent on the one query written under deadline, and that is the query that scans the full history.
+
+### Phase 4: Cost and quota governance · lane: gate (Basano)
+
+Skills: data-warehouse-experimentation (nearest anchor; procedure inline)
+Capability class: warehouse.cost-governance (declared catalog gap; nearest-miss data-warehouse-experimentation)
+Input: the wired access layer; the warehouse's billing and quota controls
+Run:
+
+    Invoke data-warehouse-experimentation's cost discipline as a gate. Issue an
+    unbounded query and confirm it is rejected; issue a bounded query and confirm
+    it scans only the requested partitions. Set a budget alert and a quota ceiling
+    on the billing project. Report the enforcement result and the alert
+    configuration per source. Change nothing about the access layer here; report
+    what holds and what does not.
+
+Output artifact: a governance report (bounds-rejection confirmed, partition scan confirmed, budget alert and quota set)
+Done when: an unbounded query is confirmed rejected, a bounded query is confirmed to scan only its partitions, and a budget alert exists
+Fails look like: an unbounded scan reaching the warehouse. It is a cost incident waiting for a cron job, and it bills for the whole history every time it runs.
+
+### Phase 5: Stand up the sensing layer · lane: convergent (Tholo)
+
+Skills: monitoring-and-alerting, analytics-strategy
+Capability class: sensing.standup (substitute equivalents if off-catalog)
+Input: the metric warehouse with at least one series accruing
+Run:
+
+    Invoke monitoring-and-alerting to define the sensing layer and analytics-strategy
+    to decide what is worth sensing. Per series, set a freshness threshold and a
+    movement threshold sized to that series' own cadence, a cadence check that
+    fires when an expected update is late, and an anomaly flag on a schedule. Each
+    threshold is derived from the series' own history, never copied from another
+    series. Emit the sensing definitions and the schedule; the layer flags and
+    never acts.
+
+Output artifact: the sensing definitions per series (freshness, movement, cadence, anomaly) and the schedule
+Done when: every live series has thresholds derived from its own history and a scheduled check, and the layer only flags
+Fails look like: thresholds copied between series of different cadences. A daily series' movement band applied to a weekly one alarms on every normal week and trains the team to ignore it.
+
+### Phase 6: Verification pass · lane: gate (Basano)
+
+Skills: data-warehouse-experimentation (nearest anchor; procedure inline)
+Capability class: warehouse.verify (declared catalog gap; nearest-miss data-warehouse-experimentation)
+Input: the wired plane; one known query per source
+Run:
+
+    Invoke data-warehouse-experimentation's verification discipline as a gate.
+    Round-trip one bounded query per source through the read path: a
+    search-console query, an analytics query, and a warehouse derivation, each
+    with a date range, each returning the expected shape against a value known by
+    hand. Confirm the position offset is applied where it should be. Report pass
+    or fail per source with the returned evidence. Report only.
+
+Output artifact: a verification report (one bounded round-trip per source, expected-versus-returned, offset confirmed)
+Done when: each source returns the expected shape through the bounded path, or the discrepancy is filed with its evidence
+Fails look like: verifying the warehouse holds data without verifying the read path returns it correctly. The tables can be perfect while the domain layer drops the offset, and every downstream number inherits the error.
+
+## Failure modes
+
+- Exports enabled last: history that never exists (Phase 1's failure, the load-bearing one).
+- One store, both jobs: metric history and operational decisions in a single store, coupling cost to writes and losing the boundary.
+- Unbounded scans: a warehouse call with no partition filter (Phase 4's failure), a cost incident waiting for a cron job.
+- Copied sensing thresholds: bands moved between series of different cadences (Phase 5's failure), which alarms on normal variation.
+- Region drift: exports landing in mismatched regions, which forces a migration to join them.
+- Read path unverified: trusting the tables without proving the domain layer returns them with the offsets applied.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a showcase-designated property; the scheduled occasion is the search-console bulk-export and warehouse enablement session on an outdoor-sports content property, already on the critical path. Status flips to validated when that run record links here.
+
+## Boundaries
+
+- Data Surface Integrity (design v2, publishing later) consumes the series this workflow stands up; this owns the plane, that owns the freshness and consistency of what renders from it.
+- Conversion-by-Source Diagnosis and Revenue Tracking Integrity read through the bounded access this workflow wires; each states its own warehouse bounds and inherits them here.
+- Content Pipeline with Prove Gates ranks from the demand data this plane serves; the export enablement here is the prerequisite its demand source assumes.


### PR DESCRIPTION
## What this ships

Wave A of the workflows tier: four reviewed files at **template** status, their README rows flipped, and `WORKFLOWS.lock` regenerated to nine entries. Held draft; do not merge. Andy squash-merges.

- ci-prove-gate-wiring (FDE)
- warehouse-data-plane-standup (FDE)
- link-graph-and-metadata-parity-audit (FDM)
- revenue-tracking-integrity (FDA)

## Acceptance evidence

**1. Four files byte-match their sources.** `diff` of each placed file against its reviewed draft is empty:

```
ci-prove-gate-wiring                    IDENTICAL
warehouse-data-plane-standup            IDENTICAL
link-graph-and-metadata-parity-audit    IDENTICAL
revenue-tracking-integrity              IDENTICAL
```

**2. README: nine linked rows + six defined-publishing.** Exactly four rows flipped from `defined, publishing` to `[Name](slug.md) | Track | template`, matching the shipped rows' format. Counts by grep: 9 linked-with-template rows, 6 `defined, publishing` rows. No other README change; no counts in prose.

**3. WORKFLOWS.lock: nine entries, additions only.** The five prior entries are byte-unchanged (`content-pipeline-prove-gates`, `conversion-by-source-diagnosis`, `corpus-integrity-and-correction`, `post-deploy-live-verification`, `traffic-drop-triage`); the four new entries are added; none removed. The lock is LF and `python tools/gen_workflows_lock.py --check` prints `WORKFLOWS.lock is current (9 workflows).`

**4. CI checks green; bound-slug list.**
- **Lock current:** `gen_workflows_lock.py --check` passes.
- **Drift green:** `No drift: every bound slug exists in SKILLS.lock.` The slugs these four files bind, each verified present in `SKILLS.lock` at base `8d20efe`:
  - New to the tier this wave: `data-warehouse-experimentation`, `monitoring-and-alerting`.
  - Bound this wave and already in the tier: `analytics-strategy`, `seo-site-health-audit`, `product-analytics-setup`.
  - Repeats: `qa-testing`, `seo-technical`, `seo-onpage`.
  All eight verified against the lock; zero invented slugs. The capability-class gaps (for example `ci.inventory`, `warehouse.standup`, `revenue.path-map`) are declared gaps with a real-slug anchor and inline procedure, so they are not slugs and are not drift.
- **Fence:** `git diff <base> -- SKILLS.lock` reports 0 changed files; `SKILLS.lock` is byte-identical to base (sha256 `901c2bc8…52a151`, 103 skills), and `gen_skills_lock.py --check` prints `SKILLS.lock is current.`
- **Catalog lint unchanged:** `lint_skills.py` passes, 103 skills validated (em-dash, brand-leak, and README-catalog checks all OK; the single warning is the pre-existing `documentation-strategy` line count, untouched here).

**5. Style, signing, LF.** Em-dash, en-dash, banned marketing phrases, and "not just" greps across the four files and the README diff: zero. Commit signed (ED25519); all committed blobs are LF.

## Note

The four files ship with the score breakdowns amended post-review, taken as they sit on disk. On merge, the `rampstack.co/engines/deployment/workflows` page updates itself within the hour (it revalidates hourly against this lock); no site PR is needed or wanted.
