### PR TITLE
fix(workflows): the honest-stop convention as the tier's honesty contract

### DIFF
--- a/WORKFLOWS.lock
+++ b/WORKFLOWS.lock
@@ -1,77 +1,77 @@
 {
   "autonomy-review": {
     "file": "autonomy-review.md",
-    "sha256": "37be1706427e67ece0c2298548e3b44774618c026e7bc559051fb89e09b8b34f",
+    "sha256": "015327accc407228b7fd0cf0dc9a12f86052c66f043ba7a55becf3c2bfe65c61",
     "status": "template"
   },
   "ci-prove-gate-wiring": {
     "file": "ci-prove-gate-wiring.md",
-    "sha256": "a2f9142a5c617deaad527d6ff253e223c1a994f6fd67e2ed9e7ce46157653f39",
+    "sha256": "be2b7a529de74940af780c345b49ae3a439832f59b18fc4ef579be8f296604b2",
     "status": "template"
   },
   "content-pipeline-prove-gates": {
     "file": "content-pipeline-prove-gates.md",
-    "sha256": "e24fb05ebfacef4c2b6c51e6e80d6627dd4c573481746aa35ee404a35a4cfc14",
+    "sha256": "2b8c6d13282f0fdc0c8e36bd5e5f2152ab4b33a98fda0e94a1c91877cd5805da",
     "status": "validated"
   },
   "conversion-by-source-diagnosis": {
     "file": "conversion-by-source-diagnosis.md",
-    "sha256": "2f32f96291fc60df5a1d021a83d0d875f6a951dabd822ae79a8c26814a3b8904",
+    "sha256": "3f29afdecf1066ef1e82494da01810cf0f38b458356b1742a067ebb57a1f8c70",
     "status": "template"
   },
   "corpus-integrity-and-correction": {
     "file": "corpus-integrity-and-correction.md",
-    "sha256": "2d5a3bb1f1ae31591a91dd9b9c48a6f83658e34cd83204484db2fbd1d558bcd1",
+    "sha256": "6eb19ad829dc1f786717e594dd51cf569955eda3ff3d827b0636b2aed066e0fd",
     "status": "template"
   },
   "data-surface-integrity": {
     "file": "data-surface-integrity.md",
-    "sha256": "a59f78552b118014ab91b0e76ebe5cd61604da4981fe5880f30b5195979dafa9",
+    "sha256": "9fdc0f3d652a99d3272f8ce8488450c58ddad3b9c30d1e7cd75df8a28dbd48dc",
     "status": "template"
   },
   "experiment-loop-with-pre-registered-gates": {
     "file": "experiment-loop-with-pre-registered-gates.md",
-    "sha256": "1cc120f33b0f23f0ce9d15c664b6291e73b6759b12f5dd39a25c6c0f11d64416",
+    "sha256": "a384e8f1ea7ce427c532fc5ded30f6f42853cbdea5b5255d6eccd6098236398c",
     "status": "template"
   },
   "incident-response-and-lane-demotion": {
     "file": "incident-response-and-lane-demotion.md",
-    "sha256": "aae0893096ba7617e6f02a17eae7801708c367267e13c75fe0c5b3a634f74d3e",
+    "sha256": "1273f53fa1e3f6f64ff16795f871958ef6a96e01551677febbbb82a9d13e35df",
     "status": "template"
   },
   "link-graph-and-metadata-parity-audit": {
     "file": "link-graph-and-metadata-parity-audit.md",
-    "sha256": "fbff88b7f123b345e0c2ad33e6fd67a02b816f831891e067efb255f002cc972c",
+    "sha256": "7c070e24a87f7216d02c2e1a497c459eaaeb7165cbe59fb04d6b0bd4f1adfbdc",
     "status": "template"
   },
   "migration-with-verification": {
     "file": "migration-with-verification.md",
-    "sha256": "35f25ed19b1b04659b2a71038a2225242a5353b14a9b222ac9837e58326382c8",
+    "sha256": "230b0492e040de69850b1c71609a6ee6155461d5e2e6bafc37ad05cda4ac96a1",
     "status": "template"
   },
   "post-deploy-live-verification": {
     "file": "post-deploy-live-verification.md",
-    "sha256": "08fd462eae54a1017bd01d535bebe0891b2a4aca580d84d6a630900a2ba2b168",
+    "sha256": "6552a022380d9dd8f76d9dfb81c48f712b96e4c605fabe9d988752595bca6013",
     "status": "template"
   },
   "regulated-content-compliance-gate": {
     "file": "regulated-content-compliance-gate.md",
-    "sha256": "4ef16945eb0fdec5b72e17592f0bf7185e4c4de2d42ba2457438b4b3af5b3b2a",
+    "sha256": "9547ff05cc30d66874d986a96da68c3a201b274c1c47be6a5d2143d74c30e111",
     "status": "template"
   },
   "revenue-tracking-integrity": {
     "file": "revenue-tracking-integrity.md",
-    "sha256": "e1028d72571c52fdb03f35d3b6b8df73fe206152a8c679d5eccff306da0d6fab",
+    "sha256": "97a9484f79a7c29ea20f10d56c9f0340a9e4682dbe7a48cb5f69e887fca2598b",
     "status": "template"
   },
   "traffic-drop-triage": {
     "file": "traffic-drop-triage.md",
-    "sha256": "81e76ac5a725654df07cac7c5c4fa925aa4291b97a8013e93183749ece70c5e5",
+    "sha256": "2faf9cced43dc45746d31d2cf94aff0efe35337ed8043bf0ac4f57a5442a92b9",
     "status": "template"
   },
   "warehouse-data-plane-standup": {
     "file": "warehouse-data-plane-standup.md",
-    "sha256": "9c791cb252e21cfce068bea806102b77a58d6fd64824a8c3350fd9dbda7464e8",
+    "sha256": "0c61cbbc088752ec8083df36a589983d8dcdc1bcd4895bb2e006a4bd22af4ada",
     "status": "template"
   }
 }

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -34,6 +34,10 @@ Every shipped file below enters at template. Content Pipeline with Prove Gates i
 
 Checks report and fail, engines propose and stop, a human merges; autonomy is earned per lane under the published doctrine, never asserted.
 
+## The honest-stop convention
+
+Every workflow carries the same "If a prerequisite is unmet" section, between its prerequisites and its phases. When a phase's required input, tool, access, or data is unavailable or unverifiable, the sanctioned output is a report-blocked statement, and that statement satisfies the phase's done-when; fabricating the missing number never does. The convention exists because instructions should not require what circumstances may not permit, and a done-when that demands numbers with no sanctioned way to stop is an instruction to invent them.
+
 ## The set
 
 WORKFLOWS.lock is the canonical manifest and the source for any count. The table is the list. Shipped files link, and with this wave every file is shipped, so no row remains defined and publishing.

--- a/workflows/autonomy-review.md
+++ b/workflows/autonomy-review.md
@@ -40,6 +40,14 @@ The agreement log has no connector class, deliberately. It is operated substrate
 - The tier's per-lane thresholds and, for graded lanes, the `guardrail_confidence` cutoff, recorded and version-controlled.
 - The published merge-authority doctrine (the three layers: access mode, gate auto-pass, merge authority), so a promotion proposal is measured against a written rule.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Assemble the window · lane: convergent (Tholo)
@@ -60,7 +68,7 @@ Run:
     evaluate no promotion yet.
 
 Output artifact: the per-lane window (four-way agreement rates, row counts, the waived line reported separately)
-Done when (public gate): every lane in the window has its four-way rates and row count, and waived rows are reported on their own line outside the rates
+Done when (public gate): every lane in the window has its four-way rates and row count, and waived rows are reported on their own line outside the rates, or a report-blocked statement per the prerequisite-unmet rule
 Operated-layer note: the window is read from the operated log instance; the schema and the four-way agreement values are public (AGREEMENT-LOG.md), and a reader runs this against their own log while RampStack's rows stay operated
 Fails look like: folding waived rows into the rates. A waive is a recorded human override, not a guardrail miss, and counting it as a false_pass or false_fail poisons the exact number promotion depends on.
 
