### PR TITLE
feat(workflows): publish wave B, data surface and the autonomy pair

### DIFF
--- a/WORKFLOWS.lock
+++ b/WORKFLOWS.lock
@@ -1,4 +1,9 @@
 {
+  "autonomy-review": {
+    "file": "autonomy-review.md",
+    "sha256": "14bf6e2a8188c92c816529b95ebbb3e3e6f4b1a43df67ebbf68024e1ab72ecc3",
+    "status": "template"
+  },
   "ci-prove-gate-wiring": {
     "file": "ci-prove-gate-wiring.md",
     "sha256": "137d850bef7d84b4c0351e8b85a37c77aea8674dd93c9d2b7d5de9be8e75ac17",
@@ -17,6 +22,16 @@
   "corpus-integrity-and-correction": {
     "file": "corpus-integrity-and-correction.md",
     "sha256": "f700641957273b279a9656b5bb5b4675bfddc1a6db2759abea8fff4607e15832",
+    "status": "template"
+  },
+  "data-surface-integrity": {
+    "file": "data-surface-integrity.md",
+    "sha256": "786f573deff77b6182064d98a2ded989e8ab30dad7d5a75269bc29e3bfb27241",
+    "status": "template"
+  },
+  "incident-response-and-lane-demotion": {
+    "file": "incident-response-and-lane-demotion.md",
+    "sha256": "e547a5cff6fcdf990bf630faf4f4846aa3d5bae69d9eb30752bf4861eae2e0bb",
     "status": "template"
   },
   "link-graph-and-metadata-parity-audit": {

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -40,7 +40,7 @@ WORKFLOWS.lock is the canonical manifest and the source for any count. The table
 | Workflow | Track | Status |
 |---|---|---|
 | [Post-Deploy Live Verification](post-deploy-live-verification.md) | FDE | template |
-| Data Surface Integrity | FDE | defined, publishing |
+| [Data Surface Integrity](data-surface-integrity.md) | FDE | template |
 | Migration with Verification | FDE | defined, publishing |
 | [CI Prove-Gate Wiring](ci-prove-gate-wiring.md) | FDE | template |
 | [Warehouse Data Plane Standup](warehouse-data-plane-standup.md) | FDE | template |
@@ -52,8 +52,8 @@ WORKFLOWS.lock is the canonical manifest and the source for any count. The table
 | [Traffic-Drop Triage](traffic-drop-triage.md) | FDA | template |
 | [Conversion-by-Source Diagnosis](conversion-by-source-diagnosis.md) | FDA | template |
 | [Revenue Tracking Integrity](revenue-tracking-integrity.md) | FDA | template |
-| Incident Response and Lane Demotion | cross | defined, publishing |
-| Autonomy Review | cross | defined, publishing |
+| [Incident Response and Lane Demotion](incident-response-and-lane-demotion.md) | cross | template |
+| [Autonomy Review](autonomy-review.md) | cross | template |
 
 ## Roadmap: named, not launched
 

--- a/workflows/autonomy-review.md
+++ b/workflows/autonomy-review.md
@@ -1,0 +1,156 @@
+# Autonomy Review
+
+```
+name:            Autonomy Review
+slug:            autonomy-review
+tier:            forward-deployed (operations)
+role:            cross
+status:          template
+score:           43 (demand 3, pain 4, differentiation 5, usability 4, connectors 4)
+intent:          the periodic ceremony over the agreement log: per-lane agreement rates,
+                 which gate classes have earned auto-pass under the tier's thresholds, and
+                 which divergences mean a rubric constant needs tuning
+when to use:     on a cadence or at a row threshold, once the agreement log holds enough
+                 rows per lane to evaluate
+when not to use: executing a revocation when a promoted lane regresses (Incident Response
+                 and Lane Demotion); defining the schema (AGREEMENT-LOG.md is the spec,
+                 this file is its consumer)
+gap note:        the agreement-log math is RampStack's and has no catalog skill by design;
+                 every analytic phase is inline procedure with no nearest-miss anchor. It
+                 is written to run against any log that implements AGREEMENT-LOG.md.
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  warehouse.query
+    access:      read
+    bounds:      every query carries a date range pushed down as a partition filter   # only if an outcome join is needed
+  - capability:  repo.change
+    access:      write-held      # only Phase 5's rubric-tuning follow-ups
+```
+
+The agreement log has no connector class, deliberately. It is operated substrate, not a connectable capability (see CONNECTORS.md): the schema is public (AGREEMENT-LOG.md), the instance and its write path are not. This ceremony reads the operated log and proposes; it never gains a write path to the log, and the promotion it licenses is an operated decision, not a published capability.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- An agreement log implementing the AGREEMENT-LOG.md schema, with enough rows per lane to evaluate; the minimum sample below is a real gate, not a formality.
+- The tier's per-lane thresholds and, for graded lanes, the `guardrail_confidence` cutoff, recorded and version-controlled.
+- The published merge-authority doctrine (the three layers: access mode, gate auto-pass, merge authority), so a promotion proposal is measured against a written rule.
+
+## Phases
+
+### Phase 1: Assemble the window · lane: convergent (Tholo)
+
+Skills: none; the agreement-log math is a DECLARED GAP with no catalog anchor, procedure inline
+Capability class: autonomy.window-assembly (declared catalog gap; no nearest-miss, the log math is RampStack's)
+Input: the agreement log for the review window (a log implementing AGREEMENT-LOG.md)
+Run:
+
+    Read the agreement log for the window and group rows by lane. Per lane,
+    compute the four-way agreement rates over true_pass, false_pass, true_fail,
+    and false_fail, and the row count. Pull the waived rows (human_verdict =
+    waive) out first: they carry an authored agreement value plus a required
+    human_reason, are excluded from false-pass and false-fail rate computations,
+    and report as their own line. Agreement is the authored value on each row,
+    never derived from the verdict pair; read it, do not recompute it. Present the
+    per-lane window with the waived line kept separate from the rates, and
+    evaluate no promotion yet.
+
+Output artifact: the per-lane window (four-way agreement rates, row counts, the waived line reported separately)
+Done when (public gate): every lane in the window has its four-way rates and row count, and waived rows are reported on their own line outside the rates
+Operated-layer note: the window is read from the operated log instance; the schema and the four-way agreement values are public (AGREEMENT-LOG.md), and a reader runs this against their own log while RampStack's rows stay operated
+Fails look like: folding waived rows into the rates. A waive is a recorded human override, not a guardrail miss, and counting it as a false_pass or false_fail poisons the exact number promotion depends on.
+
+### Phase 2: Threshold evaluation per lane · lane: gate (Basano)
+
+Skills: none; the promotion math is a DECLARED GAP with no catalog anchor, procedure inline
+Capability class: autonomy.threshold-eval (declared catalog gap; no nearest-miss)
+Input: the per-lane window; the tier's per-lane thresholds and the `guardrail_confidence` cutoff
+Run:
+
+    For each lane, evaluate three conditions against the written rule and report a
+    pass or fail on each, changing nothing. One: the false-pass-among-passes rate
+    is at or below the lane's tier threshold. Two: the lane's row count meets the
+    minimum sample, because a lane under sample is not evaluable and "insufficient
+    sample" is a verdict, not a delay. Three, for graded lanes only: the lane's
+    guardrail_confidence clears the confidence cutoff. A lane earns eligibility
+    for auto-pass only when every applicable condition holds. Report the per-lane
+    evaluation with the numbers; this gate reports and decides nothing.
+
+Output artifact: the per-lane eligibility evaluation (each condition, pass or fail, with the numbers)
+Done when: every evaluable lane has a verdict on the threshold, the minimum sample, and (for graded lanes) the confidence cutoff, and under-sample lanes are marked not-evaluable
+Fails look like: a ceremony on insufficient sample. A lane declared eligible on five rows has measured noise, and the promotion it licenses regresses on the first real week.
+
+### Phase 3: The ceiling · lane: gate (Basano)
+
+Skills: none; the ceiling is doctrine, procedure inline
+Capability class: autonomy.ceiling-check (declared catalog gap; no nearest-miss)
+Input: the per-lane eligibility evaluation
+Run:
+
+    Apply the ceiling before any proposal is written. Tier-3 judgment and boundary
+    gates (honesty and disclosure lines, the open-versus-operated boundary,
+    positioning, naming, and the meta-decision of when any lane graduates) are
+    PERMANENTLY ineligible: they never earn auto-pass and never earn merge
+    authority, at any status, on any sample. The ceremony that licenses a
+    graduation is itself a Tier-3 act, so it can never license its own class.
+    Strike every Tier-3 lane from the eligible set regardless of its rates, and
+    record that the strike is structural, not a close call. Report the eligible
+    set after the ceiling.
+
+Output artifact: the eligible set with every Tier-3 lane struck, and each strike recorded as permanent
+Done when: no Tier-3 lane remains in the eligible set, and the graduation meta-decision is marked as itself Tier 3 and ineligible
+Fails look like: a lane graduating the ceremony's own class. The moment the review licenses the authority that licenses reviews, the ceiling is gone and the ladder is a pricing page with extra steps.
+
+### Phase 4: Promotion, demotion, and tuning proposals · lane: divergent (human)
+
+Skills: none; the decision is deliberately human
+Input: the eligible set after the ceiling; the divergences the window surfaced
+Run: a person decides. For each eligible lane, the human decides whether to
+    promote it (grant gate auto-pass, or merge authority, per the doctrine's
+    layers) with the evidence attached; whether a lane's divergences mean a rubric
+    constant needs tuning rather than a promotion; and whether any lane should be
+    demoted. Promotion is licensed here and nowhere else, and it stays revocable.
+    The decision and its evidence are recorded.
+Output artifact: the recorded decisions (promote, tune, demote, or hold) per lane, with evidence
+Done when: every eligible lane has a recorded human decision with its evidence, or is explicitly held for more sample
+Operated-layer note: in an operated deployment each decision is a Tier-3 act recorded against the lane in the agreement log; the licensing, the log instance, and the promotion are operated, and a reader running this against their own log makes their own decisions (AGREEMENT-LOG.md, open versus operated)
+Fails look like: the ceremony drifting into a rubber stamp. If every review promotes and none tunes or demotes, the ceremony has stopped reviewing, and its own agreement rate, its proposals against what the evidence supported, is the number that catches it.
+
+### Phase 5: Rubric-tuning follow-ups · lane: convergent (Tholo)
+
+Skills: none; rubric constants are config, the change is procedure inline
+Capability class: rubric.tune (write-held)
+Input: the tuning decisions from Phase 4
+Run:
+
+    For each tuning decision, prepare the rubric-constant change as a held change
+    (repo.change): the constant, its old and new value, and the divergence
+    evidence that motivated it. Nothing auto-applies; a human merges the tuning
+    the way any other held change is merged. Record the follow-up against the lane
+    so the next window can tell whether the tuning moved the agreement rate.
+
+Output artifact: held rubric-tuning changes, each tied to its lane and its motivating divergence
+Done when: every Phase 4 tuning decision is a held change with its evidence, and nothing has auto-applied
+Fails look like: tuning a constant to make a lane pass. A threshold moved to promote a lane it was blocking is the promotion wearing a disguise, and the divergence evidence is what keeps the tuning honest.
+
+## Failure modes
+
+- Ceremonies on insufficient sample: a lane declared eligible on too few rows (Phase 2's failure); insufficient sample is a verdict, not a delay.
+- Counting waives in the rates: a recorded human override contaminating the false-pass or false-fail computation (Phase 1's failure).
+- The ceremony as rubber stamp: a review that only ever promotes, its own agreement rate reviewable (Phase 4's failure).
+- Promotion without the demotion counterpart wired: granting autonomy with no revocation path is the asymmetry the doctrine forbids; Incident Response and Lane Demotion must exist and be armed before any lane graduates.
+- Licensing the ceiling's own class: a Tier-3 graduation (Phase 3's failure).
+- Tuning to pass: moving a constant to promote a lane it was blocking (Phase 5's failure).
+
+## Worked example
+
+Pending. Populates when this ceremony is first run against the agreement log at a row threshold rather than a date; a small number of real rows exist today and the cadence adds more. Status flips to validated when that run record links here.
+
+## Boundaries
+
+- Incident Response and Lane Demotion executes the revocation this ceremony's promotions promise: it demotes a lane when a promoted lane's post_merge_outcome regresses, and no lane should graduate here until that counterpart is armed.
+- AGREEMENT-LOG.md is the schema this ceremony consumes; that file is the spec and this workflow is its reader, and every column, verdict, and rule this file uses is defined there.

--- a/workflows/data-surface-integrity.md
+++ b/workflows/data-surface-integrity.md
@@ -1,0 +1,162 @@
+# Data Surface Integrity
+
+```
+name:            Data Surface Integrity
+slug:            data-surface-integrity
+tier:            forward-deployed (operations)
+role:            fde
+status:          template
+score:           49 (demand 4, pain 5, differentiation 5, usability 4, connectors 4)
+intent:          keep machine-rendered data series honest: per-series freshness guards,
+                 two-surface consistency from one source, honest degradation, and
+                 discontinued-series retirement
+when to use:     any property that renders live or periodic data series (rates, prices,
+                 counts, stats) a reader is expected to trust
+when not to use: authored claims about the world (Corpus Integrity and Correction);
+                 whether a surface is current at all after a deploy (Post-Deploy Live
+                 Verification)
+validation note: gated on a designated data surface existing or the allowlist expanding;
+                 neither designated property renders external data series today
+gap note:        the freshness-guard and consistency cores are DECLARED CATALOG GAPS with
+                 monitoring-and-alerting and seo-technical as the nearest anchors; those
+                 phases are inline procedure. It is written to be runnable anyway.
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  warehouse.query
+    access:      read
+    bounds:      every query carries a date range pushed down as a partition filter
+  - capability:  crawl.read
+    access:      read
+  - capability:  repo.change
+    access:      write-held      # only Phase 5's retirement changes
+```
+
+Read-only until Phase 5; retirement changes land held, a human merges. Nothing in the audit acts on production.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- The property's machine-rendered data series and the source each renders from (the warehouse tables or feeds behind them).
+- The live surfaces that render each series (crawl.read), including metadata and any narration that cites the series.
+- The per-series cadence each source actually updates on.
+- A place to record the discontinued-series registry and the correction-note format (the same format Corpus Integrity and Correction uses).
+
+## Phases
+
+### Phase 1: Series inventory · lane: convergent (Tholo)
+
+Skills: monitoring-and-alerting (nearest anchor; the series-inventory core is a DECLARED GAP, procedure inline)
+Capability class: data.series-inventory (declared catalog gap; nearest-miss monitoring-and-alerting)
+Input: the property's data sources; the live surfaces (crawl.read)
+Run:
+
+    Invoke monitoring-and-alerting's series discipline. Inventory every
+    machine-rendered series ONE series at a time: its source, the cadence that
+    source actually updates on, and every surface that consumes it (tiles, tables,
+    metadata, and any narration that cites it). Key the inventory by series, never
+    by dataset, because a dataset holds many series on different cadences. Produce
+    the per-series inventory; guard nothing yet.
+
+Output artifact: the per-series inventory (each series: source, real cadence, every consuming surface)
+Done when: every machine-rendered series is inventoried by series with its source, cadence, and consuming surfaces, including metadata and narration
+Fails look like: inventorying by dataset. A dataset marked fresh can carry one series that froze months ago, and a dataset-level view never sees the frozen series inside it.
+
+### Phase 2: Guard audit · lane: gate (Basano)
+
+Skills: monitoring-and-alerting (nearest anchor; the freshness-guard core is a DECLARED GAP, procedure inline)
+Capability class: data.freshness-guard (declared catalog gap; nearest-miss monitoring-and-alerting)
+Input: the per-series inventory
+Run:
+
+    Invoke monitoring-and-alerting's threshold discipline as a gate. Per series,
+    check three guards and change nothing. Freshness: a per-series staleness
+    threshold exists and fires when the series exceeds its own cadence, never a
+    dataset-wide threshold. Discontinued registry: a series that stopped updating
+    is registered as discontinued, not silently served stale. Honest degradation:
+    when a series is stale or degraded, the surface renders honestly, showing the
+    as-of date and suppressing the trend arrows and deltas a frozen value cannot
+    support. Report a verdict per series per guard with the rendered evidence.
+
+Output artifact: the guard report (per series: freshness threshold, discontinued registration, honest degradation, each with a verdict)
+Done when: every series has a verdict on its per-series freshness threshold, its discontinued status, and its degradation rendering
+Fails look like: a trend arrow on a degraded series. An up arrow drawn from a value that stopped updating tells the reader the number is rising when it is only frozen, which is worse than showing nothing.
+
+### Phase 3: Two-surface consistency · lane: gate (Basano)
+
+Skills: seo-technical, qa-testing (nearest anchors; the consistency build-test core is a DECLARED GAP, procedure inline)
+Capability class: data.two-surface-consistency (declared catalog gap; nearest-miss seo-technical, qa-testing)
+Input: the per-series inventory (series rendered on more than one surface)
+Run:
+
+    Invoke seo-technical and qa-testing. For any value that appears on two or more
+    surfaces, prove it renders from ONE source module, and back that proof with a
+    build test that fails if the two surfaces ever derive the value independently.
+    Check the caches too: two surfaces reading one module in code can still
+    diverge when their cache lifetimes differ, so the test covers served output,
+    not only source. Report consistency per shared value with the build-test
+    evidence.
+
+Output artifact: the consistency report (each shared value: single-source proof, the build test, the cache-lifetime check)
+Done when: every value on two or more surfaces is proven single-source with a build test, or the divergence is flagged with evidence
+Fails look like: one source in code, two lifetimes in cache. Two surfaces importing the same module look consistent in review and serve different numbers in production because one cache outlived the other.
+
+### Phase 4: Cadence-copy alignment · lane: gate (Basano)
+
+Skills: editorial-qa, monitoring-and-alerting (nearest anchors; the cadence-claim core is a DECLARED GAP, procedure inline)
+Capability class: data.cadence-alignment (declared catalog gap; nearest-miss editorial-qa, monitoring-and-alerting)
+Input: the per-series inventory; the surface copy that claims an update frequency
+Run:
+
+    Invoke editorial-qa to find the copy and monitoring-and-alerting to check the
+    mechanism. Wherever a surface states its own update frequency ("updated
+    daily", "live rates", "refreshed weekly"), verify the series behind it
+    actually updates on that cadence. A page promising daily data over a series
+    that updates monthly is a false claim the reader cannot see is false. Report
+    each cadence claim against its series' real cadence with a verdict. Report
+    only.
+
+Output artifact: the cadence-alignment report (each stated frequency, the series' real cadence, a verdict)
+Done when: every surface claim about its own update frequency has a verdict against the series' real cadence
+Fails look like: trusting the copy. "Updated daily" is a claim like any other, and a series that refreshes monthly behind it is a dated claim that rots the moment the copy ships.
+
+### Phase 5: Retirement protocol · lane: convergent (Tholo)
+
+Skills: editorial-qa, brand-voice
+Capability class: data.series-retirement (write-held)
+Input: the discontinued series from Phase 2; the property's correction-note format
+Run:
+
+    Invoke editorial-qa and brand-voice for the retirement, the same correction
+    discipline Corpus Integrity and Correction uses. For each discontinued series:
+    remove it from current renders (the tile, the table, the metadata), and add a
+    visible correction note anywhere the corpus narrates the series, stating that
+    it is discontinued and as of when. The narration is retired with the tile, not
+    left behind to describe a number that no longer renders. Everything lands
+    held; a human merges.
+
+Output artifact: held retirement changes per discontinued series (removed from renders, correction note on any narration)
+Done when: every discontinued series is removed from current renders and its narration carries a visible correction note, all as held changes
+Fails look like: retiring the tile but not the narration. The number disappears from the dashboard while a paragraph elsewhere still explains what it means and where it is heading, describing a series that no longer exists.
+
+## Failure modes
+
+- Dataset-level guards (Phase 1 and Phase 2's failure): a frozen series hiding inside a fresh dataset.
+- Trend arrows on degraded series (Phase 2's failure): an arrow drawn from a value that stopped moving.
+- One source in code, two lifetimes in cache (Phase 3's failure): two surfaces diverging past a shared module because their caches expire differently.
+- Retiring the tile but not the narration (Phase 5's failure): the render gone, the prose still describing it.
+- Cadence copy outrunning the mechanism (Phase 4's failure): a stated update frequency the series never meets.
+- Guards written once and never re-run: a series added after the audit renders unguarded, so the guard set is only as complete as its last inventory.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a designated property that renders live data series; neither designated property renders external data series today, so it is gated on such a surface existing or the allowlist expanding. The freshness and degradation patterns generalize production incidents on an unnamed property (a series serving a frozen value behind a live trend arrow); that origin informs the guards but is not validation evidence.
+
+## Boundaries
+
+- Corpus Integrity and Correction owns authored claims about the world; this workflow owns machine-rendered data series, and Phase 5's retirement uses that workflow's correction-note pattern for any narration of a discontinued series.
+- Post-Deploy Live Verification owns whether a surface is current at all after a deploy; this workflow owns whether the series it renders stay fresh, consistent, and honestly degraded between deploys.
+- Warehouse Data Plane Standup stands up the bounded warehouse access and the sensing layer this workflow's guards read through.

--- a/workflows/incident-response-and-lane-demotion.md
+++ b/workflows/incident-response-and-lane-demotion.md
@@ -1,0 +1,176 @@
+# Incident Response and Lane Demotion
+
+```
+name:            Incident Response and Lane Demotion
+slug:            incident-response-and-lane-demotion
+tier:            forward-deployed (operations)
+role:            cross
+status:          template
+score:           49 (demand 4, pain 5, differentiation 5, usability 4, connectors 4)
+intent:          the event-driven counterpart to Autonomy Review: when a promoted lane's
+                 post_merge_outcome regresses, demote the lane to human-gated first, then
+                 roll back, then audit the false-pass row
+when to use:     a promoted lane shows a post-merge regression, a known suspect rather
+                 than a mystery
+when not to use: a traffic drop with no known cause (Traffic-Drop Triage); an ordinary
+                 defect on a lane that was never promoted (the normal held-fix flow)
+gap note:        the attribution and false-pass-audit cores are DECLARED CATALOG GAPS with
+                 incident-response as the nearest anchor; those phases are inline procedure.
+                 It is written to be runnable anyway.
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  crawl.read
+    access:      read
+  - capability:  warehouse.query
+    access:      read
+    bounds:      every query carries a date range pushed down as a partition filter
+  - capability:  repo.change
+    access:      write-held      # the rollback and any fix land as held changes
+```
+
+The rollback and the fix land held; a human merges them through the now human-gated lane. The demotion itself and the agreement-log rows are operated actions on the operated instance; this workflow never promotes or re-promotes a lane.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- A running autonomy program with at least one promoted lane and the agreement log behind it (AGREEMENT-LOG.md); with no promoted lane, Phase 2 routes elsewhere and this workflow does not apply.
+- The `post_merge_outcome` signal source: the monitoring and verification outputs that populate it.
+- The lane's `post_merge_outcome` budget, the regression threshold that makes a demotion mandatory.
+- The rollback mechanism for the lane's changes.
+
+## Phases
+
+### Phase 1: Detection intake · lane: convergent (Tholo)
+
+Skills: incident-response, launch-runbook
+Capability class: incident.intake (substitute equivalents if off-catalog)
+Input: the `post_merge_outcome` signals for the window; the monitoring and verification outputs
+Run:
+
+    Invoke incident-response and launch-runbook to classify the intake. Enumerate
+    what counts as a lane-attributable regression: the post_merge_outcome signal
+    classes (a verification failure that recurs on a promoted lane's deploys, a
+    monitored metric crossing its regression budget) as distinct from ordinary
+    noise. For each signal, record the lane it points at, the merges in the
+    window, and the post_merge_outcome evidence. Produce the intake; attribute
+    nothing to a promoted lane yet.
+
+Output artifact: the intake record (each signal, its candidate lane, the window's merges, the post_merge_outcome evidence)
+Done when: every regression signal in the window is recorded with its candidate lane and its post_merge_outcome evidence
+Fails look like: treating every wobble as an incident. A metric breathing inside its normal band is not a regression, and an intake that flags noise trains the team to demote on nothing.
+
+### Phase 2: Attribution · lane: gate (Basano)
+
+Skills: incident-response (nearest anchor; the lane-attribution core is a DECLARED GAP, procedure inline)
+Capability class: incident.attribution (declared catalog gap; nearest-miss incident-response)
+Input: the intake record
+Run:
+
+    Invoke incident-response's attribution discipline as a gate. For each signal,
+    answer one question with evidence: is this regression attributable to a
+    PROMOTED lane's merge? Read the agreement log for the lane's recent merges and
+    their proposal_to_merge_diff, and line the regression up against a specific
+    promoted-lane merge. If the lane was never promoted (gate auto-pass and merge
+    authority never granted), this workflow does not apply: route a mystery drop
+    to Traffic-Drop Triage and an ordinary defect to the normal held-fix flow, and
+    say which. Report attribution per signal: a promoted-lane regression with the
+    merge named, or routed elsewhere with the destination named.
+
+Output artifact: the attribution verdict per signal (promoted-lane regression with the merge identified, or routed elsewhere)
+Done when: every signal is either attributed to a specific promoted-lane merge with evidence, or routed to Traffic-Drop Triage or the normal defect flow with the destination named
+Operated-layer note: the attribution reads the operated agreement log's rows and proposal_to_merge_diff for the lane; the schema is public (AGREEMENT-LOG.md), the instance and its rows are operated
+Fails look like: blaming the gate before the evidence lands. Attributing a regression to a promoted lane without lining it up against a specific merge demotes a lane for a coincidence while the real cause keeps running.
+
+### Phase 3: Demote first · lane: divergent (human)
+
+Skills: none; the demotion is a deliberate human act
+Input: the attribution verdict for a confirmed promoted-lane regression
+Run: before any fix is written, a person returns the lane to human-gated. The
+    lane stops auto-passing and stops holding merge authority at once, so it
+    cannot merge again while it is being debugged. This is the ordinary first
+    move, not a punishment: a promoted lane that regressed has lost the evidence
+    that earned it, and it gets that evidence back the ordinary way, by re-earning
+    it. Record the demotion and its reason.
+Output artifact: the lane returned to human-gated, with the demotion and its reason recorded
+Done when: the lane is human-gated and cannot auto-pass or auto-merge, confirmed before any fix is written
+Operated-layer note: in an operated deployment the demotion is recorded as an agreement-log action against the lane, with the regression as its reason; the demotion of the operated lane is an operated act (AGREEMENT-LOG.md)
+Fails look like: fixing before demoting. While the fix is being written the lane is still promoted and still merging, so the machine that produced the regression keeps producing, and the incident grows a second head.
+
+### Phase 4: Roll back and fix as held changes · lane: convergent (Tholo)
+
+Skills: incident-response (nearest anchor; procedure inline)
+Capability class: incident.rollback (write-held)
+Input: the demoted lane; the attributed merge
+Run:
+
+    Invoke incident-response's rollback discipline. Roll back the attributed merge,
+    or land the corrective fix, as a HELD change (repo.change) a human merges
+    through the now human-gated lane. Verify the change against the
+    post_merge_outcome signal that detected the regression: it closes only when
+    that signal clears. Nothing here re-promotes the lane; the change merges
+    through the human gate the way every change on this lane now does.
+
+Output artifact: the held rollback or fix, tied to the attributed merge, with the post_merge_outcome signal it must clear
+Done when: the rollback or fix is a held change and the regression signal has cleared against it, with the lane still human-gated
+Fails look like: closing the incident on the merge instead of on the signal. The change meant to fix the regression is verified by re-running the post_merge_outcome check that caught it, not by the fact that a PR merged.
+
+### Phase 5: The false-pass audit · lane: gate (Basano)
+
+Skills: incident-response (nearest anchor; the false-pass-audit core is a DECLARED GAP, procedure inline)
+Capability class: incident.false-pass-audit (declared catalog gap; nearest-miss incident-response)
+Input: the agreement log row for the regressed merge; the gate that passed it
+Run:
+
+    Invoke incident-response's post-incident discipline as a gate. Find the
+    agreement-log row where the guardrail passed the merge that regressed: it is a
+    false_pass, and the audit asks what the gate misses STRUCTURALLY, not who
+    erred. Name the class of fault the gate could not see, and turn it into a
+    specific gate improvement (a new check, a tightened threshold) so the same
+    miss cannot re-promote a lane later. Report the audit with the false_pass row
+    and the proposed gate improvement.
+
+Output artifact: the false-pass audit (the false_pass row, the structural gap named, the proposed gate improvement)
+Done when (public gate): the structural gap is named and a specific gate improvement is proposed as a held change
+Operated-layer note: the audited row is the operated log's false_pass for the regressed merge; the schema and the four-way agreement values are public (AGREEMENT-LOG.md), the row is operated
+Fails look like: demotion without the audit. A lane demoted and fixed but never audited leaves the gate that missed the fault unchanged, and the same miss re-promotes the same class of regression next quarter.
+
+### Phase 6: Re-promotion path · lane: convergent (Tholo)
+
+Skills: none; the re-promotion rule is doctrine, procedure inline
+Capability class: incident.re-promotion (procedure inline)
+Input: the demoted lane; the gate improvement from Phase 5
+Run:
+
+    State the re-promotion path and record it; do not walk it here. Re-promotion
+    is never automatic. The lane re-earns gate auto-pass and merge authority the
+    ordinary way, under Autonomy Review's thresholds, over a RESET window that
+    starts after the fix and the gate improvement land, so the rows that regressed
+    do not count toward the lane's recovery. Record the reset window's start and
+    the conditions the lane must meet, and hand the lane to Autonomy Review.
+
+Output artifact: the recorded reset window (its start, the thresholds the lane must re-earn) handed to Autonomy Review
+Done when: the reset window is recorded with its start and re-earning conditions, and the lane is handed to Autonomy Review rather than re-promoted here
+Fails look like: quietly re-promoting the lane once the fix lands. A lane restored to autonomy without re-earning it under a reset window has learned nothing, and the demotion was theater.
+
+## Failure modes
+
+- Fixing before demoting (Phase 3's failure): the lane keeps merging while you debug it.
+- Blaming the gate on noise: attributing a regression to a promoted lane before lining it up against a specific merge (Phase 2's failure); attribution rigor comes before demotion.
+- Demotion without the false-pass audit (Phase 5's failure): the same miss re-promotes later.
+- Automatic or quiet re-promotion (Phase 6's failure): the lane restored without re-earning under a reset window.
+- Treating demotion as shameful: demotion is the system working, the ordinary first move, and a tone that makes it an emergency makes teams avoid promoting at all.
+- Closing on the merge, not the signal (Phase 4's failure): the fix verified by a merged PR rather than a cleared post_merge_outcome.
+
+## Worked example
+
+Pending. Populates when a promoted lane first regresses and this workflow demotes it; no lane is promoted today, so this stays template until the autonomy program has a lane to demote. Status flips to validated when that run record links here.
+
+## Boundaries
+
+- Traffic-Drop Triage owns the mystery drop with no known suspect; this workflow owns the regression with a known suspect, a promoted lane's own merge, and Phase 2 routes to that workflow when no promoted lane is attributable.
+- Autonomy Review owns promotion; this workflow owns the revocation that promotion promised, and the two are a pair: no lane graduates there until this is armed here.
+- AGREEMENT-LOG.md is the schema whose post_merge_outcome this workflow reads and whose false_pass row it audits; that file defines the columns and the four-way agreement values this workflow uses.


### PR DESCRIPTION
## What this ships

Wave B of the workflows tier: three reviewed files at **template** status, their README rows flipped, and `WORKFLOWS.lock` regenerated to twelve entries. Held draft; do not merge. Andy squash-merges.

- data-surface-integrity (FDE)
- incident-response-and-lane-demotion (cross)
- autonomy-review (cross)

## Acceptance evidence

**1. Three files byte-match their sources.** `diff` of each placed file against its reviewed draft is empty:

```
data-surface-integrity                  IDENTICAL
incident-response-and-lane-demotion     IDENTICAL
autonomy-review                         IDENTICAL
```

**2. README: twelve linked rows + three defined-publishing.** Exactly three rows flipped from `defined, publishing` to `[Name](slug.md) | Track | template`, matching the shipped rows' format. Counts by grep: 12 linked-with-template rows, 3 `defined, publishing` rows. No other README change; no counts in prose.

**3. WORKFLOWS.lock: twelve entries, additions only.** The nine prior entries are byte-unchanged; the three new entries (`autonomy-review`, `data-surface-integrity`, `incident-response-and-lane-demotion`) are added; none removed. The lock is LF and `python tools/gen_workflows_lock.py --check` prints `WORKFLOWS.lock is current (12 workflows).`

**4. CI checks green; bound-slug list and the zero-slug note.**
- **Lock current:** `gen_workflows_lock.py --check` passes.
- **Drift green:** `No drift: every bound slug exists in SKILLS.lock.` The slugs this wave binds, each verified present in `SKILLS.lock` at base `99b58a3`: `incident-response`, `launch-runbook`, `monitoring-and-alerting`, `seo-technical`, `qa-testing`, `editorial-qa`, `brand-voice`. Zero invented slugs; the declared-gap capability classes (for example `data.freshness-guard`, `incident.attribution`) carry a real-slug anchor and inline procedure.
- **autonomy-review binds zero slugs, by design.** All five of its `Skills:` lines read `none`: the agreement-log math is RampStack's and has no catalog skill (design v2 section 14), so its analytic phases are declared gaps with no anchor and inline procedure. The drift check passes on a file with zero bound slugs.
- **Fence:** `git diff <base> -- SKILLS.lock` reports 0 changed files; `SKILLS.lock` is byte-identical to base (sha256 `901c2bc8…52a151`, 103 skills), and `gen_skills_lock.py --check` prints `SKILLS.lock is current.`
- **Catalog lint unchanged:** `lint_skills.py` passes, 103 skills validated (em-dash, brand-leak, and README-catalog checks all OK; the single warning is the pre-existing `documentation-strategy` line count, untouched here).

**5. Style, signing, LF.** Em-dash, en-dash, banned marketing phrases, and "not just" greps across the three files and the README diff: zero. Commit signed (ED25519); all committed blobs are LF.

## Doctrine consistency

The two doctrine files converge with `AGREEMENT-LOG.md` on the vocabulary and rules: the verdict set merge/reject/revise/waive, the four-way agreement values, the authored-not-derived agreement rule, and the waived-rows-excluded-from-rates rule (quoted). `human_note` (the pre-rulings name) appears nowhere; `human_reason` is used. autonomy-review holds the ceiling structurally (Tier-3 permanently ineligible, the ceremony cannot license its own class) and incident-response holds the revocation (demote first, reset-window re-promotion), and the pair cross-references correctly.

## Note

The three files ship with the score breakdowns amended post-review, taken as they sit on disk. On merge, the `rampstack.co/engines/deployment/workflows` page updates itself within the hour via its hourly revalidate against this lock; no site PR is needed or wanted.
