### PR TITLE
fix(dist): ship all 103 skills in dist/pi, pin LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,53 @@
+# Line-ending policy for the catalog.
+#
+# Why this file exists: Git for Windows ships with core.autocrlf=true at the
+# system level. Without a committed policy, a Windows contributor gets a CRLF
+# working tree while the repository content is LF. The generated distributions
+# are then byte-compared against a fresh build by their drift guards, so every
+# file reads as different and the guard is red before it has checked anything.
+# A guard that is always red catches nothing. Committing the policy here makes
+# the LF guarantee travel with the repository instead of depending on a local
+# .git/config that only exists on one machine.
+
+# Default: let Git detect text and store it LF in the repository.
+* text=auto eol=lf
+
+# Authored catalog sources.
+skills/**        text eol=lf
+workflows/**     text eol=lf
+
+# Generated distribution output. These are byte-compared against a fresh build,
+# so their line endings have to be stable in the working tree, not only in the
+# repository.
+dist/**          text eol=lf
+
+# Vendored third-party content, if any is added later.
+vendor/**        text eol=lf
+
+# Generator inputs and outputs.
+scripts/**       text eol=lf
+tools/**         text eol=lf
+.github/**       text eol=lf
+SKILLS.lock      text eol=lf
+WORKFLOWS.lock   text eol=lf
+*.md             text eol=lf
+*.py             text eol=lf
+*.mjs            text eol=lf
+*.js             text eol=lf
+*.json           text eol=lf
+*.yml            text eol=lf
+*.yaml           text eol=lf
+
+# Binary assets. Never touch these.
+*.png            binary
+*.jpg            binary
+*.jpeg           binary
+*.gif            binary
+*.webp           binary
+*.ico            binary
+*.pdf            binary
+*.woff           binary
+*.woff2          binary
+*.ttf            binary
+*.otf            binary
+*.zip            binary

--- a/dist/pi/.agents/skills/evidence-based-reviews/SKILL.md
+++ b/dist/pi/.agents/skills/evidence-based-reviews/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: evidence-based-reviews
+description: "Produce honest product reviews and buying guides without fabricated first-hand experience, using disclosed evidence tiers: verified specs, owner-experience synthesis at scale, expert triangulation, and hands-on only when true. Use this skill whenever the user wants to write product reviews or buying guides without hands-on access, set up a review methodology, add evidence disclosure to review content, align reviews with Google's reviews system or FTC affiliate disclosure expectations, or decide when Review and Product schema are honest to use. Triggers on product review, buying guide, best-of list, review methodology, evidence basis, hands-on testing, we tested, affiliate review site, review disclosure, methodology block, original research, reviews system. Also triggers when review content claims testing that did not happen, or when an affiliate site needs a trust mechanism that survives scrutiny."
+category: content
+catalog_summary: "Evidence tiers, methodology disclosure, honest review claims"
+display_order: 13
+---
+
+# Evidence-Based Reviews
+
+Produce product reviews and buying guides whose claims match their evidence. The method is evidence synthesis with a disclosed basis, and one rule anchors everything: never claim hands-on time that did not happen.
+
+Most review sites fail this rule quietly. "We tested" appears above content assembled from spec sheets, and readers have learned to smell it. The honest alternative is stronger, not weaker: synthesis of owner experience at scale, verified specifications, and triangulated expert sources is demonstrable original analysis, and disclosing it builds the trust that fabricated testing destroys.
+
+---
+
+## When to use
+
+- Writing product reviews or buying guides when hands-on access is partial or absent
+- Setting up the review methodology for a new review or affiliate site
+- Adding evidence disclosure to existing review content
+- Auditing review content for claims its evidence cannot support
+- Deciding whether Review or Product schema is honest for a given piece
+- Aligning review content with Google's reviews system and FTC disclosure expectations
+
+## When NOT to use
+
+- General content writing and editing (use `content-and-copy`; this skill governs the evidence and claims layer of review content specifically)
+- Defining how the brand sounds (use `brand-voice`)
+- Optimizing the review page itself for search (use `seo-onpage`)
+- Per-piece editorial briefs (use `content-brief-authoring`)
+- Instructional how-to content that teaches a procedure or concept to a first-time reader, such as a tutorial or an explainer: a teaching piece of this kind is owned by its writing, its structure, and its search craft, with the evidence discipline riding alongside as a constraint on its claims, so this skill is one input among several rather than the single choice for it
+
+If genuine hands-on testing at scale exists, with instrumentation and protocols, this skill still applies: the tiers do not change, the methodology block simply states tier 4 and the testing protocol becomes the disclosed basis.
+
+---
+
+## Required inputs
+
+- The product category and the pieces planned (reviews, buying guides, or both)
+- Access to evidence sources: manufacturer pages, retailer review corpora, forums or owner communities, expert publications
+- The brand's disclosure language, if one exists (this skill supplies a template if not)
+- An honest inventory of what hands-on experience genuinely exists, if any
+
+---
+
+## The framework: one rule, four evidence tiers
+
+The anchor rule: never claim hands-on time that did not happen. Every other part of the method exists to make honest content strong enough that the lie is unnecessary.
+
+### Tier 1: verified manufacturer specs
+
+Specifications cited to the maker's own page, not to aggregator copies that drift. The verification step is the work: cross-check the spec against the manufacturer's current listing, note the date, and flag discrepancies between sources instead of picking one silently. A spec table built this way is a fact layer; a spec table pasted from another review site is a rumor layer.
+
+When it suffices: factual comparisons, fit and compatibility answers, price-tier groupings. It never supports a quality verdict on its own.
+
+### Tier 2: owner-experience synthesis at scale
+
+Retailer review corpora, forum threads, warranty and return patterns, read across sources and summarized honestly. Honest synthesis means:
+
+- Recurring complaints and recurring praise, not the loudest single anecdote
+- Sample-size candor: "across roughly 1,400 owner reviews" reads differently from "owners say," and the reader deserves the number
+- No cherry-picking: if owners split, the split is the finding
+- Source naming: which corpora, which communities, over what period
+
+When it suffices: durability and reliability verdicts, real-world quirks specs never show, satisfaction patterns by use case. This tier is the workhorse of honest no-hands-on reviewing, and it is genuine original analysis when done at scale.
+
+### Tier 3: expert-source triangulation
+
+Named expert sources compared against each other. Triangulation means surfacing agreement and disagreement, not averaging verdicts into mush. When two credible testers reach opposite conclusions, the honest move is to say so and explain the conditions that might account for it. Anonymous "experts agree" is not a tier; it is decoration.
+
+When it suffices: performance claims that require instrumentation the site lacks, technique-dependent judgments, category context.
+
+### Tier 4: hands-on, only when true
+
+Stated only when it happened, flagged as such, with the extent quantified: what was done, how much, under what conditions. When hands-on experience arrives later for a piece published on tiers 1 to 3, the piece is upgraded and the update is marked with what changed. Never backfilled to look like it was always hands-on; the upgrade trail is itself a trust signal.
+
+---
+
+## The methodology block
+
+Every review and buying guide carries a short disclosure block naming its evidence basis, placed with the criteria, written for readers rather than lawyers. The fillable template and a worked example live in [`references/methodology-block-template.md`](references/methodology-block-template.md).
+
+The block names: the criteria in the order they were weighted, the tiers actually used (specifically, with sources), what was done hands-on or the words "none claimed," and the update line. A block that claims a tier the piece did not use is the same lie the anchor rule bans, in smaller type.
+
+---
+
+## Structure discipline the method implies
+
+- **Criteria stated and ordered before picks.** A verdict the reader cannot trace to a stated criterion is an opinion wearing a methodology costume.
+- **A named drawback per recommended pick.** Every product has one; a review that finds none has not looked. Consistent placement makes the honesty visible.
+- **Update transparency.** Dated updates with what changed. Stale best-of content silently rotting is one of the most common failures in the category, and a dated what-changed line beats the field.
+
+---
+
+## Google reviews-system alignment
+
+The guidance asks for demonstrated first-hand experience OR demonstrable original research and analysis. The second branch is this skill's lane, and "original analysis" means concrete work product:
+
+- The synthesis itself: owner-experience patterns no single source contains
+- Comparative tables built from verified data, structured around the stated criteria
+- Decision frameworks: who each pick fits and who it does not
+- What paraphrased spec sheets are not: rearranging a manufacturer's bullet points is neither experience nor analysis, and ranks accordingly
+
+A site that does tier 2 and 3 work honestly is doing original analysis by the guidance's own definition. The methodology block is how the work shows.
+
+---
+
+## FTC alignment
+
+Affiliate relationships are disclosed in plain language, placed where the recommendation is, not in a footer. The disclosure travels with the monetized content: near the picks, in body-size text, before or beside the first affiliate link a reader can act on. "Plain language" means a reader who has never heard the word affiliate understands that the site earns a commission and that the price they pay does not change. Euphemisms ("partner links," "support the site") fail the plain-language test.
+
+---
+
+## Schema judgment
+
+Markup is a claim. Apply the same honesty to structured data as to prose:
+
+- **Review and Product markup** only when the piece's claims support what the markup asserts. Review markup asserts an evaluative review of an item the reviewer assessed; a tier 1-to-3 buying guide asserting hands-on style review markup is making a machine-readable version of the banned claim.
+- **Buying guides without hands-on** use guide-shaped markup: ItemList for the picks, Article for the piece.
+- When tier 4 is real and stated, Review markup becomes honest; add it then, per piece, not as a template default.
+
+---
+
+## Workflow
+
+1. **Inventory the evidence honestly.** What tiers are actually available for this category? What hands-on exists, if any?
+2. **Set the criteria first.** Ordered, before any product is examined, so the criteria cannot quietly bend toward a favored pick.
+3. **Gather per tier.** Verify specs at the source. Pull owner corpora at scale and note sample sizes. Collect named expert sources, including the disagreements.
+4. **Synthesize.** Findings per criterion, drawbacks per pick, splits surfaced.
+5. **Write the methodology block** from what was actually done, not from what sounds good.
+6. **Match the markup to the claims.** ItemList and Article by default; Review only where tier 4 is true.
+7. **Maintain.** Date updates, state what changed, upgrade pieces when hands-on arrives, and mark the upgrade.
+
+---
+
+## Failure patterns
+
+- **"We tested" inflation.** The anchor-rule violation. It is also unnecessary: honest synthesis outperforms fake testing once readers compare the work.
+- **Aggregator specs.** Spec tables copied from other reviews, drift included. Verify at the maker's page or do not publish the number.
+- **Anecdote dressed as synthesis.** Three forum posts is not owner experience at scale. State the sample or downgrade the claim.
+- **Averaged experts.** Splitting the difference between conflicting expert verdicts erases the most useful information: that credible testers disagree, and why.
+- **The drawback-free pick.** A recommendation with no named drawback reads as advertising because it is structured like advertising.
+- **Backfilled hands-on.** Quietly rewriting an old synthesis piece as if it had been tested all along. The upgrade-and-mark pattern exists so this never has to happen.
+- **Footer disclosure.** An affiliate disclosure the reader has to hunt for fails both the FTC's placement expectations and the trust purpose it exists to serve.
+- **Schema overreach.** Review markup on synthesis content. The piece's prose is honest and its markup lies.
+
+---
+
+## Output format
+
+For a methodology setup: a short methodology standard the site adopts (the tiers, the block template filled with the site's sources, the schema policy), suitable for docs or an editorial guide.
+
+For a piece-level engagement: the methodology block for that piece, the criteria list, the evidence file (sources gathered per tier with sample sizes), and the claims audit if the piece existed before this skill did.
+
+---
+
+## Reference files
+
+- [`references/evidence-tiers.md`](references/evidence-tiers.md) - The four tiers in depth: verification steps, synthesis honesty, triangulation practice, and the upgrade-and-mark pattern.
+- [`references/methodology-block-template.md`](references/methodology-block-template.md) - The fillable per-piece disclosure block, a worked example, and placement rules.

--- a/dist/pi/.agents/skills/evidence-based-reviews/references/evidence-tiers.md
+++ b/dist/pi/.agents/skills/evidence-based-reviews/references/evidence-tiers.md
@@ -1,0 +1,46 @@
+# The four evidence tiers, in depth
+
+The tiers are not a ladder of prestige; they are different kinds of knowledge with different verification work and different claims they can support. A strong piece usually combines two or three, and says which.
+
+## Tier 1: verified manufacturer specs
+
+**The verification step.** Cite the specification to the manufacturer's own current product page. Aggregators, retailer listings, and other reviews drift: units get converted wrong, superseded model years linger, and one site's typo becomes the category's consensus number. When the manufacturer's page and a retailer listing disagree, note the discrepancy in the piece; the disagreement is information.
+
+**Date the pull.** Specs change across model years. A spec table that says when its numbers were verified survives the next revision; one that does not becomes silently wrong.
+
+**What tier 1 supports:** factual comparison (weights, dimensions, capacities, materials), compatibility and fit answers, price-tier groupings. **What it cannot support:** any quality verdict. A spec sheet cannot tell you the thing rattles.
+
+## Tier 2: owner-experience synthesis at scale
+
+The workhorse tier for review work without hands-on access, and the one most often done dishonestly. The honest version:
+
+**Scale and candor.** Read across sources: retailer review corpora, owner forums, warranty and return discussions. State the scale in the piece ("across roughly 1,400 retailer reviews and two seasons of forum threads"). If the sample is small, say so and weaken the claim to match.
+
+**Recurrence over volume.** The finding is the pattern that recurs across independent sources, not the most dramatic single report. One catastrophic failure post is an anecdote; the same failure described by unrelated owners across two sites is a finding.
+
+**Splits are findings.** When owners divide (half love the trigger, half send it back), the split is the most useful thing the piece can report, usually with the variable that explains it (hand size, draw weight, use case).
+
+**No cherry-picking.** Deciding the verdict first and quoting only supporting owners is fabrication with extra steps. The synthesis is written from the pattern, not toward a pick.
+
+**Name the corpora.** Which retailers, which communities, what period. This is what makes the synthesis auditable and what makes it original analysis rather than vibes.
+
+## Tier 3: expert-source triangulation
+
+**Named sources only.** "Experts agree" without names is decoration. Name the publication or tester, and link where possible.
+
+**Triangulate, never average.** Three credible sources agreeing is strong signal; two credible sources disagreeing is stronger content. Surface the disagreement and look for the condition that explains it: different test protocols, different units, different use assumptions. Averaging opposite verdicts into "mixed reviews" throws away exactly what the reader came for.
+
+**Independence check.** Three reviews that all trace to the same press kit are one source wearing three hats.
+
+## Tier 4: hands-on, only when true
+
+**Quantify the experience.** "We shot it" hides more than it tells. The honest form states extent and conditions: how many arrows or hours or miles, over what period, in what setting, with what comparison points. The quantification is what separates a real claim from a vibe.
+
+**Flag it.** On a site where synthesis is the norm, hands-on time is the exception worth marking. Flagging it does double duty: it strengthens the piece that has it and keeps every other piece honest by contrast.
+
+**The upgrade-and-mark pattern.** When hands-on experience arrives for a piece originally published on tiers 1 to 3:
+
+1. Update the piece with the hands-on findings.
+2. Update the methodology block: the hands-on line changes from "none claimed" to the quantified statement.
+3. Mark the update with the date and what changed ("Updated [date]: added hands-on findings after six weeks with the production unit; the durability verdict held, the comfort note changed").
+4. Never rewrite history. The piece does not pretend it was always hands-on; the visible upgrade is itself evidence the site's claims mean something.

--- a/dist/pi/.agents/skills/evidence-based-reviews/references/methodology-block-template.md
+++ b/dist/pi/.agents/skills/evidence-based-reviews/references/methodology-block-template.md
@@ -1,0 +1,33 @@
+# The methodology block: template, example, placement
+
+The per-piece disclosure block. Short, placed with the criteria, written for readers. It names what the piece's verdicts rest on, and it never claims a tier the piece did not use.
+
+## The template
+
+> **How we reviewed this**
+> **Criteria:** [the 3 to 5 criteria, in the order they were weighted, stated before the picks].
+> **Evidence:** [the tiers actually used, specifically: verified manufacturer specs (noting where and when); owner-experience synthesis at scale (name the corpora and the rough sample size); expert-source triangulation (name the sources)].
+> **Hands-on:** [what was physically done, quantified, or the words "none claimed for this piece"].
+> **Updated:** [date]: [what changed and why].
+
+## A worked example (generic category)
+
+> **How we reviewed this**
+> **Criteria:** noise under load, durability across a season, build quality, price against the field, in that order.
+> **Evidence:** manufacturer specs verified against each maker's current product page (May 2026); owner-experience synthesis across roughly 1,400 retailer reviews and two seasons of forum threads from three owner communities; expert triangulation across two named publications, whose durability verdicts disagreed (the disagreement and the likely cause are discussed under pick 2).
+> **Hands-on:** none claimed for this piece.
+> **Updated:** June 2026: replaced the budget pick after recurring owner reports of a failed adjustment mechanism; previous pick moved to the skip-it section with the evidence.
+
+## Placement rules
+
+- The block sits with the criteria, before or immediately after the picks summary, never below the fold of a long piece and never in a footer.
+- Body-size text. A disclosure styled to be skipped is a disclosure in name only.
+- The hands-on line is mandatory even when the answer is "none claimed." The absence stated plainly is the trust mechanism; the absence omitted is the lie of implication.
+- The affiliate disclosure is a sibling, not a substitute: it travels with the recommendation per FTC expectations and says in plain language that the site earns a commission and that the reader's price does not change. The methodology block discloses the evidence; the affiliate block discloses the money. A piece with affiliate links carries both.
+
+## Anti-patterns
+
+- A block that lists every tier the site has ever used instead of the tiers this piece used.
+- "Extensive research" as the evidence line. Name the corpora or do not claim the scale.
+- A block written in legal register. The reader should finish it trusting the piece more, not feeling warned.
+- The block as template default with fields unfilled. An unfilled block is a claim generator; every line must be true per piece.


### PR DESCRIPTION
## What this fixes

The committed Pi distribution shipped **102 of 103 skills**: `evidence-based-reviews` was absent. This PR rebuilds it, and adds the `.gitattributes` policy that prevents the class of blindness which let it ship unnoticed.

## Refreshed onto current main (post-#106)

**Update method: merge, not rebase.** `main` moved while this sat held: #106 squash-merged as `45641e9`, changing the install line in all 15 workflow files plus `workflows/README.md` and `workflows/GETTING-STARTED.md`. I merged `origin/main` into this branch as `1e8368c`. Merge rather than rebase because the branch is a pushed held draft, merge needs no force-push, and the squash-merge collapses the merge commit anyway. **No conflicts.**

Diff scope against the refreshed `main` is unchanged, still four additions and zero modifications:

```
A  .gitattributes
A  dist/pi/.agents/skills/evidence-based-reviews/SKILL.md
A  dist/pi/.agents/skills/evidence-based-reviews/references/evidence-tiers.md
A  dist/pi/.agents/skills/evidence-based-reviews/references/methodology-block-template.md
```

### Line endings: renormalize result is ZERO diffs

With this PR's `.gitattributes` in effect over the merged tree:

```
$ git add --renormalize .
$ git diff --cached --name-only | wc -l
0
```

**Zero files changed. #106 shipped LF, not CRLF**, so there is nothing here to correct. Confirmed independently by scanning the committed blobs rather than trusting the working tree:

```
committed workflows/*.md blobs containing a CR byte:  0
git ls-files --eol workflows/*.md:                    i/lf w/lf eol=lf  (all 17)
```

The attributes are genuinely in force, so that zero is a real result and not a no-op:

```
$ git check-attr text eol -- workflows/traffic-drop-triage.md
text: set
eol: lf
```

This is the outcome the PR wanted rather than a missed defect. It also keeps the PR's original framing intact: on line endings this change stays **preventive, not corrective**.

## Correcting the premise (please read, it changes what this PR is)

The audit that prompted this work reported that *"the committed dist is CRLF while source is LF."* **That is not the case, and I verified it rather than assuming it.**

`git ls-files --eol` before any change:

```
skills/  ->  593 files   i/lf  w/lf
dist/    ->  592 files   i/lf  w/crlf
```

`i/lf` on both sides means the **committed content was already uniformly LF**. The CRLF existed only in the *working tree* copy of `dist/`. Confirmed independently: `git add --renormalize .` produced **zero content churn**.

The cause is that Git for Windows sets `core.autocrlf=true` at the system level. This repo happens to carry `core.autocrlf=false` in a local `.git/config`, which is not committed and exists on one machine. Any contributor without it gets a CRLF working tree, `build-pi.mjs --check` byte-compares a fresh build against it, every file reads as different, and the guard is red before it has checked anything. A guard that is always red catches nothing.

So this PR is **preventive, not corrective**, on line endings. There is no normalization diff because there was nothing committed to normalize. The one real defect was the missing skill.

## Diff scope

Four additions, zero modifications, zero deletions:

```
A  .gitattributes
A  dist/pi/.agents/skills/evidence-based-reviews/SKILL.md
A  dist/pi/.agents/skills/evidence-based-reviews/references/evidence-tiers.md
A  dist/pi/.agents/skills/evidence-based-reviews/references/methodology-block-template.md
```

## Guard proof, red and green both ways

A guard that has only ever been seen green is not verified. Run on `dist/pi`:

Re-run in full against the **merged** tree (not carried over from the earlier run):

| Step | Action | Expected | `--check` exit | Result |
|---|---|---|---|---|
| 1 | Baseline, merged tree | green | 0 | PASS |
| 2a | Append a line to `evidence-based-reviews/SKILL.md` | red | 1 | FAIL, `content differs: evidence-based-reviews/SKILL.md` |
| 2b | Restore | green | 0 | PASS |
| 3a | Change **line endings only** to CRLF, no content change (11887 to 12048 bytes) | red | 1 | FAIL, `content differs: evidence-based-reviews/SKILL.md` |
| 3b | Restore | green | 0 | PASS |

Working tree clean after restore (`git status --short` empty).

Step 3 matters most: it proves the guard detects the exact failure mode at issue, rather than only detecting content edits.

## Fresh-clone verification

The real test of `.gitattributes` is whether it survives a contributor who does not have the local override. Cloned the branch with `core.autocrlf=true` forced:

```
git clone -c core.autocrlf=true -b chore/dist-integrity-lf-normalize ...

skills/ + dist/  ->  1188 files   i/lf  w/lf  attr/text eol=lf
CR bytes in sampled dist file: 0
build-pi.mjs --check:          PASS (exit 0)
skills=103  dist=103           evidence-based-reviews PRESENT
```

Before this PR the same clone produced a CRLF working tree and a wholesale-red guard.

## Distribution target sweep

The dispatch asked for a sweep of codex, antigravity, and any other targets. **Only one distribution target exists in this repository.** Evidence:

```
dist/ subdirs:                      dist/pi          (re-confirmed post-merge)
builders emitting to dist/:         scripts/build-pi.mjs
dist/ paths referenced in tooling:  dist/pi  (only)
```

Open PRs #87 and #88 would add `dist/antigravity` and `dist/codex`, but neither is merged and neither touches `.gitattributes` or `dist/pi`, so they do not overlap this PR. Inventory check across all open PRs: **#104 is the only one touching `.gitattributes` or `dist/pi`.**

The Codex and Antigravity dists are referenced only in a comparative comment at `scripts/build-pi.mjs:8-9`; they live in sibling family repos, not here. I did not invent results for targets that are not present.

| Target | Present | Rebuild and diff | Skill count vs SKILLS.lock (103) | Line endings | Action |
|---|---|---|---|---|---|
| `dist/pi` | yes | PASS byte-identical (re-run on merged tree) | 103 / 103, sets identical | all `i/lf w/lf` | rebuilt, skill added |
| codex | no | n/a | n/a | n/a | not in this repo |
| antigravity | no | n/a | n/a | n/a | not in this repo |
| `.claude-plugin/` manifests | yes, not a skill dist | n/a | n/a | LF | no change needed |

## SKILLS.lock

**Untouched, and it should be.** Re-confirmed after the merge: `git diff origin/main HEAD -- SKILLS.lock WORKFLOWS.lock` is **empty**, so normalization forced no hash changes in either lock. No file under `skills/` changed in this PR, so there are no hashes to move. `python tools/gen_skills_lock.py --check` reports `SKILLS.lock is current.` There are therefore no line-ending-driven hash changes to report, because there are no hash changes at all.

## Verification suite

| Check | Command | Result |
|---|---|---|
| Pi dist drift | `node scripts/build-pi.mjs --check` | PASS |
| Pi dist validate | `node scripts/build-pi.mjs --validate` | VALIDATION PASS |
| Skills manifest | `tools/gen_skills_lock.py --check` | `SKILLS.lock is current.` |
| Workflows manifest | `tools/gen_workflows_lock.py --check` | current, 15 workflows |
| Workflow drift | `tools/check_workflow_drift.py` | no drift |
| README catalog | `scripts/generate_readme_catalog.py --check` | PASS |
| Skill linter | `.github/scripts/lint_skills.py` | see note below |

**Linter note, stated plainly:** the linter exits non-zero locally with `BRAND_WATCHLIST_FILE is not set`. This is environmental, not a regression. I verified it fails identically on a pristine `origin/main` worktree, so it is pre-existing and unrelated to this change. CI fetches the watchlist from the private `rampstack/lint-config`, so it should pass there. Its `check_em_dashes` check reported `[OK]`.

## Recommended follow-up, not done here

`build-pi.mjs --check` is **not wired into CI**. Nothing under `.github/workflows/` references it, so the distribution drift guard has never run automatically. Fixing the guard's blindness does not help if nobody runs it. A one-job addition to a workflow would close this properly, but it is outside the scope I was given, so I have left it for a separate decision.

Held as a draft.

