### PR TITLE
fix(skills): correct five retired GSC features in the technical-SEO audit template (W1-a)

### DIFF
--- a/SKILLS.lock
+++ b/SKILLS.lock
@@ -727,7 +727,7 @@
   },
   "seo-technical": {
     "SKILL.md": "8b874b2a102ac52c059f8860aae1119d36c14ecd8a63b5e7bcda7c04830d79f4",
-    "references/audit-template.md": "71d840bec52223e82eaebf518ad20636dcff163a316edc79923a5703f82ce92b",
+    "references/audit-template.md": "b7a7047ec9a46e6432bc1de45f9ec9c73d640ff5cedc1527f9715aac9b8f9829",
     "references/migration-checklist.md": "7f9a4dbdd9653d4a2d8a9c8795376562ac26545568db6f493a21c3f5bc485bb9"
   },
   "seo-traffic-diagnosis": {

--- a/dist/pi/.agents/skills/seo-technical/references/audit-template.md
+++ b/dist/pi/.agents/skills/seo-technical/references/audit-template.md
@@ -37,7 +37,7 @@ Can search engines crawl the site?
 ### Robots.txt
 
 - [ ] File exists at `/robots.txt`
-- [ ] File is syntactically valid (test in GSC)
+- [ ] File is syntactically valid (the GSC robots.txt report surfaces warnings and errors; Google's open-source robots.txt parser tests syntax locally)
 - [ ] Critical sections of the site are not accidentally disallowed
 - [ ] Specific user agents are not blocked (`Googlebot`, `Bingbot`)
 - [ ] Sitemap location is declared (`Sitemap: https://example.com/sitemap.xml`)
@@ -67,7 +67,7 @@ Can search engines crawl the site?
 - [ ] No crawl traps (calendar pages, infinite faceted nav, session ID parameters)
 - [ ] Faceted nav uses `noindex,follow` or controlled parameter handling
 - [ ] No duplicate URLs from URL parameter variations (UTMs, tracking, sort orders)
-- [ ] Pagination handled with `rel="next"` and `rel="prev"` or paginated URL structure (no infinite scroll for important content)
+- [ ] Pagination uses a crawlable paginated URL structure (no infinite scroll for important content)
 
 ---
 
@@ -122,7 +122,7 @@ Can search engines render JavaScript-dependent content?
 ### Rendering strategy
 
 - [ ] Critical content is in the initial HTML response (server-rendered or static)
-- [ ] If JS-rendered, "fetch as Google" via URL Inspection in GSC shows full content
+- [ ] If JS-rendered, "Test live URL" in the GSC URL Inspection tool shows full content
 - [ ] No reliance on user interaction to load primary content (no "click to load article")
 
 ### Specific rendering risks
@@ -148,7 +148,6 @@ Can search engines render JavaScript-dependent content?
 - [ ] No schema violations in GSC enhancement reports
 - [ ] BreadcrumbList schema implemented (often-overlooked CTR boost)
 - [ ] Organization schema on the homepage
-- [ ] WebSite schema with SearchAction (enables sitelinks search box)
 - [ ] No schema for content not visible on the page
 
 ---
@@ -177,7 +176,7 @@ For detailed performance audit, see `performance-optimization` skill.
 ### Mobile
 
 - [ ] Responsive (single URL, single HTML, CSS adapts)
-- [ ] Mobile usability passes in GSC
+- [ ] Mobile usability verified with Lighthouse and Core Web Vitals field data
 - [ ] No tap targets too close together
 - [ ] Viewport meta tag set
 
@@ -196,7 +195,7 @@ If the site is multilingual or multi-region:
 - [ ] `hreflang` includes self-reference
 - [ ] `x-default` set for language picker fallback
 - [ ] Language and region codes follow ISO standards
-- [ ] No hreflang errors in GSC International Targeting report
+- [ ] No hreflang errors (validate with URL Inspection and a third-party crawler)
 - [ ] URL structure follows a consistent pattern (subdir / subdomain / ccTLD)
 
 ---

--- a/skills/seo-technical/references/audit-template.md
+++ b/skills/seo-technical/references/audit-template.md
@@ -37,7 +37,7 @@ Can search engines crawl the site?
 ### Robots.txt
 
 - [ ] File exists at `/robots.txt`
-- [ ] File is syntactically valid (test in GSC)
+- [ ] File is syntactically valid (the GSC robots.txt report surfaces warnings and errors; Google's open-source robots.txt parser tests syntax locally)
 - [ ] Critical sections of the site are not accidentally disallowed
 - [ ] Specific user agents are not blocked (`Googlebot`, `Bingbot`)
 - [ ] Sitemap location is declared (`Sitemap: https://example.com/sitemap.xml`)
@@ -67,7 +67,7 @@ Can search engines crawl the site?
 - [ ] No crawl traps (calendar pages, infinite faceted nav, session ID parameters)
 - [ ] Faceted nav uses `noindex,follow` or controlled parameter handling
 - [ ] No duplicate URLs from URL parameter variations (UTMs, tracking, sort orders)
-- [ ] Pagination handled with `rel="next"` and `rel="prev"` or paginated URL structure (no infinite scroll for important content)
+- [ ] Pagination uses a crawlable paginated URL structure (no infinite scroll for important content)
 
 ---
 
@@ -122,7 +122,7 @@ Can search engines render JavaScript-dependent content?
 ### Rendering strategy
 
 - [ ] Critical content is in the initial HTML response (server-rendered or static)
-- [ ] If JS-rendered, "fetch as Google" via URL Inspection in GSC shows full content
+- [ ] If JS-rendered, "Test live URL" in the GSC URL Inspection tool shows full content
 - [ ] No reliance on user interaction to load primary content (no "click to load article")
 
 ### Specific rendering risks
@@ -148,7 +148,6 @@ Can search engines render JavaScript-dependent content?
 - [ ] No schema violations in GSC enhancement reports
 - [ ] BreadcrumbList schema implemented (often-overlooked CTR boost)
 - [ ] Organization schema on the homepage
-- [ ] WebSite schema with SearchAction (enables sitelinks search box)
 - [ ] No schema for content not visible on the page
 
 ---
@@ -177,7 +176,7 @@ For detailed performance audit, see `performance-optimization` skill.
 ### Mobile
 
 - [ ] Responsive (single URL, single HTML, CSS adapts)
-- [ ] Mobile usability passes in GSC
+- [ ] Mobile usability verified with Lighthouse and Core Web Vitals field data
 - [ ] No tap targets too close together
 - [ ] Viewport meta tag set
 
@@ -196,7 +195,7 @@ If the site is multilingual or multi-region:
 - [ ] `hreflang` includes self-reference
 - [ ] `x-default` set for language picker fallback
 - [ ] Language and region codes follow ISO standards
-- [ ] No hreflang errors in GSC International Targeting report
+- [ ] No hreflang errors (validate with URL Inspection and a third-party crawler)
 - [ ] URL structure follows a consistent pattern (subdir / subdomain / ccTLD)
 
 ---


### PR DESCRIPTION
**Wave 1, PR a** of the currency-fix plan in `third-party-currency-inventory-2026-08.md` §6. Mechanical corrections only, no authorial rulings. Held as a draft: Andy merges W1-a through W1-e in order.

Scope is the single worst file in the catalog, alone: `skills/seo-technical/references/audit-template.md`. Six line-level edits, each one traced below to the verdict row that authorizes it. Every verdict in this PR carries **check date 2026-08-09**.

Two numbering systems appear in the report. §2.1 numbers these R1 through R5; Appendix C1 (verifier V1) numbers the same five items R3 through R7. Both citations are given per edit.

---

### 1. GSC robots.txt tester

**Before** (`:40`)
```
- [ ] File is syntactically valid (test in GSC)
```
**After**
```
- [ ] File is syntactically valid (the GSC robots.txt report surfaces warnings and errors; Google's open-source robots.txt parser tests syntax locally)
```
**Verdict row** (§2.1 R3 / Appendix C1 R5, RETIRED, checked 2026-08-09)
> Legacy robots.txt Tester sunset late 2023, replaced by the GSC robots.txt report (shows fetched files, crawl status, warnings/errors, not an interactive rule tester). Per-URL blocking tests: URL Inspection; syntax testing: Google's open-source robots.txt parser or third-party validators. Sources: seroundtable.com/google-search-console-robots-txt-report-36400.html ; support.google.com/webmasters/answer/6062598

---

### 2. "Fetch as Google"

**Before** (`:125`)
```
- [ ] If JS-rendered, "fetch as Google" via URL Inspection in GSC shows full content
```
**After**
```
- [ ] If JS-rendered, "Test live URL" in the GSC URL Inspection tool shows full content
```
**Verdict row** (§2.1 R4 / Appendix C1 R6, RETIRED (name), checked 2026-08-09)
> "Fetch as Google" died with legacy Search Console in 2019; the function is the URL Inspection tool's "Test Live URL" / "View crawled page". The checklist's intent survives; the name should be corrected. Source: theseosystem.com/fetch-as-google-new-search-console-url-inspection/

---

### 3. Sitelinks search box (WebSite SearchAction)

**Before** (`:151`)
```
- [ ] WebSite schema with SearchAction (enables sitelinks search box)
```
**After**
```
(line deleted)
```
**Verdict row** (§2.1 R5 / Appendix C1 R7, RETIRED, checked 2026-08-09)
> Google announced deprecation 2024-10-21; the feature stopped appearing globally 2024-11-21; docs and the Rich Results Test highlight were removed. Markup is harmless but does nothing in Google. Source: developers.google.com/search/blog/2024/10/sitelinks-search-box

Deleted rather than reworded: the line's entire content was the parenthetical payoff, and the verdict is that the markup is inert in Google. Nothing survives to keep.

---

### 4. GSC Mobile Usability report

**Before** (`:180`)
```
- [ ] Mobile usability passes in GSC
```
**After**
```
- [ ] Mobile usability verified with Lighthouse and Core Web Vitals field data
```
**Verdict row** (§2.1 R1 / Appendix C1 R3, RETIRED, checked 2026-08-09)
> Report retired 2023-12-04 along with the Mobile-Friendly Test tool and API. Replacement: Lighthouse / Core Web Vitals + general page-experience guidance. Source: searchengineland.com/google-officially-drops-mobile-usability-report-mobile-friendly-test-tool-and-mobile-friendly-test-api-435377

---

### 5. GSC International Targeting report

**Before** (`:199`)
```
- [ ] No hreflang errors in GSC International Targeting report
```
**After**
```
- [ ] No hreflang errors (validate with URL Inspection and a third-party crawler)
```
**Verdict row** (§2.1 R2 / Appendix C1 R4, RETIRED, checked 2026-08-09)
> Removed 2022-09-22; country targeting no longer supported; there is no dedicated GSC hreflang report today. Replacement: URL Inspection + third-party crawlers for hreflang validation. Sources: searchengineland.com/google-search-console-to-remove-international-targeting-report-387477 ; support.google.com/webmasters/answer/12474899

---

### 6. rel=next/prev pagination requirement

**Before** (`:70`)
```
- [ ] Pagination handled with `rel="next"` and `rel="prev"` or paginated URL structure (no infinite scroll for important content)
```
**After**
```
- [ ] Pagination uses a crawlable paginated URL structure (no infinite scroll for important content)
```
**Verdict row** (Appendix C1 R8, RETIRED (in Google; template row needs fixing), checked 2026-08-09)
> Google confirmed in 2019 it no longer uses rel=next/prev (and hadn't for years). SKILL.md:65 is correct; the template line is the stale half of a genuine internal contradiction. Correction: delete the checklist requirement; keep self-canonical paginated URLs (template's own line 97 already agrees). Source: yoast.com/google-doesnt-use-rel-prev-next-for-pagination/

This is the §4 contradiction repair as well: `SKILL.md:65` calls rel=next/prev deprecated while its own template required it. The SKILL was right. Line 97 (`Pagination uses self-canonicals`) already carries the surviving guidance, so nothing is lost by the deletion.

---

## Deliberately skipped, flagged for Andy

§6 lists "FAQ/HowTo caveat rows" under W1-a. **Not done here**, on purpose. Wave 2 ruling **R-1** explicitly holds the FAQ/HowTo strategy question open ("delete the rich-result rationale, or reframe FAQPage as comprehension-only markup?"), and the report specifies no replacement wording. Writing a caveat would be making R-1's ruling inside a no-rulings PR. `:145` is untouched and waits on R-1.

One further item in this file is verified but assigned to no wave: GSC's **"Coverage" report is now "Page indexing"** (Appendix C1 S3, STALE (naming), checked 2026-08-09, `:231` and `:292`). §6 does not list it under W1-a or anywhere else in Wave 1. Left untouched rather than widening scope. Say the word and it folds into this PR as two more mechanical edits.

---

## Checks

Run locally against this branch, all green:

| Check | Command | Result |
|---|---|---|
| Skills manifest | `tools/gen_skills_lock.py --check` | `SKILLS.lock is current.` |
| Distribution drift | `node scripts/build-pi.mjs --check` | `PASS: committed dist/pi/.agents/skills matches a fresh build (byte-identical).` |
| Distribution validate | `node scripts/build-pi.mjs --validate` | `VALIDATION PASS` (490 reference files) |
| Skill linter | `.github/scripts/lint_skills.py` | `PASSED: 103 skills validated, 1 warnings.` |

The single linter warning is pre-existing and unrelated (`documentation-strategy/SKILL.md` is 428 lines against a 400-line target). It is present on `main` and untouched here.

`SKILLS.lock` moves by exactly one hash (`seo-technical/references/audit-template.md`). `dist/pi` is rebuilt in the same commit, as `dist-drift.yml` requires of any `skills/**` change.

**Writing law:** no em dashes introduced; replacements are declarative and name a concrete current surface rather than an abstraction.

**Negative-claim audit:** every factual assertion added by this PR (the GSC robots.txt report surfacing warnings and errors, the open-source parser, "Test live URL", Lighthouse plus CWV field data, URL Inspection plus third-party crawlers) is quoted verbatim from a verdict row above. No claim is introduced that the inventory did not verify on 2026-08-09.
