### PR TITLE
fix(skills): retire dead ad formats and correct platform facts across the ads cluster (W1-b)

### DIFF
--- a/SKILLS.lock
+++ b/SKILLS.lock
@@ -6,24 +6,24 @@
     "references/wcag-quick-reference.md": "4d70c669894200c64c9940dbec2ddf959173d7ad8d9dcb594206ea0c18d3cd8e"
   },
   "ads-creative-development": {
-    "SKILL.md": "2663c08171e2abe3abc758947afe679eee7c2a5b8f8095fc5ce0dee1a153543b",
+    "SKILL.md": "8952371efed4baa08f55456beaaf287c50eb6abf9a0afc618c274e95f0ed9201",
     "references/brand-voice-performance-balance.md": "1bbfe4c196fd80ebc4635ccf7a79e3a901eee0ea6648ab4825fc00e34e9ca7eb",
     "references/creative-variation-templates.md": "6639d23b01a813d84656ec2f163fad8ce38ed6b68e3be91375c17674234212a7",
-    "references/fatigue-detection-checklist.md": "8cc07d83c0245c0380cadb08fca5ff59799de43cd23c45552e0d6e1ae2c1aeab",
+    "references/fatigue-detection-checklist.md": "025bc752682b7d311ccc5831bf7f9e2cbd894b4568a25da414b6376403718667",
     "references/format-decision-matrix.md": "6a323059143aba50c1561bde659547a31c81a3a7b11a93b44c437dcc891af37a",
     "references/hook-pattern-library.md": "900cd2a43ab2440f434bf039886f8fbd0ec1801f18d14a268ff7fb71c3874e3d",
-    "references/platform-creative-norms.md": "7fa8579b1ac1f029ae124c0204acfe143213c29b9dd4386962bf98fcd7bf3562",
+    "references/platform-creative-norms.md": "cce603586e070dda8810bc410834aad164d18a75b292165e708f034c95b855ad",
     "references/testing-cadence-playbook.md": "7266af1fe12d7f0b374589cb93682c83458634fc0229809c64873b46896a9bb5"
   },
   "ads-performance-analytics": {
-    "SKILL.md": "686dc2e7b2651170b8f77014a02e751d9060651852402f398650afcfe5ea8188",
-    "references/attribution-model-comparison.md": "fff3d7c5afc4c55ca9c75888a949b827de0338b2de9bb646a7733570cee96a63",
+    "SKILL.md": "b9627b0602040c8ddd6e5ad3ffc362f277397cb9bcc9c3222227ade3bafbaaed",
+    "references/attribution-model-comparison.md": "677ff179987ce840a1bd8cefe1e6e77aa40daed145791728f0347976946cc35f",
     "references/cohort-analysis-templates.md": "c15602571f8ce6d28b92d6c50918b2c6c07314b16f83c0d910e694fa332d460f",
     "references/common-interpretation-failures.md": "754a4c0ed869899d876fca5d38c5b6e0d2563f43fff4675dd567fcc38dbe2149",
     "references/dashboard-reconciliation-patterns.md": "8d9acce69c46b159866d823a2b38841eebc538bbadf4fdc4263b3afdbf011e80",
-    "references/incrementality-testing-playbook.md": "5bc88f03f7173636edcf249f67efd660466de4439961a340485ec7498a92e010",
-    "references/metric-definitions-glossary.md": "33baa687b9af6fbcf3edcacc411d714e7869df6bf7bb0ae03719c89895fbbdd2",
-    "references/platform-reporting-quirks.md": "5df612e2f8a93adda50ed7830e5becee254e5f9ec7e87154e179b3d949c9a9e9"
+    "references/incrementality-testing-playbook.md": "fefae9132f9e001d835978a99a322a3f633030119706c85b4fccb7b2c1131417",
+    "references/metric-definitions-glossary.md": "4daaf5524e5322bcded9b521ace499bd0e202f791723919c478b48a72af84c88",
+    "references/platform-reporting-quirks.md": "d5352c0a6c24a42a23da227eddd3509d9531c0d081b1caf971b4b129ecc472d8"
   },
   "after-action-report": {
     "SKILL.md": "89bcf92ced995da4701b560163775bae0168a6b55e49937c224b223edf09ba6e",
@@ -563,12 +563,12 @@
     "references/wizard-decision-criteria.md": "4e976611c41b6b2c3281bd053f458bee5f5e69daaf706df04f808bc4daa8895a"
   },
   "paid-media-strategy": {
-    "SKILL.md": "afb2aae08a0d45a30c09c44de958ea56cd13eafea7589bdce1306dc23ead2f20",
-    "references/ads-platform-comparison.md": "133636975a25f212a9e913975b3ba3696b34a8c42b894eb8b8ace1424e7a1af3",
+    "SKILL.md": "0d53dd7241b0c04f92acd90806f1d00f66c7cb7dddf51cecac8847bdbed09602",
+    "references/ads-platform-comparison.md": "c34b60d89cf64ae8962158351bbb4958de24fd36eddfc79ab9395bd99b879002",
     "references/audience-segmentation-patterns.md": "ede2b4d02b6c2316a310cf5cbbb52f56aaab1d55b76bfb28cf7a9cea14b675a3",
-    "references/bid-strategy-reference.md": "4797fb17d4b30a96a59a5ba039a115266faf55f5e4012bcb46ab29f392030d60",
+    "references/bid-strategy-reference.md": "4bc71a446a858144151f2b6d58ae1a14aea310773d94aec926b250e627f0adda",
     "references/budget-allocation-templates.md": "53aaaa53dab15cfc86874c0986ed3544e6de1fce7c051ce8371e2722832e0e0c",
-    "references/campaign-type-reference.md": "8a2f977a925fa6372b02f81ed652819d4a9b943755435a3977150598537a1cc1",
+    "references/campaign-type-reference.md": "4318166cb4649b6e4de6cd72a87242a07068134a3efe35f6468b24da0d628a76",
     "references/channel-decision-matrix.md": "e5e74225e2a09fe39ec5d79d0cb1ee26e8b3ae87cd7a744149845ad48b62edc6",
     "references/common-failures.md": "55c73def01e20f38568f193f0c0345b2a9f9e784875044eaa4b7e657fea2e871"
   },

--- a/dist/pi/.agents/skills/ads-creative-development/SKILL.md
+++ b/dist/pi/.agents/skills/ads-creative-development/SKILL.md
@@ -134,7 +134,7 @@ Fatigue is real. The same audience seeing the same creative six times a week tun
 2. **CTR declining 30%+ week over week.** The creative is no longer fresh to the audience.
 3. **CPM increasing without audience saturation explanation.** The platform is having to bid harder to deliver impressions because engagement signals are weakening.
 4. **Negative comments increasing.** A direct user signal that the audience is irritated.
-5. **Hide ratio increasing.** Meta exposes this as "negative feedback rate." TikTok exposes "not interested" rate.
+5. **Quality ranking dropping.** Meta folds hide and report signals into Quality ranking (above average, average, below average) rather than exposing a negative-feedback-rate column. TikTok exposes "not interested" rate.
 
 Refresh cadence. Weekly for high-spend campaigns ($50K+/month). Biweekly for medium spend. Monthly for low spend. The economics: producing a fresh variant is cheaper than running tired creative for one extra week.
 
@@ -164,11 +164,11 @@ Each platform has native norms. Violating them tanks performance. The fix is pro
 
 **Meta (Facebook plus Instagram).** In-feed visual hierarchy. Captions on by default (most users watch sound-off). Native-feeling production beats studio production for direct response. Vertical 9:16 for Reels and Stories; 1:1 or 4:5 for in-feed. CTAs above the fold or in first 2 lines of caption.
 
-**TikTok.** Vertical 9:16 only. Native-creator aesthetic; phone-shot is the default. Fast cuts every 1 to 2 seconds. Captions for accessibility. Music-driven; trending sounds compound reach but expire fast. Spark Ads (boost an existing organic post) consistently outperform pure paid because they retain organic engagement signal.
+**TikTok.** Vertical 9:16 recommended, with 1:1 and 16:9 also accepted. Native-creator aesthetic; phone-shot is the default. Fast cuts every 1 to 2 seconds. Captions for accessibility. Music-driven; trending sounds compound reach but expire fast. Spark Ads (boost an existing organic post) consistently outperform pure paid because they retain organic engagement signal.
 
 **LinkedIn.** Professional tone. Slower pacing tolerated; B2B audiences are in research mode rather than scroll mode. B2B vocabulary is fine; consumer-style copy reads as off-platform. Thought leadership angle works; product pitches feel salesy.
 
