### PR TITLE
fix(workflows): complete the install instruction so a fresh user gets the catalog

### DIFF
--- a/WORKFLOWS.lock
+++ b/WORKFLOWS.lock
@@ -1,77 +1,77 @@
 {
   "autonomy-review": {
     "file": "autonomy-review.md",
-    "sha256": "14bf6e2a8188c92c816529b95ebbb3e3e6f4b1a43df67ebbf68024e1ab72ecc3",
+    "sha256": "37be1706427e67ece0c2298548e3b44774618c026e7bc559051fb89e09b8b34f",
     "status": "template"
   },
   "ci-prove-gate-wiring": {
     "file": "ci-prove-gate-wiring.md",
-    "sha256": "137d850bef7d84b4c0351e8b85a37c77aea8674dd93c9d2b7d5de9be8e75ac17",
+    "sha256": "a2f9142a5c617deaad527d6ff253e223c1a994f6fd67e2ed9e7ce46157653f39",
     "status": "template"
   },
   "content-pipeline-prove-gates": {
     "file": "content-pipeline-prove-gates.md",
-    "sha256": "31948660c4d2c97098edb79c3ca88b123dd0e9f54fd6643c65ddf49ed39c4431",
+    "sha256": "e24fb05ebfacef4c2b6c51e6e80d6627dd4c573481746aa35ee404a35a4cfc14",
     "status": "validated"
   },
   "conversion-by-source-diagnosis": {
     "file": "conversion-by-source-diagnosis.md",
-    "sha256": "56c2965d1612f152365fac22fae68b41d0e8f9a7c2016fbaaaf95d2e1c8e9908",
+    "sha256": "2f32f96291fc60df5a1d021a83d0d875f6a951dabd822ae79a8c26814a3b8904",
     "status": "template"
   },
   "corpus-integrity-and-correction": {
     "file": "corpus-integrity-and-correction.md",
-    "sha256": "f700641957273b279a9656b5bb5b4675bfddc1a6db2759abea8fff4607e15832",
+    "sha256": "2d5a3bb1f1ae31591a91dd9b9c48a6f83658e34cd83204484db2fbd1d558bcd1",
     "status": "template"
   },
   "data-surface-integrity": {
     "file": "data-surface-integrity.md",
-    "sha256": "786f573deff77b6182064d98a2ded989e8ab30dad7d5a75269bc29e3bfb27241",
+    "sha256": "a59f78552b118014ab91b0e76ebe5cd61604da4981fe5880f30b5195979dafa9",
     "status": "template"
   },
   "experiment-loop-with-pre-registered-gates": {
     "file": "experiment-loop-with-pre-registered-gates.md",
-    "sha256": "cb64aac8a19f31f87d0631a1b9f6e1b054458949ea2c40a6349611ce79a5784b",
+    "sha256": "1cc120f33b0f23f0ce9d15c664b6291e73b6759b12f5dd39a25c6c0f11d64416",
     "status": "template"
   },
   "incident-response-and-lane-demotion": {
     "file": "incident-response-and-lane-demotion.md",
-    "sha256": "e547a5cff6fcdf990bf630faf4f4846aa3d5bae69d9eb30752bf4861eae2e0bb",
+    "sha256": "aae0893096ba7617e6f02a17eae7801708c367267e13c75fe0c5b3a634f74d3e",
     "status": "template"
   },
   "link-graph-and-metadata-parity-audit": {
     "file": "link-graph-and-metadata-parity-audit.md",
-    "sha256": "b541c4f63c63a29191c913bc8f3620d365c2a4776694a4df1011c8f200ea5fe3",
+    "sha256": "fbff88b7f123b345e0c2ad33e6fd67a02b816f831891e067efb255f002cc972c",
     "status": "template"
   },
   "migration-with-verification": {
     "file": "migration-with-verification.md",
-    "sha256": "20524d52acc1739745560d09ebb7b8b0500204c4bbf4e1a7d9dbef99e55565b6",
+    "sha256": "35f25ed19b1b04659b2a71038a2225242a5353b14a9b222ac9837e58326382c8",
     "status": "template"
   },
   "post-deploy-live-verification": {
     "file": "post-deploy-live-verification.md",
-    "sha256": "944d20aa8740eb54f12fba5457b3f897b4f66cbed7a20e09dc89341e11bea90c",
+    "sha256": "08fd462eae54a1017bd01d535bebe0891b2a4aca580d84d6a630900a2ba2b168",
     "status": "template"
   },
   "regulated-content-compliance-gate": {
     "file": "regulated-content-compliance-gate.md",
-    "sha256": "b518f64433a1ff410f003a3d2ec81d8ea957c962f3aa4aaf6057b7cb74210254",
+    "sha256": "4ef16945eb0fdec5b72e17592f0bf7185e4c4de2d42ba2457438b4b3af5b3b2a",
     "status": "template"
   },
   "revenue-tracking-integrity": {
     "file": "revenue-tracking-integrity.md",
-    "sha256": "9a94e01de89e4a5e79c276ecee1618ce3a958ef2f40fa3bf6089e37d707f1ddd",
+    "sha256": "e1028d72571c52fdb03f35d3b6b8df73fe206152a8c679d5eccff306da0d6fab",
     "status": "template"
   },
   "traffic-drop-triage": {
     "file": "traffic-drop-triage.md",
-    "sha256": "2f00f2c4f2d08e0df0699d057b5061300254a2adb0b9f7344eee2d9cf5cf8569",
+    "sha256": "81e76ac5a725654df07cac7c5c4fa925aa4291b97a8013e93183749ece70c5e5",
     "status": "template"
   },
   "warehouse-data-plane-standup": {
     "file": "warehouse-data-plane-standup.md",
-    "sha256": "0d1b753d34023c8344b5f4bb5ecc9a74a644a7a1a8fff1ba80bb11eec413d303",
+    "sha256": "9c791cb252e21cfce068bea806102b77a58d6fd64824a8c3350fd9dbda7464e8",
     "status": "template"
   }
 }