@@ -81,7 +89,7 @@ Run:
     evaluation with the numbers; this gate reports and decides nothing.
 
 Output artifact: the per-lane eligibility evaluation (each condition, pass or fail, with the numbers)
-Done when: every evaluable lane has a verdict on the threshold, the minimum sample, and (for graded lanes) the confidence cutoff, and under-sample lanes are marked not-evaluable
+Done when: every evaluable lane has a verdict on the threshold, the minimum sample, and (for graded lanes) the confidence cutoff, and under-sample lanes are marked not-evaluable, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: a ceremony on insufficient sample. A lane declared eligible on five rows has measured noise, and the promotion it licenses regresses on the first real week.
 
 ### Phase 3: The ceiling · lane: gate (Basano)
@@ -102,7 +110,7 @@ Run:
     set after the ceiling.
 
 Output artifact: the eligible set with every Tier-3 lane struck, and each strike recorded as permanent
-Done when: no Tier-3 lane remains in the eligible set, and the graduation meta-decision is marked as itself Tier 3 and ineligible
+Done when: no Tier-3 lane remains in the eligible set, and the graduation meta-decision is marked as itself Tier 3 and ineligible, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: a lane graduating the ceremony's own class. The moment the review licenses the authority that licenses reviews, the ceiling is gone and the ladder is a pricing page with extra steps.
 
 ### Phase 4: Promotion, demotion, and tuning proposals · lane: divergent (human)
@@ -134,7 +142,7 @@ Run:
     so the next window can tell whether the tuning moved the agreement rate.
 
 Output artifact: held rubric-tuning changes, each tied to its lane and its motivating divergence
-Done when: every Phase 4 tuning decision is a held change with its evidence, and nothing has auto-applied
+Done when: every Phase 4 tuning decision is a held change with its evidence, and nothing has auto-applied, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: tuning a constant to make a lane pass. A threshold moved to promote a lane it was blocking is the promotion wearing a disguise, and the divergence evidence is what keeps the tuning honest.
 
 ## Failure modes

--- a/workflows/ci-prove-gate-wiring.md
+++ b/workflows/ci-prove-gate-wiring.md
@@ -39,6 +39,14 @@ Everything this workflow changes lands held: the gate wiring and any fix a gate 
 - A build command that produces the artifact production serves; a dev-flag build is a different artifact.
 - Branch protection you can configure, or the access to request it.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Inventory the pipeline and the gate candidates · lane: convergent (Tholo)
@@ -56,7 +64,7 @@ Run:
     inventory; propose nothing yet.
 
 Output artifact: the gate-candidate inventory (each candidate, its inputs, source-versus-built, current advisory or blocking state)
-Done when: every candidate has its inputs and current state recorded, including the checks that already block
+Done when: every candidate has its inputs and current state recorded, including the checks that already block, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: inventorying the CI config and missing the by-hand checks. The gate a team runs manually and trusts is the one worth wiring, and it never appears in the YAML.
 
 ### Phase 2: Define the gate set and the report contract · lane: divergent (Krine)
@@ -91,7 +99,7 @@ Run:
     event against the branch build. Land the wiring as a held PR; merge nothing.
 
 Output artifact: the gate implementations and their CI wiring, as a held PR that emits the report contract
-Done when: each gate runs on the pull-request event against the built output and emits the report contract, in a held PR
+Done when: each gate runs on the pull-request event against the built output and emits the report contract, in a held PR, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: asserting against a dev-flag build. A gate that passes on the dev server while the real build serves something else has verified a machine no user visits.
 
 ### Phase 4: Deliberate-failure demonstration · lane: gate (Basano)
@@ -109,7 +117,7 @@ Run:
     is reverted, never merged.
 
 Output artifact: per-gate failure evidence (the seeded fault, the captured red with its report, the reverted green)
-Done when: every gate has a captured red on its seeded fault and a captured green after revert
+Done when: every gate has a captured red on its seeded fault and a captured green after revert, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: shipping a gate no one has seen fail. A gate that has only ever passed is indistinguishable from a gate that checks nothing, and the difference surfaces the day it should have caught something.
 
 ### Phase 5: Install as required checks and branch protection · lane: divergent (human)
@@ -122,7 +130,7 @@ Run: a person sets the gates as REQUIRED status checks and enables branch
     and they stay human. The person records which gates were made required and on
     which branches.
 Output artifact: the required-check and branch-protection configuration, recorded against the gate set
-Done when: the named gates are required on the protected branches and a failing gate blocks the merge, confirmed by the human
+Done when: the named gates are required on the protected branches and a failing gate blocks the merge, confirmed by the human, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: gates that run but are not required. An advisory gate is a suggestion, and a pipeline under deadline merges past suggestions.
 
 ### Phase 6: Drift watch · lane: convergent (Tholo)
@@ -139,7 +147,7 @@ Run:
     re-proofs and updates as held changes.
 
 Output artifact: a drift record per gate (the canon version proven against, the last re-proof) and held updates for any stale gate
-Done when: every gate names the canon version it was last proven against, and no gate is enforcing against moved canon unproven
+Done when: every gate names the canon version it was last proven against, and no gate is enforcing against moved canon unproven, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: a gate frozen against last quarter's rules. It still passes and still blocks, and it is now enforcing a standard the team no longer holds.
 
 ## Failure modes

--- a/workflows/content-pipeline-prove-gates.md
+++ b/workflows/content-pipeline-prove-gates.md
@@ -44,6 +44,14 @@ One of cms.draft or repo.change is required, matching how the property publishes
 - A claims-and-style standard file (STANDARDS.md or equivalent): voice rules, phrase rules, sourcing requirements.
 - A route list or sitemap the link checks can resolve against.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Rank the backlog from demand · lane: divergent (Krine)
@@ -81,7 +89,7 @@ Run:
     publish, schedule, or merge.
 
 Output artifact: a held draft with sources inline, plus the brief it was written against
-Done when: the draft exists in held state and nothing has published
+Done when: the draft exists in held state and nothing has published, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: the draft publishing directly because the target's draft mechanism was skipped. Write-held is the seam; a pipeline that can publish in this phase is a different and more dangerous machine
 
 ### Phase 3: Pre-publish gate · lane: gate (Basano)
@@ -99,7 +107,7 @@ Run:
     verdict per check with evidence. Do not fix anything; report only.
 
 Output artifact: a prove report (verdict per check, evidence attached), attached to the held draft
-Done when (public gate): every check passes, or a failure is waived in writing with a recorded rationale attached to the held draft
+Done when (public gate): every check passes, or a failure is waived in writing with a recorded rationale attached to the held draft, or a report-blocked statement per the prerequisite-unmet rule
 Operated-layer note: in an operated deployment, the verdict and any waiver land as an agreement-log row; this is operated substrate, not part of the public package
 Fails look like: the gate passing on a claim citing a source that does not contain the number (source-shape checking, not source-presence checking)
 
@@ -130,7 +138,7 @@ Run:
     publish. Report verdict per check with the live evidence.
 
 Output artifact: a live-audit report tied to the production URL
-Done when: every check passes against the live render, or the discrepancy is filed as a defect with the live evidence attached
+Done when: every check passes against the live render, or the discrepancy is filed as a defect with the live evidence attached, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: verifying the preview. Merged is not live; a published piece can serve a stale render or the wrong metadata while the preview looks perfect, and only the production URL is ground truth
 
 ### Phase 6: Outcomes and the refresh trigger · lane: convergent (Tholo)
@@ -148,7 +156,7 @@ Run:
     topics on the same criteria.
 
 Output artifact: outcome records per piece; decay flags entering the Phase 1 queue
-Done when: outcomes are queryable for the next ranking cycle and decay candidates are in the queue
+Done when: outcomes are queryable for the next ranking cycle and decay candidates are in the queue, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: refresh running as its own separate pipeline. Decay is a demand source, not a second loop; the moment refreshes bypass the ranking, the pipeline has two front doors and the criteria govern only one of them
 
 ## Failure modes

