### PR TITLE
fix(skills): single-source the numbers a reference already owns (T3 Wave B)

### DIFF
--- a/SKILLS.lock
+++ b/SKILLS.lock
@@ -16,7 +16,7 @@
     "references/testing-cadence-playbook.md": "7266af1fe12d7f0b374589cb93682c83458634fc0229809c64873b46896a9bb5"
   },
   "ads-performance-analytics": {
-    "SKILL.md": "9f45008134458f37e12812c42ad4bf863a5595e65db5c8cfa771aab8d9db58e7",
+    "SKILL.md": "686dc2e7b2651170b8f77014a02e751d9060651852402f398650afcfe5ea8188",
     "references/attribution-model-comparison.md": "fff3d7c5afc4c55ca9c75888a949b827de0338b2de9bb646a7733570cee96a63",
     "references/cohort-analysis-templates.md": "c15602571f8ce6d28b92d6c50918b2c6c07314b16f83c0d910e694fa332d460f",
     "references/common-interpretation-failures.md": "754a4c0ed869899d876fca5d38c5b6e0d2563f43fff4675dd567fcc38dbe2149",
@@ -46,7 +46,7 @@
     "references/event-taxonomy-template.md": "74bea752cf246b3c5c73a9597554c9786ae8836b627541708ca2f0d676adb8e4"
   },
   "art-direction": {
-    "SKILL.md": "fd8502c74cd2ed63f1bf2f2f75260b79666d71a3757c09f553e43ab6232d4965",
+    "SKILL.md": "3444cf2c4b932665df33509e16e0dfdcd370b1507b43a2bb157fd54e391e3c8d",
     "references/creative-brief-template.md": "dead6a017ca53c2109f324481e9481a785a86670f07922c92144efb7134593a2",
     "references/illustration-brief.md": "5f5d4be6388c11bcdcd1aeda2e8c6a13709f25d778be7c2fc3fc32b245687c00",
     "references/photo-shoot-brief.md": "531a005e77f7d10d71d9b4320fd4f13a2f6734516b92422c36a7aefe34d28e83"
@@ -123,7 +123,7 @@
     "references/style-guide-template.md": "e7e67c874d4495f6a558437cc06a05ac6f5e060ebf5c089e5f718fc498a10006"
   },
   "brand-voice": {
-    "SKILL.md": "4219ad5c33eb0a32733c8ef3d98f3396d2abfd0f55f4be8ab1b98ba5cbcd585b",
+    "SKILL.md": "7b88607af04d6847639083f498a1b8040372e364da3bfdfeb5715b20109b1009",
     "references/voice-document-template.md": "3ecb680f2fab6ac6c056078eec6af588594b3f4947f56f6fa6342750c435d747",
     "references/voice-frameworks.md": "ddf10b3826f5d16806aad27a34d865ec990b0c910102ae7f289bb6ae19173153"
   },
@@ -324,14 +324,14 @@
     "references/dns-record-reference.md": "bf7f15dcd0e7e3f6e54d789319593c6b94c20415bf81c5b20f604d8c3499127a"
   },
   "editorial-qa": {
-    "SKILL.md": "ba80b09baea0aa564e8d0dacf77e3fef6ca648a4ea348ff8fbaecf94be4d4907",
-    "references/ai-content-audit-patterns.md": "5af73d5b614ab2456b9b4a6927f8228d9d5a399cb093282ca6d02a8623fcb5ff",
+    "SKILL.md": "487b4f8a87f12c9915f0e1c1932b6ef1cd99eba1826669e6c7b9a6ce35026975",
+    "references/ai-content-audit-patterns.md": "daf8cf38538f290925a30284701effef84cc652ae0ff7037e49d7704a4963707",
     "references/brief-adherence-checklist.md": "75ce474f7fd6ad22b240fe4441e60a47395922fb6b97833e083e261019bda10d",
     "references/common-qa-failures.md": "5023275955bd31c8f1934a1bab73bd5e07a33649dce45ba59ab31824f508b35b",
     "references/fact-accuracy-and-citation-discipline.md": "2a9bcf77720b5136c9d8d941bff1326a19086387ef8f1e120201c2e8e88132e5",
     "references/internal-linking-and-schema-validation.md": "06d81225921d5c59c01906d639a46e9bc5a089ce89496539f09ef370625860c5",
     "references/qa-at-scale-patterns.md": "670c89a5ee37207c86df70f0528b61150c6b94cfdf2b2d197694c5e9e618edfd",
-    "references/qa-workflow-templates.md": "6182aa3efc8c1f7a53cbe4ba827fd3fb8e8aa12f26b5c4fc5de20ef862df7ec7",
+    "references/qa-workflow-templates.md": "634ec0076bb0d0535cc43d568dba8476932e67722dc45ae2cdc7509ef8003bcc",
     "references/seo-aeo-compliance-checklist.md": "9f51c6706673e2df8e1ef8b3b86c5fae74290ce422f165980718261fb54cab6a",
     "references/structure-and-clarity-review.md": "002258d5b0d87ed35e42799cc4c28a1da02553bdc707a24900586972dcdf2a6c",
     "references/voice-consistency-patterns.md": "65752a7c97f84aad0832ddcd492496e0df0011b02cd0c4c375e000a5d4942377"
@@ -476,7 +476,7 @@
     "references/job-statement-structure-patterns.md": "80cac04e5df9c3b27ce922d6e606e00914d899fa2df88053369c3f333fff0033"
   },
   "landing-page-copy": {
-    "SKILL.md": "c1eb89620e911e26bd6bb5a75d63e36d13ff11a5623098539f88c5b9dbd89b05",
+    "SKILL.md": "8233592fe17c89c3561bf775c26ea36fbdfc3ce2217977140614d63cb7a00030",
     "references/hero-formulas.md": "654fedde24827379c2ef62f9f9c5ef283cf23d0a1e58b991a51714b65d9a47cb",
     "references/objection-library.md": "bc0ee97281d1d5710dfb453f1018434d0d86c090fc1f5991506f93e4789ea585"
   },