--- a/workflows/GETTING-STARTED.md
+++ b/workflows/GETTING-STARTED.md
@@ -2,7 +2,7 @@
 
 Each workflow in this directory is a runnable procedure, not an essay. The shape is identical across all of them:
 
-1. Install the catalog once: /plugin marketplace add rampstackco/claude-skills
+1. Install the catalog once: /plugin marketplace add rampstackco/claude-skills then /plugin install rampstack-skills@rampstack
 2. Open the workflow file. Check "when to use / when not to use" first; half the value of the tier is the routing between workflows.
 3. Work the prerequisites checklist. If it names a data export, enable it before anything else; the exports named here do not backfill.
 4. Run the phases in order. Each phase names the skills it invokes, the input it consumes, a Run block you copy and adapt, the output artifact it produces, and a binary done-when. Phases marked as declared gaps carry their procedure inline; the capability-class line tells you what to substitute if you are off-catalog.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -8,6 +8,7 @@ Install the catalog these workflows invoke:
 
 ```
 /plugin marketplace add rampstackco/claude-skills
+/plugin install rampstack-skills@rampstack
 ```
 
 ## Tracks

--- a/workflows/autonomy-review.md
+++ b/workflows/autonomy-review.md
@@ -35,7 +35,7 @@ The agreement log has no connector class, deliberately. It is operated substrate
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - An agreement log implementing the AGREEMENT-LOG.md schema, with enough rows per lane to evaluate; the minimum sample below is a real gate, not a formality.
 - The tier's per-lane thresholds and, for graded lanes, the `guardrail_confidence` cutoff, recorded and version-controlled.
 - The published merge-authority doctrine (the three layers: access mode, gate auto-pass, merge authority), so a promotion proposal is measured against a written rule.

--- a/workflows/ci-prove-gate-wiring.md
+++ b/workflows/ci-prove-gate-wiring.md
@@ -33,7 +33,7 @@ Everything this workflow changes lands held: the gate wiring and any fix a gate 
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - A repo with CI you can add status checks to, and the permission to make a check required.
 - The prove checks you intend to gate on, already runnable against the repo by hand.
 - A build command that produces the artifact production serves; a dev-flag build is a different artifact.

--- a/workflows/content-pipeline-prove-gates.md
+++ b/workflows/content-pipeline-prove-gates.md
@@ -38,7 +38,7 @@ One of cms.draft or repo.change is required, matching how the property publishes
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - A demand source the ranking can read: a search-performance export, keyword data, or query logs. If using warehouse exports, enable them before anything else; they do not backfill.
 - A publishable target with a draft-and-hold mechanism (CMS drafts or PRs).
 - A claims-and-style standard file (STANDARDS.md or equivalent): voice rules, phrase rules, sourcing requirements.

--- a/workflows/conversion-by-source-diagnosis.md
+++ b/workflows/conversion-by-source-diagnosis.md
@@ -37,7 +37,7 @@ Fully read-only. This workflow diagnoses and ranks; it changes nothing. Its outp
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - Conversion events landing in the warehouse or analytics store with source attribution (the native analytics export into the warehouse is the reference setup; enable exports before anything else, they do not backfill).
 - A defined conversion event set and, where it exists, a value per event; if value is unknown, the ranking uses volume and says so.
 - Enough history for a stable baseline per segment (thin segments produce loud noise; the workflow flags them rather than ranking them).