-**Google Search.** Text-only headlines plus descriptions. Character limits are real constraints (30-character headlines, 90-character descriptions). RSA (Responsive Search Ads) optimization rewards 15+ headline variations and 4+ descriptions; the platform mixes them.
+**Google Search.** Text-only headlines plus descriptions. Character limits are real constraints (30-character headlines, 90-character descriptions). RSA (Responsive Search Ads) optimization rewards filling all 15 headline slots and all 4 descriptions, which are the platform caps; the platform mixes them.
 
 **Google Display and YouTube.** Depends on placement. YouTube allows longer narrative (15s to 6m); Display is fast banner-style. Skippable YouTube ads need to earn the next second of attention; non-skippable annoys.
 

--- a/dist/pi/.agents/skills/ads-creative-development/references/fatigue-detection-checklist.md
+++ b/dist/pi/.agents/skills/ads-creative-development/references/fatigue-detection-checklist.md
@@ -48,13 +48,13 @@ The principle. Creative fatigue is a real economic cost. The tired ad still spen
 
 **Action.** Pull the creative within 24 hours. Negative comments compound; the audience that complains often is the audience that complains to friends.
 
-### 5. Hide ratio (negative feedback) increasing
+### 5. Quality ranking dropping (negative feedback)
 
-**Threshold.** Meta exposes "negative feedback rate"; trigger refresh when it exceeds 1.5% of impressions or rises 50% week over week.
+**Threshold.** Meta does not expose a negative-feedback-rate column. Hide and report signals surface through Quality ranking (above average, average, below average). Trigger refresh when Quality ranking falls to below average.
 
 **Why it matters.** Hide is a stronger signal than scroll-past. The audience is actively rejecting the ad. Platform algorithms penalize creatives with high hide ratios by reducing reach.
 
-**Where to check.** Meta Ads Manager: customize columns to expose negative feedback. Other platforms: less direct equivalents (TikTok "not interested" rate is similar).
+**Where to check.** Meta Ads Manager: the Quality ranking column at the ad level. Other platforms: less direct equivalents (TikTok "not interested" rate is similar).
 
 **Action.** Pull the creative immediately. The cost is real: the platform will deliver less of all your ads to that audience as it learns to weight negative signals.
 

--- a/dist/pi/.agents/skills/ads-creative-development/references/platform-creative-norms.md
+++ b/dist/pi/.agents/skills/ads-creative-development/references/platform-creative-norms.md
@@ -24,7 +24,7 @@ Per-platform creative requirements and unwritten conventions. Each platform has 
 
 ## TikTok
 
-**Aspect ratios.** 9:16 vertical only. Anything else is rejected by the algorithm.
+**Aspect ratios.** TikTok Ads Manager accepts 9:16, 1:1, and 16:9. 9:16 vertical is the recommended default.
 
 **Length.** 15 to 30 seconds for performance. The platform tolerates and rewards longer dwell than Meta.
 
@@ -42,7 +42,7 @@ Per-platform creative requirements and unwritten conventions. Each platform has 
 
 ## LinkedIn
 
-**Aspect ratios.** 1:1 or 16:9 for feed. 9:16 vertical works for Stories but Stories has limited reach on LinkedIn relative to other platforms.
+**Aspect ratios.** 1:1 or 16:9 for feed.
 
 **Length.** 15 to 60 seconds. Slower pacing tolerated; B2B audiences are in research mode rather than scroll mode. 30 seconds is a strong default.
 
@@ -64,7 +64,7 @@ Per-platform creative requirements and unwritten conventions. Each platform has 
 
 **Character limits.** Headlines 30 characters; 15 headline variants for RSA. Descriptions 90 characters; 4 description variants. Path 1 and Path 2 in the display URL: 15 characters each.
 
-**RSA optimization.** Provide 15+ headline variants and 4 description variants. The platform mixes them. More variants give the platform more material to optimize against.
+**RSA optimization.** Provide the full 15 headline variants and 4 description variants. Those are the platform caps, not floors. The platform mixes them; filling every slot gives it the most material to optimize against.
 
 **Voice.** Direct. Specific. Action-led. The search query is high-intent; the ad's job is to confirm the user is in the right place.
 
@@ -86,7 +86,7 @@ Per-platform creative requirements and unwritten conventions. Each platform has 
 
 ### YouTube
 
-**Format.** Skippable video ads (TrueView), non-skippable, bumper (6s), in-feed video.
+**Format.** Skippable in-stream, non-skippable in-stream, bumper (6s), in-feed video.
 
 **Length.** Skippable: 15s to 6m. Non-skippable: 15s. Bumper: 6s.
 

--- a/dist/pi/.agents/skills/ads-performance-analytics/SKILL.md
+++ b/dist/pi/.agents/skills/ads-performance-analytics/SKILL.md
@@ -168,7 +168,7 @@ Four methods.
 
 **Geo holdout.** Hold one region out from the campaign. Measure the difference in conversions between the holdout region and the matched test region. The cleanest causal test for paid media at scale.
 
-**Ghost bidding (Google).** Google's own incrementality tool. Bids on a holdout share of impressions but does not actually serve the ad. Reports incremental conversions. Honest signal; some teams find the math opaque.
+**Conversion Lift and Experiments (Google).** "Ghost bidding" is a term from the incrementality-testing literature, not a Google Ads feature you can switch on. Google's real surfaces are Conversion Lift studies, which a Google rep enables, and geo or holdback Experiments you configure yourself.
 
 **Conversion lift studies (Meta).** Splits audiences into test and control. Test sees the ad; control does not. Reports incremental lift. The cleanest within-Meta test.
 
