### PR TITLE
ci: run the dist/pi drift guard on every PR that can invalidate it

### DIFF
--- a/.github/workflows/dist-drift.yml
+++ b/.github/workflows/dist-drift.yml
@@ -1,0 +1,75 @@
+# Distribution drift guard.
+#
+# Why this exists: dist/pi is a generated distribution, byte-compared against a
+# fresh build by `scripts/build-pi.mjs --check`. That guard existed and worked,
+# but nothing ran it automatically, so it had never once run in CI. A guard
+# nobody runs catches nothing: dist/pi shipped 102 of 103 skills for an entire
+# release cycle without a single red build (fixed in #104).
+#
+# DELIBERATE CONSEQUENCE, read before "fixing" a red run here:
+#
+#   A PR that edits skills/** WITHOUT rebuilding dist/pi WILL GO RED.
+#
+# That is the invariant working, not noise. A shipped distribution must move
+# with its source in the same PR, otherwise the catalog on disk and the catalog
+# users actually install drift apart silently, which is precisely the failure
+# #104 had to clean up. The fix for a red run is to rebuild and commit:
+#
+#   node scripts/build-pi.mjs
+#   git add dist/pi && git commit
+#
+# Do NOT relax the path filters or add a skip to make this green. If a change
+# genuinely must not touch the dist, say so explicitly in the PR.
+#
+# SCOPE: dist/pi only, because dist/pi is the only distribution target that
+# exists on main today. `dist/` has one subdirectory, and build-pi.mjs is the
+# only builder emitting into it.
+#
+# TODO(dist-targets): extend this workflow to the Codex and Antigravity
+# builders when PR #87 (feat/port-antigravity) and PR #88 (feat/port-codex)
+# land on main. Those add dist/antigravity and dist/codex along with their own
+# builders. Until they merge there is nothing to check, and pre-wiring a step
+# for a builder that does not exist yet would fail on a missing file and teach
+# people to ignore this workflow. Add a matrix entry per target at that point,
+# not before.
+
+name: Distribution drift
+
+on:
+  pull_request:
+    paths:
+      # Source: a skills change must be accompanied by a dist rebuild.
+      - "skills/**"
+      # The generated output itself.
+      - "dist/**"
+      # The builder, whose behaviour defines what a correct dist looks like.
+      - "scripts/build-pi.mjs"
+      # Line-ending policy: the guard byte-compares, so this is load-bearing.
+      - ".gitattributes"
+      # This workflow.
+      - ".github/workflows/dist-drift.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  pi-dist:
+    name: dist/pi matches a fresh build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      # build-pi.mjs is dependency-free (Node ESM, fs and path only), so there
+      # is nothing to install and no lockfile to cache.
+      - name: Drift check, committed dist/pi vs a fresh build
+        run: node scripts/build-pi.mjs --check
+
+      # Cheap (same traversal, no second build), so it runs unconditionally
+      # rather than hiding behind a flag.
+      - name: Validate emitted output against the Pi skill rules
+        if: always()
+        run: node scripts/build-pi.mjs --validate


### PR DESCRIPTION
## What this fixes

`scripts/build-pi.mjs --check` byte-compares the committed distribution against a fresh build. The guard already worked. **Nothing ever ran it**, so it had never once executed in CI.

That is not a theoretical gap. It is how `dist/pi` shipped **102 of 103 skills** for a full release cycle without a single red build, which #104 had to clean up. A guard nobody runs catches nothing.

## The deliberate consequence, stated up front

> **A PR that edits `skills/**` without rebuilding `dist/pi` will go RED.**

**That is the invariant working, not noise.** A shipped distribution has to move with its source in the same PR. Otherwise the catalog on disk and the catalog users actually install drift apart silently, which is exactly the failure this repo just spent a PR cleaning up.

The fix for a red run is to rebuild and commit:

```
node scripts/build-pi.mjs
git add dist/pi && git commit
```

The fix is **never** to relax the path filter or add a skip. This is written into the workflow file header as well as here, so the next person to hit it finds the reasoning at the point of failure rather than in PR archaeology.