--- a/workflows/conversion-by-source-diagnosis.md
+++ b/workflows/conversion-by-source-diagnosis.md
@@ -42,6 +42,14 @@ Fully read-only. This workflow diagnoses and ranks; it changes nothing. Its outp
 - A defined conversion event set and, where it exists, a value per event; if value is unknown, the ranking uses volume and says so.
 - Enough history for a stable baseline per segment (thin segments produce loud noise; the workflow flags them rather than ranking them).
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Frame the funnel and the baseline · lane: convergent (Tholo)
@@ -59,7 +67,7 @@ Run:
     needs. Produce the frame document. No analysis yet.
 
 Output artifact: the frame (events, segments, baseline window, known value per event or the stated absence)
-Done when: the frame names every dimension the sweep will cut by, and each named event is confirmed present in the data
+Done when: the frame names every dimension the sweep will cut by, and each named event is confirmed present in the data, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: framing after looking. A frame written once the divergences are visible quietly becomes a justification for them; the frame comes first so the sweep cannot be steered
 
 ### Phase 2: The divergence sweep · lane: convergent (Tholo)
@@ -80,7 +88,7 @@ Run:
     finding.
 
 Output artifact: the divergence table (finding, segment, magnitude, volume, baseline)
-Done when: every finding carries its numbers and thin cells are marked not-rankable
+Done when: every finding carries its numbers and thin cells are marked not-rankable, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: averaging across segments, the same failure that breaks traffic triage. A flat blended conversion rate can hide one template at half its peers; the cuts in the frame exist so the blend cannot
 
 ### Phase 3: Measurement gate · lane: gate (Basano)
@@ -101,7 +109,7 @@ Run:
     finding: BEHAVIOR, MEASUREMENT, or MIXED, with evidence. Report only.
 
 Output artifact: the divergence table, annotated with measurement verdicts
-Done when: every finding carries a verdict; MEASUREMENT findings route to a tracking fix, not an optimization
+Done when: every finding carries a verdict, or a report-blocked statement per the prerequisite-unmet rule; MEASUREMENT findings route to a tracking fix, not an optimization
 Fails look like: optimizing a consent artifact. A quarter spent lifting a segment whose conversions were merely unmeasured is the expensive version of this failure, and it is common
 
 ### Phase 4: Hypothesis ranking · lane: divergent (Krine)
@@ -137,7 +145,7 @@ Run:
     routing so experiment verdicts flow back against the original finding.
 
 Output artifact: routed work items, each tied to its finding and hypothesis
-Done when: every selected hypothesis is in the experiment queue or routed as a held fix, with the return path recorded
+Done when: every selected hypothesis is in the experiment queue or routed as a held fix, with the return path recorded, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: the diagnosis running its own tests. The moment this workflow ships a variant, pre-registration is retrofitted to a change already believed in, and the experiment gate is theater
 
 ## Failure modes

--- a/workflows/corpus-integrity-and-correction.md
+++ b/workflows/corpus-integrity-and-correction.md
@@ -43,6 +43,14 @@ Read-only until Phase 4; corrections land held, a human merges.
 - The property's canonical data sources for checkable claims (the statistics pages, standards bodies, or datasets its content cites).
 - A decision, made once and recorded, of what counts as a visible correction on this property (the correction-note format and where it renders).
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Claim inventory · lane: convergent (Tholo)
@@ -63,7 +71,7 @@ Run:
     if known.
 
 Output artifact: the claim register
-Done when: the register covers the corpus including metadata surfaces, and every claim carries a class
+Done when: the register covers the corpus including metadata surfaces, and every claim carries a class, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: inventorying body copy only. Claims rot fastest in the surfaces nobody rereads: meta descriptions, schema fields, comparison tables, and footer boilerplate
 
 ### Phase 2: Truth check · lane: gate (Basano)
@@ -87,7 +95,7 @@ Run:
     fix anything; report only.
 
 Output artifact: the discrepancy report
-Done when: every register entry has a verdict, including the clean ones
+Done when: every register entry has a verdict, including the clean ones, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: source-presence checking. A claim citing a live source that no longer contains the claimed value passes a lazy check and fails a reader; the check is against the source's current content, not its existence
 
 ### Phase 3: Triage and the correction plan · lane: divergent (Krine)
@@ -125,7 +133,7 @@ Run:
     lands held: CMS drafts or a draft change, never a direct publish.
 
 Output artifact: held corrections, each tied to its plan item; correction notes in place
-Done when: every approved item has a held change and nothing has published
+Done when: every approved item has a held change and nothing has published, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: silent edits to relied-upon claims. A correction a reader cannot see is indistinguishable from hoping nobody noticed, and on the day someone diffs the archive, it reads exactly that way
 
 ### Phase 5: Verify live and install the guard · lane: gate (Basano)
@@ -143,7 +151,7 @@ Run:
     which is what keeps the next pass small.
 
 Output artifact: live verification per correction; the standing cadence and authoring rule, recorded
-Done when: every merged correction is verified on its production URL and the cadence is scheduled
+Done when: every merged correction is verified on its production URL and the cadence is scheduled, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: counting the fix as done at merge. Merged is not live; a correction that renders on the preview and not on production has corrected nothing
 
 ## Failure modes

--- a/workflows/data-surface-integrity.md
+++ b/workflows/data-surface-integrity.md
@@ -45,6 +45,14 @@ Read-only until Phase 5; retirement changes land held, a human merges. Nothing i
 - The per-series cadence each source actually updates on.
 - A place to record the discontinued-series registry and the correction-note format (the same format Corpus Integrity and Correction uses).
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Series inventory · lane: convergent (Tholo)
@@ -62,7 +70,7 @@ Run:
     the per-series inventory; guard nothing yet.
 
 Output artifact: the per-series inventory (each series: source, real cadence, every consuming surface)
-Done when: every machine-rendered series is inventoried by series with its source, cadence, and consuming surfaces, including metadata and narration
+Done when: every machine-rendered series is inventoried by series with its source, cadence, and consuming surfaces, including metadata and narration, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: inventorying by dataset. A dataset marked fresh can carry one series that froze months ago, and a dataset-level view never sees the frozen series inside it.
 
 ### Phase 2: Guard audit · lane: gate (Basano)
@@ -82,7 +90,7 @@ Run:
     support. Report a verdict per series per guard with the rendered evidence.
 
 Output artifact: the guard report (per series: freshness threshold, discontinued registration, honest degradation, each with a verdict)
-Done when: every series has a verdict on its per-series freshness threshold, its discontinued status, and its degradation rendering
+Done when: every series has a verdict on its per-series freshness threshold, its discontinued status, and its degradation rendering, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: a trend arrow on a degraded series. An up arrow drawn from a value that stopped updating tells the reader the number is rising when it is only frozen, which is worse than showing nothing.
 
 ### Phase 3: Two-surface consistency · lane: gate (Basano)
@@ -101,7 +109,7 @@ Run:
     evidence.
 
 Output artifact: the consistency report (each shared value: single-source proof, the build test, the cache-lifetime check)
-Done when: every value on two or more surfaces is proven single-source with a build test, or the divergence is flagged with evidence
+Done when: every value on two or more surfaces is proven single-source with a build test, or the divergence is flagged with evidence, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: one source in code, two lifetimes in cache. Two surfaces importing the same module look consistent in review and serve different numbers in production because one cache outlived the other.
 
 ### Phase 4: Cadence-copy alignment · lane: gate (Basano)