--- a/workflows/corpus-integrity-and-correction.md
+++ b/workflows/corpus-integrity-and-correction.md
@@ -38,7 +38,7 @@ Read-only until Phase 4; corrections land held, a human merges.
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - A crawlable corpus (the live site) and, for git-published properties, the content source tree.
 - The property's canonical data sources for checkable claims (the statistics pages, standards bodies, or datasets its content cites).
 - A decision, made once and recorded, of what counts as a visible correction on this property (the correction-note format and where it renders).

--- a/workflows/data-surface-integrity.md
+++ b/workflows/data-surface-integrity.md
@@ -39,7 +39,7 @@ Read-only until Phase 5; retirement changes land held, a human merges. Nothing i
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - The property's machine-rendered data series and the source each renders from (the warehouse tables or feeds behind them).
 - The live surfaces that render each series (crawl.read), including metadata and any narration that cites the series.
 - The per-series cadence each source actually updates on.

--- a/workflows/experiment-loop-with-pre-registered-gates.md
+++ b/workflows/experiment-loop-with-pre-registered-gates.md
@@ -36,7 +36,7 @@ The variant and its config land held; a human allocates traffic and launches. Tr
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - A hypothesis from Conversion-by-Source Diagnosis (mechanism, expected effect, segment), or an equivalent stated the same way.
 - Enough traffic in the target segment to power a test; if the segment cannot reach the sample the math requires, the honest outcome is not to run.
 - The experiment platform (experiment.read) and the analytics that will measure the primary metric.

--- a/workflows/incident-response-and-lane-demotion.md
+++ b/workflows/incident-response-and-lane-demotion.md
@@ -36,7 +36,7 @@ The rollback and the fix land held; a human merges them through the now human-ga
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - A running autonomy program with at least one promoted lane and the agreement log behind it (AGREEMENT-LOG.md); with no promoted lane, Phase 2 routes elsewhere and this workflow does not apply.
 - The `post_merge_outcome` signal source: the monitoring and verification outputs that populate it.
 - The lane's `post_merge_outcome` budget, the regression threshold that makes a demotion mandatory.

--- a/workflows/link-graph-and-metadata-parity-audit.md
+++ b/workflows/link-graph-and-metadata-parity-audit.md
@@ -29,7 +29,7 @@ Read-only until Phase 4; fixes land held, a human merges. Nothing in the audit a
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - The production site, crawlable, and the route registry or sitemap to reconcile the crawl against.
 - The templates behind the routes, for fixes that belong at the template rather than the page.
 - The list of money or conversion surfaces the graph is expected to feed.

--- a/workflows/migration-with-verification.md
+++ b/workflows/migration-with-verification.md
@@ -34,7 +34,7 @@ Read-only until the held redirect map and fixes. The cutover itself, the DNS and
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - Crawl access to both the old property and the new one.
 - The complete list of old URLs, from the old sitemap, the crawl, and the search-performance export together, because any one alone misses pages.
 - Search-performance history for the old property, to pre-register baselines before cutover.

--- a/workflows/post-deploy-live-verification.md
+++ b/workflows/post-deploy-live-verification.md
@@ -35,7 +35,7 @@ Verification is read-only. Fixes it surfaces land held; deploy-platform actions 
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - The production domain, and the list of routes the change touched plus the routes that share templates or data with them.
 - A way to read which build produced a served page (a deployment id, build hash, or asset fingerprint in the rendered HTML; every modern host embeds one).
 - The approved state: the merged content, metadata, and values the pages are supposed to show.

--- a/workflows/regulated-content-compliance-gate.md
+++ b/workflows/regulated-content-compliance-gate.md
@@ -32,7 +32,7 @@ This gate is read-only: it reads the content pipeline's held drafts and the buil
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - The property's regulatory context: the disclosure requirements, the list of citable authorities, and the prohibited-claim patterns for its vertical.
 - A register owner: the human accountable for the compliance register and its waivers.
 - The content pipeline's held drafts as input; this gate runs inside Content Pipeline Phase 3 for regulated properties.

--- a/workflows/revenue-tracking-integrity.md
+++ b/workflows/revenue-tracking-integrity.md
@@ -38,7 +38,7 @@ Fully read-only until Phase 5, and Phase 5 only ever produces held changes and a
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - The list of monetized link and event classes the property runs (affiliate links, checkout events, lead events).
 - Read access to the platform that reports revenue or clicks, and to the analytics and warehouse stores the events land in.
 - Enough accrued revenue or click data for a reconciliation window to be meaningful.