## Trigger scope

```yaml
paths:
  - "skills/**"                              # source must not move without the dist
  - "dist/**"                                # the generated output itself
  - "scripts/build-pi.mjs"                   # the builder defines what correct means
  - ".gitattributes"                         # load-bearing: the guard compares BYTES
  - ".github/workflows/dist-drift.yml"       # this file
```

`.gitattributes` is in the list deliberately rather than incidentally. The guard is a byte comparison, so the committed line-ending policy from #104 is what keeps a Windows checkout from reading as wholly different. A change to that file can invalidate the guard, so it has to retrigger it.

## Red/green proof, from real CI runs

A CI job that has only ever been seen green is unverified. Proven on a throwaway branch (#108, now closed, branch deleted), then on this branch clean.

| # | Branch state | Expected | Actual | Run |
|---|---|---|---|---|
| 1 | Seeded drift in `dist/pi` | RED | **fail**, exit 1 | [runs/31048047106](https://github.com/rampstackco/claude-skills/actions/runs/31048047106) |
| 2 | `skills/` edited, dist deliberately **not** rebuilt | RED | **fail**, exit 1 | [runs/31048123381](https://github.com/rampstackco/claude-skills/actions/runs/31048123381) |
| 3 | This branch, clean | GREEN | **pass** | [runs/31048002467](https://github.com/rampstackco/claude-skills/actions/runs/31048002467) |

Case 1 log:

```
FAIL: committed dist/pi is stale. 1 difference(s):
  content differs: evidence-based-reviews/SKILL.md
##[error]Process completed with exit code 1.
```

**Case 2 is the one that matters most.** It is not a generic failure test, it is the documented deliberate consequence reproduced end to end: source edited, distribution left stale, job red. Same failure output. If that case did not go red, the invariant claimed above would be fiction.

### The gap this closes, visible in case 1

On the seeded-drift run, **`Validate catalog structure` passed**. Every pre-existing check was green on a distribution that provably did not match its source. Only the new job caught it. That is precisely the blindness being fixed, demonstrated rather than asserted.

Case 3 also confirms the self-referential path filter works: the job ran on its own PR, because `.github/workflows/dist-drift.yml` is in its own trigger list.

*(Case 2's run also shows `verify-lock` red. That is an artifact of the seeded edit touching `skills/` without regenerating `SKILLS.lock`, not a behaviour of this workflow. Noting it so the run link is not confusing.)*

## Scope: `dist/pi` only

Scoped honestly to what is on `main` today:

```
dist/ subdirs:                      dist/pi   (only)
builders emitting to dist/:         scripts/build-pi.mjs
dist/ paths referenced in tooling:  dist/pi
```

The workflow carries a marked `TODO(dist-targets)` for extending to the Codex and Antigravity builders when #88 and #87 land. **I did not pre-wire checks for those targets.** A step invoking a builder that does not exist yet fails on a missing file, and a workflow that fails for reasons unrelated to the thing it guards is one people learn to ignore. A matrix entry per target belongs in the PR that adds the target.

## Verification

| Check | Result |
|---|---|
| YAML parses (`yaml.safe_load`) | OK, job `pi-dist`, 5 path triggers |
| `node scripts/build-pi.mjs --check` locally | `PASS ... byte-identical`, exit 0 |
| `node scripts/build-pi.mjs --validate` locally | `VALIDATION PASS`, exit 0 |
| Action versions | `checkout@v7`, `setup-node@v7`, matching the repo's existing v7 convention |
| Diff scope | **one file added**, nothing else |
| Em-dashes / en-dashes | 0 |
| Commit signed | yes, verified |

```
A  .github/workflows/dist-drift.yml
```

No changes outside the workflow file. `build-pi.mjs` is dependency-free (Node ESM, `fs` and `path` only), so there is nothing to install and no lockfile to cache.

## Note on `--validate`

It runs unconditionally with `if: always()`, so a drift failure still reports whether the emitted output is structurally valid. Same traversal, no second build, so the cost is negligible.

Held as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