@@ -120,7 +128,7 @@ Run:
     only.
 
 Output artifact: the cadence-alignment report (each stated frequency, the series' real cadence, a verdict)
-Done when: every surface claim about its own update frequency has a verdict against the series' real cadence
+Done when: every surface claim about its own update frequency has a verdict against the series' real cadence, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: trusting the copy. "Updated daily" is a claim like any other, and a series that refreshes monthly behind it is a dated claim that rots the moment the copy ships.
 
 ### Phase 5: Retirement protocol · lane: convergent (Tholo)
@@ -139,7 +147,7 @@ Run:
     held; a human merges.
 
 Output artifact: held retirement changes per discontinued series (removed from renders, correction note on any narration)
-Done when: every discontinued series is removed from current renders and its narration carries a visible correction note, all as held changes
+Done when: every discontinued series is removed from current renders and its narration carries a visible correction note, all as held changes, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: retiring the tile but not the narration. The number disappears from the dashboard while a paragraph elsewhere still explains what it means and where it is heading, describing a series that no longer exists.
 
 ## Failure modes

--- a/workflows/experiment-loop-with-pre-registered-gates.md
+++ b/workflows/experiment-loop-with-pre-registered-gates.md
@@ -42,6 +42,14 @@ The variant and its config land held; a human allocates traffic and launches. Tr
 - The experiment platform (experiment.read) and the analytics that will measure the primary metric.
 - A person who allocates traffic and launches; the workflow never does.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Intake · lane: convergent (Tholo)
@@ -78,7 +86,7 @@ Run:
     a delay. Report the pre-registration, or the not-run verdict, with the math.
 
 Output artifact: the frozen pre-registration (stopping rule, MDE, sample size, primary metric, window), or the "insufficient n, do not run" verdict with its math
-Done when: the test is pre-registered with all five fields frozen, or it is declared underpowered and not run, with the sample-size math shown either way
+Done when: the test is pre-registered with all five fields frozen, or it is declared underpowered and not run, with the sample-size math shown either way, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: shipping first and pre-registering after. A stopping rule and a metric written once the variant is believed in are fitted to the hope, and the test becomes a search for a number that agrees with it.
 
 ### Phase 3: Variant SEO-safety gate · lane: gate (Basano)
@@ -96,7 +104,7 @@ Run:
     with the evidence. Report only.
 
 Output artifact: the SEO-safety report (cloaking, canonical consistency, layout-shift, each with a verdict)
-Done when: the variant carries a verdict on cloaking risk, canonical consistency, and layout-shift, all clear or the risk flagged
+Done when: the variant carries a verdict on cloaking risk, canonical consistency, and layout-shift, all clear or the risk flagged, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: an experiment that wins by getting deindexed. A variant that trims the content search ranked for can lift the on-page metric while the page quietly falls out of the results, and the test would call that a win.
 
 ### Phase 4: Launch as a held config change · lane: divergent (human)
@@ -109,7 +117,7 @@ Run: the variant and its experiment config land as a HELD change (repo.change).
     launches against the frozen pre-registration, allocating exactly the design
     the math called for, and records the launch.
 Output artifact: the launched experiment, recorded against its pre-registration, with the variant and config as held changes a human merged
-Done when: the experiment is launched by a human at the pre-registered allocation, with the config held and merged by a person
+Done when: the experiment is launched by a human at the pre-registered allocation, with the config held and merged by a person, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: an agent turning traffic on. Allocating traffic is a production act on real users, and it stays with a person the same way merging and deploying do.
 
 ### Phase 5: The verdict · lane: gate (Basano)
@@ -128,7 +136,7 @@ Run:
     numbers. Report only.
 
 Output artifact: the verdict against the pre-registered rule (win, loss, or inconclusive) with the numbers at the pre-registered point
-Done when: the verdict is computed at the pre-registered point against the pre-registered primary metric and stopping rule, with the numbers attached
+Done when: the verdict is computed at the pre-registered point against the pre-registered primary metric and stopping rule, with the numbers attached, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: peeking, then stopping on a good look. Checking the test daily and stopping the day it crosses significance turns noise into a false win, because the more often you look, the more often chance alone crosses the line.
 
 ### Phase 6: Closeout · lane: convergent (Tholo)
@@ -147,7 +155,7 @@ Run:
     experiment never publishes itself. Record the closeout.
 
 Output artifact: the routed verdict and hypothesis outcome to Conversion-by-Source Diagnosis, and the consolidation path (with its SEO-safety re-check) recorded where a variant won
-Done when (public gate): the verdict and hypothesis outcome are recorded and routed to Conversion-by-Source Diagnosis, and any winning variant is queued for the ordinary held-fix flow with an SEO-safety re-check, not published from here
+Done when (public gate): the verdict and hypothesis outcome are recorded and routed to Conversion-by-Source Diagnosis, and any winning variant is queued for the ordinary held-fix flow with an SEO-safety re-check, not published from here, or a report-blocked statement per the prerequisite-unmet rule
 Operated-layer note: in an operated deployment the pre-registration, the verdict, and their agreement land as an agreement-log row; the verdict-versus-pre-registration agreement is what calibrates this lane (AGREEMENT-LOG.md)
 Fails look like: shipping the winner without re-checking the consolidated version. A variant proven safe in isolation can regress SEO once it is merged into the real page with the rest of the layout, and the win does not carry a waiver for that.
 

--- a/workflows/incident-response-and-lane-demotion.md
+++ b/workflows/incident-response-and-lane-demotion.md
@@ -42,6 +42,14 @@ The rollback and the fix land held; a human merges them through the now human-ga
 - The lane's `post_merge_outcome` budget, the regression threshold that makes a demotion mandatory.
 - The rollback mechanism for the lane's changes.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Detection intake · lane: convergent (Tholo)
@@ -60,7 +68,7 @@ Run:
     nothing to a promoted lane yet.
 
 Output artifact: the intake record (each signal, its candidate lane, the window's merges, the post_merge_outcome evidence)
-Done when: every regression signal in the window is recorded with its candidate lane and its post_merge_outcome evidence
+Done when: every regression signal in the window is recorded with its candidate lane and its post_merge_outcome evidence, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: treating every wobble as an incident. A metric breathing inside its normal band is not a regression, and an intake that flags noise trains the team to demote on nothing.
 
 ### Phase 2: Attribution · lane: gate (Basano)
@@ -96,7 +104,7 @@ Run: before any fix is written, a person returns the lane to human-gated. The
     that earned it, and it gets that evidence back the ordinary way, by re-earning
     it. Record the demotion and its reason.
 Output artifact: the lane returned to human-gated, with the demotion and its reason recorded
-Done when: the lane is human-gated and cannot auto-pass or auto-merge, confirmed before any fix is written
+Done when: the lane is human-gated and cannot auto-pass or auto-merge, confirmed before any fix is written, or a report-blocked statement per the prerequisite-unmet rule
 Operated-layer note: in an operated deployment the demotion is recorded as an agreement-log action against the lane, with the regression as its reason; the demotion of the operated lane is an operated act (AGREEMENT-LOG.md)
 Fails look like: fixing before demoting. While the fix is being written the lane is still promoted and still merging, so the machine that produced the regression keeps producing, and the incident grows a second head.
 
@@ -115,7 +123,7 @@ Run:
     through the human gate the way every change on this lane now does.
 
 Output artifact: the held rollback or fix, tied to the attributed merge, with the post_merge_outcome signal it must clear
-Done when: the rollback or fix is a held change and the regression signal has cleared against it, with the lane still human-gated
+Done when: the rollback or fix is a held change and the regression signal has cleared against it, with the lane still human-gated, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: closing the incident on the merge instead of on the signal. The change meant to fix the regression is verified by re-running the post_merge_outcome check that caught it, not by the fact that a PR merged.
 
 ### Phase 5: The false-pass audit · lane: gate (Basano)
@@ -134,7 +142,7 @@ Run:
     and the proposed gate improvement.
 
 Output artifact: the false-pass audit (the false_pass row, the structural gap named, the proposed gate improvement)
-Done when (public gate): the structural gap is named and a specific gate improvement is proposed as a held change
+Done when (public gate): the structural gap is named and a specific gate improvement is proposed as a held change, or a report-blocked statement per the prerequisite-unmet rule
 Operated-layer note: the audited row is the operated log's false_pass for the regressed merge; the schema and the four-way agreement values are public (AGREEMENT-LOG.md), the row is operated
 Fails look like: demotion without the audit. A lane demoted and fixed but never audited leaves the gate that missed the fault unchanged, and the same miss re-promotes the same class of regression next quarter.
 
@@ -153,7 +161,7 @@ Run:
     the conditions the lane must meet, and hand the lane to Autonomy Review.
 
 Output artifact: the recorded reset window (its start, the thresholds the lane must re-earn) handed to Autonomy Review
-Done when: the reset window is recorded with its start and re-earning conditions, and the lane is handed to Autonomy Review rather than re-promoted here
+Done when: the reset window is recorded with its start and re-earning conditions, and the lane is handed to Autonomy Review rather than re-promoted here, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: quietly re-promoting the lane once the fix lands. A lane restored to autonomy without re-earning it under a reset window has learned nothing, and the demotion was theater.
 
 ## Failure modes

--- a/workflows/link-graph-and-metadata-parity-audit.md
+++ b/workflows/link-graph-and-metadata-parity-audit.md
@@ -34,6 +34,14 @@ Read-only until Phase 4; fixes land held, a human merges. Nothing in the audit a
 - The templates behind the routes, for fixes that belong at the template rather than the page.
 - The list of money or conversion surfaces the graph is expected to feed.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Build the link graph · lane: convergent (Tholo)
@@ -52,7 +60,7 @@ Run:
     Produce the graph; judge nothing yet.
 
 Output artifact: the link graph (routes, edges, per-route metadata) reconciled against the route registry
-Done when: every registry route is a node and every internal link is an edge, with crawl-versus-registry discrepancies marked
+Done when: every registry route is a node and every internal link is an edge, with crawl-versus-registry discrepancies marked, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: crawling the preview. A staging crawl maps a link graph no user traverses, and the orphan on production is the page staging linked fine.
 
 ### Phase 2: Orphan and dead-end detection · lane: gate (Basano)
@@ -71,7 +79,7 @@ Run:
     outbound degree, and the path that is missing.
 
 Output artifact: the orphan-and-dead-end report (each flagged route, its degrees, the missing path, its weight)
-Done when: every route with zero inbound, or zero outbound to an outcome surface, is flagged with evidence, including the clean high-value routes confirmed reachable
+Done when: every route with zero inbound, or zero outbound to an outcome surface, is flagged with evidence, including the clean high-value routes confirmed reachable, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: counting orphans without weighting them. A thousand orphaned tag pages and one orphaned money page are not the same finding, and an unweighted list buries the one that pays.
 
 ### Phase 3: Metadata parity per route · lane: gate (Basano)
@@ -89,7 +97,7 @@ Run:
     metadata as evidence. Report only.
 
 Output artifact: the metadata-parity report (verdict per route per check, rendered metadata attached)
-Done when: every route carries a verdict for uniqueness, per-route OG and Twitter, self-canonical, and suffix dedup
+Done when: every route carries a verdict for uniqueness, per-route OG and Twitter, self-canonical, and suffix dedup, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: checking presence, not uniqueness. Every page carrying the homepage's OG image passes a presence check and fails a reader who sees the same card for forty different links.
 
 ### Phase 4: Triage and held fixes · lane: divergent (Krine) then convergent (Tholo)

--- a/workflows/migration-with-verification.md
+++ b/workflows/migration-with-verification.md
@@ -40,6 +40,14 @@ Read-only until the held redirect map and fixes. The cutover itself, the DNS and
 - Search-performance history for the old property, to pre-register baselines before cutover.
 - The cutover runbook's platform access (DNS, hosting), held by the human who performs it.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Inventory and pre-register the baselines · lane: convergent (Tholo)
@@ -59,7 +67,7 @@ Run:
     pre-registered baseline record.
 
 Output artifact: the complete old-URL inventory and the pre-registered baseline record (traffic, rankings, the recovery metric), dated before cutover
-Done when: every old URL is inventoried from the three sources unioned, and the baselines and recovery metric are recorded before any cutover step
+Done when: every old URL is inventoried from the three sources unioned, and the baselines and recovery metric are recorded before any cutover step, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: baselines chosen after cutover. A recovery metric written once traffic has moved is fitted to whatever happened and will always find recovery; the baseline means something only if it predates the flip.
 
 ### Phase 2: Redirect-map completeness gate · lane: gate (Basano)
@@ -78,7 +86,7 @@ Run:
     disposition's evidence. This gate reports and fixes nothing.
 
 Output artifact: the redirect map (every old URL, its disposition, the rationale for drops) with a zero-uncovered coverage report
-Done when: every old URL in the inventory carries a disposition, the uncovered count is zero, and each drop has a recorded rationale
+Done when: every old URL in the inventory carries a disposition, the uncovered count is zero, and each drop has a recorded rationale, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: a sampled map. A redirect map spot-checked instead of completed passes review and drops the long tail, and the long tail is where the accumulated ranking equity quietly lived.
 
 ### Phase 3: Parity audit, old versus new · lane: gate (Basano)
@@ -96,7 +104,7 @@ Run:
     old counterpart carried. Report parity per pair with the evidence. Report only.
 
 Output artifact: the parity report (each mapped pair, per-check verdict, the evidence)
-Done when: every mapped pair has a parity verdict across metadata, canonical, structured data, content presence, and internal links
+Done when: every mapped pair has a parity verdict across metadata, canonical, structured data, content presence, and internal links, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: parity by URL existence. A new URL that returns 200 can still have lost the title, the schema, and half the body the old one ranked for, and a check that stops at "the page exists" certifies a page that will not hold the ranking.
 
 ### Phase 4: Staged cutover · lane: divergent (human)
@@ -134,7 +142,7 @@ Run:
     redirect verdicts together.
 
 Output artifact: the Post-Deploy Live Verification closure for the new property plus the live redirect verdicts from the map
-Done when: Post-Deploy Live Verification closes VERIFIED on the new property and the mapped redirects fire live with the right status codes, or the discrepancies are filed with their evidence
+Done when: Post-Deploy Live Verification closes VERIFIED on the new property and the mapped redirects fire live with the right status codes, or the discrepancies are filed with their evidence, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: declaring the migration done at the DNS flip. DNS resolving is not the property migrated; the redirects, the parity, and the live render are, and only production fetches prove them.
 
 ### Phase 6: Monitoring window against the pre-registered baselines · lane: gate (Basano)
@@ -153,7 +161,7 @@ Run:
     routes out of this workflow.
 
 Output artifact: monitoring reports on cadence, and a closure record when the pre-registered recovery condition holds
-Done when: the pre-registered recovery condition holds across its window and the closure is recorded, or the window breaks baseline and the regression is routed to Traffic-Drop Triage
+Done when: the pre-registered recovery condition holds across its window and the closure is recorded, or the window breaks baseline and the regression is routed to Traffic-Drop Triage, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: closing on the first good week. Migration traffic is noisy in the weeks after cutover, and a recovery declared on one datapoint reopens a month later as a mystery with the trail already cold.
 
 ## Failure modes

--- a/workflows/post-deploy-live-verification.md
+++ b/workflows/post-deploy-live-verification.md
@@ -40,6 +40,14 @@ Verification is read-only. Fixes it surfaces land held; deploy-platform actions 
 - A way to read which build produced a served page (a deployment id, build hash, or asset fingerprint in the rendered HTML; every modern host embeds one).
 - The approved state: the merged content, metadata, and values the pages are supposed to show.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Capture the expected state · lane: convergent (Tholo)
@@ -59,7 +67,7 @@ Run:
     Record the newest deployment or build identifier the platform reports.
 
 Output artifact: the expected-state sheet (route, expected values, discriminator value, expected build id)
-Done when: every touched and blast-radius route has expected values and a discriminator
+Done when: every touched and blast-radius route has expected values and a discriminator, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: verifying only the changed route. The route you edited is the one you will look at anyway; the regression ships on the sibling route nobody listed
 
 ### Phase 2: Production fetch and identity check · lane: gate (Basano)
@@ -81,7 +89,7 @@ Run:
     or WRONG (current build, unexpected values).
 
 Output artifact: the live report (verdict, evidence, build id per route, both fetches)
-Done when: every route on the sheet has a verdict from production fetches
+Done when: every route on the sheet has a verdict from production fetches, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: trusting the deploy dashboard. The platform saying the deployment succeeded is a claim about the build, not about what a given route serves; tool-reported success is not verified state, and only the rendered production URL is ground truth
 
 ### Phase 3: Discriminate the failure class · lane: convergent (Tholo)
@@ -104,7 +112,7 @@ Run:
     ambiguous.
 
 Output artifact: the failure-class finding with its evidence
-Done when: every non-verified route has a named failure class or a named ambiguity with the next check specified
+Done when: every non-verified route has a named failure class or a named ambiguity with the next check specified, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: purge-and-hope. Purging a cache without knowing whether the deploy promoted treats two different diseases with one drug; when it happens to work, nothing was learned, and when it does not, the next hour is spent purging harder
 
 ### Phase 4: Route the fix · lane: divergent (human)
@@ -136,7 +144,7 @@ Run:
     definition of done.
 
 Output artifact: the closure record (all routes VERIFIED, final build ids, timestamps)
-Done when: all routes VERIFIED on production, and the closure record exists
+Done when: all routes VERIFIED on production, and the closure record exists, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: closing at merge, or closing on the first good fetch after a purge. Done is a property of what production serves, held across both fetches, on every route on the sheet
 
 ## Failure modes

--- a/workflows/regulated-content-compliance-gate.md
+++ b/workflows/regulated-content-compliance-gate.md
@@ -38,6 +38,14 @@ This gate is read-only: it reads the content pipeline's held drafts and the buil
 - The content pipeline's held drafts as input; this gate runs inside Content Pipeline Phase 3 for regulated properties.
 - A production-equivalent build, because placement is verified on the rendered page.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: The compliance register · lane: divergent (human)
@@ -53,7 +61,7 @@ Run: the register owner writes the compliance register once and approves it:
     not derived per draft. It is versioned, and it carries a review cadence
     against its own regulatory sources.
 Output artifact: the approved compliance register (disclosures and placements, the authority list, prohibited patterns, the review cadence)
-Done when: the register owner has approved the register and its review cadence, and it is versioned
+Done when: the register owner has approved the register and its review cadence, and it is versioned, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: a register derived per draft. A standard invented fresh for each piece is not a standard, and it drifts to whatever the current draft happens to satisfy.
 
 ### Phase 2: The compliance gate · lane: gate (Basano)
@@ -74,7 +82,7 @@ Run:
     draft.
 
 Output artifact: the compliance verdict per check (disclosures, authority-sourced claims, prohibited patterns), evidence attached
-Done when: the draft carries a verdict on disclosures present, every regulated claim authority-sourced, and prohibited patterns absent
+Done when: the draft carries a verdict on disclosures present, every regulated claim authority-sourced, and prohibited patterns absent, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: source-presence instead of authority-list checking. A claim with a citation attached passes a lazy check and fails the register when the citation is a blog rather than a listed authority; the presence of a source is not the same as sourcing to an authority.
 
 ### Phase 3: Placement verification on the built page · lane: gate (Basano)
@@ -92,7 +100,7 @@ Run:
     the rendered evidence. Report only.
 
 Output artifact: the placement report (each disclosure, its required placement, its rendered placement, a verdict)
-Done when: every required disclosure has a placement verdict against the register's rule, checked on the built render
+Done when: every required disclosure has a placement verdict against the register's rule, checked on the built render, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: verifying placement in the source. A disclosure in the markup that a collapsed accordion hides at render is present to a grep and absent to a reader, and the reader is who the rule protects.
 
 ### Phase 4: Waiver protocol · lane: divergent (human)
@@ -105,7 +113,7 @@ Run: only the register owner may waive a compliance failure, and a waiver is
     Repeated waivers of the same rule are a signal that the register is wrong or
     the process is, and they surface for review rather than accumulating silently.
 Output artifact: the recorded waiver (the rule, the draft, the register owner's rationale), or the confirmation that no waiver was granted
-Done when (public gate): every compliance failure is either fixed and re-gated, or waived in writing by the register owner with a recorded rationale
+Done when (public gate): every compliance failure is either fixed and re-gated, or waived in writing by the register owner with a recorded rationale, or a report-blocked statement per the prerequisite-unmet rule
 Operated-layer note: in an operated deployment a waiver lands as an agreement-log row with human_verdict = waive and a required human_reason, excluded from the false-pass and false-fail rate computations and reported on its own line (AGREEMENT-LOG.md)
 Fails look like: routine waivers. A waiver any reviewer can grant, or one that passes without the register owner and a rationale, turns the gate into a formality the pipeline learns to wave through.
 

--- a/workflows/revenue-tracking-integrity.md
+++ b/workflows/revenue-tracking-integrity.md
@@ -44,6 +44,14 @@ Fully read-only until Phase 5, and Phase 5 only ever produces held changes and a
 - Enough accrued revenue or click data for a reconciliation window to be meaningful.
 - The attribution parameter set: which parameters must survive the redirect chain.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Map the money path · lane: convergent (Tholo)
@@ -61,7 +69,7 @@ Run:
     the money-path map; test nothing yet.
 
 Output artifact: the money-path map (each class: link, redirect chain, required params, event, platform record)
-Done when: every monetized class is mapped from on-page link to platform record, with its required attribution parameters named
+Done when: every monetized class is mapped from on-page link to platform record, with its required attribution parameters named, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: mapping link instances instead of classes. Ten thousand affiliate links share a handful of classes, and a map keyed to instances misses the class-wide break while drowning in duplicates.
 
 ### Phase 2: Liveness and parameter survival · lane: gate (Basano)
@@ -81,7 +89,7 @@ Run:
     chain as evidence. Report only.
 
 Output artifact: a liveness-and-survival report per class (resolves live, params arrived, the chain)
-Done when: every link class has a liveness verdict and a parameter-survival verdict with its redirect chain recorded
+Done when: every link class has a liveness verdict and a parameter-survival verdict with its redirect chain recorded, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: testing one link and trusting the class. One affiliate link resolving does not prove the class resolves, and the broken subset earns nothing while the test stays green.
 
 ### Phase 3: Consent-state matrix · lane: gate (Basano)
@@ -100,7 +108,7 @@ Run:
     fired-and-attributed verdict per cell. Report only.
 
 Output artifact: the consent matrix (event by consent state, fired and attributed verdict per cell)
-Done when: every money event has a verdict under every consent state the property supports
+Done when: every money event has a verdict under every consent state the property supports, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: testing only the granted state. Consent-denied and undecided states are where attribution quietly zeroes, and a matrix that skips them certifies a path that loses money in the states most users are actually in.
 
 ### Phase 4: Reconciliation · lane: gate (Basano)
@@ -119,7 +127,7 @@ Run:
     filter. Report the reconciliation per source with the variance. Report only.
 
 Output artifact: the reconciliation report (platform versus warehouse per source, variance, tolerance verdict)
-Done when: every source is reconciled within tolerance for the window, or the per-source variance is flagged with evidence
+Done when: every source is reconciled within tolerance for the window, or the per-source variance is flagged with evidence, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: reconciling totals while per-source rows drift. A matching grand total made of two offsetting errors reads as healthy and is two broken sources wearing a coincidence.
 
 ### Phase 5: Findings triage, held fixes, and the standing cadence · lane: divergent (Krine) then convergent (Tholo)

--- a/workflows/traffic-drop-triage.md
+++ b/workflows/traffic-drop-triage.md
@@ -44,6 +44,14 @@ This workflow is read-only until Phase 4, and Phase 4 only ever produces held ch
 - Enough history to compute a baseline: the same period last year if seasonality is plausible, or at minimum several stable weeks pre-drop.
 - The deploy log or release history for the drop window.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Pin the drop · lane: convergent (Tholo)
@@ -58,9 +66,12 @@ Run:
     pre-drop baseline, and its shape across segments: which page templates,
     which query classes, which devices, which countries, which traffic
     sources. Do not explain the drop yet. Produce the drop profile only.
+    If a source is missing a segment, or the baseline window has no data,
+    report that cut as blocked with what was obtained rather than
+    estimating the number.
 
 Output artifact: a drop profile (start date, magnitude, segment breakdown)
-Done when: the profile states when, how much, and where, each with a number
+Done when: the profile states when, how much, and where, each with a number, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: averaging over segments. A sitewide average of minus 30 percent can be one template at minus 90 and everything else flat, and those are different diagnoses; the segment breakdown is the whole point of this phase
 
 ### Phase 2: Run the branches · lane: gate (Basano)
@@ -118,7 +129,7 @@ Run:
     who took them and with what.
 
 Output artifact: a branch evidence table: five branches, evidence for, evidence against, per-branch confidence
-Done when: all five branches have evidence recorded, including the branches that came back clean
+Done when: all five branches have evidence recorded, including the branches that came back clean, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: stopping at the first guilty-looking branch. Real drops are frequently compound (an update lands the same week a consent banner breaks measurement), and a one-branch diagnosis on a compound drop fixes half the problem while the other half compounds
 
 ### Phase 3: Diagnosis · lane: divergent (Krine)
@@ -170,7 +181,7 @@ Run:
     on the first good week.
 
 Output artifact: recovery reports on cadence; a closure record when the pre-registered condition holds
-Done when: recovery is declared against the pre-registered condition, or the diagnosis is reopened because the trajectory contradicts it
+Done when: recovery is declared against the pre-registered condition, or the diagnosis is reopened because the trajectory contradicts it, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: victory on one good week. Traffic is noisy; a recovery declared on a single datapoint reopens as a mystery a month later, now with the trail cold
 
 ## Failure modes

--- a/workflows/warehouse-data-plane-standup.md
+++ b/workflows/warehouse-data-plane-standup.md
@@ -45,6 +45,14 @@ This workflow stands up read-only access and wires no write path. Enabling the e
 - An operational store separate from the warehouse, or the ability to provision one.
 - The access controls to grant a scoped, read-only service identity.
 
+## If a prerequisite is unmet
+
+Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.
+
+- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
+- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
+- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
+
 ## Phases
 
 ### Phase 1: Enable the exports · lane: divergent (human)
@@ -58,7 +66,7 @@ Run: a person enables the search-console bulk export and the analytics
     history starts the day the export is enabled and the clock only runs
     forward. Turn them on before any other step.
 Output artifact: the exports enabled per property, with the enablement date recorded
-Done when: every in-scope property has both exports enabled with a recorded start date, confirmed in the source consoles
+Done when: every in-scope property has both exports enabled with a recorded start date, confirmed in the source consoles, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: doing this last. Every day the exports are off is a day of history that will never exist, and no later step can recover it.
 
 ### Phase 2: Separate the two stores · lane: convergent (Tholo)
@@ -78,7 +86,7 @@ Run:
     the operational store. Record the boundary as written policy.
 
 Output artifact: the two stores stood up, the region fixed, and the store-boundary policy recorded
-Done when: both stores exist, the region matches across exports, and the boundary policy names which data lives where
+Done when: both stores exist, the region matches across exports, and the boundary policy names which data lives where, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: one store doing both jobs. A single store for metrics and decisions couples query cost to operational writes and loses the separation the whole plane depends on.
 
 ### Phase 3: Wire read-only access with mandatory bounds · lane: convergent (Tholo)
@@ -98,7 +106,7 @@ Run:
     date range is rejected, not run. No write tool is present on this path.
 
 Output artifact: the read-only access layer, the scoped identity, and the bounds-and-offset rules encoded in the domain layer
-Done when: every warehouse call goes through the bounded read path, an unbounded call is rejected, and the identity carries no write scope
+Done when: every warehouse call goes through the bounded read path, an unbounded call is rejected, and the identity carries no write scope, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: bounds enforced by convention instead of code. A partition filter that is supposed to be there is absent on the one query written under deadline, and that is the query that scans the full history.
 
 ### Phase 4: Cost and quota governance · lane: gate (Basano)
@@ -116,7 +124,7 @@ Run:
     what holds and what does not.
 
 Output artifact: a governance report (bounds-rejection confirmed, partition scan confirmed, budget alert and quota set)
-Done when: an unbounded query is confirmed rejected, a bounded query is confirmed to scan only its partitions, and a budget alert exists
+Done when: an unbounded query is confirmed rejected, a bounded query is confirmed to scan only its partitions, and a budget alert exists, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: an unbounded scan reaching the warehouse. It is a cost incident waiting for a cron job, and it bills for the whole history every time it runs.
 
 ### Phase 5: Stand up the sensing layer · lane: convergent (Tholo)
@@ -135,7 +143,7 @@ Run:
     never acts.
 
 Output artifact: the sensing definitions per series (freshness, movement, cadence, anomaly) and the schedule
-Done when: every live series has thresholds derived from its own history and a scheduled check, and the layer only flags
+Done when: every live series has thresholds derived from its own history and a scheduled check, and the layer only flags, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: thresholds copied between series of different cadences. A daily series' movement band applied to a weekly one alarms on every normal week and trains the team to ignore it.
 
 ### Phase 6: Verification pass · lane: gate (Basano)
@@ -153,7 +161,7 @@ Run:
     or fail per source with the returned evidence. Report only.
 
 Output artifact: a verification report (one bounded round-trip per source, expected-versus-returned, offset confirmed)
-Done when: each source returns the expected shape through the bounded path, or the discrepancy is filed with its evidence
+Done when: each source returns the expected shape through the bounded path, or the discrepancy is filed with its evidence, or a report-blocked statement per the prerequisite-unmet rule
 Fails look like: verifying the warehouse holds data without verifying the read path returns it correctly. The tables can be perfect while the domain layer drops the offset, and every downstream number inherits the error.
 
 ## Failure modes


### PR DESCRIPTION
## What this fixes

The 2026-08 validation battery (T8) found the tier's honesty guardrail sitting in the wrong place. Models degrade honestly today, 6 of 6 with zero fabrication, but zero of the fifteen workflows define any prerequisite-unmet path. The guardrail lives in the current models' character rather than in the artifacts, so it is not a property of this repository at all.

The sharp case the battery named: Traffic-Drop Triage Phase 1's done-when demands numbers with no sanctioned way to stop, and a fabricated Phase 1 propagates silently into Phases 2 and 3, where every branch and the ranked diagnosis inherit the invented profile.

Scope is the workflows tier only. The skills-tier anti-fabrication pass (96 of 103 skills lack the language) is deferred to the third-party-currency inventory dispatch, which will classify which skills' outputs actually demand data. Nothing under `skills/` or `dist/` is touched here.

## The canonical block, verbatim

This is the review object. The same text lands in all fifteen files, byte-identical.

```markdown
## If a prerequisite is unmet

Any phase can find a required input, tool, access, or data source unavailable or unverifiable. When that happens, the sanctioned output is a report-blocked statement: what the phase required, what was actually verified or obtained, and where the run stops or continues degraded.

- A report-blocked statement satisfies the phase's done-when. Partial completion counts as completion when it is stated as partial.
- Fabricating, estimating, or interpolating a required number to satisfy a done-when is never sanctioned.
- A phase handed a report-blocked upstream treats it as its own unmet prerequisite and reports blocked in turn, rather than running on an input that does not exist.
```

## Placement, and why there

The block sits between `## Prerequisites` and `## Phases`, at the same structural position in all fifteen files. Verified: the three headings appear in that order in every file, with identical spacing.

The rule is about prerequisites, so it belongs where prerequisites are already being read, and every phase's done-when now refers back to it, so it has to be read before the phases rather than discovered inside one. Placing it inside the phase blocks would have meant repeating it per phase or picking one phase to host it, and a rule hosted by Phase 3 is a rule Phase 1 does not have.

## Done-when edits

65 done-when lines gain the escape clause by exact-quote edit. 64 take it appended:

> `..., or a report-blocked statement per the prerequisite-unmet rule`

One takes it at an interior clause boundary, because a trailing append would have attached to the wrong clause. Conversion-by-Source Diagnosis Phase 3:

```
- Done when: every finding carries a verdict; MEASUREMENT findings route to a tracking fix, not an optimization
+ Done when: every finding carries a verdict, or a report-blocked statement per the prerequisite-unmet rule; MEASUREMENT findings route to a tracking fix, not an optimization
```

**The rule applied:** a done-when gets the clause when its satisfying condition requires data, tool, access, or platform state that an unmet prerequisite can deny. It is left alone when the condition is closed by the operator's own judgment (a report-blocked statement lands in front of that judgment, and the judgment still closes the phase), or when it already names a not-obtained outcome as satisfying.

| File | Phases edited | Phases left |
|---|---|---|
| autonomy-review | 1, 2, 3, 5 | 4 |
| ci-prove-gate-wiring | 1, 3, 4, 5, 6 | 2 |
| content-pipeline-prove-gates | 2, 3, 5, 6 | 1, 4 |
| conversion-by-source-diagnosis | 1, 2, 3, 5 | 4 |
| corpus-integrity-and-correction | 1, 2, 4, 5 | 3 |
| data-surface-integrity | 1, 2, 3, 4, 5 | none |
| experiment-loop-with-pre-registered-gates | 2, 3, 4, 5, 6 | 1 |
| incident-response-and-lane-demotion | 1, 3, 4, 5, 6 | 2 |
| link-graph-and-metadata-parity-audit | 1, 2, 3 | 4 |
| migration-with-verification | 1, 2, 3, 5, 6 | 4 |
| post-deploy-live-verification | 1, 2, 3, 5 | 4 |
| regulated-content-compliance-gate | 1, 2, 3, 4 | none |
| revenue-tracking-integrity | 1, 2, 3, 4 | 5 |
| traffic-drop-triage | 1, 2, 5 | 3, 4 |
| warehouse-data-plane-standup | 1, 2, 3, 4, 5, 6 | none |

### The 14 left as written, each with its reason

Closed by the operator's own judgment, which is available whether or not the data arrived:

- autonomy-review Phase 4: `every eligible lane has a recorded human decision with its evidence, or is explicitly held for more sample`
- ci-prove-gate-wiring Phase 2: `a human has approved the gate set and the report contract, or returned them with changes`
- content-pipeline-prove-gates Phase 1: `a human selects the go item from the ranking`
- content-pipeline-prove-gates Phase 4: `a human has merged, published, or rejected; the pipeline never advances this phase on its own`
- conversion-by-source-diagnosis Phase 4: `a human selects which hypotheses proceed`
- corpus-integrity-and-correction Phase 3: `a human approves the plan, including the correction classes`
- link-graph-and-metadata-parity-audit Phase 4: `a human has approved the plan, and every approved fix is a held change with nothing published`
- revenue-tracking-integrity Phase 5: `a human has approved the plan, every approved fix is held, and the recurring cadence is scheduled`
- traffic-drop-triage Phase 3: `a human has confirmed the diagnosis or sent specific branches back for deeper evidence`

Already naming a not-obtained outcome as satisfying:

- experiment-loop Phase 1: `or returned to Conversion-by-Source Diagnosis as too vague to test`
- incident-response Phase 2: `or routed to Traffic-Drop Triage or the normal defect flow with the destination named`
- migration-with-verification Phase 4: `or the cutover is held at a failed checkpoint`
- post-deploy-live-verification Phase 4: `the action for every non-verified route is taken or explicitly deferred`
- traffic-drop-triage Phase 4: `every confirmed cause has a routed response or an explicit decision to accept it`

Worth flagging for review: the second group's disjuncts sanction stopping, which is why they are left, but each still presumes the phase got far enough to route or defer. If you would rather they carry the clause too, that is a four-line follow-up and I will take it.

## Worked application: Traffic-Drop Triage Phase 1

The battery's sharp case gets the rule applied concretely, inside the Run block where the numbers are demanded.

Before:

```
    Invoke seo-traffic-diagnosis against the traffic data. Establish, with
    numbers: when the drop started (day precision), its magnitude vs the
    pre-drop baseline, and its shape across segments: which page templates,
    which query classes, which devices, which countries, which traffic
    sources. Do not explain the drop yet. Produce the drop profile only.

Output artifact: a drop profile (start date, magnitude, segment breakdown)
Done when: the profile states when, how much, and where, each with a number
```

After:

```
    Invoke seo-traffic-diagnosis against the traffic data. Establish, with
    numbers: when the drop started (day precision), its magnitude vs the
    pre-drop baseline, and its shape across segments: which page templates,
    which query classes, which devices, which countries, which traffic
    sources. Do not explain the drop yet. Produce the drop profile only.
    If a source is missing a segment, or the baseline window has no data,
    report that cut as blocked with what was obtained rather than
    estimating the number.

Output artifact: a drop profile (start date, magnitude, segment breakdown)
Done when: the profile states when, how much, and where, each with a number, or a report-blocked statement per the prerequisite-unmet rule
```

## workflows/README.md

One paragraph, added as `## The honest-stop convention` between the merge doctrine and the set, since it is a tier-wide rule of the same kind:

> Every workflow carries the same "If a prerequisite is unmet" section, between its prerequisites and its phases. When a phase's required input, tool, access, or data is unavailable or unverifiable, the sanctioned output is a report-blocked statement, and that statement satisfies the phase's done-when; fabricating the missing number never does. The convention exists because instructions should not require what circumstances may not permit, and a done-when that demands numbers with no sanctioned way to stop is an instruction to invent them.

## WORKFLOWS.lock

Regenerated by `tools/gen_workflows_lock.py`. The diff is 15 changed lines, all of them `sha256`:

- 15 hashes moved, one per workflow file, which is every file in the manifest and exactly the set this PR edits.
- Zero `file` or `status` lines moved.
- `content-pipeline-prove-gates` retains `"status": "validated"`, and its `run record: run-records/content-pipeline-prove-gates-run-1.md` front-matter link is intact and still resolves to the file on disk.
- Manifest count stays 15.

## Verification

- `python tools/gen_workflows_lock.py --check`: `WORKFLOWS.lock is current (15 workflows).`
- `python tools/check_workflow_drift.py`: `No drift: every bound slug exists in SKILLS.lock.` No `Skills:` line was touched.
- Block present in 15/15 files, at the same location in each: `## Prerequisites` then `## If a prerequisite is unmet` then `## Phases`, verified by line-number ordering per file.
- Zero workflows whose done-when still unconditionally demands data outputs. The 14 exceptions are enumerated above with reasons; none of them demand data unconditionally.
- Writing law greps over the diff: 0 em-dashes, 0 en-dashes, 0 banned phrases, 0 "not just" constructions.
- Line endings: LF, per `.gitattributes` `workflows/** text eol=lf`.

### CI expectations

- **Workflows manifest** fires (paths include `workflows/**`). All three jobs should be green: lock verify passes on the regenerated lock; drift-check passes with no `Skills:` line touched; the fence test passes because `SKILLS.lock` is byte-identical to base (`git diff --stat SKILLS.lock` is empty).
- **Lint skills** fires (no path filter on PRs to main) and should be green; nothing under `skills/` changed.
- **Skills manifest** correctly does NOT fire: no `skills/**`, no `tools/gen_skills_lock.py`.
- **Distribution drift** correctly does NOT fire: no `skills/**`, `dist/**`, `scripts/build-pi.mjs`, or `.gitattributes`.

Held as a draft for squash-merge.
