### PR TITLE
chore(ci): source brand watchlist from private lint-config (HEAD scrub)

### DIFF
--- a/.github/scripts/lint_skills.py
+++ b/.github/scripts/lint_skills.py
@@ -17,6 +17,7 @@ Designed to be:
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -36,37 +37,58 @@ README = REPO_ROOT / "README.md"
 
 # Brand watchlist. Any case-insensitive hit fails the build, except for the
 # explicitly-allowed legitimate public references in ALLOWED_BRAND_CONTEXTS.
-BRAND_WATCHLIST = [
-    "adunn08",
-    "GameDesk",
-    "ANDY.md",
-    "bankranked",
-    "wirly",
-    "vehiclemd",
-    "carcabin",
-    "codeblu",
-    "stayrentals",
-    "insurrates",
-    "mycarneedsthis",
-    "tereks",
-    "checkvin",
-    "credit-factor",
-    "straightstocks",
-    "econgrader",
-    "degreemath",
-    "taxgrader",
-    "retiregrader",
-    "smallbizgrader",
-    "bankscored",
-    "401klens",
-    "diplomavalue",
-    "degreegrade",
-    "studentdebtmath",
-    "nesteggnerd",
-    "bizmoneymath",
-    "retireranked",
-    "taxscoped",
-]
+#
+# The roster itself is NOT stored in this public repo: it lives in the private
+# rampstack/lint-config repo, and CI fetches it into the path named by
+# BRAND_WATCHLIST_FILE. Keeping the list inline here published the very names
+# this check exists to keep out.
+#
+# Fail closed: if the file is not provided, is missing, or is empty, the run
+# FAILS. The one exception is the fork-pull-request path, where repository
+# secrets are unavailable by design; those runs set ALLOW_MISSING_BRAND_WATCHLIST,
+# the check is skipped loudly, and the push-to-main run is the enforcing backstop.
+
+BRAND_WATCHLIST_ENV = "BRAND_WATCHLIST_FILE"
+ALLOW_MISSING_ENV = "ALLOW_MISSING_BRAND_WATCHLIST"
+
+
+def load_brand_watchlist() -> list[str] | None:
+    """Load the watchlist named by BRAND_WATCHLIST_FILE.
+
+    Returns the token list, or None when the check is explicitly skipped on a
+    fork PR. Exits non-zero rather than silently passing.
+    """
+    path = os.environ.get(BRAND_WATCHLIST_ENV, "").strip()
+    if not path:
+        if os.environ.get(ALLOW_MISSING_ENV, "").strip():
+            print(
+                f"WARNING: {BRAND_WATCHLIST_ENV} is not set; brand watchlist check "
+                "SKIPPED. Expected on fork pull requests, where repository secrets "
+                "are unavailable. The push-to-main run enforces this check."
+            )
+            return None
+        print(
+            f"ERROR: {BRAND_WATCHLIST_ENV} is not set. The brand watchlist could not "
+            "be loaded, so the check cannot run. CI fetches it from "
+            "rampstack/lint-config; see .github/workflows/lint.yml.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    watchlist_path = Path(path)
+    if not watchlist_path.is_file():
+        print(f"ERROR: brand watchlist file not found: {watchlist_path}", file=sys.stderr)
+        sys.exit(1)
+
+    tokens = [
+        line.strip()
+        for line in watchlist_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    if not tokens:
+        print(f"ERROR: brand watchlist at {watchlist_path} is empty.", file=sys.stderr)
+        sys.exit(1)
+    return tokens
 
 # `rampstack` requires special handling: legitimate as the public org name
 # `rampstackco` and the public domain `rampstack.co`, never as `rampstack`
@@ -143,13 +165,16 @@ def check_em_dashes(result: LintResult) -> None:
 
 def check_brand_leaks(result: LintResult) -> None:
     """Forbidden brand mentions from the watchlist."""
+    watchlist = load_brand_watchlist()
+    if watchlist is None:
+        return
     for md in REPO_ROOT.rglob("*.md"):
         if any(part in (".git", "node_modules") for part in md.parts):
             continue
         text = read_text(md)
 
         text_lower = text.lower()
-        for needle in BRAND_WATCHLIST:
+        for needle in watchlist:
             if needle.lower() in text_lower:
                 result.fail(
                     f"Brand watchlist hit '{needle}' in {md.relative_to(REPO_ROOT)}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,5 +23,26 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
+      - name: Fetch brand watchlist (private)
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          LINT_CONFIG_TOKEN: ${{ secrets.LINT_CONFIG_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "${LINT_CONFIG_TOKEN:-}"
+          curl -fsSL \
+            -H "Authorization: Bearer $LINT_CONFIG_TOKEN" \
+            -H "Accept: application/vnd.github.raw" \
+            "https://api.github.com/repos/rampstack/lint-config/contents/brand-watchlist.txt?ref=v1" \
+            -o "$RUNNER_TEMP/brand-watchlist.txt"
+          echo "BRAND_WATCHLIST_FILE=$RUNNER_TEMP/brand-watchlist.txt" >> "$GITHUB_ENV"
+
+      - name: Skip brand watchlist on fork PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "Fork PR: repository secrets are unavailable, so the brand watchlist"
+          echo "check is skipped here. The push-to-main run is the enforcing backstop."
+          echo "ALLOW_MISSING_BRAND_WATCHLIST=1" >> "$GITHUB_ENV"
+
       - name: Run skill linter
         run: python .github/scripts/lint_skills.py


### PR DESCRIPTION
## Move the brand watchlist out of the public repo (HEAD scrub)

The linter's brand/real-firm watchlist was a **plaintext roster of private brand and project names committed to this public repo** — the guard meant to keep those names out of published content was itself publishing them. This moves the roster to the private **`rampstack/lint-config`** repo and fetches it in CI.

### What changes
- **Linter:** the inline `*_WATCHLIST = [...]` literal is removed and replaced with a `load_*_watchlist()` that reads the path in `*_WATCHLIST_FILE`, one token per line. **Fail-closed:** unset var / missing file / empty list → the run exits non-zero. Matching semantics are unchanged (case-insensitive substring, any hit fails; the `rampstack` special-case is untouched).
- **`.github/workflows/lint.yml`:** a step fetches the list from `rampstack/lint-config` at **`?ref=v1`** with a read-only `LINT_CONFIG_TOKEN`, into `$RUNNER_TEMP`, and exports the env var. A second step handles **fork PRs** — where repository secrets are unavailable by design — by skipping the check with a loud SKIPPED notice; the **push-to-`main`** run is the enforcing backstop.

### Verified locally
- No env → exit 1 with a clear error (fail-closed).
- Fork-skip path → check skipped with warning, lint passes.
- Populated from `v1` → `check_brand_leaks` runs and the full lint passes.
- Positive control (injected a forbidden token) → still fails with a watchlist hit.
- Zero roster tokens remain anywhere in the linter.

### Scope boundary
This is a **HEAD scrub only.** The watchlist is present from this repo's initial commit, so the roster remains reachable in git history after this merges. History remediation (`git filter-repo` vs delete-recreate) is tracked separately.

**Held draft** pending review of the audit evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
