### PR TITLE
docs(readme): add the org map next to Family repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,24 @@ claude-skills is the parent catalog. Curated subsets and companion repos focus o
 
 Each family repo is MIT-licensed, conforms to the Agent Skills Specification, and is stack-agnostic. Use the full catalog for breadth; use a specialty subset when working in one domain.
 
+## How this org fits together
+
+The table above covers the skill catalogs. They are one part of a larger set, and the rest of it is below. All of it is public.
+
+**Skills.** This repo is the canonical home for all skill content. Alongside it sits the [workflows tier](workflows/): fifteen multi-skill runbooks with their connectors, a getting-started guide, and published run records for the ones that have been executed as written.
+
+**Subsets.** The five curated repos in the table above copy from this catalog with attribution and track it upstream.
+
+**Design direction themes.** Eight register repos, each shipping annotated design tokens with their measured contrast ratios, a component layer, two Tailwind adapters, and a demo that opens from a file with nothing installed: [neobrutalism](https://github.com/rampstackco/neobrutalism-theme), [glassmorphism](https://github.com/rampstackco/glassmorphism-theme), [Swiss style](https://github.com/rampstackco/swiss-style-theme), [bento grid](https://github.com/rampstackco/bento-grid-theme), [brutalist web](https://github.com/rampstackco/brutalist-web-theme), [corporate memphis](https://github.com/rampstackco/corporate-memphis-theme), [SaaS landing](https://github.com/rampstackco/saas-landing-theme), and [terminal UI](https://github.com/rampstackco/terminal-ui-theme). The gallery is at [rampstack.co/themes](https://rampstack.co/themes).
+
+**Creative direction.** The themes are not eight moods. Each one states its coordinates in the [creative direction framework](https://rampstack.co/framework/creative-direction), which sets brand direction on four axes, and the [showcase](https://rampstack.co/showcase/creative-direction) renders archetypes at each position on it.
+
+**Engines.** [Krine](https://github.com/rampstackco/krine), [Tholo](https://github.com/rampstackco/tholo), and [Basano](https://github.com/rampstackco/basano) run on one runtime: Krine decides, Tholo builds, Basano proves. [The engines page](https://rampstack.co/engines) covers what the three share.
+
+**Research.** The [SERP event registry](https://github.com/rampstackco/serp-event-registry) is a dated, sourced, confidence-tagged record of AI model releases, search feature changes, and confirmed algorithm updates, [rendered on the site](https://rampstack.co/research/serp-event-registry) from the repository that holds it.
+
+What shipped, and when, is recorded at [rampstack.co/updates](https://rampstack.co/updates).
+
 ---
 
 <!-- COUNT_CATALOG_HEADER:START -->


### PR DESCRIPTION
Adds `## How this org fits together` next to `Family repos`.

## Why a new section

Per the ruling: the skill-count table is correct for what it covers and is untouched. The gap it leaves is that someone landing on this README has no way to learn that the workflows tier, the eight theme repos, the three engines, or the research registry exist. This is a sibling section, placed between the `Family repos` closing paragraph and the generated catalog header.

## What it says

One line each, links only to public things.

| Line | Links |
| --- | --- |
| Skills | this repo, plus `workflows/` |
| Subsets | points at the table above rather than restating it |
| Design direction themes | eight repos + the `/themes` gallery |
| Creative direction | framework + showcase |
| Engines | krine, tholo, basano + the engines page |
| Research | SERP event registry repo + the rendered page |

It closes with a pointer to `/updates`.

## Counts

Derived or quoted from canonical sources, not typed fresh:

- **103 skills** is what the generated `COUNT_CATALOG_HEADER` region already states.
- **Fifteen workflows** is derived from the workflow file set (19 `.md` files in `workflows/` minus `AGREEMENT-LOG`, `CONNECTORS`, `GETTING-STARTED` and `README`), and matches the shipped updates entry "The fifteen-workflow set is complete".
- **Eight themes** is derived from the repositories themselves, not assumed. I checked all eight: each is public and non-empty, each carries `tokens`, `components` and `demo`, and each has a built Pages site. So the claim that all eight ship tokens, a component layer and a live demo is verified rather than generalized from the four I had seen.

## Held at draft: `/themes` is 404

Verified before writing, per the dispatch: **`https://rampstack.co/themes` returns 404.** The gallery index has not deployed.

Every other link in the new section resolves: 17 of 18 web links at 200, plus the one relative link (`workflows/`) confirmed on disk. The only failure is the gallery.

Under shipped-only this PR should not merge while that link is dead, so it is held. The line is written to survive the wait: the eight repositories are each linked directly and all return 200, so the map is useful even before the gallery lands, and the gallery link stops being a promise the moment it deploys.

## Constraints

- No generated marker touched. Verified mechanically: the diff contains no line matching `:START`, `:END` or `AUTO-GENERATED`.
- No lock file touched, no JSON touched. `README.md` is the only changed file.
- LF preserved, `git diff --check` clean.
- Em-dashes and en-dashes: 0. Banned phrases: 0.

Held for @adunn08. Not merging.
