### PR TITLE
feat(workflows): publish wave C, completing the fifteen-workflow set

### DIFF
--- a/WORKFLOWS.lock
+++ b/WORKFLOWS.lock
@@ -29,6 +29,11 @@
     "sha256": "786f573deff77b6182064d98a2ded989e8ab30dad7d5a75269bc29e3bfb27241",
     "status": "template"
   },
+  "experiment-loop-with-pre-registered-gates": {
+    "file": "experiment-loop-with-pre-registered-gates.md",
+    "sha256": "cb64aac8a19f31f87d0631a1b9f6e1b054458949ea2c40a6349611ce79a5784b",
+    "status": "template"
+  },
   "incident-response-and-lane-demotion": {
     "file": "incident-response-and-lane-demotion.md",
     "sha256": "e547a5cff6fcdf990bf630faf4f4846aa3d5bae69d9eb30752bf4861eae2e0bb",
@@ -39,9 +44,19 @@
     "sha256": "b541c4f63c63a29191c913bc8f3620d365c2a4776694a4df1011c8f200ea5fe3",
     "status": "template"
   },
+  "migration-with-verification": {
+    "file": "migration-with-verification.md",
+    "sha256": "20524d52acc1739745560d09ebb7b8b0500204c4bbf4e1a7d9dbef99e55565b6",
+    "status": "template"
+  },
   "post-deploy-live-verification": {
     "file": "post-deploy-live-verification.md",
     "sha256": "944d20aa8740eb54f12fba5457b3f897b4f66cbed7a20e09dc89341e11bea90c",
+    "status": "template"
+  },
+  "regulated-content-compliance-gate": {
+    "file": "regulated-content-compliance-gate.md",
+    "sha256": "b518f64433a1ff410f003a3d2ec81d8ea957c962f3aa4aaf6057b7cb74210254",
     "status": "template"
   },
   "revenue-tracking-integrity": {

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -35,20 +35,20 @@ Checks report and fail, engines propose and stop, a human merges; autonomy is ea
 
 ## The set
 
-WORKFLOWS.lock is the canonical manifest and the source for any count. The table is the list. Shipped files link; the rest are defined here and publish in later waves.
+WORKFLOWS.lock is the canonical manifest and the source for any count. The table is the list. Shipped files link, and with this wave every file is shipped, so no row remains defined and publishing.
 
 | Workflow | Track | Status |
 |---|---|---|
 | [Post-Deploy Live Verification](post-deploy-live-verification.md) | FDE | template |
 | [Data Surface Integrity](data-surface-integrity.md) | FDE | template |
-| Migration with Verification | FDE | defined, publishing |
+| [Migration with Verification](migration-with-verification.md) | FDE | template |
 | [CI Prove-Gate Wiring](ci-prove-gate-wiring.md) | FDE | template |
 | [Warehouse Data Plane Standup](warehouse-data-plane-standup.md) | FDE | template |
 | [Content Pipeline with Prove Gates](content-pipeline-prove-gates.md) | FDM | validated |
 | [Corpus Integrity and Correction](corpus-integrity-and-correction.md) | FDM | template |
 | [Link Graph and Metadata Parity Audit](link-graph-and-metadata-parity-audit.md) | FDM | template |
-| Regulated-Content Compliance Gate | FDM | defined, publishing |
-| Experiment Loop with Pre-Registered Gates | FDM | defined, publishing |
+| [Regulated-Content Compliance Gate](regulated-content-compliance-gate.md) | FDM | template |
+| [Experiment Loop with Pre-Registered Gates](experiment-loop-with-pre-registered-gates.md) | FDM | template |
 | [Traffic-Drop Triage](traffic-drop-triage.md) | FDA | template |
 | [Conversion-by-Source Diagnosis](conversion-by-source-diagnosis.md) | FDA | template |
 | [Revenue Tracking Integrity](revenue-tracking-integrity.md) | FDA | template |

--- a/workflows/experiment-loop-with-pre-registered-gates.md
+++ b/workflows/experiment-loop-with-pre-registered-gates.md
@@ -1,0 +1,171 @@
+# Experiment Loop with Pre-Registered Gates
+
+```
+name:            Experiment Loop with Pre-Registered Gates
+slug:            experiment-loop-with-pre-registered-gates
+tier:            forward-deployed (operations)
+role:            fdm
+status:          template
+score:           43 (demand 4, pain 4, differentiation 3, usability 4, connectors 5)
+intent:          Basano on the test design: the stopping rule, MDE, and sample-size math
+                 pre-registered before any variant ships, the SEO safety of variants gated,
+                 and the verdict computed only against the pre-registered rule
+when to use:     a mechanism hypothesis worth a controlled test on a property with enough
+                 traffic to power it
+when not to use: finding the hypothesis in the first place (Conversion-by-Source Diagnosis);
+                 a defect fix rather than a test (the ordinary held-fix flow)
+validation note: gated on adequate traffic on a designated property; it holds at template
+                 until a designated property has the traffic and a mechanism to test
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  experiment.read
+    access:      read
+  - capability:  analytics.read
+    access:      read
+  - capability:  crawl.read
+    access:      read            # variant SEO-safety checks on the built variant
+  - capability:  repo.change
+    access:      write-held      # the variant and its config land as held changes
+```
+
+The variant and its config land held; a human allocates traffic and launches. Traffic allocation is never an agent action. The verdict is computed against the pre-registered rule and nothing else.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- A hypothesis from Conversion-by-Source Diagnosis (mechanism, expected effect, segment), or an equivalent stated the same way.
+- Enough traffic in the target segment to power a test; if the segment cannot reach the sample the math requires, the honest outcome is not to run.
+- The experiment platform (experiment.read) and the analytics that will measure the primary metric.
+- A person who allocates traffic and launches; the workflow never does.
+
+## Phases
+
+### Phase 1: Intake · lane: convergent (Tholo)
+
+Skills: analytics-strategy
+Capability class: experiment.intake (substitute equivalents if off-catalog)
+Input: the hypothesis from Conversion-by-Source Diagnosis (mechanism, expected effect, segment)
+Run:
+
+    Invoke analytics-strategy to frame the incoming hypothesis as a testable spec:
+    the mechanism it claims (what about the page or offer would move the metric,
+    and why), the expected effect size, the primary metric it would move, and the
+    exact segment. A hypothesis that arrives as an aspiration rather than a
+    mechanism goes back to Conversion-by-Source Diagnosis; this workflow tests
+    mechanisms, not hopes. Produce the framed spec.
+
+Output artifact: the framed experiment spec (mechanism, expected effect size, primary metric, segment)
+Done when: the hypothesis is framed as a mechanism with an expected effect size, a primary metric, and a segment, or returned to Conversion-by-Source Diagnosis as too vague to test
+Fails look like: testing an aspiration. "Improve the CTA" names no mechanism and predicts no effect, so whatever the test does, nothing is learned; the spec has to say why the gap exists before a test can falsify it.
+
+### Phase 2: Pre-registration · lane: gate (Basano)
+
+Skills: experiment-design, experimentation-analytics
+Capability class: experiment.pre-registration (substitute equivalents if off-catalog)
+Input: the framed experiment spec; the segment's available traffic
+Run:
+
+    Invoke experiment-design and experimentation-analytics to pre-register the
+    test BEFORE anything ships: the stopping rule, the minimum detectable effect,
+    the sample-size math the MDE and the segment's traffic imply, the primary
+    metric, and the window. Write them down and freeze them. If the segment cannot
+    reach the required sample in a reasonable window, the pre-registration verdict
+    is "insufficient n, do not run", which is a respectable and final outcome, not
+    a delay. Report the pre-registration, or the not-run verdict, with the math.
+
+Output artifact: the frozen pre-registration (stopping rule, MDE, sample size, primary metric, window), or the "insufficient n, do not run" verdict with its math
+Done when: the test is pre-registered with all five fields frozen, or it is declared underpowered and not run, with the sample-size math shown either way
+Fails look like: shipping first and pre-registering after. A stopping rule and a metric written once the variant is believed in are fitted to the hope, and the test becomes a search for a number that agrees with it.
+
+### Phase 3: Variant SEO-safety gate · lane: gate (Basano)
+
+Skills: seo-technical
+Capability class: experiment.seo-safety (substitute equivalents if off-catalog)
+Input: the built variant (crawl.read); the pre-registration
+Run:
+
+    Invoke seo-technical against the built variant. Check that the variant is safe
+    to serve to search: no cloaking risk (the variant does not show crawlers and
+    users materially different content in a way search treats as deceptive),
+    canonical consistency across the variant and the control, and no layout-shift
+    or core-vitals regression the variant introduces. Report a verdict per check
+    with the evidence. Report only.
+
+Output artifact: the SEO-safety report (cloaking, canonical consistency, layout-shift, each with a verdict)
+Done when: the variant carries a verdict on cloaking risk, canonical consistency, and layout-shift, all clear or the risk flagged
+Fails look like: an experiment that wins by getting deindexed. A variant that trims the content search ranked for can lift the on-page metric while the page quietly falls out of the results, and the test would call that a win.
+
+### Phase 4: Launch as a held config change · lane: divergent (human)
+
+Skills: none; the launch and the traffic allocation are deliberately human
+Input: the pre-registration and the passing SEO-safety report
+Run: the variant and its experiment config land as a HELD change (repo.change).
+    A person allocates traffic and launches the test; traffic allocation is never
+    an agent action, because it is a live change to what real users see. The human
+    launches against the frozen pre-registration, allocating exactly the design
+    the math called for, and records the launch.
+Output artifact: the launched experiment, recorded against its pre-registration, with the variant and config as held changes a human merged
+Done when: the experiment is launched by a human at the pre-registered allocation, with the config held and merged by a person
+Fails look like: an agent turning traffic on. Allocating traffic is a production act on real users, and it stays with a person the same way merging and deploying do.
+
+### Phase 5: The verdict · lane: gate (Basano)
+
+Skills: experimentation-analytics
+Capability class: experiment.verdict (substitute equivalents if off-catalog)
+Input: the running experiment's results; the frozen pre-registration
+Run:
+
+    Invoke experimentation-analytics to compute the verdict ONLY against the
+    pre-registered rule, at the pre-registered point. The stopping rule decides
+    when the test ends; interim looks are not stopping decisions, and a result
+    that looks significant early is not a verdict until the pre-registered point.
+    The primary metric is the one pre-registered, not whichever moved. Report the
+    verdict (win, loss, or inconclusive) against the pre-registered rule, with the
+    numbers. Report only.
+
+Output artifact: the verdict against the pre-registered rule (win, loss, or inconclusive) with the numbers at the pre-registered point
+Done when: the verdict is computed at the pre-registered point against the pre-registered primary metric and stopping rule, with the numbers attached
+Fails look like: peeking, then stopping on a good look. Checking the test daily and stopping the day it crosses significance turns noise into a false win, because the more often you look, the more often chance alone crosses the line.
+
+### Phase 6: Closeout · lane: convergent (Tholo)
+
+Skills: experimentation-analytics
+Capability class: experiment.closeout (substitute equivalents if off-catalog)
+Input: the verdict; the original hypothesis and its Conversion-by-Source finding
+Run:
+
+    Invoke experimentation-analytics to close the loop. Route the verdict and the
+    hypothesis outcome back to Conversion-by-Source Diagnosis as calibration: a
+    hypothesis that won, lost, or came back inconclusive updates that workflow's
+    hit-rate, which is what makes its next ranking better. If a winning variant is
+    to consolidate into the live page, it re-enters the SEO-safety check on the
+    consolidated version before it ships through the ordinary held-fix flow; the
+    experiment never publishes itself. Record the closeout.
+
+Output artifact: the routed verdict and hypothesis outcome to Conversion-by-Source Diagnosis, and the consolidation path (with its SEO-safety re-check) recorded where a variant won
+Done when (public gate): the verdict and hypothesis outcome are recorded and routed to Conversion-by-Source Diagnosis, and any winning variant is queued for the ordinary held-fix flow with an SEO-safety re-check, not published from here
+Operated-layer note: in an operated deployment the pre-registration, the verdict, and their agreement land as an agreement-log row; the verdict-versus-pre-registration agreement is what calibrates this lane (AGREEMENT-LOG.md)
+Fails look like: shipping the winner without re-checking the consolidated version. A variant proven safe in isolation can regress SEO once it is merged into the real page with the rest of the layout, and the win does not carry a waiver for that.
+
+## Failure modes
+
+- Peeking (Phase 5's failure): interim looks becoming stopping decisions, which manufactures false wins.
+- Post-hoc metric switching: reporting whichever metric moved instead of the pre-registered primary.
+- Retrofitted pre-registration (Phase 2's failure): registering the rule after the variant is believed in.
+- Shipping the winner without the SEO-safety re-check on the consolidated version (Phase 6's failure).
+- Underpowered tests run anyway: ignoring the "insufficient n, do not run" verdict and running a test that cannot detect the effect; not-rankable is a verdict here too.
+- An agent allocating traffic (Phase 4's failure): a production act on real users that stays human.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a designated property with adequate traffic to power a test; it holds at template until a designated property has both the traffic and a mechanism hypothesis to run. Status flips to validated when a run record links here.
+
+## Boundaries
+
+- Conversion-by-Source Diagnosis supplies this workflow's intake (its ranked hypotheses) and consumes its verdicts as calibration; the two form the diagnose-then-test loop, and neither runs the other's step.
+- Revenue Tracking Integrity underwrites the measurement this workflow trusts: a verdict computed over a money path that does not survive redirects or consent is a verdict over noise.
+- Content Pipeline with Prove Gates owns the publish path; a winning variant consolidates through the ordinary held-fix flow with an SEO-safety re-check, and the experiment never self-selects into publishing.

--- a/workflows/migration-with-verification.md
+++ b/workflows/migration-with-verification.md
@@ -1,0 +1,175 @@
+# Migration with Verification
+
+```
+name:            Migration with Verification
+slug:            migration-with-verification
+tier:            forward-deployed (operations)
+role:            fde
+status:          template
+score:           47 (demand 4, pain 5, differentiation 4, usability 4, connectors 4)
+intent:          migrate a property with the redirect map gated for completeness, old and
+                 new parity proven, cutover staged behind a human, and recovery watched
+                 against baselines pre-registered before the flip
+when to use:     moving a property to a new domain, platform, or URL structure, where old
+                 URLs carry traffic and rankings worth keeping
+when not to use: verifying a single deploy on an unchanged property (Post-Deploy Live
+                 Verification); a traffic drop with no known cause (Traffic-Drop Triage)
+validation note: gated on a real migration of a designated property; none is planned, so
+                 it holds at template until such a migration occurs
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  crawl.read
+    access:      read            # both the old and the new property
+  - capability:  search-performance.read
+    access:      read            # the pre-cutover baselines
+  - capability:  repo.change
+    access:      write-held      # the redirect map and any fix land as held changes
+```
+
+Read-only until the held redirect map and fixes. The cutover itself, the DNS and platform actions, is a human phase; nothing here flips a property.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Crawl access to both the old property and the new one.
+- The complete list of old URLs, from the old sitemap, the crawl, and the search-performance export together, because any one alone misses pages.
+- Search-performance history for the old property, to pre-register baselines before cutover.
+- The cutover runbook's platform access (DNS, hosting), held by the human who performs it.
+
+## Phases
+
+### Phase 1: Inventory and pre-register the baselines · lane: convergent (Tholo)
+
+Skills: content-migration, seo-technical
+Capability class: migration.baseline (substitute equivalents if off-catalog)
+Input: the old property (crawl.read), its search-performance history, the new property's planned structure
+Run:
+
+    Invoke content-migration to inventory the old property and seo-technical to
+    read its structure. Build the complete old-URL list as the union of the
+    sitemap, the crawl, and the search-performance export, because any single
+    source misses pages. Then PRE-REGISTER the baselines before cutover: the
+    traffic and ranking levels per key segment, and the recovery metric (which
+    segment, back to what level, measured over what window) written down now,
+    while the old property is still live. Produce the inventory and the
+    pre-registered baseline record.
+
+Output artifact: the complete old-URL inventory and the pre-registered baseline record (traffic, rankings, the recovery metric), dated before cutover
+Done when: every old URL is inventoried from the three sources unioned, and the baselines and recovery metric are recorded before any cutover step
+Fails look like: baselines chosen after cutover. A recovery metric written once traffic has moved is fitted to whatever happened and will always find recovery; the baseline means something only if it predates the flip.
+
+### Phase 2: Redirect-map completeness gate · lane: gate (Basano)
+
+Skills: content-migration
+Capability class: migration.redirect-completeness (substitute equivalents if off-catalog)
+Input: the complete old-URL inventory; the new property's URL structure
+Run:
+
+    Invoke content-migration against the old-URL inventory. For EVERY old URL, not
+    a sample, assign one of three dispositions: a 301 to a specific new URL,
+    gone-with-intent (a 410 or an intentional removal with the reason recorded),
+    or explicitly dropped with a written rationale. The gate is completeness: an
+    old URL with no disposition is a fail, and the map is not done until the
+    uncovered count is zero. Report the map with its coverage and every
+    disposition's evidence. This gate reports and fixes nothing.
+
+Output artifact: the redirect map (every old URL, its disposition, the rationale for drops) with a zero-uncovered coverage report
+Done when: every old URL in the inventory carries a disposition, the uncovered count is zero, and each drop has a recorded rationale
+Fails look like: a sampled map. A redirect map spot-checked instead of completed passes review and drops the long tail, and the long tail is where the accumulated ranking equity quietly lived.
+
+### Phase 3: Parity audit, old versus new · lane: gate (Basano)
+
+Skills: seo-technical, seo-onpage
+Capability class: migration.parity-audit (substitute equivalents if off-catalog)
+Input: the old and new properties (crawl.read); the redirect map
+Run:
+
+    Invoke seo-technical and seo-onpage against matched old and new URLs. For each
+    mapped pair, check parity: title and meta, the canonical target, structured
+    data, the presence of the content the old page ranked for, and the
+    internal-link graph around it. Flag any new page that lost metadata, changed a
+    canonical away from itself, dropped structured data, or is missing content its
+    old counterpart carried. Report parity per pair with the evidence. Report only.
+
+Output artifact: the parity report (each mapped pair, per-check verdict, the evidence)
+Done when: every mapped pair has a parity verdict across metadata, canonical, structured data, content presence, and internal links
+Fails look like: parity by URL existence. A new URL that returns 200 can still have lost the title, the schema, and half the body the old one ranked for, and a check that stops at "the page exists" certifies a page that will not hold the ranking.
+
+### Phase 4: Staged cutover · lane: divergent (human)
+
+Skills: launch-runbook
+Capability class: migration.cutover (write-held runbook; the actions are human)
+Input: the passing redirect map and parity report
+Run:
+
+    Invoke launch-runbook to author the staged cutover runbook: the ordered DNS
+    and platform steps, each stage with a checkpoint that must pass before the
+    next. Then a person performs the cutover per the runbook; DNS and platform
+    changes are production state changes and stay human. The human records which
+    stage was executed when, and holds at any checkpoint that fails rather than
+    proceeding.
+
+Output artifact: the staged cutover runbook, and the human's record of each stage executed with its checkpoint result
+Done when: the cutover stages are executed per the runbook with each checkpoint recorded, or the cutover is held at a failed checkpoint
+Fails look like: a big-bang cutover with no checkpoints. Flipping everything at once removes the one thing staging buys, the chance to catch a broken stage before the next one lands on top of it.
+
+### Phase 5: Post-cutover verification · lane: gate (Basano)
+
+Skills: none; the engine is the Post-Deploy Live Verification workflow, executed as written
+Capability class: deploy.live-verify (delegated to Post-Deploy Live Verification)
+Input: the new property; the redirect map
+Run:
+
+    Run Post-Deploy Live Verification as written against the new property's touched
+    and blast-radius routes. Do not restate its procedure here: it owns the
+    discriminator value, the build-identity read, and the two-fetch production
+    discipline, and this phase inherits all of it. Then add the migration-specific
+    check: verify the redirect map fires on the live property, the highest-traffic
+    and the gone-with-intent URLs first, each old URL landing on its mapped target
+    with the right status code. Report the live-verification verdict and the
+    redirect verdicts together.
+
+Output artifact: the Post-Deploy Live Verification closure for the new property plus the live redirect verdicts from the map
+Done when: Post-Deploy Live Verification closes VERIFIED on the new property and the mapped redirects fire live with the right status codes, or the discrepancies are filed with their evidence
+Fails look like: declaring the migration done at the DNS flip. DNS resolving is not the property migrated; the redirects, the parity, and the live render are, and only production fetches prove them.
+
+### Phase 6: Monitoring window against the pre-registered baselines · lane: gate (Basano)
+
+Skills: seo-rank-tracking, seo-traffic-diagnosis
+Capability class: migration.monitor (substitute equivalents if off-catalog)
+Input: the pre-registered baseline record; the new property's search-performance and ranking data on a cadence
+Run:
+
+    Invoke seo-rank-tracking and seo-traffic-diagnosis against the new property on
+    a fixed cadence through the monitoring window. Measure the affected segments
+    against the baselines pre-registered in Phase 1, and report the trajectory.
+    Declare the migration recovered only when the pre-registered recovery metric
+    holds across its pre-registered window, not on the first good week. If the
+    trajectory contradicts the baseline, the migration has a regression and it
+    routes out of this workflow.
+
+Output artifact: monitoring reports on cadence, and a closure record when the pre-registered recovery condition holds
+Done when: the pre-registered recovery condition holds across its window and the closure is recorded, or the window breaks baseline and the regression is routed to Traffic-Drop Triage
+Fails look like: closing on the first good week. Migration traffic is noisy in the weeks after cutover, and a recovery declared on one datapoint reopens a month later as a mystery with the trail already cold.
+
+## Failure modes
+
+- The redirect map sampled instead of complete (Phase 2's failure): the long tail dropped, and with it the accumulated equity.
+- Baselines chosen after cutover (Phase 1's failure): a recovery metric fitted to what happened always finds recovery.
+- Declaring success at the DNS flip (Phase 5's failure): cutover is not migration; the redirects, the parity, and the live render are.
+- The old property's cache serving past cutover: after the flip, some request paths keep serving the old property's cached render for a while, so a page can look migrated on one fetch and stale on another. Verification covers cookie-less vantages and does not stop at the first clean fetch; a clean read from one path is a sample, not the verdict. This is the split-serving class at its worst possible moment, when two properties are briefly both answering.
+- Parity by URL existence (Phase 3's failure): a 200 that lost the title, the schema, and half the body.
+- A big-bang cutover (Phase 4's failure): no checkpoint to catch a broken stage before the next lands on it.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on a real migration of a designated property; none is planned, so it holds at template until such a migration occurs. The split-serving pattern in the failure modes generalizes production incidents on an unnamed property, where a render persisted on one request path after a change while another path served current data; that lesson informs Phase 5's vantage discipline but is not validation evidence. Status flips to validated when a run record links here.
+
+## Boundaries
+
+- Post-Deploy Live Verification is Phase 5's engine: this workflow runs it as written against the new property and adds the redirect checks, rather than restating its procedure.
+- Traffic-Drop Triage takes over when the monitoring window breaks baseline: a post-cutover regression that contradicts the pre-registered recovery metric is a diagnosable drop, and that workflow owns the diagnosis.

--- a/workflows/regulated-content-compliance-gate.md
+++ b/workflows/regulated-content-compliance-gate.md
@@ -1,0 +1,128 @@
+# Regulated-Content Compliance Gate
+
+```
+name:            Regulated-Content Compliance Gate
+slug:            regulated-content-compliance-gate
+tier:            forward-deployed (operations)
+role:            fdm
+status:          template
+score:           45 (demand 3, pain 5, differentiation 4, usability 4, connectors 5)
+intent:          a YMYL pre-publish gate that runs inside the content pipeline for regulated
+                 properties: required disclosures present and placed, every regulated claim
+                 sourced to a citable authority, and prohibited-claim patterns absent
+when to use:     a regulated or YMYL property (finance, health, legal, and the like) where a
+                 published claim carries real-world consequence
+when not to use: an unregulated property (Content Pipeline Phase 3's ordinary gate is
+                 enough); correcting already-published regulated content (Corpus Integrity
+                 and Correction, under both workflows' rules)
+gap note:        the placement-verification core is a DECLARED CATALOG GAP with seo-technical
+                 as the nearest anchor; that phase is inline procedure. It is written to be
+                 runnable anyway.
+```
+
+## Connectors
+
+```
+connectors:
+  - capability:  crawl.read
+    access:      read            # placement verification on the built page
+```
+
+This gate is read-only: it reads the content pipeline's held drafts and the built page, and reports. A failing gate blocks the merge; it never edits the draft. Waivers are human decisions by the register owner.
+
+## Prerequisites
+
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- The property's regulatory context: the disclosure requirements, the list of citable authorities, and the prohibited-claim patterns for its vertical.
+- A register owner: the human accountable for the compliance register and its waivers.
+- The content pipeline's held drafts as input; this gate runs inside Content Pipeline Phase 3 for regulated properties.
+- A production-equivalent build, because placement is verified on the rendered page.
+
+## Phases
+
+### Phase 1: The compliance register · lane: divergent (human)
+
+Skills: none; the register is written to the property's regulatory requirements and owned by a human
+Capability class: compliance.register (human-owned)
+Input: the property's regulatory context; the register owner
+Run: the register owner writes the compliance register once and approves it:
+    the disclosure requirements and where each must be placed, the list of
+    citable authorities a regulated claim may be sourced to, the prohibited-claim
+    patterns, and the placement rules. The register is the standard every draft
+    is gated against, so it is authored and human-approved before the gate runs,
+    not derived per draft. It is versioned, and it carries a review cadence
+    against its own regulatory sources.
+Output artifact: the approved compliance register (disclosures and placements, the authority list, prohibited patterns, the review cadence)
+Done when: the register owner has approved the register and its review cadence, and it is versioned
+Fails look like: a register derived per draft. A standard invented fresh for each piece is not a standard, and it drifts to whatever the current draft happens to satisfy.
+
+### Phase 2: The compliance gate · lane: gate (Basano)
+
+Skills: evidence-based-reviews, editorial-qa
+Capability class: compliance.gate (substitute equivalents if off-catalog)
+Input: a held draft from Content Pipeline Phase 3; the approved register
+Run:
+
+    Invoke evidence-based-reviews and editorial-qa against the held draft, gated
+    on the register. Check three things and change nothing. Disclosures: every
+    required disclosure is present. Claims: every regulated claim is sourced to a
+    specific authority ON THE REGISTER'S LIST, which is authority-list checking,
+    not source-presence checking; a claim citing some source that is not a listed
+    authority fails, even though a source is present. Prohibited patterns: none of
+    the register's prohibited-claim patterns appear. Report a verdict per check
+    with the evidence. Report only; this gate blocks a merge, it does not edit the
+    draft.
+
+Output artifact: the compliance verdict per check (disclosures, authority-sourced claims, prohibited patterns), evidence attached
+Done when: the draft carries a verdict on disclosures present, every regulated claim authority-sourced, and prohibited patterns absent
+Fails look like: source-presence instead of authority-list checking. A claim with a citation attached passes a lazy check and fails the register when the citation is a blog rather than a listed authority; the presence of a source is not the same as sourcing to an authority.
+
+### Phase 3: Placement verification on the built page · lane: gate (Basano)
+
+Skills: seo-technical (nearest anchor; the placement-verification core is a DECLARED GAP, procedure inline)
+Capability class: compliance.placement-verify (declared catalog gap; nearest-miss seo-technical)
+Input: the built page (crawl.read); the register's placement rules
+Run:
+
+    Invoke seo-technical against the BUILT page, not the source. For each required
+    disclosure, verify it renders where the register's placement rule requires: a
+    disclosure that exists in the source but renders below the fold, inside a
+    collapsed element, or on a path the reader does not take, fails placement even
+    though it is present. Report placement per disclosure against its rule, with
+    the rendered evidence. Report only.
+
+Output artifact: the placement report (each disclosure, its required placement, its rendered placement, a verdict)
+Done when: every required disclosure has a placement verdict against the register's rule, checked on the built render
+Fails look like: verifying placement in the source. A disclosure in the markup that a collapsed accordion hides at render is present to a grep and absent to a reader, and the reader is who the rule protects.
+
+### Phase 4: Waiver protocol · lane: divergent (human)
+
+Skills: none; a waiver is the register owner's decision
+Input: a compliance failure the team proposes to waive
+Run: only the register owner may waive a compliance failure, and a waiver is
+    never routine. The owner records what was waived, the specific rule, and the
+    rationale, and the waiver is scoped to the one draft, not the standard.
+    Repeated waivers of the same rule are a signal that the register is wrong or
+    the process is, and they surface for review rather than accumulating silently.
+Output artifact: the recorded waiver (the rule, the draft, the register owner's rationale), or the confirmation that no waiver was granted
+Done when (public gate): every compliance failure is either fixed and re-gated, or waived in writing by the register owner with a recorded rationale
+Operated-layer note: in an operated deployment a waiver lands as an agreement-log row with human_verdict = waive and a required human_reason, excluded from the false-pass and false-fail rate computations and reported on its own line (AGREEMENT-LOG.md)
+Fails look like: routine waivers. A waiver any reviewer can grant, or one that passes without the register owner and a rationale, turns the gate into a formality the pipeline learns to wave through.
+
+## Failure modes
+
+- Source-presence instead of authority-list checking (Phase 2's failure): a citation present but not to a listed authority.
+- Disclosure present but mis-placed (Phase 3's failure): rendered below the fold or inside a collapsed element.
+- The register going stale against changed rules: a regulatory requirement moves and the register does not; the Phase 1 review cadence on the register itself is the guard.
+- Treating this gate as Content Pipeline Phase 3: it is additive, an extra gate for regulated properties, never a replacement for that phase's ordinary pre-publish gate.
+- Routine waivers (Phase 4's failure): waivers granted without the register owner, or so often they stop meaning anything.
+- Gating the draft but not the built page: passing on source presence and never checking the render is how a compliant draft ships as a non-compliant page.
+
+## Worked example
+
+Pending. Populates when this workflow is executed as written on regulated content reaching a designated property; no designated property carries regulated content today, so it holds at template until such content exists on one. Status flips to validated when a run record links here.
+
+## Boundaries
+
+- This gate runs INSIDE Content Pipeline with Prove Gates, Phase 3, for regulated properties: it is additive to that phase's ordinary gate, never a substitute, and a regulated draft passes both.
+- Corpus Integrity and Correction owns corrections to already-published regulated content; a correction to a regulated claim runs under both this workflow's authority-list rule and that workflow's visible-correction pattern.


### PR DESCRIPTION
## What this ships

Wave C, the final wave: the last three reviewed workflow files at **template** status, their README rows flipped, and `WORKFLOWS.lock` regenerated to fifteen entries. **This completes the fifteen-workflow set** designed in the tier README. Held draft; do not merge. Andy squash-merges.

- migration-with-verification (FDE)
- regulated-content-compliance-gate (FDM)
- experiment-loop-with-pre-registered-gates (FDM)

## Acceptance evidence

**1. Three files byte-match their sources.** `diff` of each placed file against its reviewed draft is empty:

```
migration-with-verification                    IDENTICAL
regulated-content-compliance-gate              IDENTICAL
experiment-loop-with-pre-registered-gates      IDENTICAL
```

**2. README: fifteen linked rows, zero defined-publishing.** The final three rows flipped from `defined, publishing` to `[Name](slug.md) | Track | template`. Counts by grep: 15 linked rows, 0 `defined, publishing`.

One clause was updated to completion tense, the same rule as the accepted PR #100 fix, because the set is now complete and the clause otherwise contradicts the table. Exact before/after (the only prose change; no counts in prose):

- Before: `The table is the list. Shipped files link; the rest are defined here and publish in later waves.`
- After: `The table is the list. Shipped files link, and with this wave every file is shipped, so no row remains defined and publishing.`

The "Roadmap: named, not launched" section is untouched: those items (AI-Surface Visibility Baseline, Attribution and Outcome Reporting, the product-manager track) are genuinely not launched and are not part of the fifteen.

**3. WORKFLOWS.lock: fifteen entries, additions only.** The twelve prior entries are byte-unchanged (content-pipeline-prove-gates stays `validated`); the three new entries are added; none removed. Statuses total **14 template + 1 validated**. The lock is LF and `python tools/gen_workflows_lock.py --check` prints `WORKFLOWS.lock is current (15 workflows).`

**4. CI checks green; bound-slug list.**
- **Lock current:** `gen_workflows_lock.py --check` passes.
- **Drift green:** `No drift: every bound slug exists in SKILLS.lock.` The slugs this wave binds, each verified present in `SKILLS.lock` at base `a6f61fc`:
  - New to the tier this wave: `content-migration`, `experiment-design`, `experimentation-analytics`.
  - Bound this wave and already in the tier: `seo-rank-tracking`, `seo-technical`, `seo-onpage`, `launch-runbook`, `evidence-based-reviews`, `editorial-qa`, `analytics-strategy`, `seo-traffic-diagnosis`.
  All eleven verified against the lock; zero invented slugs. The one declared gap, `compliance.placement-verify` (regulated-content Phase 3), binds nothing and carries `seo-technical` as its nearest-miss anchor with inline procedure. migration Phase 5 delegates to the shipped Post-Deploy Live Verification workflow as its engine (not a skill).
- **Fence:** `git diff <base> -- SKILLS.lock` reports 0 changed files; `SKILLS.lock` is byte-identical to base (sha256 `901c2bc8…52a151`, 103 skills), and `gen_skills_lock.py --check` prints `SKILLS.lock is current.`
- **Catalog lint unchanged:** `lint_skills.py` passes, 103 skills validated (em-dash, brand-leak, and README-catalog checks all OK; the single warning is the pre-existing `documentation-strategy` line count, untouched here).

**5. Style, signing, LF.** Em-dash, en-dash, banned marketing phrases, and "not just" greps across the three files and the README diff: zero. Commit signed (ED25519); all committed blobs are LF.

## Note

The three files ship with the score breakdowns amended post-review, taken as they sit on disk. This completes the set designed in the tier's public README: on merge the `rampstack.co/engines/deployment/workflows` page renders all fifteen linked within the hour via its hourly revalidate against this lock, and its "defined, publishing" state retires itself.