--- a/workflows/traffic-drop-triage.md
+++ b/workflows/traffic-drop-triage.md
@@ -39,7 +39,7 @@ This workflow is read-only until Phase 4, and Phase 4 only ever produces held ch
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - At least one demand-side data source (search-performance export) AND one behavior-side source (analytics events), because the single most valuable discriminator in the tree is whether they disagree.
 - Enough history to compute a baseline: the same period last year if seasonality is plausible, or at minimum several stable weeks pre-drop.
 - The deploy log or release history for the drop window.

--- a/workflows/warehouse-data-plane-standup.md
+++ b/workflows/warehouse-data-plane-standup.md
@@ -39,7 +39,7 @@ This workflow stands up read-only access and wires no write path. Enabling the e
 
 ## Prerequisites
 
-- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills`
+- Claude with the catalog installed: `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`
 - A warehouse you can create datasets in, with a billing project.
 - Admin access to the search-console and analytics properties whose exports you will enable.
 - An operational store separate from the warehouse, or the ability to provision one.


### PR DESCRIPTION
## The bug

Every workflow file, `GETTING-STARTED.md`, and `workflows/README.md` told a new user to run only:

```
/plugin marketplace add rampstackco/claude-skills
```

That registers the marketplace and **installs nothing**. The install path failed for anyone starting clean, including the workflow badged `validated`.

## The canonical form, from README.md

The dispatch asked which form README canonically uses. **README.md's canonical form is a two-step: add the marketplace, then install the plugin.** From `README.md` lines 31-43, under "Install in Claude Code", introduced by the sentence "Add the marketplace, then install the plugin you want:":

```
/plugin marketplace add rampstackco/claude-skills

# full catalog (103 skills)
/plugin install rampstack-skills@rampstack
```

`CHANGELOG.md` line 13 already carries the same pair inline, joined by "then", which is the in-repo precedent for expressing the two-step on one line:

> `/plugin marketplace add rampstackco/claude-skills` then `/plugin install rampstack-skills@rampstack`

Names verified against `.claude-plugin/marketplace.json`: the marketplace is `rampstack`, the full-catalog plugin is `rampstack-skills`. Full catalog is the right target since the workflows invoke skills across many categories.

So the fix places the **complete two-step**, not half of it.

## Files changed: 17 content files + the lock

Grep for `marketplace add` across the repo returned 20 hits. Three were already correct and are untouched:

| File | Line | Disposition |
|---|---|---|
| `README.md` | 34 | Correct (canonical source, two-step) |
| `README.md` | 48 | Correct (`rampstackco/plugins` alt, followed by its install) |
| `CHANGELOG.md` | 13 | Correct, and a historical entry; not edited |

The 17 that were broken, all fixed:

| # | File | Line | Form |
|---|---|---|---|
| 1 | `workflows/autonomy-review.md` | 38 | bullet |
| 2 | `workflows/ci-prove-gate-wiring.md` | 36 | bullet |
| 3 | `workflows/content-pipeline-prove-gates.md` | 41 | bullet (**the validated one**) |
| 4 | `workflows/conversion-by-source-diagnosis.md` | 40 | bullet |
| 5 | `workflows/corpus-integrity-and-correction.md` | 41 | bullet |
| 6 | `workflows/data-surface-integrity.md` | 42 | bullet |
| 7 | `workflows/experiment-loop-with-pre-registered-gates.md` | 39 | bullet |
| 8 | `workflows/incident-response-and-lane-demotion.md` | 39 | bullet |
| 9 | `workflows/link-graph-and-metadata-parity-audit.md` | 32 | bullet |
| 10 | `workflows/migration-with-verification.md` | 37 | bullet |
| 11 | `workflows/post-deploy-live-verification.md` | 38 | bullet |
| 12 | `workflows/regulated-content-compliance-gate.md` | 35 | bullet |
| 13 | `workflows/revenue-tracking-integrity.md` | 41 | bullet |
| 14 | `workflows/traffic-drop-triage.md` | 42 | bullet |
| 15 | `workflows/warehouse-data-plane-standup.md` | 42 | bullet |
| 16 | `workflows/GETTING-STARTED.md` | 5 | numbered list, plain text |
| 17 | `workflows/README.md` | 10 | fenced code block |

Plus `WORKFLOWS.lock`. **18 files, 32 insertions, 31 deletions.**

Each file keeps its own formatting: backticked in the workflow prerequisites (all 15 were byte-identical), a second line inside the fence in `workflows/README.md`, and plain text in `GETTING-STARTED.md` (which has zero backticks anywhere). Only **three distinct lines** were added across all 17 files. Nothing else in any file changed.

## Lock regeneration

Regenerated with `python tools/gen_workflows_lock.py`. The tool reads each workflow's status from its own opening fenced block, and no fenced block was touched, so statuses carry through by construction.

Verified mechanically:

- Keys identical before and after: **true**, 15 workflows
- Status changes: **NONE**
- Filename changes: **NONE**
- sha256 changes: **15** (all 15, expected: every workflow file changed)
- `content-pipeline-prove-gates` status after regeneration: **`validated`**
- Only `validated` entry: `content-pipeline-prove-gates`

A raw diff of the lock shows 30 changed lines, all of them `sha256`. No key added, removed, or reordered.

## Fresh-environment proof

The stranger condition that caught the bug, reproduced end to end. Isolated `CLAUDE_CONFIG_DIR`, no prior catalog install, running the corrected instruction exactly as a workflow file now states it.

**Baseline, clean context:**
```
$ CLAUDE_CONFIG_DIR=<fresh> claude plugin list
No plugins installed. Use `claude plugin install` to install a plugin.
```

**Step 1, the old half-instruction, on its own:**
```
$ claude plugin marketplace add rampstackco/claude-skills
✔ Successfully added marketplace: rampstack (declared in user settings)