@@ -635,8 +635,8 @@
     "references/when-pseo-works-decision.md": "3033a8f6687e9533fb0ff996267b80ef48a1e964b23694c8706b1ec1213bedc4"
   },
   "qa-testing": {
-    "SKILL.md": "bffe3827e182bbfbb4b067966bcc98cddc33bc8317aea6614c4a0933176e65ef",
-    "references/qa-report-template.md": "241fbc871bfee946964decd1496e0ec4ad87861e8a77a8ca0565e3559c358358"
+    "SKILL.md": "e162c4b987764edfd9d2a8c729eaa975214bfef7cea51f62f05613e4c9410915",
+    "references/qa-report-template.md": "31d1c63aa41ae736dcb10d9da93f96abdcb261606d265ace37452cc1a3bf8091"
   },
   "quiz-and-assessment-design": {
     "SKILL.md": "9e2a56cb5c4439eca01b7f81bcc590303b1fa1d04948be89c6d5a504030d4b9a",
@@ -676,8 +676,8 @@
     "references/llms-txt-guide.md": "008c48e172172ae440564956e7486014b91fdd93831bdcdc52e2dfbae3a00063"
   },
   "seo-audit-orchestration": {
-    "SKILL.md": "5763168e22bf43e990a875222d757352eea86fbff92339280b28ad95b19cb68e",
-    "references/audit-rollup-template.md": "70563185132deda3957df63a228a0f0cd59c302d72351dc8b73427433f81f456"
+    "SKILL.md": "d79f6c3f6d92f526c2ef76661f65c0ad6e6fe10050713f39e422df231e199c51",
+    "references/audit-rollup-template.md": "585ea8aa7a1124a9598c8715f54b8e3f5913ab81d9105fd2848ead4673fcd504"
   },
   "seo-backlink-audit": {
     "SKILL.md": "37551a8024bdc7491038fc73c19953b363659f7b2e76a0b65a8c327e6f8a8808",
@@ -718,12 +718,12 @@
     "references/title-and-meta-patterns.md": "174d10417509e11d5c3654d0e4e018343f79e5bec317fa55d8003f7988c67ae6"
   },
   "seo-rank-tracking": {
-    "SKILL.md": "d3c729f8de84247999ec04d6a525e804c6b75e96fa016add9c4901fd23262454",
-    "references/dashboard-template.md": "efb302269ec3f0e9122a99034e1e95e0a65976b4833c9a6bd91353efde924feb"
+    "SKILL.md": "1276d75881093f18e20474862d08036daaad182a4cbaec98d30483adc06abdf5",
+    "references/dashboard-template.md": "c3a67a6373add2721902216eb4652c3a1077f9e5fd45daee4b9dc76bbb740296"
   },
   "seo-site-health-audit": {
-    "SKILL.md": "78684edafdac6e2f73ce48c23d261ae81386fbd04a26b56ea0003334a8d1bb1e",
-    "references/issue-impact-table.md": "e59a5c298f0130d60ba9ad1c6855217e95168161a743e67c0988f766bb9efd24"
+    "SKILL.md": "74e00e5931262631b948ed29fce08bf528427a27b80ffbff1ba11eb02a15147e",
+    "references/issue-impact-table.md": "3380c9ebfe0861c477c438088f9c160eb55b6c756eb948c64ac7f783323336e7"
   },
   "seo-technical": {
     "SKILL.md": "8b874b2a102ac52c059f8860aae1119d36c14ecd8a63b5e7bcda7c04830d79f4",

--- a/dist/pi/.agents/skills/ads-performance-analytics/SKILL.md
+++ b/dist/pi/.agents/skills/ads-performance-analytics/SKILL.md
@@ -113,9 +113,9 @@ ROAS is short-term. Revenue from purchases attributed to a campaign in a fixed w
 
 Decisions made on ROAS can be wrong if LTV varies by channel. A worked example.
 
-Meta drives 2.5x ROAS at $40 CAC with $80 LTV. The 7-day-click revenue covers 1.5x payback over the customer lifetime.
+Meta drives 2.5x ROAS at $40 CAC with $80 LTV. That is 2.0x payback over the customer lifetime.
 
-Google drives 1.8x ROAS at $60 CAC with $200 LTV. The 7-day-click revenue covers 3.3x payback over the customer lifetime.
+Google drives 1.8x ROAS at $60 CAC with $200 LTV. That is 3.3x payback over the customer lifetime.
 
 Google looks worse on ROAS, better on LTV-adjusted return. Allocating budget to Meta because the ROAS is higher is the wrong move.
 

--- a/dist/pi/.agents/skills/art-direction/SKILL.md
+++ b/dist/pi/.agents/skills/art-direction/SKILL.md
@@ -69,7 +69,7 @@ The visual treatment.
 - Color palette (true color, treated, monochrome)
 - Locations (specific or general direction)
 - Wardrobe and props
-- Mood references (3 to 5 reference images)
+- Mood references (the photo brief template sets how many)
 
 **For illustration:**
 - Style (flat, dimensional, hand-drawn, geometric, abstract)
@@ -77,7 +77,7 @@ The visual treatment.
 - Line treatment
 - Composition style
 - Detail level
-- Reference artists or works (with explicit "we want like X but NOT like Y")
+- Reference artists or works, with explicit "we want like X but NOT like Y" (the illustration brief template sets how many)
 
 **For video / motion:**
 - Pacing (slow, medium, fast cuts)
@@ -85,7 +85,7 @@ The visual treatment.
 - Color grading
 - Transitions and effects
 - Audio direction (music, voiceover, ambient)
-- Reference work (3 to 5 examples)
+- Reference work (3 to 5 examples; no template covers motion, so this count is the one to use)
 
 ### 3. The execution
 
@@ -143,10 +143,10 @@ The quality bar.
 1. **Confirm the inputs.** Brand identity locked. Audience and goal clear. Budget and timeline known.
 2. **Develop the concept.** Premise, emotional through-line, takeaway.
 3. **Build the look.** Mood references. Specific direction on style elements.
-4. **Write the spec.** Production-level direction. Variants. Constraints.
+4. **Write the spec.** Production-level direction. Variants. Constraints. Licensing and usage rights, agreed before the shoot or the first sketch, not after: both brief templates make licensing a pre-production section for the reason that renegotiating it against finished work costs more.
 5. **Brief the vendor.** In writing. Walk through it live. Allow questions.
 6. **Review milestones.** Treatment review, halfway review, final review. Don't skip the early reviews; corrections compound.
-7. **Approve and document.** What was produced, what's licensed for what use.
+7. **Approve and document.** What was produced, and confirmation that it shipped under the licensing agreed at step 4.
 
 ### For directing in-house creative
 
@@ -178,16 +178,17 @@ The quality bar.
 
 ## Output format
 
-Default output is a creative brief at `creative-brief-[project].md`.
+Default output is a creative brief at `creative-brief-[project].md`, written against one of the brief templates in `references/`. The template you pick is the structure: use [`references/photo-shoot-brief.md`](references/photo-shoot-brief.md) for photography, [`references/illustration-brief.md`](references/illustration-brief.md) for illustration, and [`references/creative-brief-template.md`](references/creative-brief-template.md) for anything else or for a mixed production. Each template owns its own section list, section order, and reference-image count. Do not write to the five-layer outline below and hope it maps; the templates carry sections the layers do not, licensing and usage rights among them, and those sections are load-bearing before production starts, not after it.
 
-Structure:
+The five layers are the thinking. Every template covers all five, in its own order:
+
 1. The story (premise, through-line, role of brand, takeaway)
 2. The look (visual treatment with references)
 3. The execution (specs, variants, constraints)
 4. The standards (quality bar, examples of acceptable and unacceptable)
-5. The logistics (timeline, milestones, budget, deliverables)
+5. The logistics (timeline, milestones, budget, deliverables, licensing and usage rights)
 
-Plus a separate moodboard or visual reference doc with images.
+Plus a separate moodboard or visual reference doc with images, at the count the chosen template gives.
 
 ---
 

--- a/dist/pi/.agents/skills/brand-voice/SKILL.md
+++ b/dist/pi/.agents/skills/brand-voice/SKILL.md
@@ -126,36 +126,23 @@ For each major content type, show:
 - Good example (on-voice)
 - Brief note on what changed
 
-Common content types to cover:
+Cover the content types listed in the paired examples library of [`references/voice-document-template.md`](references/voice-document-template.md). The template owns that list, so there is one list to maintain rather than two that drift apart.
 
-- Headline
-- Subheadline
-- Hero CTA
-- Feature description
-- Testimonial intro
-- Email subject line
-- Email opening
-- Push notification
-- Error message
-- Success message
-- About page paragraph
-- Social post
-- Sales page paragraph
-
-Aim for 15 to 25 paired examples. This is the most-used part of the voice doc in practice.
+The floor is 15 paired examples. One pair per type in the template clears it. Past 25 the library gets harder to scan than to use, so treat 25 as the practical ceiling, not a hard cap. This is the most-used part of the voice doc in practice.
 
 ---
 
 ## Workflow
 
-1. **Audit existing copy** if it exists. Identify what is on-brand, what is off, what patterns recur.
-2. **Layer 1: Voice attributes.** Generate 5 to 8 candidates with "we are X, not Y" framing. Pick 3 to 5.
-3. **Layer 2: Tone shifts.** List 8 to 15 contexts the brand writes in. Note the tone shift for each.
-4. **Layer 3: Vocabulary and grammar.** Define preferences. Skip default rules unless they actually distinguish the brand.
-5. **Layer 4: Examples.** Build the paired-example library. 15 to 25 minimum.
-6. **Stress-test.** Pick a fresh writing brief and apply the voice doc. Does it produce on-voice copy? If not, the doc is incomplete.
-7. **Document.** Use the template in [`references/voice-document-template.md`](references/voice-document-template.md).
-8. **Distribute.** Voice docs only work if they get used. Make the doc easy to reference inline (link to it from CMS templates, brief templates, AI assistant prompts).
+1. **Pick the entry point.** [`references/voice-frameworks.md`](references/voice-frameworks.md) has a "Choosing a framework" section that decides this. A brand starting from zero begins with archetypes there, then dimensions, then attributes, and rejoins this workflow at step 2. Everything below assumes copy exists to audit.
+2. **Audit existing copy** if it exists. Identify what is on-brand, what is off, what patterns recur.
+3. **Layer 1: Voice attributes.** Generate 5 to 8 candidates with "we are X, not Y" framing. Pick 3 to 5.
+4. **Layer 2: Tone shifts.** List 8 to 15 contexts the brand writes in. Note the tone shift for each.
+5. **Layer 3: Vocabulary and grammar.** Define preferences. Skip default rules unless they actually distinguish the brand.
+6. **Layer 4: Examples.** Build the paired-example library against the template's content-type list, to the floor stated in the Layer 4 section above.
+7. **Stress-test.** Pick a fresh writing brief and apply the voice doc. Score the result with the stress test in [`references/voice-frameworks.md`](references/voice-frameworks.md): 1 to 5 against each attribute, and anything scoring below 3 on any attribute is off-voice. Below 3 means the doc is incomplete, not that the copy needs another pass.
+8. **Document.** Use the template in [`references/voice-document-template.md`](references/voice-document-template.md).
+9. **Distribute.** Voice docs only work if they get used. Make the doc easy to reference inline (link to it from CMS templates, brief templates, AI assistant prompts).
 
 ---
 

--- a/dist/pi/.agents/skills/editorial-qa/SKILL.md
+++ b/dist/pi/.agents/skills/editorial-qa/SKILL.md
@@ -220,9 +220,9 @@ For pieces shipping at programmatic-SEO scale (100s to 100,000s of pages), full-
 
 **Sampling strategy.**
 
-- Random sample 50 to 200 pages per audit cycle
+- Random sample per audit cycle, sized by the sample-size schedule in [`references/qa-at-scale-patterns.md`](references/qa-at-scale-patterns.md), which owns the numbers
 - Balance the sample across data shape (sparse versus dense records, recent versus old generation, popular versus niche categories)
-- Fixed sample percentage as set grows; absolute count plateaus around 200 once the set is large
+- The schedule is a fixed count per set-size band, rising to a plateau at the largest band. The percentage sampled therefore falls as the set grows, which is deliberate: past a certain size, more pages stop buying more signal
 
 **Automated checks at scale.**
 
@@ -257,7 +257,7 @@ Ownership and sequencing.
 
 **Single QA owner per piece**, not a committee. The owner is accountable for what shipped. Committees diffuse accountability; nobody owns a problem that reaches readers.
 
-**Sequencing.** Brief-adherence, then fact-accuracy, then structure, then AI-content audit, then voice, then SEO/AEO, then internal linking, then schema. Brief-adherence first because it is the cheapest gate; SEO/AEO checks last because they are easiest to fix and rarely halt-conditions.
+**Sequencing.** Run the gates in the order set by the sequencing template in [`references/qa-workflow-templates.md`](references/qa-workflow-templates.md), which owns the gate list and its order. Brief-adherence runs first: it is the cheapest gate that can halt a piece, and it catches the largest class of failures. The SEO/AEO and linking-and-schema gates sit near the end because most of their failures are auto-fixable and rarely halt anything. A final read closes the sequence.
 
 **Halt vs flag vs auto-fix.**
 

--- a/dist/pi/.agents/skills/editorial-qa/references/ai-content-audit-patterns.md
+++ b/dist/pi/.agents/skills/editorial-qa/references/ai-content-audit-patterns.md
@@ -8,7 +8,7 @@ The 11 AI tells, the 6 hallucination patterns, voice drift detection, a worked e
 
 Pattern recognition. Read with these top-of-mind; flag any match.
 
-**1. Excessive em-dashes.** Model-default punctuation. A piece with 8 em-dashes per 1,000 words is almost certainly AI-drafted. The fix: replace with periods, semicolons, or rephrase the sentence.
+**1. Excessive em-dashes.** Model-default punctuation. Flag at 8 em-dashes per 1,000 words; a piece at that rate is almost certainly AI-drafted. This rate is the one threshold for the tell, used everywhere in this file. The fix: replace with periods, semicolons, or rephrase the sentence.
 
 **2. Predictable opening phrasings.** Throat-clearing openers that announce what the piece is about to do (the fast-paced-world opener, the importance-noting opener, the whether-you-are-X-or-Y opener). These openings appear in AI output across topics; pattern-match against the team's curated do-not-use list and cut.
 
@@ -101,7 +101,7 @@ For each AI-co-authored draft, walk this checklist.
 1. Read the first 200 words. Does the opening match any of the 11 AI tells? Flag.
 2. Sample 2 paragraphs from the middle. Does either match AI tells? Does the voice match the brand voice doc? Flag.
 3. Read the last 200 words. Does the closing match any of the 11 AI tells? Flag.
-4. Search the piece for em-dashes; count. More than 5 in a 1,500-word piece is suspicious.
+4. Search the piece for em-dashes; count. Flag at the rate in pattern 1, 8 per 1,000 words, which is 12 in a 1,500-word piece.
 5. Search for forced bilateral framing patterns. Count.
 6. Verify every statistic, quote, case study, citation, and product claim per the fact-accuracy methodology.
 7. Sample 3 to 5 internal links; verify they go where the brief specified and the targets exist.

--- a/dist/pi/.agents/skills/editorial-qa/references/qa-workflow-templates.md
+++ b/dist/pi/.agents/skills/editorial-qa/references/qa-workflow-templates.md
@@ -22,7 +22,7 @@ The principle. One person is accountable for what shipped. Committees diffuse ac
 
 ## The sequencing template
 
-Run QA gates in this order. Each gate is cheaper than the next; running them in order saves the editor's time on pieces that should restart.
+Run QA gates in this order. The order is not a cost ranking (fact-accuracy is the most expensive gate and runs second). It front-loads the two gates that can halt a piece, cheapest of those first, so a piece that should restart consumes as little review time as possible. The cycle-time table below gives the real per-gate costs.
 
 1. **Brief-adherence.** First. Cheapest to run. Catches the largest class of failures.
 2. **Fact-accuracy.** Second. Halt-condition; AI hallucinations do not progress past this gate.

--- a/dist/pi/.agents/skills/landing-page-copy/SKILL.md
+++ b/dist/pi/.agents/skills/landing-page-copy/SKILL.md
@@ -184,7 +184,7 @@ Buttons matter. Treat the button copy as a whole-page-worth of attention.
 6. **Draft sections.** Section by section. Don't polish until the structure is sound.
 7. **Edit for friction.** Remove every word that doesn't earn its place. Landing pages do not have words to spare.
 8. **Test the CTA.** Read the page aloud. By the end, is the visitor's next action obvious?
-9. **Pre-publish:** check links, spell-check, mobile preview, SEO basics if SEO is a goal.
+9. **Hand off with a post-import checklist.** The deliverable is a markdown document, not a built page, so step 9 is not something you perform: it is a list you attach for whoever builds the page. Spell-check the copy yourself, then hand over the rest. Every destination URL resolves. Mobile preview of the built page. SEO basics if SEO is a goal. If the page is already built and you are revising it in place, run the checklist yourself instead of handing it over.
 
 ---
 

--- a/dist/pi/.agents/skills/qa-testing/SKILL.md
+++ b/dist/pi/.agents/skills/qa-testing/SKILL.md
@@ -62,7 +62,7 @@ const smoke = {
   titleLen: document.title.length,
   canonical: document.querySelector('link[rel="canonical"]')?.href,
   h1Count: document.querySelectorAll('h1').length,
-  missingAlts: [...document.querySelectorAll('img')].filter(i => !i.alt).length,
+  missingAlts: [...document.querySelectorAll('img')].filter(i => !i.hasAttribute('alt')).length,
   schema: [...document.querySelectorAll('script[type="application/ld+json"]')]
     .map(s => { try { return JSON.parse(s.innerText)['@type'] } catch(e) { return 'invalid' } }),
   brokenImages: [...document.querySelectorAll('img')].filter(i => !i.complete || i.naturalWidth === 0).length,
@@ -74,9 +74,9 @@ console.log(JSON.stringify(smoke, null, 2));
 - Title exists and is 30 to 60 characters
 - Canonical points at the production domain (never staging or preview URLs)
 - Exactly one H1
-- Zero missing alts
+- Zero images missing the `alt` attribute. An empty `alt=""` on a decorative image is correct markup and passes; only an absent attribute fails.
 - Zero broken images
-- Schema includes the expected types for the page
+- Every schema block parses (no `invalid` entries in the snippet output). Whether the types are the right ones for the page is a Full-tier check, against the Rich Results Test.
 
 If any of these fail, do not proceed with deeper testing until the smoke issue is fixed.
 
@@ -101,7 +101,7 @@ const audit = {
   h2Count: document.querySelectorAll('h2').length,
   h2s: [...document.querySelectorAll('h2')].map(h => h.innerText.trim().slice(0, 60)),
   totalImages: document.querySelectorAll('img').length,
-  missingAlts: [...document.querySelectorAll('img')].filter(i => !i.alt).length,
+  missingAlts: [...document.querySelectorAll('img')].filter(i => !i.hasAttribute('alt')).length,
   brokenImages: [...document.querySelectorAll('img')].filter(i => !i.complete || i.naturalWidth === 0).length,
   externalLinksWithoutNoopener: [...document.querySelectorAll('a[target="_blank"]')]
     .filter(a => !a.rel?.includes('noopener')).length,
@@ -112,7 +112,8 @@ const audit = {
         return d['@graph'] ? d['@graph'].map(x => x['@type']) : d['@type'];
       } catch(e) { return 'invalid' }
     }),
-  hasSkipLink: !!document.querySelector('a[href^="#"]:first-of-type'),
+  hasSkipLink: [...document.querySelectorAll('a[href^="#"]')].slice(0, 3)
+    .some(a => /skip/i.test(a.textContent) && !!document.getElementById(a.getAttribute('href').slice(1))),
   pageLanguage: document.documentElement.lang || 'NOT SET',
   hasFavicon: !!document.querySelector('link[rel*="icon"]'),
 };