@@ -257,7 +257,7 @@ The output of the framework is one of three answers. Scale (the campaign is incr
 - [`references/metric-definitions-glossary.md`](references/metric-definitions-glossary.md) - CTR, CPC, CPM, CPA, ROAS, LTV, AOV, frequency, reach, impressions, conversion window, view-through, modeled conversion, blended CAC, MER.
 - [`references/attribution-model-comparison.md`](references/attribution-model-comparison.md) - Last-click, first-click, linear, time-decay, U-shaped, DDA, MMM. Decision matrix by business stage.
 - [`references/platform-reporting-quirks.md`](references/platform-reporting-quirks.md) - Google PMax black box, Meta iOS impact and Conversions API, LinkedIn 30-day click defaults, TikTok video-completion attribution, programmatic viewability gates.
-- [`references/incrementality-testing-playbook.md`](references/incrementality-testing-playbook.md) - Geo holdout, ghost bidding, conversion lift, PSA tests, switchback designs. Setup, duration, analysis pattern, expected incremental rates.
+- [`references/incrementality-testing-playbook.md`](references/incrementality-testing-playbook.md) - Geo holdout, Conversion Lift and Experiments, PSA tests, switchback designs. Setup, duration, analysis pattern, expected incremental rates.
 - [`references/dashboard-reconciliation-patterns.md`](references/dashboard-reconciliation-patterns.md) - Warehouse as canonical, platform as in-flight signal, blended CAC formula, board-deck patterns, reconciliation cadence.
 - [`references/cohort-analysis-templates.md`](references/cohort-analysis-templates.md) - By acquisition month, channel, and campaign. Retention curves, when to act on cohort signals.
 - [`references/common-interpretation-failures.md`](references/common-interpretation-failures.md) - Twelve failure patterns with symptom, root cause, fix, prevention.

--- a/dist/pi/.agents/skills/ads-performance-analytics/references/attribution-model-comparison.md
+++ b/dist/pi/.agents/skills/ads-performance-analytics/references/attribution-model-comparison.md
@@ -62,7 +62,7 @@ The principle. No model is right. They are all approximations. The discipline is
 
 **Definition.** Machine-learning model that distributes credit based on observed conversion paths. Compares paths that did and did not convert; assigns credit to touchpoints that correlate with conversion.
 
-**When it fits.** Mature accounts with sufficient conversion volume (Google requires 600+ conversions per month for DDA). Cross-channel optimization.
+**When it fits.** Cross-channel optimization. Google removed DDA's conversion-volume floors in October 2021, when DDA became the default for new conversion actions, so there is no minimum to clear.
 
 **When it does not fit.** Sub-scale accounts. Accounts that need explainability for regulators or boards. The black-box nature is hard to audit.
 

--- a/dist/pi/.agents/skills/ads-performance-analytics/references/incrementality-testing-playbook.md
+++ b/dist/pi/.agents/skills/ads-performance-analytics/references/incrementality-testing-playbook.md
@@ -34,11 +34,11 @@ The cleanest causal test for paid media at scale.
 
 ---
 
-## Method 2: Ghost bidding (Google)
+## Method 2: Conversion Lift and Experiments (Google)
 
-Google's own incrementality tool. The platform bids on a holdout share of impressions but does not actually serve the ad. The reported delta between served and ghost is incremental.
+"Ghost bids" and "ghost ads" are terms from the incrementality-testing literature for withholding an ad from users who would otherwise have seen it. They name a methodology, not a Google Ads product you can configure. Google's actual surfaces are Conversion Lift studies and geo or holdback Experiments.
 
-**Setup.** Configure within Google Ads. Choose the campaigns and the holdout share (typically 5 to 20%).
+**Setup.** Conversion Lift studies are enabled by a Google rep, not self-serve. Experiments you configure yourself in Google Ads, splitting traffic between a test arm and a control arm.
 
 **Duration.** Two to four weeks.
 
@@ -107,7 +107,7 @@ Alternate weeks of campaign on and off. Compare on-weeks to off-weeks.
 
 | Constraint | Recommended method |
 |---|---|
-| Single platform, want quick answer | Platform-native (ghost bidding for Google, conversion lift for Meta) |
+| Single platform, want quick answer | Platform-native (Conversion Lift or Experiments for Google, Conversion Lift for Meta) |
 | Cross-platform incremental test | Geo holdout |
 | Small account, limited budget | Geo holdout in two small matched markets |
 | Long campaign cycle, steady-state | Switchback |

--- a/dist/pi/.agents/skills/ads-performance-analytics/references/metric-definitions-glossary.md
+++ b/dist/pi/.agents/skills/ads-performance-analytics/references/metric-definitions-glossary.md
@@ -64,7 +64,7 @@ The point of an explicit glossary. Two teams using the same metric name often co
 
 **CTR (click-through rate).** Clicks divided by impressions. Formula: `clicks / impressions`. Useful for hook quality. Less useful for conversion quality; high CTR with low conversion rate means the hook is too aggressive for the offer.
 
-**Hide ratio (negative feedback).** Count of users who explicitly hid or marked the ad as not-interested, divided by impressions. Above 1.5% is the alarm; the platform algorithm will throttle delivery to that audience.
+**Hide ratio (negative feedback).** Count of users who explicitly hid or marked the ad as not-interested, divided by impressions. Meta does not expose this as a column; it folds the signal into Quality ranking (above average, average, below average). Read the platform's own quality signal rather than a fixed percentage threshold.
 
 **Engagement rate.** Likes plus comments plus shares plus saves divided by impressions. Useful for organic-style content; less directly tied to performance for paid.
 

--- a/dist/pi/.agents/skills/ads-performance-analytics/references/platform-reporting-quirks.md
+++ b/dist/pi/.agents/skills/ads-performance-analytics/references/platform-reporting-quirks.md
@@ -36,7 +36,7 @@ Per-platform reporting behaviors that affect how to read the numbers. The platfo
 
 **Frequency reporting at the ad set level.** Meta exposes frequency in the Ads Manager. Use it as the primary fatigue signal; CTR decay is downstream of frequency rising.
 
-**Negative feedback rate.** Meta exposes "negative feedback rate" as a customizable column. Above 1.5% is the alarm; the algorithm penalizes high-feedback creatives by reducing reach.
+**Quality ranking.** Meta does not expose a standalone "negative feedback rate" column. Hide and report signals are folded into Quality ranking (above average, average, below average) and into account quality. Read Quality ranking; there is no percentage threshold to read instead.
 
 ---
 
@@ -60,7 +60,7 @@ Per-platform reporting behaviors that affect how to read the numbers. The platfo
 
 **Default attribution.** 7-day click and 1-day view-through, similar to Meta.
 
-**Video-completion-based attribution.** TikTok counts conversions even when the user did not click but watched the full video. This is unique among the platforms covered here. The signal is real for awareness; it inflates direct-response numbers.
+**Engaged view-through attribution (EVTA).** TikTok counts conversions when the user did not click but watched at least 6 seconds, or the full duration for videos shorter than 6 seconds, within a window of up to 7 days. The signal is real for awareness; it inflates direct-response numbers.
 
 **iOS impact, less mature modeling.** TikTok faces similar ATT-driven tracking gaps as Meta. The modeling is less mature, which means iOS-heavy audiences see more under-reporting on TikTok than on Meta.
 

--- a/dist/pi/.agents/skills/paid-media-strategy/SKILL.md
+++ b/dist/pi/.agents/skills/paid-media-strategy/SKILL.md
@@ -112,8 +112,6 @@ Bid strategy depends on data state. New campaigns need a different strategy than
 
 **Maximum Conversion Value.** Like maximize conversions but optimizes for total revenue, not count. Use when high-value conversions are the goal and you have the conversion-value data wired in.
 
-**Enhanced CPC.** Manual CPC with platform adjustments. Hybrid; rarely the right answer because it muddies the signal.
-
 The progression for new campaigns: start manual or maximize conversions to gather data, switch to tCPA or tROAS once you have 30+ conversions, revisit periodically.
 
 Common mistakes. Using tCPA before you have 30+ conversions (no data to optimize against). Setting tROAS too aggressively (platform throttles delivery). Switching strategies too often (each change resets the learning phase). Detail in [`references/bid-strategy-reference.md`](references/bid-strategy-reference.md).
@@ -124,11 +122,11 @@ Common mistakes. Using tCPA before you have 30+ conversions (no data to optimize
 
 For each major platform, the campaign types and when to use them.
 
-**Google Ads.** Search, Shopping, Performance Max, Display, Video (YouTube), Demand Gen, Discovery, App. Search for direct demand capture. PMax for catalog-driven e-commerce. Display for retargeting. Video for awareness or consideration.
+**Google Ads.** Search, Shopping, Performance Max, Display, Video (YouTube), Demand Gen, App. Search for direct demand capture. PMax for catalog-driven e-commerce. Display for retargeting. Video for awareness or consideration.
 
 **Meta.** Sales, Leads, Engagement, Awareness, Traffic, App Promotion. Sales for direct response. Awareness for brand at scale. Leads for B2B with native lead forms.
 
-**LinkedIn.** Sponsored Content, Message Ads, Conversation Ads, Lead Gen Forms. Format types: Single Image, Carousel, Video. Lead Gen Forms convert hardest because they pre-fill from LinkedIn profile data. Message Ads have stigma in many B2B segments; use carefully.
+**LinkedIn.** Sponsored Content, Conversation Ads, Lead Gen Forms. Format types: Single Image, Carousel, Video. Lead Gen Forms convert hardest because they pre-fill from LinkedIn profile data. Sponsored messaging cannot target EU members, so Conversation Ads are non-EU only.
 
 **TikTok.** In-Feed, TopView, Spark Ads, Branded Hashtag Challenge. Spark Ads (boost organic posts) outperform pure paid creative because they retain organic-feel signal. Use Spark when you have organic posts performing.
 

--- a/dist/pi/.agents/skills/paid-media-strategy/references/ads-platform-comparison.md
+++ b/dist/pi/.agents/skills/paid-media-strategy/references/ads-platform-comparison.md
@@ -60,7 +60,7 @@ The platforms do not agree on what counts as a conversion or how long a click sh
 **Conversion windows.** Adjustable. TikTok also supports a "video view" event that is unique to the platform.
 
 **Quirks to know.**
-- Video-completion-based attribution: TikTok counts conversions even when the user did not click but watched the full video. This is real signal for awareness; it inflates direct-response numbers.
+- Engaged view-through attribution (EVTA): TikTok counts conversions when the user did not click but watched at least 6 seconds (or the full duration for videos shorter than 6 seconds), within a window of up to 7 days. This is real signal for awareness; it inflates direct-response numbers.
 - iOS impact similar to Meta but less mature in the modeling.
 - Spark Ads attribution is shared between paid and organic. The same view that drove a conversion shows up in both surfaces; be careful not to double-count when reconciling.
 

--- a/dist/pi/.agents/skills/paid-media-strategy/references/bid-strategy-reference.md
+++ b/dist/pi/.agents/skills/paid-media-strategy/references/bid-strategy-reference.md
@@ -66,15 +66,13 @@ The decision shape. Bid strategy depends on data state. New campaigns need a dif
 
 ---
 
-## Enhanced CPC
+## Enhanced CPC (retired)
 
 **Definition.** Manual CPC with platform adjustments based on conversion likelihood.
 
-**When to use.** Rarely. The hybrid muddies the signal. If you want manual control, run pure manual CPC. If you want automation, graduate to Maximize Conversions or tCPA.
+**Status.** Retired. Google stopped accepting new Enhanced CPC campaigns in October 2024 and migrated the remaining Search and Display campaigns to Manual CPC in March 2025. You cannot select it today.
 
-**When not to use.** Most situations. The hybrid is a transitional state from a previous platform default; modern campaigns should pick a clear strategy.
-
-**Common mistakes.** Treating Enhanced CPC as the safe default. It is neither full control nor full automation; the worst of both.
+**What to use instead.** Manual CPC if you want control. Maximize Conversions or Maximum Conversion Value if you want automation.
 
 ---
 

--- a/dist/pi/.agents/skills/paid-media-strategy/references/campaign-type-reference.md
+++ b/dist/pi/.agents/skills/paid-media-strategy/references/campaign-type-reference.md
@@ -54,11 +54,11 @@ Per-platform campaign type guide. For each campaign type: what it is, when it fi
 
 **Pitfalls.** Newer campaign type with less optimization history; results are more volatile than Search or Shopping. Treat as a tested channel.
 
-### Discovery
+### Discovery (retired)
 
-**What it is.** Visual ads across Google's discovery surfaces. Being merged with Demand Gen.
+**What it was.** Visual ads across Google's discovery surfaces.
 
-**When to use.** Largely deprecated in favor of Demand Gen. Migrate existing Discovery campaigns.
+**Status.** Retired. Google force-upgraded every Discovery campaign to Demand Gen between January and March 2024. Discovery no longer exists as a campaign type. Use Demand Gen.
 
 ### App
 
@@ -132,13 +132,11 @@ Per-platform campaign type guide. For each campaign type: what it is, when it fi
 
 **Pitfalls.** High floor (CPM 5 to 10x consumer platforms). Justify with B2B LTV; otherwise unprofitable.
 
-### Message Ads
+### Message Ads (retired)
 
-**What it is.** Direct messages delivered via LinkedIn InMail.
+**What it was.** Direct messages delivered via LinkedIn InMail.
 
-**When to use.** High-intent B2B nudges where the message reads as a personal note.
-
-**Pitfalls.** Stigma in many segments. Treated as spam if the message reads generic. Personalize aggressively or skip.
+**Status.** Retired. LinkedIn phased Message Ads out between May and July 2023 in favor of Conversation Ads. Sponsored messaging has also been blocked for EU targeting since December 2021 under the ePrivacy ruling, so Conversation Ads are non-EU only.
 
 ### Conversation Ads
 

--- a/skills/ads-creative-development/SKILL.md
+++ b/skills/ads-creative-development/SKILL.md
@@ -134,7 +134,7 @@ Fatigue is real. The same audience seeing the same creative six times a week tun
 2. **CTR declining 30%+ week over week.** The creative is no longer fresh to the audience.
 3. **CPM increasing without audience saturation explanation.** The platform is having to bid harder to deliver impressions because engagement signals are weakening.
 4. **Negative comments increasing.** A direct user signal that the audience is irritated.
-5. **Hide ratio increasing.** Meta exposes this as "negative feedback rate." TikTok exposes "not interested" rate.
+5. **Quality ranking dropping.** Meta folds hide and report signals into Quality ranking (above average, average, below average) rather than exposing a negative-feedback-rate column. TikTok exposes "not interested" rate.
 
 Refresh cadence. Weekly for high-spend campaigns ($50K+/month). Biweekly for medium spend. Monthly for low spend. The economics: producing a fresh variant is cheaper than running tired creative for one extra week.
 
@@ -164,11 +164,11 @@ Each platform has native norms. Violating them tanks performance. The fix is pro
 
 **Meta (Facebook plus Instagram).** In-feed visual hierarchy. Captions on by default (most users watch sound-off). Native-feeling production beats studio production for direct response. Vertical 9:16 for Reels and Stories; 1:1 or 4:5 for in-feed. CTAs above the fold or in first 2 lines of caption.
 
-**TikTok.** Vertical 9:16 only. Native-creator aesthetic; phone-shot is the default. Fast cuts every 1 to 2 seconds. Captions for accessibility. Music-driven; trending sounds compound reach but expire fast. Spark Ads (boost an existing organic post) consistently outperform pure paid because they retain organic engagement signal.
+**TikTok.** Vertical 9:16 recommended, with 1:1 and 16:9 also accepted. Native-creator aesthetic; phone-shot is the default. Fast cuts every 1 to 2 seconds. Captions for accessibility. Music-driven; trending sounds compound reach but expire fast. Spark Ads (boost an existing organic post) consistently outperform pure paid because they retain organic engagement signal.
 
 **LinkedIn.** Professional tone. Slower pacing tolerated; B2B audiences are in research mode rather than scroll mode. B2B vocabulary is fine; consumer-style copy reads as off-platform. Thought leadership angle works; product pitches feel salesy.
 
-**Google Search.** Text-only headlines plus descriptions. Character limits are real constraints (30-character headlines, 90-character descriptions). RSA (Responsive Search Ads) optimization rewards 15+ headline variations and 4+ descriptions; the platform mixes them.
+**Google Search.** Text-only headlines plus descriptions. Character limits are real constraints (30-character headlines, 90-character descriptions). RSA (Responsive Search Ads) optimization rewards filling all 15 headline slots and all 4 descriptions, which are the platform caps; the platform mixes them.
 
 **Google Display and YouTube.** Depends on placement. YouTube allows longer narrative (15s to 6m); Display is fast banner-style. Skippable YouTube ads need to earn the next second of attention; non-skippable annoys.
 

--- a/skills/ads-creative-development/references/fatigue-detection-checklist.md
+++ b/skills/ads-creative-development/references/fatigue-detection-checklist.md
@@ -48,13 +48,13 @@ The principle. Creative fatigue is a real economic cost. The tired ad still spen
 
 **Action.** Pull the creative within 24 hours. Negative comments compound; the audience that complains often is the audience that complains to friends.
 
-### 5. Hide ratio (negative feedback) increasing
+### 5. Quality ranking dropping (negative feedback)
 
-**Threshold.** Meta exposes "negative feedback rate"; trigger refresh when it exceeds 1.5% of impressions or rises 50% week over week.
+**Threshold.** Meta does not expose a negative-feedback-rate column. Hide and report signals surface through Quality ranking (above average, average, below average). Trigger refresh when Quality ranking falls to below average.
 
 **Why it matters.** Hide is a stronger signal than scroll-past. The audience is actively rejecting the ad. Platform algorithms penalize creatives with high hide ratios by reducing reach.
 
-**Where to check.** Meta Ads Manager: customize columns to expose negative feedback. Other platforms: less direct equivalents (TikTok "not interested" rate is similar).
+**Where to check.** Meta Ads Manager: the Quality ranking column at the ad level. Other platforms: less direct equivalents (TikTok "not interested" rate is similar).
 
 **Action.** Pull the creative immediately. The cost is real: the platform will deliver less of all your ads to that audience as it learns to weight negative signals.
 

--- a/skills/ads-creative-development/references/platform-creative-norms.md
+++ b/skills/ads-creative-development/references/platform-creative-norms.md
@@ -24,7 +24,7 @@ Per-platform creative requirements and unwritten conventions. Each platform has 
 
 ## TikTok
 
-**Aspect ratios.** 9:16 vertical only. Anything else is rejected by the algorithm.
+**Aspect ratios.** TikTok Ads Manager accepts 9:16, 1:1, and 16:9. 9:16 vertical is the recommended default.
 
 **Length.** 15 to 30 seconds for performance. The platform tolerates and rewards longer dwell than Meta.
 
@@ -42,7 +42,7 @@ Per-platform creative requirements and unwritten conventions. Each platform has 
 
 ## LinkedIn
 
-**Aspect ratios.** 1:1 or 16:9 for feed. 9:16 vertical works for Stories but Stories has limited reach on LinkedIn relative to other platforms.
+**Aspect ratios.** 1:1 or 16:9 for feed.
 
 **Length.** 15 to 60 seconds. Slower pacing tolerated; B2B audiences are in research mode rather than scroll mode. 30 seconds is a strong default.
 
@@ -64,7 +64,7 @@ Per-platform creative requirements and unwritten conventions. Each platform has 
 
 **Character limits.** Headlines 30 characters; 15 headline variants for RSA. Descriptions 90 characters; 4 description variants. Path 1 and Path 2 in the display URL: 15 characters each.
 
-**RSA optimization.** Provide 15+ headline variants and 4 description variants. The platform mixes them. More variants give the platform more material to optimize against.
+**RSA optimization.** Provide the full 15 headline variants and 4 description variants. Those are the platform caps, not floors. The platform mixes them; filling every slot gives it the most material to optimize against.
 
 **Voice.** Direct. Specific. Action-led. The search query is high-intent; the ad's job is to confirm the user is in the right place.
 
@@ -86,7 +86,7 @@ Per-platform creative requirements and unwritten conventions. Each platform has 
 
 ### YouTube
 
-**Format.** Skippable video ads (TrueView), non-skippable, bumper (6s), in-feed video.
+**Format.** Skippable in-stream, non-skippable in-stream, bumper (6s), in-feed video.
 
 **Length.** Skippable: 15s to 6m. Non-skippable: 15s. Bumper: 6s.
 

--- a/skills/ads-performance-analytics/SKILL.md
+++ b/skills/ads-performance-analytics/SKILL.md
@@ -168,7 +168,7 @@ Four methods.
 
 **Geo holdout.** Hold one region out from the campaign. Measure the difference in conversions between the holdout region and the matched test region. The cleanest causal test for paid media at scale.
 
-**Ghost bidding (Google).** Google's own incrementality tool. Bids on a holdout share of impressions but does not actually serve the ad. Reports incremental conversions. Honest signal; some teams find the math opaque.
+**Conversion Lift and Experiments (Google).** "Ghost bidding" is a term from the incrementality-testing literature, not a Google Ads feature you can switch on. Google's real surfaces are Conversion Lift studies, which a Google rep enables, and geo or holdback Experiments you configure yourself.
 
 **Conversion lift studies (Meta).** Splits audiences into test and control. Test sees the ad; control does not. Reports incremental lift. The cleanest within-Meta test.
 
@@ -257,7 +257,7 @@ The output of the framework is one of three answers. Scale (the campaign is incr
 - [`references/metric-definitions-glossary.md`](references/metric-definitions-glossary.md) - CTR, CPC, CPM, CPA, ROAS, LTV, AOV, frequency, reach, impressions, conversion window, view-through, modeled conversion, blended CAC, MER.
 - [`references/attribution-model-comparison.md`](references/attribution-model-comparison.md) - Last-click, first-click, linear, time-decay, U-shaped, DDA, MMM. Decision matrix by business stage.
 - [`references/platform-reporting-quirks.md`](references/platform-reporting-quirks.md) - Google PMax black box, Meta iOS impact and Conversions API, LinkedIn 30-day click defaults, TikTok video-completion attribution, programmatic viewability gates.
-- [`references/incrementality-testing-playbook.md`](references/incrementality-testing-playbook.md) - Geo holdout, ghost bidding, conversion lift, PSA tests, switchback designs. Setup, duration, analysis pattern, expected incremental rates.
+- [`references/incrementality-testing-playbook.md`](references/incrementality-testing-playbook.md) - Geo holdout, Conversion Lift and Experiments, PSA tests, switchback designs. Setup, duration, analysis pattern, expected incremental rates.
 - [`references/dashboard-reconciliation-patterns.md`](references/dashboard-reconciliation-patterns.md) - Warehouse as canonical, platform as in-flight signal, blended CAC formula, board-deck patterns, reconciliation cadence.
 - [`references/cohort-analysis-templates.md`](references/cohort-analysis-templates.md) - By acquisition month, channel, and campaign. Retention curves, when to act on cohort signals.
 - [`references/common-interpretation-failures.md`](references/common-interpretation-failures.md) - Twelve failure patterns with symptom, root cause, fix, prevention.

--- a/skills/ads-performance-analytics/references/attribution-model-comparison.md
+++ b/skills/ads-performance-analytics/references/attribution-model-comparison.md
@@ -62,7 +62,7 @@ The principle. No model is right. They are all approximations. The discipline is
 
 **Definition.** Machine-learning model that distributes credit based on observed conversion paths. Compares paths that did and did not convert; assigns credit to touchpoints that correlate with conversion.
 
-**When it fits.** Mature accounts with sufficient conversion volume (Google requires 600+ conversions per month for DDA). Cross-channel optimization.
+**When it fits.** Cross-channel optimization. Google removed DDA's conversion-volume floors in October 2021, when DDA became the default for new conversion actions, so there is no minimum to clear.
 
 **When it does not fit.** Sub-scale accounts. Accounts that need explainability for regulators or boards. The black-box nature is hard to audit.
 

--- a/skills/ads-performance-analytics/references/incrementality-testing-playbook.md
+++ b/skills/ads-performance-analytics/references/incrementality-testing-playbook.md
@@ -34,11 +34,11 @@ The cleanest causal test for paid media at scale.
 
 ---
 
-## Method 2: Ghost bidding (Google)
+## Method 2: Conversion Lift and Experiments (Google)
 
-Google's own incrementality tool. The platform bids on a holdout share of impressions but does not actually serve the ad. The reported delta between served and ghost is incremental.
+"Ghost bids" and "ghost ads" are terms from the incrementality-testing literature for withholding an ad from users who would otherwise have seen it. They name a methodology, not a Google Ads product you can configure. Google's actual surfaces are Conversion Lift studies and geo or holdback Experiments.
 
-**Setup.** Configure within Google Ads. Choose the campaigns and the holdout share (typically 5 to 20%).
+**Setup.** Conversion Lift studies are enabled by a Google rep, not self-serve. Experiments you configure yourself in Google Ads, splitting traffic between a test arm and a control arm.
 
 **Duration.** Two to four weeks.
 
@@ -107,7 +107,7 @@ Alternate weeks of campaign on and off. Compare on-weeks to off-weeks.
 
 | Constraint | Recommended method |
 |---|---|
-| Single platform, want quick answer | Platform-native (ghost bidding for Google, conversion lift for Meta) |
+| Single platform, want quick answer | Platform-native (Conversion Lift or Experiments for Google, Conversion Lift for Meta) |
 | Cross-platform incremental test | Geo holdout |
 | Small account, limited budget | Geo holdout in two small matched markets |
 | Long campaign cycle, steady-state | Switchback |

--- a/skills/ads-performance-analytics/references/metric-definitions-glossary.md
+++ b/skills/ads-performance-analytics/references/metric-definitions-glossary.md
@@ -64,7 +64,7 @@ The point of an explicit glossary. Two teams using the same metric name often co
 
 **CTR (click-through rate).** Clicks divided by impressions. Formula: `clicks / impressions`. Useful for hook quality. Less useful for conversion quality; high CTR with low conversion rate means the hook is too aggressive for the offer.
 
-**Hide ratio (negative feedback).** Count of users who explicitly hid or marked the ad as not-interested, divided by impressions. Above 1.5% is the alarm; the platform algorithm will throttle delivery to that audience.
+**Hide ratio (negative feedback).** Count of users who explicitly hid or marked the ad as not-interested, divided by impressions. Meta does not expose this as a column; it folds the signal into Quality ranking (above average, average, below average). Read the platform's own quality signal rather than a fixed percentage threshold.
 
 **Engagement rate.** Likes plus comments plus shares plus saves divided by impressions. Useful for organic-style content; less directly tied to performance for paid.
 

--- a/skills/ads-performance-analytics/references/platform-reporting-quirks.md
+++ b/skills/ads-performance-analytics/references/platform-reporting-quirks.md
@@ -36,7 +36,7 @@ Per-platform reporting behaviors that affect how to read the numbers. The platfo
 
 **Frequency reporting at the ad set level.** Meta exposes frequency in the Ads Manager. Use it as the primary fatigue signal; CTR decay is downstream of frequency rising.
 
-**Negative feedback rate.** Meta exposes "negative feedback rate" as a customizable column. Above 1.5% is the alarm; the algorithm penalizes high-feedback creatives by reducing reach.
+**Quality ranking.** Meta does not expose a standalone "negative feedback rate" column. Hide and report signals are folded into Quality ranking (above average, average, below average) and into account quality. Read Quality ranking; there is no percentage threshold to read instead.
 
 ---
 
@@ -60,7 +60,7 @@ Per-platform reporting behaviors that affect how to read the numbers. The platfo
 
 **Default attribution.** 7-day click and 1-day view-through, similar to Meta.
 
-**Video-completion-based attribution.** TikTok counts conversions even when the user did not click but watched the full video. This is unique among the platforms covered here. The signal is real for awareness; it inflates direct-response numbers.
+**Engaged view-through attribution (EVTA).** TikTok counts conversions when the user did not click but watched at least 6 seconds, or the full duration for videos shorter than 6 seconds, within a window of up to 7 days. The signal is real for awareness; it inflates direct-response numbers.
 
 **iOS impact, less mature modeling.** TikTok faces similar ATT-driven tracking gaps as Meta. The modeling is less mature, which means iOS-heavy audiences see more under-reporting on TikTok than on Meta.
 

--- a/skills/paid-media-strategy/SKILL.md
+++ b/skills/paid-media-strategy/SKILL.md
@@ -112,8 +112,6 @@ Bid strategy depends on data state. New campaigns need a different strategy than
 
 **Maximum Conversion Value.** Like maximize conversions but optimizes for total revenue, not count. Use when high-value conversions are the goal and you have the conversion-value data wired in.
 
-**Enhanced CPC.** Manual CPC with platform adjustments. Hybrid; rarely the right answer because it muddies the signal.
-
 The progression for new campaigns: start manual or maximize conversions to gather data, switch to tCPA or tROAS once you have 30+ conversions, revisit periodically.
 
 Common mistakes. Using tCPA before you have 30+ conversions (no data to optimize against). Setting tROAS too aggressively (platform throttles delivery). Switching strategies too often (each change resets the learning phase). Detail in [`references/bid-strategy-reference.md`](references/bid-strategy-reference.md).
@@ -124,11 +122,11 @@ Common mistakes. Using tCPA before you have 30+ conversions (no data to optimize
 
 For each major platform, the campaign types and when to use them.
 
-**Google Ads.** Search, Shopping, Performance Max, Display, Video (YouTube), Demand Gen, Discovery, App. Search for direct demand capture. PMax for catalog-driven e-commerce. Display for retargeting. Video for awareness or consideration.
+**Google Ads.** Search, Shopping, Performance Max, Display, Video (YouTube), Demand Gen, App. Search for direct demand capture. PMax for catalog-driven e-commerce. Display for retargeting. Video for awareness or consideration.
 
 **Meta.** Sales, Leads, Engagement, Awareness, Traffic, App Promotion. Sales for direct response. Awareness for brand at scale. Leads for B2B with native lead forms.
 
-**LinkedIn.** Sponsored Content, Message Ads, Conversation Ads, Lead Gen Forms. Format types: Single Image, Carousel, Video. Lead Gen Forms convert hardest because they pre-fill from LinkedIn profile data. Message Ads have stigma in many B2B segments; use carefully.
+**LinkedIn.** Sponsored Content, Conversation Ads, Lead Gen Forms. Format types: Single Image, Carousel, Video. Lead Gen Forms convert hardest because they pre-fill from LinkedIn profile data. Sponsored messaging cannot target EU members, so Conversation Ads are non-EU only.
 
 **TikTok.** In-Feed, TopView, Spark Ads, Branded Hashtag Challenge. Spark Ads (boost organic posts) outperform pure paid creative because they retain organic-feel signal. Use Spark when you have organic posts performing.
 

--- a/skills/paid-media-strategy/references/ads-platform-comparison.md
+++ b/skills/paid-media-strategy/references/ads-platform-comparison.md
@@ -60,7 +60,7 @@ The platforms do not agree on what counts as a conversion or how long a click sh
 **Conversion windows.** Adjustable. TikTok also supports a "video view" event that is unique to the platform.
 
 **Quirks to know.**
-- Video-completion-based attribution: TikTok counts conversions even when the user did not click but watched the full video. This is real signal for awareness; it inflates direct-response numbers.
+- Engaged view-through attribution (EVTA): TikTok counts conversions when the user did not click but watched at least 6 seconds (or the full duration for videos shorter than 6 seconds), within a window of up to 7 days. This is real signal for awareness; it inflates direct-response numbers.
 - iOS impact similar to Meta but less mature in the modeling.
 - Spark Ads attribution is shared between paid and organic. The same view that drove a conversion shows up in both surfaces; be careful not to double-count when reconciling.
 

--- a/skills/paid-media-strategy/references/bid-strategy-reference.md
+++ b/skills/paid-media-strategy/references/bid-strategy-reference.md
@@ -66,15 +66,13 @@ The decision shape. Bid strategy depends on data state. New campaigns need a dif
 
 ---
 
-## Enhanced CPC
+## Enhanced CPC (retired)
 
 **Definition.** Manual CPC with platform adjustments based on conversion likelihood.
 
-**When to use.** Rarely. The hybrid muddies the signal. If you want manual control, run pure manual CPC. If you want automation, graduate to Maximize Conversions or tCPA.
+**Status.** Retired. Google stopped accepting new Enhanced CPC campaigns in October 2024 and migrated the remaining Search and Display campaigns to Manual CPC in March 2025. You cannot select it today.
 
-**When not to use.** Most situations. The hybrid is a transitional state from a previous platform default; modern campaigns should pick a clear strategy.
-
-**Common mistakes.** Treating Enhanced CPC as the safe default. It is neither full control nor full automation; the worst of both.
+**What to use instead.** Manual CPC if you want control. Maximize Conversions or Maximum Conversion Value if you want automation.
 
 ---
 

--- a/skills/paid-media-strategy/references/campaign-type-reference.md
+++ b/skills/paid-media-strategy/references/campaign-type-reference.md
@@ -54,11 +54,11 @@ Per-platform campaign type guide. For each campaign type: what it is, when it fi
 
 **Pitfalls.** Newer campaign type with less optimization history; results are more volatile than Search or Shopping. Treat as a tested channel.
 
-### Discovery
+### Discovery (retired)
 
-**What it is.** Visual ads across Google's discovery surfaces. Being merged with Demand Gen.
+**What it was.** Visual ads across Google's discovery surfaces.
 
-**When to use.** Largely deprecated in favor of Demand Gen. Migrate existing Discovery campaigns.
+**Status.** Retired. Google force-upgraded every Discovery campaign to Demand Gen between January and March 2024. Discovery no longer exists as a campaign type. Use Demand Gen.
 
 ### App
 
@@ -132,13 +132,11 @@ Per-platform campaign type guide. For each campaign type: what it is, when it fi
 
 **Pitfalls.** High floor (CPM 5 to 10x consumer platforms). Justify with B2B LTV; otherwise unprofitable.
 
-### Message Ads
+### Message Ads (retired)
 
-**What it is.** Direct messages delivered via LinkedIn InMail.
+**What it was.** Direct messages delivered via LinkedIn InMail.
 
-**When to use.** High-intent B2B nudges where the message reads as a personal note.
-
-**Pitfalls.** Stigma in many segments. Treated as spam if the message reads generic. Personalize aggressively or skip.
+**Status.** Retired. LinkedIn phased Message Ads out between May and July 2023 in favor of Conversation Ads. Sponsored messaging has also been blocked for EU targeting since December 2021 under the ePrivacy ruling, so Conversation Ads are non-EU only.
 
 ### Conversation Ads
 


### PR DESCRIPTION
**Wave 1, PR b** of the currency-fix plan in `third-party-currency-inventory-2026-08.md` §6. Mechanical corrections only, no authorial rulings. Held as a draft: Andy merges W1-a through W1-e in order.

Scope is the ads cluster: `paid-media-strategy`, `ads-creative-development`, `ads-performance-analytics` and their references. 12 source files, 21 line-level edits. Every verdict in this PR carries **check date 2026-08-09** and comes from Appendix C5 (verifier V5) unless noted.

---

## Retired surfaces

### R11. Enhanced CPC

**Before** (`paid-media-strategy/SKILL.md:115`)
```
**Enhanced CPC.** Manual CPC with platform adjustments. Hybrid; rarely the right answer because it muddies the signal.
```
**After** — line deleted from the live bid-strategy list.

**Before** (`references/bid-strategy-reference.md:69-77`)
```
## Enhanced CPC
...
**When to use.** Rarely. The hybrid muddies the signal. ...
**When not to use.** Most situations. The hybrid is a transitional state from a previous platform default; ...
**Common mistakes.** Treating Enhanced CPC as the safe default. ...
```
**After**
```
## Enhanced CPC (retired)
...
**Status.** Retired. Google stopped accepting new Enhanced CPC campaigns in October 2024 and migrated the remaining Search and Display campaigns to Manual CPC in March 2025. You cannot select it today.

**What to use instead.** Manual CPC if you want control. Maximize Conversions or Maximum Conversion Value if you want automation.
```
**Verdict row** (§2.1 R11, RETIRED)
> eCPC removed: no new campaigns from Oct 2024; all remaining Search/Display campaigns migrated to Manual CPC week of March 31, 2025. RETIRED, replacement: Manual CPC or Maximize Conversions/Value. Sources: searchengineland.com/google-ads-deprecate-enhanced-cpc-search-display-446350 ; seroundtable.com/google-ads-to-sunset-enhanced-cpc-38033.html

Kept as a marked-retired section rather than deleted: a reader looking the strategy up in a per-strategy catalog needs to learn it is gone, not find nothing.

### R12. Google Discovery campaigns

**Before** (`paid-media-strategy/SKILL.md:127`)
```
**Google Ads.** Search, Shopping, Performance Max, Display, Video (YouTube), Demand Gen, Discovery, App.
```
**After**
```
**Google Ads.** Search, Shopping, Performance Max, Display, Video (YouTube), Demand Gen, App.
```
**Before** (`references/campaign-type-reference.md:57-61`)
```
### Discovery
**What it is.** Visual ads across Google's discovery surfaces. Being merged with Demand Gen.
**When to use.** Largely deprecated in favor of Demand Gen. Migrate existing Discovery campaigns.
```
**After**
```
### Discovery (retired)
**What it was.** Visual ads across Google's discovery surfaces.
**Status.** Retired. Google force-upgraded every Discovery campaign to Demand Gen between January and March 2024. Discovery no longer exists as a campaign type. Use Demand Gen.
```
**Verdict row** (§2.1 R12, RETIRED)
> All Discovery campaigns force-upgraded to Demand Gen Jan-Mar 2024. RETIRED, Discovery no longer exists as a campaign type; replacement: Demand Gen. Sources: searchengineland.com/google-demand-gen-beta-upgrade-discovery-ads-430734 ; blog.google/products/ads-commerce/google-display-ads-demand-gen/

"Being merged" was already hedged in the old text. The merge finished two years ago.

### R14. LinkedIn Message Ads

**Before** (`paid-media-strategy/SKILL.md:131`)
```
**LinkedIn.** Sponsored Content, Message Ads, Conversation Ads, Lead Gen Forms. ... Message Ads have stigma in many B2B segments; use carefully.
```
**After**
```
**LinkedIn.** Sponsored Content, Conversation Ads, Lead Gen Forms. ... Sponsored messaging cannot target EU members, so Conversation Ads are non-EU only.
```
**Before** (`references/campaign-type-reference.md:135-141`)
```
### Message Ads
**What it is.** Direct messages delivered via LinkedIn InMail.
**When to use.** High-intent B2B nudges where the message reads as a personal note.
**Pitfalls.** Stigma in many segments. Treated as spam if the message reads generic. Personalize aggressively or skip.
```
**After**
```
### Message Ads (retired)
**What it was.** Direct messages delivered via LinkedIn InMail.
**Status.** Retired. LinkedIn phased Message Ads out between May and July 2023 in favor of Conversation Ads. Sponsored messaging has also been blocked for EU targeting since December 2021 under the ePrivacy ruling, so Conversation Ads are non-EU only.
```
**Verdict row** (§2.1 R14, RETIRED)
> Message Ads phased out May-July 2023 in favor of Conversation/Conversation-Starter Ads; sponsored messaging blocked for EU targeting since Dec 2021 (ePrivacy ruling). RETIRED, replacement: Conversation Ads (non-EU only). Sources: taksudigital.com/blog/linkedin-discontinuing-inmail-message-ads ; sprinklr.com EU member targeting restrictions for LinkedIn

### R13. LinkedIn Stories

**Before** (`ads-creative-development/references/platform-creative-norms.md:45`)
```
**Aspect ratios.** 1:1 or 16:9 for feed. 9:16 vertical works for Stories but Stories has limited reach on LinkedIn relative to other platforms.
```
**After**
```
**Aspect ratios.** 1:1 or 16:9 for feed.
```
**Verdict row** (§2.1 R13, RETIRED)
> LinkedIn Stories was shut down Sept 30, 2021 (low usage; pivot to short-form video). RETIRED, remove; no Stories surface exists on LinkedIn. Source: techcrunch.com/2021/08/31/linkedin-is-scrapping-its-stories-feature-to-work-on-short-form-video

The old line advised a ratio for a surface that has not existed for five years.

### R15. YouTube "TrueView"

**Before** (`platform-creative-norms.md:89`)
```
**Format.** Skippable video ads (TrueView), non-skippable, bumper (6s), in-feed video.
```
**After**
```
**Format.** Skippable in-stream, non-skippable in-stream, bumper (6s), in-feed video.
```
**Verdict row** (§2.1 R15, RETIRED (name))
> Google retired the TrueView name; formats are now "skippable in-stream" / "non-skippable in-stream". Format itself lives on. RETIRED (name), use "skippable in-stream ads". Source: marketing-interactive.com/youtube-renames-in-stream-ad-format-to-skippable-ads-after-claims-it-misled-advertisers

---

## Corrected platform facts

### S12. Google DDA "600+ conversions/month"

**Before** (`ads-performance-analytics/references/attribution-model-comparison.md:65`)
```
**When it fits.** Mature accounts with sufficient conversion volume (Google requires 600+ conversions per month for DDA). Cross-channel optimization.
```
**After**
```
**When it fits.** Cross-channel optimization. Google removed DDA's conversion-volume floors in October 2021, when DDA became the default for new conversion actions, so there is no minimum to clear.
```
**Verdict row** (§2.2 S12, STALE)
> DDA data-eligibility floors were reduced then removed entirely in Oct 2021, when DDA became the default for new conversion actions; no volume requirement exists. Sources: blog.google/products/ads-commerce/data-driven-attribution-new-default/ ; jumpfly.com/blog/google-data-driven-attribution/

This one gated readers out of a model that is on by default.

### S13. TikTok attribution and aspect ratios

**Before** (`ads-performance-analytics/references/platform-reporting-quirks.md:63`)
```
**Video-completion-based attribution.** TikTok counts conversions even when the user did not click but watched the full video. This is unique among the platforms covered here. ...
```
**After**
```
**Engaged view-through attribution (EVTA).** TikTok counts conversions when the user did not click but watched at least 6 seconds, or the full duration for videos shorter than 6 seconds, within a window of up to 7 days. ...
```
Same correction applied at `paid-media-strategy/references/ads-platform-comparison.md:63`.

**Verdict row** (§2.2 S13, STALE)
> TikTok's Engaged View-Through Attribution (EVTA) credits a 6-second view (or full duration only for videos shorter than 6s), window up to 7 days. STALE, correct to 6-second engaged view (EVTA). Source: ads.tiktok.com/help/article/about-engaged-view-through-attribution

**Before** (`platform-creative-norms.md:27`)
```
**Aspect ratios.** 9:16 vertical only. Anything else is rejected by the algorithm.
```
**After**
```
**Aspect ratios.** TikTok Ads Manager accepts 9:16, 1:1, and 16:9. 9:16 vertical is the recommended default.
```
Same correction at `ads-creative-development/SKILL.md:167` ("Vertical 9:16 only" to "Vertical 9:16 recommended, with 1:1 and 16:9 also accepted").

**Verdict row** (§2.2 S13, STALE)
> TikTok Ads Manager accepts 9:16, 1:1, and 16:9 video (9:16 recommended). STALE, 9:16 is best practice, not a hard requirement. Sources: descript.com/blog/article/tiktok-video-size ; ads.tiktok.com creative specs

"Rejected by the algorithm" was the load-bearing falsehood: it told teams to discard usable assets.

### S14. Meta "negative feedback rate" and the 1.5% threshold

**Before** (`ads-performance-analytics/references/platform-reporting-quirks.md:39`)
```
**Negative feedback rate.** Meta exposes "negative feedback rate" as a customizable column. Above 1.5% is the alarm; the algorithm penalizes high-feedback creatives by reducing reach.
```
**After**
```
**Quality ranking.** Meta does not expose a standalone "negative feedback rate" column. Hide and report signals are folded into Quality ranking (above average, average, below average) and into account quality. Read Quality ranking; there is no percentage threshold to read instead.
```
**Before** (`ads-creative-development/references/fatigue-detection-checklist.md:51-57`)
```
### 5. Hide ratio (negative feedback) increasing
**Threshold.** Meta exposes "negative feedback rate"; trigger refresh when it exceeds 1.5% of impressions or rises 50% week over week.
...
**Where to check.** Meta Ads Manager: customize columns to expose negative feedback. ...
```
**After**
```
### 5. Quality ranking dropping (negative feedback)
**Threshold.** Meta does not expose a negative-feedback-rate column. Hide and report signals surface through Quality ranking (above average, average, below average). Trigger refresh when Quality ranking falls to below average.
...
**Where to check.** Meta Ads Manager: the Quality ranking column at the ad level. ...
```
Also corrected at `ads-creative-development/SKILL.md:137` and `ads-performance-analytics/references/metric-definitions-glossary.md:67`.

**Verdict row** (§2.2 S14, STALE)
> Meta Ads Manager does not expose a standalone "negative feedback rate" column; hide/report signals are folded into Quality ranking (above/average/below) and account quality. The 1.5% threshold has no platform surface to read it from. STALE, correct to Quality ranking; threshold unactionable as written. Sources: facebook.com/business/help/303639570334185 ; wittelsbach.ai/post/what-is-quality-ranking-in-meta-ads-above-average-average-below-average-explained

Four files told the reader to watch a column that does not exist and act on a number they cannot obtain.

### S15. "Ghost bidding" as a Google Ads product

**Before** (`ads-performance-analytics/SKILL.md:171`)
```
**Ghost bidding (Google).** Google's own incrementality tool. Bids on a holdout share of impressions but does not actually serve the ad. Reports incremental conversions. Honest signal; some teams find the math opaque.
```
**After**
```
**Conversion Lift and Experiments (Google).** "Ghost bidding" is a term from the incrementality-testing literature, not a Google Ads feature you can switch on. Google's real surfaces are Conversion Lift studies, which a Google rep enables, and geo or holdback Experiments you configure yourself.
```
**Before** (`references/incrementality-testing-playbook.md:37-41`)
```
## Method 2: Ghost bidding (Google)
Google's own incrementality tool. The platform bids on a holdout share of impressions but does not actually serve the ad. ...
**Setup.** Configure within Google Ads. Choose the campaigns and the holdout share (typically 5 to 20%).
```
**After**
```
## Method 2: Conversion Lift and Experiments (Google)
"Ghost bids" and "ghost ads" are terms from the incrementality-testing literature for withholding an ad from users who would otherwise have seen it. They name a methodology, not a Google Ads product you can configure. Google's actual surfaces are Conversion Lift studies and geo or holdback Experiments.
**Setup.** Conversion Lift studies are enabled by a Google rep, not self-serve. Experiments you configure yourself in Google Ads, splitting traffic between a test arm and a control arm.
```
**Verdict row** (§2.2 S15, STALE)
> "Ghost bids/ghost ads" is an incrementality-testing methodology term, not a self-serve Google Ads feature; Google's actual tools are Conversion Lift studies (rep-enabled) and geo/holdback Experiments. STALE, mischaracterized; no configurable "ghost bidding" product in Google Ads. Source: remerge.io/blog-post/incrementality-tests-101-intent-to-treat-psa-ghost-ads-and-ghost-bids

The old "Setup" step was unrunnable: it told the reader to configure a product that does not exist. Two downstream mentions were swept with it (`SKILL.md:260` reference blurb, `incrementality-testing-playbook.md:110` decision table).

### RSA headline and description caps

**Before** (`platform-creative-norms.md:67`)
```
**RSA optimization.** Provide 15+ headline variants and 4 description variants. ...
```
**After**
```
**RSA optimization.** Provide the full 15 headline variants and 4 description variants. Those are the platform caps, not floors. ...
```
Same correction at `ads-creative-development/SKILL.md:171`.

**Verdict row** (§2.2, STALE)
> RSA hard caps are exactly 15 headlines (30 chars) and 4 descriptions (90 chars). "15+"/"4+" exceeds the platform maximum. STALE, phrasing impossible; caps are 15/4 (the reference file's exact numbers at platform-creative-norms.md:65 are CURRENT). Source: support.google.com/google-ads/answer/7684791

Note the verdict explicitly confirms `platform-creative-norms.md:65` is already correct, so that line is untouched.

---

## Deliberately left alone

- **`ads-performance-analytics` description frontmatter** still lists `ghost bidding` among its trigger phrases. That is a search term readers actually type, not a factual claim, and no verdict row covers it. Touching descriptions would also re-open the cap check that Wave A (#111) just settled.
- **`campaign-type-reference.md:147`** ("run them as glorified Message Ads") keeps the phrase as a comparison. The retired-status block sits directly above it, and no verdict row covers this line.
- **Unsourced platform benchmarks** in this cluster (GA overcount multipliers, incrementality ranges, LinkedIn CPM multiples) are classed UNVERIFIABLE, not STALE, and belong to Wave 2 ruling **R-8**, not here.

---

## Checks

Run locally against this branch, all green:

| Check | Command | Result |
|---|---|---|
| Skills manifest | `tools/gen_skills_lock.py --check` | `SKILLS.lock is current.` |
| Distribution drift | `node scripts/build-pi.mjs --check` | `PASS: committed dist/pi/.agents/skills matches a fresh build (byte-identical).` |
| Distribution validate | `node scripts/build-pi.mjs --validate` | `VALIDATION PASS` (490 reference files) |
| Skill linter | `.github/scripts/lint_skills.py` | `PASSED: 103 skills validated, 1 warnings.` |

The single linter warning is pre-existing and unrelated (`documentation-strategy/SKILL.md` is 428 lines against a 400-line target). It is present on `main` and untouched here.

`SKILLS.lock` moves for exactly the 12 edited files across the three skills. `dist/pi` is rebuilt in the same commit, as `dist-drift.yml` requires.

**Merge-order note.** This PR overlaps W1-a, W1-c, W1-d, W1-e and the Wave 3 anti-fabrication PR only in `SKILLS.lock` and `dist/pi`. Whichever merges second rebases and **regenerates both** (`py tools/gen_skills_lock.py` then `node scripts/build-pi.mjs`) rather than hand-merging either file.

**Writing law:** no em dashes introduced; replacements are declarative and name the current surface.

**Negative-claim audit:** every factual assertion added here (the migration dates, the EVTA 6-second window, the accepted TikTok ratios, Quality ranking's three values, the rep-enabled nature of Conversion Lift, the 15/4 RSA caps) is quoted from a verdict row above. Nothing asserts a fact the inventory did not verify on 2026-08-09.