$ claude plugin marketplace list
Configured marketplaces:
  ❯ rampstack
    Source: GitHub (rampstackco/claude-skills)

$ claude plugin list
No plugins installed. Use `claude plugin install` to install a plugin.
```

**This is the bug, reproduced.** The marketplace registers; nothing installs. A fresh user following the old workflow line has no skills.

**Step 2, the half the workflows were missing:**
```
$ claude plugin install rampstack-skills@rampstack
✔ Successfully installed plugin: rampstack-skills@rampstack (scope: user)

$ claude plugin list
Installed plugins:
  ❯ rampstack-skills@rampstack
    Version: 1.2.0
    Scope: user
    Status: ✔ enabled
```

**Skill count, corrected.** The installed plugin carries **102** skills, not the 103 README advertises. Counted independently in the install cache: 102 directories, 102 `SKILL.md` files. On `main`, `skills/` holds 103 source directories while `dist/pi/.agents/skills/` holds 102, so one skill is not shipped. This is **pre-existing and out of scope for this PR** (no file here touches `dist/`); it is exactly what PR #104 fixes. Flagging it because an earlier revision of this PR body claimed 103, which was wrong.

**Named skill slugs resolve.** Taking `content-pipeline-prove-gates` (the `validated` workflow), every skill slug it names across its phases:

```
RESOLVED  brand-voice                     RESOLVED  seo-content-audit
RESOLVED  content-brief-authoring         RESOLVED  seo-keyword
RESOLVED  content-refresh-system          RESOLVED  seo-keyword-gap-audit
RESOLVED  content-strategy                RESOLVED  seo-onpage
RESOLVED  editorial-qa                    RESOLVED  seo-rank-tracking
RESOLVED  long-form-content-frameworks    RESOLVED  seo-technical
RESOLVED  qa-testing

resolved: 13  missing: 0
```

One environment note, not a repo defect: the first clone attempt failed with Windows `Filename too long` because the temp config path was deep. Re-run under a short config path with `core.longpaths` scoped to the child process only. It affected the test harness, never the instruction under test.

## Checks

- **Grep acceptance: zero remaining half-instructions.** Every `marketplace add` in the repo is now followed by a `/plugin install`. Audited with `grep -rn -A1`; all 20 hits accounted for in the tables above.
- `python tools/gen_workflows_lock.py --check`: **`WORKFLOWS.lock is current (15 workflows)`**, exit 0.
- `lint_skills.py`: `check_em_dashes` **[OK]**. It walks all `*.md` including `workflows/`, so it covers this diff.
- **Zero em-dashes and en-dashes in the added lines**, checked directly against the diff.
- `check_brand_leaks` cannot run locally (`BRAND_WATCHLIST_FILE` comes from the private `rampstack/lint-config` in CI), so local lint exits 1 for that reason alone. The diff adds no new brand tokens beyond `rampstackco`/`rampstack`, which are the repo's own and already throughout. **CI will run it fully.**
- Commit signed (SSH, verified good).

Draft, held for your squash-merge. Agent never merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