@@ -135,8 +136,8 @@ The 30-minute pre-launch check. Cover all dimensions.
 |---|---|
 | Smoke and standard | All pass |
 | Accessibility (basic) | Run browser audit tool (e.g., Lighthouse), score above 90 |
-| Performance (basic) | Lighthouse Performance score above 80, LCP under 2.5s, CLS under 0.1 |
-| Mobile responsiveness | Tested at 375px, 768px, 1024px, 1440px |
+| Performance (basic) | Every threshold in the report template's Performance checklist, INP included |
+| Mobile responsiveness | Every viewport in the report template's responsiveness checklist |
 | Cross-browser | Tested in Chrome, Safari, Firefox (and Edge if relevant audience) |
 | Forms | All forms submit successfully and validate correctly |
 | Internal links | No broken internal links (sample 20 random) |
@@ -172,7 +173,7 @@ Look for: `strict-transport-security`, `x-frame-options`, `x-content-type-option
 ```javascript
 const imgs = [...document.querySelectorAll('img')].map(i => ({
   src: i.src.split('/').pop().split('?')[0].slice(0, 60),
-  alt: i.alt || 'MISSING',
+  alt: i.hasAttribute('alt') ? (i.alt === '' ? 'DECORATIVE (empty alt)' : i.alt) : 'MISSING',
   width: i.naturalWidth,
   height: i.naturalHeight,
   loaded: i.complete && i.naturalWidth > 0,
@@ -182,6 +183,7 @@ console.log({
   total: imgs.length,
   broken: imgs.filter(i => !i.loaded).length,
   noAlt: imgs.filter(i => i.alt === 'MISSING').length,
+  decorative: imgs.filter(i => i.alt.startsWith('DECORATIVE')).length,
 });
 ```
 
@@ -264,7 +266,7 @@ if (issues.length) {
 1. **Pick the tier.** Smoke for routine deploys. Standard for new work. Full for releases.
 2. **Run the snippet.** Paste the appropriate console snippet, review output.
 3. **Note failures.** Each failure either gets fixed before ship or filed as a known issue.
-4. **For Standard tier**, add: visual review at 375px, 768px, 1440px. Test the primary user flow.
+4. **For Standard tier**, add: visual review at 375px, 768px, and 1440px. Standard deliberately skips 1024px; the Full tier picks it up with the rest of the template's responsiveness checklist. Test the primary user flow.
 5. **For Full tier**, add: cross-browser testing, Lighthouse audit, schema validation, security headers, 404 handling.
 6. **Document.** Use the template in [`references/qa-report-template.md`](references/qa-report-template.md) for full audits.
 

--- a/dist/pi/.agents/skills/qa-testing/references/qa-report-template.md
+++ b/dist/pi/.agents/skills/qa-testing/references/qa-report-template.md
@@ -27,7 +27,7 @@
 | Title tag present and 30-60 chars | ☐ | |
 | Canonical = production URL | ☐ | |
 | Exactly one H1 | ☐ | |
-| Zero missing image alts | ☐ | |
+| Zero images missing the alt attribute (empty `alt=""` on a decorative image passes) | ☐ | |
 | Zero broken images | ☐ | |
 | Schema present and valid | ☐ | |
 
@@ -60,7 +60,8 @@
 |---|---|
 | Total images | |
 | Broken images | |
-| Missing alt text | |
+| Missing the alt attribute | |
+| Decorative (empty `alt=""`, correct) | |
 
 ### Links
 | Check | Count |

--- a/dist/pi/.agents/skills/seo-audit-orchestration/SKILL.md
+++ b/dist/pi/.agents/skills/seo-audit-orchestration/SKILL.md
@@ -94,7 +94,7 @@ The child skills do the analysis. This skill sequences them and integrates the o
 
 ### Phase 4: Synthesize
 
-Combine findings into themes. A list of 200 issues is not an audit. A list of 5-7 themes is.
+Combine findings into themes. A list of 200 issues is not an audit. A short list of themes is.
 
 Themes typically emerge in categories like:
 
@@ -125,7 +125,7 @@ Produce the rollup report. See [`references/audit-rollup-template.md`](reference
 Structure:
 
 - Executive summary (1 page)
-- Themes and recommendations (5-7 themes, 1 page each)
+- Themes and recommendations (1 page each; count per audit type, from the template's length-targets table)
 - Sub-audit findings (linked or appended)
 - Roadmap (next 90 days)
 
@@ -139,7 +139,7 @@ Walk stakeholders through it. Get commitment to the next 90 days of work.
 2. **Confirm Ahrefs MCP access.** Verify the workspace has the target property and recent data.
 3. **Pull all data.** Run the gather list in phase 2. Document freshness.
 4. **Run each sub-audit.** Use the child skills. Each produces its own findings doc.
-5. **Synthesize themes.** 5-7 themes max. Each ties to an impact and a fix.
+5. **Synthesize themes.** Hold to the theme count the template's length-targets table gives for this audit type. Each theme ties to an impact and a fix.
 6. **Prioritize.** Impact/effort matrix. Quick wins surface to the top.
 7. **Draft the rollup.** Use the template. Executive summary first.
 8. **Review with the team.** Pressure-test conclusions before stakeholder readout.
@@ -166,14 +166,14 @@ Walk stakeholders through it. Get commitment to the next 90 days of work.
 
 A rollup audit report with:
 
-1. **Executive summary** (1 page).
+1. **Executive summary.**
 2. **Audit charter** (scope, goal, methodology).
-3. **Themes and recommendations** (5-7 themes, each with what, why, size of prize, fix).
+3. **Themes and recommendations** (each theme with what, why, size of prize, fix).
 4. **Sub-audit appendix** (linked outputs from each child skill).
 5. **90-day roadmap** (sequenced work with owners and targets).
 6. **Methodology notes** (data sources, pull dates, caveats).
 
-Total length: 15-30 pages including appendices. Executive summary readable in 5 minutes.
+Total length, executive summary length, and theme count all vary by audit type: a quarterly health check is not a due-diligence audit. The length-targets table in [`references/audit-rollup-template.md`](references/audit-rollup-template.md) owns those numbers per type. Whatever the type, the executive summary stays readable in 5 minutes.
 
 ---
 

--- a/dist/pi/.agents/skills/seo-audit-orchestration/references/audit-rollup-template.md
+++ b/dist/pi/.agents/skills/seo-audit-orchestration/references/audit-rollup-template.md
@@ -9,13 +9,13 @@ A template for the final SEO audit deliverable. Adapt sections to fit the audit 
 ```
 1. Executive summary           (1 page)
 2. Audit charter               (1 page)
-3. Themes and recommendations  (5-7 themes, 1 page each)
+3. Themes and recommendations  (1 page each, count by audit type)
 4. 90-day roadmap              (1-2 pages)
 5. Sub-audit appendix          (linked or attached)
 6. Methodology notes           (1 page)
 ```
 
-Total: 15-30 pages. Executive summary always readable in 5 minutes.
+Total length and theme count depend on the audit type: see "Common length targets by audit type" below. Executive summary always readable in 5 minutes.
 
 ---
 
@@ -90,7 +90,7 @@ Total: 15-30 pages. Executive summary always readable in 5 minutes.
 
 ## 3. Theme template
 
-Use one page per theme. 5-7 themes total.
+Use one page per theme. For the number of themes, see "Common length targets by audit type" below: 3-4 for a quarterly health check, 5-7 for a full annual audit, 6-10 for due diligence, 3-5 for post-migration verification.
 
 ```
 ## Theme [N]: [Name]

--- a/dist/pi/.agents/skills/seo-rank-tracking/SKILL.md
+++ b/dist/pi/.agents/skills/seo-rank-tracking/SKILL.md
@@ -37,7 +37,7 @@ Set up and run an ongoing rank tracking program using Ahrefs MCP data. Stack-agn
 - Business priorities (which segments matter)
 - Existing ranked keywords (Ahrefs Site Explorer)
 - Stakeholder reporting cadence (weekly, monthly, quarterly)
-- Confirmation Ahrefs MCP and Rank Tracker access
+- Confirmation of Ahrefs MCP and Rank Tracker access, write access included: workflow step 5 creates Rank Tracker projects
 
 ---
 
@@ -203,7 +203,7 @@ Adjust thresholds based on volatility of the niche. High-competition spaces need
 
 1. **Define scope.** Target property, market, language, stakeholders.
 2. **Pull starting data.** Existing ranked keywords, Search Console queries, competitor overlap.
-3. **Build the tracked set.** 4 buckets, 200-500 total keywords for most properties.
+3. **Build the tracked set.** Size each of the 4 buckets to its own volume band. Those bands sum to roughly 140 at every minimum and 480 at every maximum, so a small property landing near 140 is correctly scoped, not under-scoped. Most properties land between 200 and 500.
 4. **Segment with tags.** Topic, funnel stage, page mapped, etc.
 5. **Configure tracking.** Set up Ahrefs Rank Tracker projects with tags and locations.
 6. **Capture baseline.** Day-one positions and SERP composition.
@@ -217,7 +217,7 @@ Adjust thresholds based on volatility of the niche. High-competition spaces need
 ## Failure patterns
 
 - **Tracking too many keywords.** A 5,000-keyword tracker is unreadable. Pick fewer, watch closer.
-- **Tracking too few.** A 30-keyword tracker misses the picture. Most properties need 200-500.
+- **Tracking too few.** A 30-keyword tracker misses the picture. The floor is one populated bucket band per bucket, which is 140 keywords; most properties need 200 to 500.
 - **No segmentation.** Untagged tracked keywords produce dashboards that cannot be filtered.
 - **No baseline.** Without day-one snapshots, "did the campaign work" becomes unanswerable.
 - **Alert fatigue.** Loose thresholds produce too many alerts. Stakeholders stop reading. Tighten.

--- a/dist/pi/.agents/skills/seo-rank-tracking/references/dashboard-template.md
+++ b/dist/pi/.agents/skills/seo-rank-tracking/references/dashboard-template.md
@@ -70,9 +70,11 @@ The growth section.
 
 ### Headline metric
 
-- Count of opportunity keywords that broke into top 10 over the chosen window
-- Count that fell out of opportunity range (past 30 or to top 10)
+- Graduations: count of opportunity keywords that broke into top 10 over the chosen window
+- Losses: count that slipped past position 30
 - Net opportunity bucket size (with quarterly refresh)
+
+Both counts are exits from the bucket, and a keyword belongs to exactly one of them. Graduations are wins and losses are not; never report a graduation in the loss count.
 
 ### Top breakthroughs
 

--- a/dist/pi/.agents/skills/seo-site-health-audit/SKILL.md
+++ b/dist/pi/.agents/skills/seo-site-health-audit/SKILL.md
@@ -36,7 +36,7 @@ Triage technical SEO findings from Ahrefs Site Audit (or any equivalent crawler)
 - Search Console coverage and Core Web Vitals data
 - Property's organic traffic profile (which pages drive traffic)
 - Stakeholder time and developer capacity available
-- Confirmation Ahrefs MCP is connected
+- Confirmation Ahrefs MCP is connected, only when the crawl is being pulled through Ahrefs. A supplied export from any equivalent crawler satisfies the first input on its own.
 
 ---
 
@@ -64,29 +64,13 @@ A fix on Tier 1 is worth 10x a fix on Tier 3 in most cases.
 
 Does the issue actually move rankings or traffic? Some "critical" issues are aesthetic or theoretical.
 
-Categories of real impact:
+Grade every issue HIGH, MEDIUM, or LOW. [`references/issue-impact-table.md`](references/issue-impact-table.md) owns the grade for each issue type and the definition of each grade. Look the issue up there instead of judging it fresh, and use the grade it gives.
 
-| Mechanism | Examples |
-| --- | --- |
-| Indexability | Accidental noindex, robots.txt blocks, canonical errors, X-Robots-Tag |
-| Crawlability | Crawl traps, infinite redirects, 5xx errors, slow server response |
-| Renderability | JS errors blocking critical content, blocked resources |
-| Core Web Vitals | LCP, INP, CLS in the poor band |
-| Structured data | Errors on rich-result-eligible pages (not warnings) |
-| Internal link integrity | 404s on internally linked URLs, broken canonicals |
-| Hreflang | Errors on multilingual deployments |
+The issue families the reference covers, in lookup order: indexability, crawlability, renderability, Core Web Vitals, structured data, internal link integrity, hreflang, on-page elements, images, security and trust. It also carries a park-or-skip list for the findings that rarely deserve dedicated work.
 
-Categories of low or theoretical impact:
+Grades vary inside a family. Indexability rows are mostly HIGH; internal link integrity runs MEDIUM down to LOW row by row. Grade by row, never by family.
 
-| Type | Why it is lower priority |
-| --- | --- |
-| Title tag length warnings | Not a ranking factor in itself |
-| Meta description length | Not a ranking factor |
-| H1 absence on low-traffic pages | Marginal impact |
-| Alt text missing on decorative images | Accessibility issue, low SEO impact |
-| Schema warnings (not errors) | Often best-practice nudges, not ranking issues |
-
-Fix the high-mechanism categories first.
+Fix HIGH-grade issues on Tier 1 URLs first.
 
 ### Axis 3: Effort
 
@@ -102,17 +86,26 @@ Some issues are 5-minute fixes. Some are multi-sprint projects.
 
 Combine the three axes into a priority score.
 
+Mechanism here is the HIGH / MEDIUM / LOW grade the issue-impact table gives the issue. All three grades have rows: the reference grades a large share of its issue types MEDIUM, and a MEDIUM issue on a Tier 1 page still needs a band.
+
 | Tier | Mechanism | Effort | Priority |
 | --- | --- | --- | --- |
-| Tier 1 | High mechanism | S | P0 (do this week) |
-| Tier 1 | High mechanism | M | P1 (do this sprint) |
-| Tier 1 | High mechanism | L | P2 (plan as project) |
-| Tier 1 | Low mechanism | S | P3 (batch when convenient) |
-| Tier 1 | Low mechanism | M-L | Park unless evidence emerges |
-| Tier 2 | High mechanism | S | P1 |
-| Tier 2 | High mechanism | M-L | P2 |
-| Tier 3 | High mechanism | S | P3 |
+| Tier 1 | HIGH | S | P0 (do this week) |
+| Tier 1 | HIGH | M | P1 (do this sprint) |
+| Tier 1 | HIGH | L | P2 (plan as project) |
+| Tier 1 | MEDIUM | S | P1 |
+| Tier 1 | MEDIUM | M | P2 |
+| Tier 1 | MEDIUM | L | P3 |
+| Tier 1 | LOW | S | P3 (batch when convenient) |
+| Tier 1 | LOW | M-L | Park unless evidence emerges |
+| Tier 2 | HIGH | S | P1 |
+| Tier 2 | HIGH | M-L | P2 |
+| Tier 2 | MEDIUM | S | P2 |
+| Tier 2 | MEDIUM | M-L | P3 |
+| Tier 3 | HIGH | S | P3 |
 | Tier 3 | Anything else | Anything | Park |
+
+The MEDIUM rows follow one rule: a MEDIUM issue sits one band below the HIGH issue at the same tier and effort. Rows the reference grades LOW-MEDIUM take the MEDIUM row when the URL is Tier 1 and the LOW row otherwise.
 
 P0-P1 work earns the team's attention. P2 goes on the roadmap. P3 batches into routine maintenance. Park is honest about deprioritization.
 
@@ -122,7 +115,7 @@ P0-P1 work earns the team's attention. P2 goes on the roadmap. P3 batches into r
 
 1. **Pull the crawl results.** Ahrefs Site Audit + Search Console + Core Web Vitals.
 2. **Tier the URLs.** Use organic traffic data. Tag every affected URL as Tier 1, 2, or 3.
-3. **Categorize each issue by mechanism.** High or low impact mechanism.
+3. **Categorize each issue by mechanism.** Look up the HIGH, MEDIUM, or LOW grade in `references/issue-impact-table.md`.
 4. **Estimate effort per fix type.** Group similar fixes into one effort estimate.
 5. **Apply the triage matrix.** Assign P0-P3 or Park.
 6. **Cluster the fixes.** Group fixes that share an effort: one template change can resolve hundreds of issues.
@@ -181,4 +174,4 @@ Length: 5-12 pages plus a backlog spreadsheet.
 
 ## Reference files
 
-- [`references/issue-impact-table.md`](references/issue-impact-table.md) - Mapping table of common crawler issues to mechanism impact and typical fix effort, plus the triage matrix in detailed form.
+- [`references/issue-impact-table.md`](references/issue-impact-table.md) - Mapping table of common crawler issues to mechanism grade and typical fix effort, plus cluster signals and the park-or-skip list. This file is the source of truth for every issue grade; the triage matrix above turns a grade plus a tier plus an effort into a priority band.

--- a/dist/pi/.agents/skills/seo-site-health-audit/references/issue-impact-table.md
+++ b/dist/pi/.agents/skills/seo-site-health-audit/references/issue-impact-table.md
@@ -40,7 +40,7 @@ Mechanism tiers:
 | Issue | Mechanism | Typical effort | Notes |
 | --- | --- | --- | --- |
 | 5xx errors on URLs | HIGH | M-L | Investigate hosting and app errors |
-| 4xx errors on internally linked URLs | HIGH | M | Fix links or add redirects |
+| 4xx on a URL that ranked, earned external links, or sits in the sitemap | HIGH | M | Restore the page or redirect it to the closest live equivalent |
 | Redirect chain (3+ hops) | MEDIUM | M | Update final destination in links |
 | Redirect loop | HIGH | S | Fix immediately |
 | Slow time to first byte | MEDIUM | M-L | Hosting, caching, or app changes |
@@ -94,7 +94,7 @@ Pages eligible for rich results (FAQ, How-to, Recipe, Product, etc.) deserve hig
 
 | Issue | Mechanism | Typical effort | Notes |
 | --- | --- | --- | --- |
-| Internal link to 404 | MEDIUM | S | Update or remove link |
+| Internal link to 404, destination not worth restoring | MEDIUM | S | Update or remove the link. If the destination itself ranked or earned links, use the HIGH crawlability row instead |
 | Internal link to redirect | LOW | S | Update to final URL when batching |
 | Internal link with empty anchor | LOW | S | Add descriptive anchor |
 | Page receiving zero internal links (orphan) | MEDIUM | S-M | Add links or reassess if page should exist |

--- a/skills/ads-performance-analytics/SKILL.md
+++ b/skills/ads-performance-analytics/SKILL.md
@@ -113,9 +113,9 @@ ROAS is short-term. Revenue from purchases attributed to a campaign in a fixed w
 
 Decisions made on ROAS can be wrong if LTV varies by channel. A worked example.
 
-Meta drives 2.5x ROAS at $40 CAC with $80 LTV. The 7-day-click revenue covers 1.5x payback over the customer lifetime.
+Meta drives 2.5x ROAS at $40 CAC with $80 LTV. That is 2.0x payback over the customer lifetime.
 
-Google drives 1.8x ROAS at $60 CAC with $200 LTV. The 7-day-click revenue covers 3.3x payback over the customer lifetime.
+Google drives 1.8x ROAS at $60 CAC with $200 LTV. That is 3.3x payback over the customer lifetime.
 
 Google looks worse on ROAS, better on LTV-adjusted return. Allocating budget to Meta because the ROAS is higher is the wrong move.
 

--- a/skills/art-direction/SKILL.md
+++ b/skills/art-direction/SKILL.md
@@ -69,7 +69,7 @@ The visual treatment.
 - Color palette (true color, treated, monochrome)
 - Locations (specific or general direction)
 - Wardrobe and props
-- Mood references (3 to 5 reference images)
+- Mood references (the photo brief template sets how many)
 
 **For illustration:**
 - Style (flat, dimensional, hand-drawn, geometric, abstract)
@@ -77,7 +77,7 @@ The visual treatment.
 - Line treatment
 - Composition style
 - Detail level
-- Reference artists or works (with explicit "we want like X but NOT like Y")
+- Reference artists or works, with explicit "we want like X but NOT like Y" (the illustration brief template sets how many)
 
 **For video / motion:**
 - Pacing (slow, medium, fast cuts)
@@ -85,7 +85,7 @@ The visual treatment.
 - Color grading
 - Transitions and effects
 - Audio direction (music, voiceover, ambient)
-- Reference work (3 to 5 examples)
+- Reference work (3 to 5 examples; no template covers motion, so this count is the one to use)
 
 ### 3. The execution
 
@@ -143,10 +143,10 @@ The quality bar.
 1. **Confirm the inputs.** Brand identity locked. Audience and goal clear. Budget and timeline known.
 2. **Develop the concept.** Premise, emotional through-line, takeaway.
 3. **Build the look.** Mood references. Specific direction on style elements.
-4. **Write the spec.** Production-level direction. Variants. Constraints.
+4. **Write the spec.** Production-level direction. Variants. Constraints. Licensing and usage rights, agreed before the shoot or the first sketch, not after: both brief templates make licensing a pre-production section for the reason that renegotiating it against finished work costs more.
 5. **Brief the vendor.** In writing. Walk through it live. Allow questions.
 6. **Review milestones.** Treatment review, halfway review, final review. Don't skip the early reviews; corrections compound.
-7. **Approve and document.** What was produced, what's licensed for what use.
+7. **Approve and document.** What was produced, and confirmation that it shipped under the licensing agreed at step 4.
 
 ### For directing in-house creative
 
@@ -178,16 +178,17 @@ The quality bar.
 
 ## Output format
 
-Default output is a creative brief at `creative-brief-[project].md`.
+Default output is a creative brief at `creative-brief-[project].md`, written against one of the brief templates in `references/`. The template you pick is the structure: use [`references/photo-shoot-brief.md`](references/photo-shoot-brief.md) for photography, [`references/illustration-brief.md`](references/illustration-brief.md) for illustration, and [`references/creative-brief-template.md`](references/creative-brief-template.md) for anything else or for a mixed production. Each template owns its own section list, section order, and reference-image count. Do not write to the five-layer outline below and hope it maps; the templates carry sections the layers do not, licensing and usage rights among them, and those sections are load-bearing before production starts, not after it.
 
-Structure:
+The five layers are the thinking. Every template covers all five, in its own order:
+
 1. The story (premise, through-line, role of brand, takeaway)
 2. The look (visual treatment with references)
 3. The execution (specs, variants, constraints)
 4. The standards (quality bar, examples of acceptable and unacceptable)
-5. The logistics (timeline, milestones, budget, deliverables)
+5. The logistics (timeline, milestones, budget, deliverables, licensing and usage rights)
 
-Plus a separate moodboard or visual reference doc with images.
+Plus a separate moodboard or visual reference doc with images, at the count the chosen template gives.
 
 ---
 

--- a/skills/brand-voice/SKILL.md
+++ b/skills/brand-voice/SKILL.md
@@ -126,36 +126,23 @@ For each major content type, show:
 - Good example (on-voice)
 - Brief note on what changed
 
-Common content types to cover:
+Cover the content types listed in the paired examples library of [`references/voice-document-template.md`](references/voice-document-template.md). The template owns that list, so there is one list to maintain rather than two that drift apart.
 
-- Headline
-- Subheadline
-- Hero CTA
-- Feature description
-- Testimonial intro
-- Email subject line
-- Email opening
-- Push notification
-- Error message
-- Success message
-- About page paragraph
-- Social post
-- Sales page paragraph
-
-Aim for 15 to 25 paired examples. This is the most-used part of the voice doc in practice.
+The floor is 15 paired examples. One pair per type in the template clears it. Past 25 the library gets harder to scan than to use, so treat 25 as the practical ceiling, not a hard cap. This is the most-used part of the voice doc in practice.
 
 ---
 
 ## Workflow
 
-1. **Audit existing copy** if it exists. Identify what is on-brand, what is off, what patterns recur.
-2. **Layer 1: Voice attributes.** Generate 5 to 8 candidates with "we are X, not Y" framing. Pick 3 to 5.
-3. **Layer 2: Tone shifts.** List 8 to 15 contexts the brand writes in. Note the tone shift for each.
-4. **Layer 3: Vocabulary and grammar.** Define preferences. Skip default rules unless they actually distinguish the brand.
-5. **Layer 4: Examples.** Build the paired-example library. 15 to 25 minimum.
-6. **Stress-test.** Pick a fresh writing brief and apply the voice doc. Does it produce on-voice copy? If not, the doc is incomplete.
-7. **Document.** Use the template in [`references/voice-document-template.md`](references/voice-document-template.md).
-8. **Distribute.** Voice docs only work if they get used. Make the doc easy to reference inline (link to it from CMS templates, brief templates, AI assistant prompts).
+1. **Pick the entry point.** [`references/voice-frameworks.md`](references/voice-frameworks.md) has a "Choosing a framework" section that decides this. A brand starting from zero begins with archetypes there, then dimensions, then attributes, and rejoins this workflow at step 2. Everything below assumes copy exists to audit.
+2. **Audit existing copy** if it exists. Identify what is on-brand, what is off, what patterns recur.
+3. **Layer 1: Voice attributes.** Generate 5 to 8 candidates with "we are X, not Y" framing. Pick 3 to 5.
+4. **Layer 2: Tone shifts.** List 8 to 15 contexts the brand writes in. Note the tone shift for each.
+5. **Layer 3: Vocabulary and grammar.** Define preferences. Skip default rules unless they actually distinguish the brand.
+6. **Layer 4: Examples.** Build the paired-example library against the template's content-type list, to the floor stated in the Layer 4 section above.
+7. **Stress-test.** Pick a fresh writing brief and apply the voice doc. Score the result with the stress test in [`references/voice-frameworks.md`](references/voice-frameworks.md): 1 to 5 against each attribute, and anything scoring below 3 on any attribute is off-voice. Below 3 means the doc is incomplete, not that the copy needs another pass.
+8. **Document.** Use the template in [`references/voice-document-template.md`](references/voice-document-template.md).
+9. **Distribute.** Voice docs only work if they get used. Make the doc easy to reference inline (link to it from CMS templates, brief templates, AI assistant prompts).
 
 ---
 

--- a/skills/editorial-qa/SKILL.md
+++ b/skills/editorial-qa/SKILL.md
@@ -220,9 +220,9 @@ For pieces shipping at programmatic-SEO scale (100s to 100,000s of pages), full-
 
 **Sampling strategy.**
 
-- Random sample 50 to 200 pages per audit cycle
+- Random sample per audit cycle, sized by the sample-size schedule in [`references/qa-at-scale-patterns.md`](references/qa-at-scale-patterns.md), which owns the numbers
 - Balance the sample across data shape (sparse versus dense records, recent versus old generation, popular versus niche categories)
-- Fixed sample percentage as set grows; absolute count plateaus around 200 once the set is large
+- The schedule is a fixed count per set-size band, rising to a plateau at the largest band. The percentage sampled therefore falls as the set grows, which is deliberate: past a certain size, more pages stop buying more signal
 
 **Automated checks at scale.**
 
@@ -257,7 +257,7 @@ Ownership and sequencing.
 
 **Single QA owner per piece**, not a committee. The owner is accountable for what shipped. Committees diffuse accountability; nobody owns a problem that reaches readers.
 
-**Sequencing.** Brief-adherence, then fact-accuracy, then structure, then AI-content audit, then voice, then SEO/AEO, then internal linking, then schema. Brief-adherence first because it is the cheapest gate; SEO/AEO checks last because they are easiest to fix and rarely halt-conditions.
+**Sequencing.** Run the gates in the order set by the sequencing template in [`references/qa-workflow-templates.md`](references/qa-workflow-templates.md), which owns the gate list and its order. Brief-adherence runs first: it is the cheapest gate that can halt a piece, and it catches the largest class of failures. The SEO/AEO and linking-and-schema gates sit near the end because most of their failures are auto-fixable and rarely halt anything. A final read closes the sequence.
 
 **Halt vs flag vs auto-fix.**
 

--- a/skills/editorial-qa/references/ai-content-audit-patterns.md
+++ b/skills/editorial-qa/references/ai-content-audit-patterns.md
@@ -8,7 +8,7 @@ The 11 AI tells, the 6 hallucination patterns, voice drift detection, a worked e
 
 Pattern recognition. Read with these top-of-mind; flag any match.
 
-**1. Excessive em-dashes.** Model-default punctuation. A piece with 8 em-dashes per 1,000 words is almost certainly AI-drafted. The fix: replace with periods, semicolons, or rephrase the sentence.
+**1. Excessive em-dashes.** Model-default punctuation. Flag at 8 em-dashes per 1,000 words; a piece at that rate is almost certainly AI-drafted. This rate is the one threshold for the tell, used everywhere in this file. The fix: replace with periods, semicolons, or rephrase the sentence.
 
 **2. Predictable opening phrasings.** Throat-clearing openers that announce what the piece is about to do (the fast-paced-world opener, the importance-noting opener, the whether-you-are-X-or-Y opener). These openings appear in AI output across topics; pattern-match against the team's curated do-not-use list and cut.
 
@@ -101,7 +101,7 @@ For each AI-co-authored draft, walk this checklist.
 1. Read the first 200 words. Does the opening match any of the 11 AI tells? Flag.
 2. Sample 2 paragraphs from the middle. Does either match AI tells? Does the voice match the brand voice doc? Flag.
 3. Read the last 200 words. Does the closing match any of the 11 AI tells? Flag.
-4. Search the piece for em-dashes; count. More than 5 in a 1,500-word piece is suspicious.
+4. Search the piece for em-dashes; count. Flag at the rate in pattern 1, 8 per 1,000 words, which is 12 in a 1,500-word piece.
 5. Search for forced bilateral framing patterns. Count.
 6. Verify every statistic, quote, case study, citation, and product claim per the fact-accuracy methodology.
 7. Sample 3 to 5 internal links; verify they go where the brief specified and the targets exist.

--- a/skills/editorial-qa/references/qa-workflow-templates.md
+++ b/skills/editorial-qa/references/qa-workflow-templates.md
@@ -22,7 +22,7 @@ The principle. One person is accountable for what shipped. Committees diffuse ac
 
 ## The sequencing template
 
-Run QA gates in this order. Each gate is cheaper than the next; running them in order saves the editor's time on pieces that should restart.
+Run QA gates in this order. The order is not a cost ranking (fact-accuracy is the most expensive gate and runs second). It front-loads the two gates that can halt a piece, cheapest of those first, so a piece that should restart consumes as little review time as possible. The cycle-time table below gives the real per-gate costs.
 
 1. **Brief-adherence.** First. Cheapest to run. Catches the largest class of failures.
 2. **Fact-accuracy.** Second. Halt-condition; AI hallucinations do not progress past this gate.

--- a/skills/landing-page-copy/SKILL.md
+++ b/skills/landing-page-copy/SKILL.md
@@ -184,7 +184,7 @@ Buttons matter. Treat the button copy as a whole-page-worth of attention.
 6. **Draft sections.** Section by section. Don't polish until the structure is sound.
 7. **Edit for friction.** Remove every word that doesn't earn its place. Landing pages do not have words to spare.
 8. **Test the CTA.** Read the page aloud. By the end, is the visitor's next action obvious?
-9. **Pre-publish:** check links, spell-check, mobile preview, SEO basics if SEO is a goal.
+9. **Hand off with a post-import checklist.** The deliverable is a markdown document, not a built page, so step 9 is not something you perform: it is a list you attach for whoever builds the page. Spell-check the copy yourself, then hand over the rest. Every destination URL resolves. Mobile preview of the built page. SEO basics if SEO is a goal. If the page is already built and you are revising it in place, run the checklist yourself instead of handing it over.
 
 ---
 

--- a/skills/qa-testing/SKILL.md
+++ b/skills/qa-testing/SKILL.md
@@ -62,7 +62,7 @@ const smoke = {
   titleLen: document.title.length,
   canonical: document.querySelector('link[rel="canonical"]')?.href,
   h1Count: document.querySelectorAll('h1').length,
-  missingAlts: [...document.querySelectorAll('img')].filter(i => !i.alt).length,
+  missingAlts: [...document.querySelectorAll('img')].filter(i => !i.hasAttribute('alt')).length,
   schema: [...document.querySelectorAll('script[type="application/ld+json"]')]
     .map(s => { try { return JSON.parse(s.innerText)['@type'] } catch(e) { return 'invalid' } }),
   brokenImages: [...document.querySelectorAll('img')].filter(i => !i.complete || i.naturalWidth === 0).length,
@@ -74,9 +74,9 @@ console.log(JSON.stringify(smoke, null, 2));
 - Title exists and is 30 to 60 characters
 - Canonical points at the production domain (never staging or preview URLs)
 - Exactly one H1
-- Zero missing alts
+- Zero images missing the `alt` attribute. An empty `alt=""` on a decorative image is correct markup and passes; only an absent attribute fails.
 - Zero broken images
-- Schema includes the expected types for the page
+- Every schema block parses (no `invalid` entries in the snippet output). Whether the types are the right ones for the page is a Full-tier check, against the Rich Results Test.
 
 If any of these fail, do not proceed with deeper testing until the smoke issue is fixed.
 
@@ -101,7 +101,7 @@ const audit = {
   h2Count: document.querySelectorAll('h2').length,
   h2s: [...document.querySelectorAll('h2')].map(h => h.innerText.trim().slice(0, 60)),
   totalImages: document.querySelectorAll('img').length,
-  missingAlts: [...document.querySelectorAll('img')].filter(i => !i.alt).length,
+  missingAlts: [...document.querySelectorAll('img')].filter(i => !i.hasAttribute('alt')).length,
   brokenImages: [...document.querySelectorAll('img')].filter(i => !i.complete || i.naturalWidth === 0).length,
   externalLinksWithoutNoopener: [...document.querySelectorAll('a[target="_blank"]')]
     .filter(a => !a.rel?.includes('noopener')).length,
@@ -112,7 +112,8 @@ const audit = {
         return d['@graph'] ? d['@graph'].map(x => x['@type']) : d['@type'];
       } catch(e) { return 'invalid' }
     }),
-  hasSkipLink: !!document.querySelector('a[href^="#"]:first-of-type'),
+  hasSkipLink: [...document.querySelectorAll('a[href^="#"]')].slice(0, 3)
+    .some(a => /skip/i.test(a.textContent) && !!document.getElementById(a.getAttribute('href').slice(1))),
   pageLanguage: document.documentElement.lang || 'NOT SET',
   hasFavicon: !!document.querySelector('link[rel*="icon"]'),
 };
@@ -135,8 +136,8 @@ The 30-minute pre-launch check. Cover all dimensions.
 |---|---|
 | Smoke and standard | All pass |
 | Accessibility (basic) | Run browser audit tool (e.g., Lighthouse), score above 90 |
-| Performance (basic) | Lighthouse Performance score above 80, LCP under 2.5s, CLS under 0.1 |
-| Mobile responsiveness | Tested at 375px, 768px, 1024px, 1440px |
+| Performance (basic) | Every threshold in the report template's Performance checklist, INP included |
+| Mobile responsiveness | Every viewport in the report template's responsiveness checklist |
 | Cross-browser | Tested in Chrome, Safari, Firefox (and Edge if relevant audience) |
 | Forms | All forms submit successfully and validate correctly |
 | Internal links | No broken internal links (sample 20 random) |
@@ -172,7 +173,7 @@ Look for: `strict-transport-security`, `x-frame-options`, `x-content-type-option
 ```javascript
 const imgs = [...document.querySelectorAll('img')].map(i => ({
   src: i.src.split('/').pop().split('?')[0].slice(0, 60),
-  alt: i.alt || 'MISSING',
+  alt: i.hasAttribute('alt') ? (i.alt === '' ? 'DECORATIVE (empty alt)' : i.alt) : 'MISSING',
   width: i.naturalWidth,
   height: i.naturalHeight,
   loaded: i.complete && i.naturalWidth > 0,
@@ -182,6 +183,7 @@ console.log({
   total: imgs.length,
   broken: imgs.filter(i => !i.loaded).length,
   noAlt: imgs.filter(i => i.alt === 'MISSING').length,
+  decorative: imgs.filter(i => i.alt.startsWith('DECORATIVE')).length,
 });
 ```
 
@@ -264,7 +266,7 @@ if (issues.length) {
 1. **Pick the tier.** Smoke for routine deploys. Standard for new work. Full for releases.
 2. **Run the snippet.** Paste the appropriate console snippet, review output.
 3. **Note failures.** Each failure either gets fixed before ship or filed as a known issue.
-4. **For Standard tier**, add: visual review at 375px, 768px, 1440px. Test the primary user flow.
+4. **For Standard tier**, add: visual review at 375px, 768px, and 1440px. Standard deliberately skips 1024px; the Full tier picks it up with the rest of the template's responsiveness checklist. Test the primary user flow.
 5. **For Full tier**, add: cross-browser testing, Lighthouse audit, schema validation, security headers, 404 handling.
 6. **Document.** Use the template in [`references/qa-report-template.md`](references/qa-report-template.md) for full audits.
 

--- a/skills/qa-testing/references/qa-report-template.md
+++ b/skills/qa-testing/references/qa-report-template.md
@@ -27,7 +27,7 @@
 | Title tag present and 30-60 chars | ☐ | |
 | Canonical = production URL | ☐ | |
 | Exactly one H1 | ☐ | |
-| Zero missing image alts | ☐ | |
+| Zero images missing the alt attribute (empty `alt=""` on a decorative image passes) | ☐ | |
 | Zero broken images | ☐ | |
 | Schema present and valid | ☐ | |
 
@@ -60,7 +60,8 @@
 |---|---|
 | Total images | |
 | Broken images | |
-| Missing alt text | |
+| Missing the alt attribute | |
+| Decorative (empty `alt=""`, correct) | |
 
 ### Links
 | Check | Count |

--- a/skills/seo-audit-orchestration/SKILL.md
+++ b/skills/seo-audit-orchestration/SKILL.md
@@ -94,7 +94,7 @@ The child skills do the analysis. This skill sequences them and integrates the o
 
 ### Phase 4: Synthesize
 
-Combine findings into themes. A list of 200 issues is not an audit. A list of 5-7 themes is.
+Combine findings into themes. A list of 200 issues is not an audit. A short list of themes is.
 
 Themes typically emerge in categories like:
 
@@ -125,7 +125,7 @@ Produce the rollup report. See [`references/audit-rollup-template.md`](reference
 Structure:
 
 - Executive summary (1 page)
-- Themes and recommendations (5-7 themes, 1 page each)
+- Themes and recommendations (1 page each; count per audit type, from the template's length-targets table)
 - Sub-audit findings (linked or appended)
 - Roadmap (next 90 days)
 
@@ -139,7 +139,7 @@ Walk stakeholders through it. Get commitment to the next 90 days of work.
 2. **Confirm Ahrefs MCP access.** Verify the workspace has the target property and recent data.
 3. **Pull all data.** Run the gather list in phase 2. Document freshness.
 4. **Run each sub-audit.** Use the child skills. Each produces its own findings doc.
-5. **Synthesize themes.** 5-7 themes max. Each ties to an impact and a fix.
+5. **Synthesize themes.** Hold to the theme count the template's length-targets table gives for this audit type. Each theme ties to an impact and a fix.
 6. **Prioritize.** Impact/effort matrix. Quick wins surface to the top.
 7. **Draft the rollup.** Use the template. Executive summary first.
 8. **Review with the team.** Pressure-test conclusions before stakeholder readout.
@@ -166,14 +166,14 @@ Walk stakeholders through it. Get commitment to the next 90 days of work.
 
 A rollup audit report with:
 
-1. **Executive summary** (1 page).
+1. **Executive summary.**
 2. **Audit charter** (scope, goal, methodology).
-3. **Themes and recommendations** (5-7 themes, each with what, why, size of prize, fix).
+3. **Themes and recommendations** (each theme with what, why, size of prize, fix).
 4. **Sub-audit appendix** (linked outputs from each child skill).
 5. **90-day roadmap** (sequenced work with owners and targets).
 6. **Methodology notes** (data sources, pull dates, caveats).
 
-Total length: 15-30 pages including appendices. Executive summary readable in 5 minutes.
+Total length, executive summary length, and theme count all vary by audit type: a quarterly health check is not a due-diligence audit. The length-targets table in [`references/audit-rollup-template.md`](references/audit-rollup-template.md) owns those numbers per type. Whatever the type, the executive summary stays readable in 5 minutes.
 
 ---
 

--- a/skills/seo-audit-orchestration/references/audit-rollup-template.md
+++ b/skills/seo-audit-orchestration/references/audit-rollup-template.md
@@ -9,13 +9,13 @@ A template for the final SEO audit deliverable. Adapt sections to fit the audit 
 ```
 1. Executive summary           (1 page)
 2. Audit charter               (1 page)
-3. Themes and recommendations  (5-7 themes, 1 page each)
+3. Themes and recommendations  (1 page each, count by audit type)
 4. 90-day roadmap              (1-2 pages)
 5. Sub-audit appendix          (linked or attached)
 6. Methodology notes           (1 page)
 ```
 
-Total: 15-30 pages. Executive summary always readable in 5 minutes.
+Total length and theme count depend on the audit type: see "Common length targets by audit type" below. Executive summary always readable in 5 minutes.
 
 ---
 
@@ -90,7 +90,7 @@ Total: 15-30 pages. Executive summary always readable in 5 minutes.
 
 ## 3. Theme template
 
-Use one page per theme. 5-7 themes total.
+Use one page per theme. For the number of themes, see "Common length targets by audit type" below: 3-4 for a quarterly health check, 5-7 for a full annual audit, 6-10 for due diligence, 3-5 for post-migration verification.
 
 ```
 ## Theme [N]: [Name]

--- a/skills/seo-rank-tracking/SKILL.md
+++ b/skills/seo-rank-tracking/SKILL.md
@@ -37,7 +37,7 @@ Set up and run an ongoing rank tracking program using Ahrefs MCP data. Stack-agn
 - Business priorities (which segments matter)
 - Existing ranked keywords (Ahrefs Site Explorer)
 - Stakeholder reporting cadence (weekly, monthly, quarterly)
-- Confirmation Ahrefs MCP and Rank Tracker access
+- Confirmation of Ahrefs MCP and Rank Tracker access, write access included: workflow step 5 creates Rank Tracker projects
 
 ---
 
@@ -203,7 +203,7 @@ Adjust thresholds based on volatility of the niche. High-competition spaces need
 
 1. **Define scope.** Target property, market, language, stakeholders.
 2. **Pull starting data.** Existing ranked keywords, Search Console queries, competitor overlap.
-3. **Build the tracked set.** 4 buckets, 200-500 total keywords for most properties.
+3. **Build the tracked set.** Size each of the 4 buckets to its own volume band. Those bands sum to roughly 140 at every minimum and 480 at every maximum, so a small property landing near 140 is correctly scoped, not under-scoped. Most properties land between 200 and 500.
 4. **Segment with tags.** Topic, funnel stage, page mapped, etc.
 5. **Configure tracking.** Set up Ahrefs Rank Tracker projects with tags and locations.
 6. **Capture baseline.** Day-one positions and SERP composition.
@@ -217,7 +217,7 @@ Adjust thresholds based on volatility of the niche. High-competition spaces need
 ## Failure patterns
 
 - **Tracking too many keywords.** A 5,000-keyword tracker is unreadable. Pick fewer, watch closer.
-- **Tracking too few.** A 30-keyword tracker misses the picture. Most properties need 200-500.
+- **Tracking too few.** A 30-keyword tracker misses the picture. The floor is one populated bucket band per bucket, which is 140 keywords; most properties need 200 to 500.
 - **No segmentation.** Untagged tracked keywords produce dashboards that cannot be filtered.
 - **No baseline.** Without day-one snapshots, "did the campaign work" becomes unanswerable.
 - **Alert fatigue.** Loose thresholds produce too many alerts. Stakeholders stop reading. Tighten.

--- a/skills/seo-rank-tracking/references/dashboard-template.md
+++ b/skills/seo-rank-tracking/references/dashboard-template.md
@@ -70,9 +70,11 @@ The growth section.
 
 ### Headline metric
 
-- Count of opportunity keywords that broke into top 10 over the chosen window
-- Count that fell out of opportunity range (past 30 or to top 10)
+- Graduations: count of opportunity keywords that broke into top 10 over the chosen window
+- Losses: count that slipped past position 30
 - Net opportunity bucket size (with quarterly refresh)
+
+Both counts are exits from the bucket, and a keyword belongs to exactly one of them. Graduations are wins and losses are not; never report a graduation in the loss count.
 
 ### Top breakthroughs
 

--- a/skills/seo-site-health-audit/SKILL.md
+++ b/skills/seo-site-health-audit/SKILL.md
@@ -36,7 +36,7 @@ Triage technical SEO findings from Ahrefs Site Audit (or any equivalent crawler)
 - Search Console coverage and Core Web Vitals data
 - Property's organic traffic profile (which pages drive traffic)
 - Stakeholder time and developer capacity available
-- Confirmation Ahrefs MCP is connected
+- Confirmation Ahrefs MCP is connected, only when the crawl is being pulled through Ahrefs. A supplied export from any equivalent crawler satisfies the first input on its own.
 
 ---
 
@@ -64,29 +64,13 @@ A fix on Tier 1 is worth 10x a fix on Tier 3 in most cases.
 
 Does the issue actually move rankings or traffic? Some "critical" issues are aesthetic or theoretical.
 
-Categories of real impact:
+Grade every issue HIGH, MEDIUM, or LOW. [`references/issue-impact-table.md`](references/issue-impact-table.md) owns the grade for each issue type and the definition of each grade. Look the issue up there instead of judging it fresh, and use the grade it gives.
 
-| Mechanism | Examples |
-| --- | --- |
-| Indexability | Accidental noindex, robots.txt blocks, canonical errors, X-Robots-Tag |
-| Crawlability | Crawl traps, infinite redirects, 5xx errors, slow server response |
-| Renderability | JS errors blocking critical content, blocked resources |
-| Core Web Vitals | LCP, INP, CLS in the poor band |
-| Structured data | Errors on rich-result-eligible pages (not warnings) |
-| Internal link integrity | 404s on internally linked URLs, broken canonicals |
-| Hreflang | Errors on multilingual deployments |
+The issue families the reference covers, in lookup order: indexability, crawlability, renderability, Core Web Vitals, structured data, internal link integrity, hreflang, on-page elements, images, security and trust. It also carries a park-or-skip list for the findings that rarely deserve dedicated work.
 
-Categories of low or theoretical impact:
+Grades vary inside a family. Indexability rows are mostly HIGH; internal link integrity runs MEDIUM down to LOW row by row. Grade by row, never by family.
 
-| Type | Why it is lower priority |
-| --- | --- |
-| Title tag length warnings | Not a ranking factor in itself |
-| Meta description length | Not a ranking factor |
-| H1 absence on low-traffic pages | Marginal impact |
-| Alt text missing on decorative images | Accessibility issue, low SEO impact |
-| Schema warnings (not errors) | Often best-practice nudges, not ranking issues |
-
-Fix the high-mechanism categories first.
+Fix HIGH-grade issues on Tier 1 URLs first.
 
 ### Axis 3: Effort
 
@@ -102,17 +86,26 @@ Some issues are 5-minute fixes. Some are multi-sprint projects.
 
 Combine the three axes into a priority score.
 
+Mechanism here is the HIGH / MEDIUM / LOW grade the issue-impact table gives the issue. All three grades have rows: the reference grades a large share of its issue types MEDIUM, and a MEDIUM issue on a Tier 1 page still needs a band.
+
 | Tier | Mechanism | Effort | Priority |
 | --- | --- | --- | --- |
-| Tier 1 | High mechanism | S | P0 (do this week) |
-| Tier 1 | High mechanism | M | P1 (do this sprint) |
-| Tier 1 | High mechanism | L | P2 (plan as project) |
-| Tier 1 | Low mechanism | S | P3 (batch when convenient) |
-| Tier 1 | Low mechanism | M-L | Park unless evidence emerges |
-| Tier 2 | High mechanism | S | P1 |
-| Tier 2 | High mechanism | M-L | P2 |
-| Tier 3 | High mechanism | S | P3 |
+| Tier 1 | HIGH | S | P0 (do this week) |
+| Tier 1 | HIGH | M | P1 (do this sprint) |
+| Tier 1 | HIGH | L | P2 (plan as project) |
+| Tier 1 | MEDIUM | S | P1 |
+| Tier 1 | MEDIUM | M | P2 |
+| Tier 1 | MEDIUM | L | P3 |
+| Tier 1 | LOW | S | P3 (batch when convenient) |
+| Tier 1 | LOW | M-L | Park unless evidence emerges |
+| Tier 2 | HIGH | S | P1 |
+| Tier 2 | HIGH | M-L | P2 |
+| Tier 2 | MEDIUM | S | P2 |
+| Tier 2 | MEDIUM | M-L | P3 |
+| Tier 3 | HIGH | S | P3 |
 | Tier 3 | Anything else | Anything | Park |
+
+The MEDIUM rows follow one rule: a MEDIUM issue sits one band below the HIGH issue at the same tier and effort. Rows the reference grades LOW-MEDIUM take the MEDIUM row when the URL is Tier 1 and the LOW row otherwise.
 
 P0-P1 work earns the team's attention. P2 goes on the roadmap. P3 batches into routine maintenance. Park is honest about deprioritization.
 
@@ -122,7 +115,7 @@ P0-P1 work earns the team's attention. P2 goes on the roadmap. P3 batches into r
 
 1. **Pull the crawl results.** Ahrefs Site Audit + Search Console + Core Web Vitals.
 2. **Tier the URLs.** Use organic traffic data. Tag every affected URL as Tier 1, 2, or 3.
-3. **Categorize each issue by mechanism.** High or low impact mechanism.
+3. **Categorize each issue by mechanism.** Look up the HIGH, MEDIUM, or LOW grade in `references/issue-impact-table.md`.
 4. **Estimate effort per fix type.** Group similar fixes into one effort estimate.
 5. **Apply the triage matrix.** Assign P0-P3 or Park.
 6. **Cluster the fixes.** Group fixes that share an effort: one template change can resolve hundreds of issues.
@@ -181,4 +174,4 @@ Length: 5-12 pages plus a backlog spreadsheet.
 
 ## Reference files
 
-- [`references/issue-impact-table.md`](references/issue-impact-table.md) - Mapping table of common crawler issues to mechanism impact and typical fix effort, plus the triage matrix in detailed form.
+- [`references/issue-impact-table.md`](references/issue-impact-table.md) - Mapping table of common crawler issues to mechanism grade and typical fix effort, plus cluster signals and the park-or-skip list. This file is the source of truth for every issue grade; the triage matrix above turns a grade plus a tier plus an effort into a priority band.

--- a/skills/seo-site-health-audit/references/issue-impact-table.md
+++ b/skills/seo-site-health-audit/references/issue-impact-table.md
@@ -40,7 +40,7 @@ Mechanism tiers:
 | Issue | Mechanism | Typical effort | Notes |
 | --- | --- | --- | --- |
 | 5xx errors on URLs | HIGH | M-L | Investigate hosting and app errors |
-| 4xx errors on internally linked URLs | HIGH | M | Fix links or add redirects |
+| 4xx on a URL that ranked, earned external links, or sits in the sitemap | HIGH | M | Restore the page or redirect it to the closest live equivalent |
 | Redirect chain (3+ hops) | MEDIUM | M | Update final destination in links |
 | Redirect loop | HIGH | S | Fix immediately |
 | Slow time to first byte | MEDIUM | M-L | Hosting, caching, or app changes |
@@ -94,7 +94,7 @@ Pages eligible for rich results (FAQ, How-to, Recipe, Product, etc.) deserve hig
 
 | Issue | Mechanism | Typical effort | Notes |
 | --- | --- | --- | --- |
-| Internal link to 404 | MEDIUM | S | Update or remove link |
+| Internal link to 404, destination not worth restoring | MEDIUM | S | Update or remove the link. If the destination itself ranked or earned links, use the HIGH crawlability row instead |
 | Internal link to redirect | LOW | S | Update to final URL when batching |
 | Internal link with empty anchor | LOW | S | Add descriptive anchor |
 | Page receiving zero internal links (orphan) | MEDIUM | S-M | Add links or reassess if page should exist |


### PR DESCRIPTION
## What this is

T3 Wave B: the reference-coherence repairs, one PR, nine skills.

T3 found the contradiction class reproducing at **6 of 12** skills reviewed, and named the mechanism precisely:

> contradictions concentrate in skills where SKILL.md PARAPHRASES what a reference/template already owns (counts, bands, matrices, output structures)

So the repair rule is **single-source**, applied uniformly:

- The reference or template owns its numbers. SKILL.md stops restating them and points instead.
- Where T3's evidence shows the SKILL.md side is the intended value, the reference moves instead, and the row below says why.
- Both sides are quoted before and after, per repair.

Wave A (descriptions and triggers) is held separately and does not overlap this diff.

---

## The two execution-blocking repairs, first

### 1. seo-site-health-audit: the triage matrix had nowhere to put a MEDIUM issue

T3 measured this, it did not read it:

> the fixture's "Internal link to 404" and "Slow TTFB" rows are **MEDIUM** mechanism per the reference (issue-impact-table.md:97, :46), but the triage matrix (SKILL.md:105-115) has only "High mechanism" / "Low mechanism" rows. I could not assign a P-band to MEDIUM issues without inventing a rule.

The reference defines three tiers and uses all three. Counted on this branch: **24 of 60 graded rows are MEDIUM**, plus 3 more at LOW-MEDIUM. T3's "~40%" is exact.

Before, `SKILL.md:105-115`:

```
| Tier 1 | High mechanism | S | P0 (do this week) |
| Tier 1 | Low mechanism  | S | P3 (batch when convenient) |
| Tier 2 | High mechanism | S | P1 |
| Tier 3 | High mechanism | S | P3 |
| Tier 3 | Anything else  | Anything | Park |
```

After (MEDIUM rows added for Tier 1 and Tier 2; Tier 3 MEDIUM already falls under "Anything else"):

```
| Tier 1 | MEDIUM | S   | P1 |
| Tier 1 | MEDIUM | M   | P2 |
| Tier 1 | MEDIUM | L   | P3 |
| Tier 2 | MEDIUM | S   | P2 |
| Tier 2 | MEDIUM | M-L | P3 |
```

The bands are not invented. They are derived from the matrix's own logic, and the rule is now stated in the file so a reader can check it:

> The MEDIUM rows follow one rule: a MEDIUM issue sits one band below the HIGH issue at the same tier and effort. Rows the reference grades LOW-MEDIUM take the MEDIUM row when the URL is Tier 1 and the LOW row otherwise.

Mechanism labels in the matrix changed from "High mechanism" / "Low mechanism" to HIGH / MEDIUM / LOW so they read as the same vocabulary the reference uses.

**The matrix stays in SKILL.md.** Verified, not assumed: `grep -rn "triage matrix\|Tier 1 |" seo-site-health-audit/references/` returns one hit, `issue-impact-table.md:12`, which *refers to* the matrix and does not contain it. SKILL.md is its only home, so this is the one place in the PR where SKILL.md legitimately owns a table.

### 2. qa-testing: the smoke gate failed correct decorative markup and halted the run

T3 measured this too:

> the `missingAlts` filter `!i.alt` (SKILL.md:65, :104) counts the decorative image's *correct* `alt=""` as a missing alt, failing the "Zero missing alts" smoke criterion (:77) [...] per :81 ("If any of these fail, do not proceed with deeper testing") this false positive blocks the whole run

And it contradicted a sibling skill's reference, which prescribes exactly that markup:

> `seo-site-health-audit/references/issue-impact-table.md:140`: "Missing alt text on decorative images | LOW | S | Use empty `alt=""`"

The check, before and after:

| | Before | After |
|---|---|---|
| Filter (`SKILL.md:65`, `:104`) | `.filter(i => !i.alt)` | `.filter(i => !i.hasAttribute('alt'))` |
| Pass criterion (`:79`) | "Zero missing alts" | "Zero images missing the `alt` attribute. An empty `alt=""` on a decorative image is correct markup and passes; only an absent attribute fails." |
| Image audit (`:176`, `:185`) | `alt: i.alt \|\| 'MISSING'` | `alt: i.hasAttribute('alt') ? (i.alt === '' ? 'DECORATIVE (empty alt)' : i.alt) : 'MISSING'`, plus a `decorative` count |
| Template (`qa-report-template.md:30`, `:63`) | "Zero missing image alts" / "Missing alt text" | "Zero images missing the alt attribute (empty `alt=""` on a decorative image passes)" / "Missing the alt attribute" + "Decorative (empty `alt=""`, correct)" |

The third instance (the image-audit snippet) carried the same bug and was not in T3's enumeration. Fixed here because it is the same check. `grep -rn "!i\.alt\|i\.alt ||" skills/` now returns **zero hits** across all 103 skills.

---

## Full repair table

Every row: T3's quoted both-sides evidence, then what changed. "Owner" is the file that keeps the number after the repair.

| # | Skill | Contradiction (T3, both sides quoted) | Repair | Owner after |
|---|---|---|---|---|
| 1 | seo-site-health-audit | Matrix rows "High mechanism" / "Low mechanism" (`SKILL.md:105-115`) vs `issue-impact-table.md:15-19` "Mechanism tiers: HIGH... MEDIUM... LOW" | MEDIUM rows added, one band below HIGH at equal tier and effort; rule stated inline | SKILL.md (matrix), reference (grades) |
| 2 | seo-site-health-audit | `SKILL.md:76` lists "Internal link integrity: 404s on internally linked URLs" under "Categories of real impact" vs `issue-impact-table.md:97` "Internal link to 404 \| MEDIUM" | SKILL.md's two mechanism tables deleted; replaced by a pointer plus the reference's own tier definitions and the instruction "Grade by row, never by family" | reference |
| 3 | seo-site-health-audit | `SKILL.md:72` "Crawlability \| ...slow server response" (real-impact table) vs `issue-impact-table.md:46` "Slow time to first byte \| MEDIUM" | Same pointer repair as #2 resolves it | reference |
| 4 | seo-site-health-audit | `SKILL.md:11`/`:35` "Ahrefs Site Audit (or any equivalent crawler)" vs `:39` "Confirmation Ahrefs MCP is connected" | Input 5 made conditional: "only when the crawl is being pulled through Ahrefs. A supplied export from any equivalent crawler satisfies the first input on its own." | SKILL.md |
| 5 | qa-testing | `!i.alt` (`:65`, `:104`) + "Zero missing alts" (`:77`) vs `issue-impact-table.md:140` "Use empty `alt=\"\"`" | `hasAttribute('alt')`; criterion and template reworded; third instance at `:176` fixed too | SKILL.md |
| 6 | qa-testing | `SKILL.md:138` Tier 3 performance = "score above 80, LCP under 2.5s, CLS under 0.1" vs `qa-report-template.md:90` "INP under 200ms (actual: __)" | Matrix row now reads "Every threshold in the report template's Performance checklist, INP included" | template |
| 7 | qa-testing | `SKILL.md:139` "Tested at 375px, 768px, 1024px, 1440px" vs `:267` "visual review at 375px, 768px, 1440px" | Tier 3 points at the template's checklist; Standard states the 1024px omission is deliberate and says where it is picked up | template |
| 8 | qa-testing | `SKILL.md:79` "Schema includes the expected types for the page", defined nowhere (T3: grep found only this line) | Replaced with a criterion the snippet can actually answer: "Every schema block parses (no `invalid` entries in the snippet output)"; type-appropriateness moved to the Full tier's Rich Results Test | SKILL.md |
| 9 | brand-voice | `SKILL.md:145` "Aim for 15 to 25 paired examples" vs `:155` "15 to 25 minimum" | One statement: "The floor is 15 paired examples... treat 25 as the practical ceiling, not a hard cap." Workflow step points back to it | SKILL.md (one site) |
| 10 | brand-voice | 13-entry content-type list at `:129-143` cannot reach the 15 floor; template carries 16 types | List deleted; SKILL.md points at the template's paired examples library, which owns it. "One pair per type in the template clears it." | template |
| 11 | brand-voice | `:156` stress test has no pass criterion vs `voice-frameworks.md:47` "Score it 1 to 5 against each attribute. If it scores below 3... off-voice" | Workflow step now carries the rubric and cites the reference | reference |
| 12 | brand-voice | `SKILL.md:149-158` workflow starts at audit vs `voice-frameworks.md:182` "If... you need to start from zero, begin with archetypes" | New step 1 routes to the reference's "Choosing a framework" section and says where a from-zero brand rejoins. *Enumerated in T3 section 2; not itemized in its Wave B bullet. Flagged as an addition.* | reference |
| 13 | art-direction | Four counts: `SKILL.md:73` "3 to 5 reference images" vs `photo-shoot-brief.md:44` "5 to 10" vs `illustration-brief.md:43` "5 to 10" vs `creative-brief-template.md:158` "10 to 15 curated images" | SKILL.md states no count for photo or illustration; each template owns its own. See the unit note below | templates |
| 14 | art-direction | `SKILL.md:181-190` 5-section output structure vs the templates' 14-15 sections, "structurally incompatible" | Output format now names the template per production type and says the template *is* the structure. The five layers are relabelled as the thinking, which every template covers in its own order | templates |
| 15 | art-direction | SKILL.md's structure omits licensing entirely; both templates make it pre-production (`photo-shoot-brief.md:156-162`, `illustration-brief.md:141-148`) while `SKILL.md:149` defers it to "Approve and document" | Licensing added to layer 5 and to workflow step 4 ("agreed before the shoot or the first sketch"); step 7 now confirms against what step 4 agreed | SKILL.md + templates agree |
| 16 | editorial-qa | `SKILL.md:228` "Fixed sample percentage as set grows; absolute count plateaus around 200" vs `qa-at-scale-patterns.md:21-25` (50/100/150/200 by set size, a *shrinking* percentage) | SKILL.md points at the schedule and states the mechanism without numbers: fixed count per band, so the percentage falls as the set grows, deliberately | reference |
| 17 | editorial-qa | `ai-content-audit-patterns.md:11` "8 em-dashes per 1,000 words" vs same file `:104` "More than 5 in a 1,500-word piece" (2.4x apart) | One threshold, 8 per 1,000 words, declared at `:11` as "the one threshold for the tell"; `:104` cites it and gives the 1,500-word equivalent (12) so no reader does the arithmetic twice | reference `:11` |
| 18 | editorial-qa | `SKILL.md:260` "SEO/AEO checks last" contradicted by the two gates it lists after SEO/AEO; and its 8 named items vs `qa-workflow-templates.md:34`'s different 8-gate list (adds "Final read") | SKILL.md stops listing gates and points at the sequencing template, keeping only a corrected rationale | reference |
| 19 | editorial-qa | `qa-workflow-templates.md:25` "Each gate is cheaper than the next" vs same file `:131-139` (fact-accuracy, gate 2, is 10-30 min; gates 3-5 are 10/5/5) | Rationale corrected: the order front-loads halt-capable gates, cheapest of those first, and is not a cost ranking. *Enumerated in T3 section 2; not itemized in its Wave B bullet. Flagged as an addition.* | reference |
| 20 | seo-audit-orchestration | `SKILL.md:176` + `audit-rollup-template.md:18` "Total: 15-30 pages" vs the template's per-type table `:218-223` ("Quarterly health check 10-15... due diligence 30-50") | Both flat statements removed; the per-type table owns length | template table |
| 21 | seo-audit-orchestration | `SKILL.md:171` "5-7 themes" stated as fixed vs `:220-222` "Quarterly... 3-4 themes", "due diligence... 6-10 themes" | Five further universal "5-7 themes" assertions were found by the audit grep (`SKILL.md:97`, `:128`, `:142`; template `:12`, `:93`) and all now defer to the per-type table | template table |
| 22 | ads-performance-analytics | `SKILL.md:119` "Meta drives 2.5x ROAS at $40 CAC with $80 LTV... covers **1.5x** payback" vs the same paragraph's Google line applying LTV/CAC ("$60 CAC with $200 LTV... 3.3x") | $80/$40 = **2.0x**. Corrected, and both sentences reworded to "That is Nx payback" so the formula is visibly the same on both lines | SKILL.md |
| 23 | landing-page-copy | `SKILL.md:187` step 9 "check links, spell-check, mobile preview" presumes a built page vs `:205` "Default output is a structured markdown document... ready to import into the CMS" | Step 9 becomes a post-import handoff checklist: spell-check is yours, the rest is attached for whoever builds the page, with an in-place-revision branch | SKILL.md |
| 24 | seo-rank-tracking | `SKILL.md:40` "Confirmation Ahrefs MCP and Rank Tracker access" (dropped word; write access ambiguous vs step 5 creating projects) | "Confirmation **of** Ahrefs MCP and Rank Tracker access, write access included: workflow step 5 creates Rank Tracker projects" | SKILL.md |
| 25 | seo-rank-tracking | Bucket bands sum to 140-480 (`:62`, `:74`, `:88`, `:102`) vs `:206` "200-500 total keywords for most properties" | The total is now derived from the buckets, not asserted against them: a property at every bucket minimum lands near 140 and is correctly scoped. Failure pattern at `:220` updated to match | bucket bands |
| 26 | seo-rank-tracking | `dashboard-template.md:73-74`: "broke into top 10" counted as a win, then "fell out of opportunity range (past 30 **or to top 10**)" counts the same keyword as a loss | Split into Graduations (top 10) and Losses (past 30), with the rule stated: both are exits, a keyword is in exactly one, never report a graduation as a loss | reference |

### Note on art-direction's counts (row 13)

The repair resolves them into three distinct units rather than one number, because they measure different things. Stating it explicitly so the next reader does not re-file it as unfixed:

| Unit | Count | Owner |
|---|---|---|
| Per-attribute reference sets (lighting, treatment) | 3 to 5 | `creative-brief-template.md:121`, `:137` |
| The brief's visual/style references | 5 to 10 | `photo-shoot-brief.md:44`, `illustration-brief.md:43` |
| The separate moodboard | 10 to 15 | `creative-brief-template.md:158` |
| Motion reference work | 3 to 5 | `SKILL.md:88`, because no motion template exists, and the file now says so |

---

## Explicitly out of scope, sequenced to Wave D

Untouched, and verified untouched rather than asserted:

| Wave D item | Why it waits | Verification |
|---|---|---|
| qa-testing vs editorial-qa title/meta bands (30-60 vs 50-65; 120-160 vs 140-160) | Needs the ownership ruling: one canonical band shared by both gates, checked against seo-onpage. Picking one here would be a design decision disguised as a coherence fix | `git diff` over both skills, filtered for those bands: **zero hits** |
| H-1 handoff contract and H-2 suite membership | H-2 must land before H-1 is well-defined; both touch README, frontmatter categories, and orchestrator Phase 3 | `git diff` over the orchestrator, filtered for Phase 3, child names, Required inputs: **zero hits** |
| editorial-qa per-piece gate contract | Requires the Required-inputs and per-piece Output-format design that 14 workflow call sites assume | `git diff` over editorial-qa, filtered for those headings: **zero hits** |
| Skills-tier honest-stop / anti-fabrication language | Wave C, and its scope now comes from the currency pass's 60-YES classification | No stop/degrade language added anywhere in this diff |

`README.md`, `MAPPING.md`, and `workflows/**` are untouched: **zero hits** on `git diff --name-only`.

---

## Dispatch premise correction

The dispatch describes a **10-skill** Wave B list. T3 section 6's Wave B names **nine**: brand-voice, art-direction, seo-site-health-audit, qa-testing, editorial-qa, seo-audit-orchestration, ads-performance-analytics, landing-page-copy, seo-rank-tracking. All nine are repaired here. No tenth skill was invented to close the gap; if one was intended, it did not reach the report.

Two further notes on the input, since both affect how these rows should be read:

- T3's own headline rate is **6 of 12 skills** carrying a contradiction, class-skewed 0/4 data, 3/4 judgment, 3/4 orchestration. Nine skills appear in Wave B because several non-contradiction defects (the arithmetic slip, the dropped word, the workflow-step mismatch) were batched into the same mechanical pass.
- Rows 12 and 19 are contradictions T3 enumerated in its section 2 evidence but did not itemize in its Wave B bullet list. Both are the same class, both are one-line repairs adjacent to text this PR already rewrites, and leaving them would have left a contradiction sitting beside its own fix. Flagged rather than folded in silently.

## Repairs found by the negative-claim audit, not by the report

The audit greps caught two places where the stated repair was incomplete. Recording them because a "done" claim that a grep would have refuted is the failure mode the audit exists to catch:

1. **seo-audit-orchestration's theme band.** Fixing the Output format left "5-7 themes" asserted universally in five other places. All five now defer to the per-type table. Only the table's own `5-7 themes` row survives, where it belongs.
2. **The site-health reference contradicted itself** on the issue the repair had to align SKILL.md against: `:43` graded "4xx errors on internally linked URLs" HIGH while `:97` graded "Internal link to 404" MEDIUM, same finding, two grades, different efforts. SKILL.md could not be aligned to a reference that disagreed with itself. The two rows are now genuinely distinct: `:43` covers a URL that ranked, earned external links, or sits in the sitemap (HIGH, restore or redirect); `:97` covers a link whose destination is not worth restoring (MEDIUM, update or remove) and cross-references the HIGH row. T3 did not surface this; it only becomes visible when you try to perform the alignment.

## Checks

| Check | Result |
|---|---|
| `tools/gen_skills_lock.py --check` | SKILLS.lock is current |
| `scripts/build-pi.mjs --check` | Committed dist/pi matches a fresh build, byte-identical |
| `scripts/build-pi.mjs --validate` | VALIDATION PASS (103 skills, 490 reference files) |
| `.github/scripts/lint_skills.py` | PASSED, 103 skills, 1 warning |
| Em-dash rule | `check_em_dashes` OK |

The one lint warning is `documentation-strategy/SKILL.md: 428 lines`, pre-existing on main and untouched by this PR.

Note for reviewers on the diff size: this clone's working tree predated the `.gitattributes` LF policy from #104, so 604 tracked files sat CRLF on disk while the index held LF. They were normalized to LF before the lock was generated, otherwise every hash in SKILLS.lock would have changed. The commit contains only the 31 files that changed in content: 15 sources, their 15 dist mirrors, and SKILLS.lock.

## Status

Draft, per dispatch. Stopping here for the ownership rulings that Wave D depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
