### PR TITLE
fix(skills): drop dead privacy signals and fix two product names (W1-c)

### DIFF
--- a/SKILLS.lock
+++ b/SKILLS.lock
@@ -43,7 +43,7 @@
   },
   "analytics-strategy": {
     "SKILL.md": "111bcd57af348b778dfc2e8801b79f79c83a5bfdea28da670113a3c9437e6cb4",
-    "references/event-taxonomy-template.md": "74bea752cf246b3c5c73a9597554c9786ae8836b627541708ca2f0d676adb8e4"
+    "references/event-taxonomy-template.md": "04ab0efbc566f2ee8e33f8e2f262ba5fd7d86edc3fb23af0eaa5c85c0737d49d"
   },
   "art-direction": {
     "SKILL.md": "3444cf2c4b932665df33509e16e0dfdcd370b1507b43a2bb157fd54e391e3c8d",
@@ -155,7 +155,7 @@
     "SKILL.md": "1833c32ede91b3cc8fbda7ddc69de495c8f4bf4a6af3044d0b94c4249472efbd",
     "references/nextjs-patterns.md": "afdaa25a148693f8209a36c7e5690a7389d0e5490f61781092b9eba6d322836f",
     "references/review-template.md": "0ca48f838085ee176dc8098618aa1f8681bbc7f1c5d787464cf087f8282c2f8e",
-    "references/wordpress-headless-patterns.md": "28ebedafeccf5b3b672d23b9e0551d9ac6a61780bc709f12963cd08b3fc54b8c"
+    "references/wordpress-headless-patterns.md": "d3bb754f3208e2db38fbaade7053e90e6a0b4525745dfad83c63325b7af699e3"
   },
   "comparison-tool-design": {
     "SKILL.md": "24ce1daec98fc356616d00cf1799f2eca7b80248e980da0ad5e7a863b50b7d0e",
@@ -667,8 +667,8 @@
     "references/scheduler-decision-criteria.md": "02a4237ac2d3101ab0d84c273f9b5f22d501d530fd76d250775e311d2f403196"
   },
   "security-baseline": {
-    "SKILL.md": "8af28729093ff8a97796cba7b37db6d621e50d5d31e684baf1ba8bc98383daaf",
-    "references/headers-checklist.md": "5e24408454905148cccf616dcf3f707204e971b3e28a5ea017a13e88a76cad95"
+    "SKILL.md": "5b4bc0cd3724939b6ef8a41cd0ecc9cba2e75805087071a671739514516a0612",
+    "references/headers-checklist.md": "5ee3c6c626cd7c6dd3b85b1df1e4271d66b888f1c0d222b7e4ed11d4f7daa56e"
   },
   "seo-aeo-geo": {
     "SKILL.md": "573caeaa6d9e988fb7539bb79c397756ca7fb4645ab4f79a69d3a14017988529",

--- a/SKILLS.lock
+++ b/SKILLS.lock
@@ -667,8 +667,8 @@
     "references/scheduler-decision-criteria.md": "02a4237ac2d3101ab0d84c273f9b5f22d501d530fd76d250775e311d2f403196"
   },
   "security-baseline": {
-    "SKILL.md": "5b4bc0cd3724939b6ef8a41cd0ecc9cba2e75805087071a671739514516a0612",
-    "references/headers-checklist.md": "5ee3c6c626cd7c6dd3b85b1df1e4271d66b888f1c0d222b7e4ed11d4f7daa56e"
+    "SKILL.md": "70fe166514864d409e8cd2fae46388ab61204bd4a1c9ed00b4cf026ead14ccf5",
+    "references/headers-checklist.md": "cd659520f4b307f8c74031b3cff887a3adc2d847819e60a2d303496859a53c4e"
   },
   "seo-aeo-geo": {
     "SKILL.md": "573caeaa6d9e988fb7539bb79c397756ca7fb4645ab4f79a69d3a14017988529",
@@ -727,7 +727,7 @@
   },
   "seo-technical": {
     "SKILL.md": "8b874b2a102ac52c059f8860aae1119d36c14ecd8a63b5e7bcda7c04830d79f4",
-    "references/audit-template.md": "b7a7047ec9a46e6432bc1de45f9ec9c73d640ff5cedc1527f9715aac9b8f9829",
+    "references/audit-template.md": "1be66990a30a44f6cfac1f6cd89494d513954375571aba48782d110cabc587a6",
     "references/migration-checklist.md": "7f9a4dbdd9653d4a2d8a9c8795376562ac26545568db6f493a21c3f5bc485bb9"
   },
   "seo-traffic-diagnosis": {

--- a/dist/pi/.agents/skills/analytics-strategy/references/event-taxonomy-template.md
+++ b/dist/pi/.agents/skills/analytics-strategy/references/event-taxonomy-template.md
@@ -378,7 +378,7 @@ Common reserved names:
 Common compliance patterns:
 
 - **Consent before tracking.** Cookie banner, opt-in flow.
-- **Honor Do Not Track.** Browsers signal preferences.
+- **Honor Global Privacy Control (GPC).** Browsers signal the preference, and it is enforceable under CCPA and CPRA.
 - **Right to deletion.** User can request all their data deleted (GDPR, CCPA).
 - **Right to export.** User can request their data in machine-readable format.
 - **No cross-site tracking without consent.** Some jurisdictions require explicit opt-in.

--- a/dist/pi/.agents/skills/code-review-web/references/wordpress-headless-patterns.md
+++ b/dist/pi/.agents/skills/code-review-web/references/wordpress-headless-patterns.md
@@ -192,7 +192,7 @@ JWT plugins offer a more standard auth flow but add a plugin dependency.
 
 ### "API returns 403 from server-side fetch"
 
-**Cause 1:** A bot mitigation service (Cloudflare's "Attack Challenge Mode" or similar) is challenging the server-to-server request.
+**Cause 1:** A bot mitigation service (Cloudflare's "Under Attack mode" or similar) is challenging the server-to-server request.
 
 **Fix:** Disable bot mitigation challenges for the CMS API path, or whitelist the frontend's server IPs.
 

--- a/dist/pi/.agents/skills/security-baseline/SKILL.md
+++ b/dist/pi/.agents/skills/security-baseline/SKILL.md
@@ -252,7 +252,7 @@ When compliance applies, the baseline is necessary but not the full answer.
 
 **HSTS without `includeSubDomains`.** Attacker tricks browser into HTTP on a subdomain you haven't HTTPS'd yet.
 
-**HSTS preload without commitment.** Once preloaded, removing it takes weeks. Don't preload until HTTPS is solid across all subdomains forever.
+**HSTS preload without commitment.** Once preloaded, removing it takes months to reach users through a Chrome update, with no guarantee for other browsers. Don't preload until HTTPS is solid across all subdomains forever.
 
 **CSP with `unsafe-inline`.** Defeats most of CSP. Either go strict (nonce-based) or accept that CSP is providing limited protection.
 

--- a/dist/pi/.agents/skills/security-baseline/SKILL.md
+++ b/dist/pi/.agents/skills/security-baseline/SKILL.md
@@ -169,7 +169,7 @@ Strict CSP requires application changes (every inline script needs a nonce). The
 
 ### Step 1: Run a baseline scan
 
-Use a free scanner: securityheaders.com, observatory.mozilla.org. Get a current grade. This is the floor.
+Use a free scanner: securityheaders.com, or the MDN HTTP Observatory at developer.mozilla.org/en-US/observatory. Get a current grade. This is the floor.
 
 ### Step 2: Inventory the surface
 

--- a/dist/pi/.agents/skills/security-baseline/references/headers-checklist.md
+++ b/dist/pi/.agents/skills/security-baseline/references/headers-checklist.md
@@ -2,7 +2,7 @@
 
 Copy-paste reference for HTTP response headers that improve security. Organized by tier of importance.
 
-Test current headers with: securityheaders.com or observatory.mozilla.org.
+Test current headers with: securityheaders.com or the MDN HTTP Observatory at developer.mozilla.org/en-US/observatory.
 
 ---
 
@@ -140,8 +140,7 @@ Permissions-Policy:
   magnetometer=(),
   microphone=(),
   payment=(),
-  usb=(),
-  interest-cohort=()
+  usb=()
 ```
 
 This denies all listed features by default. Allow specific ones if needed:
@@ -149,8 +148,6 @@ This denies all listed features by default. Allow specific ones if needed:
 ```
 Permissions-Policy: camera=(self), geolocation=(self "https://maps.example.com")
 ```
-
-`interest-cohort=()` opts the site out of FLoC and similar third-party tracking.
 
 ---
 

--- a/dist/pi/.agents/skills/security-baseline/references/headers-checklist.md
+++ b/dist/pi/.agents/skills/security-baseline/references/headers-checklist.md
@@ -20,7 +20,7 @@ Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 - `max-age`: lifetime in seconds (31536000 = 1 year, recommended for stable HTTPS deployments)
 - `includeSubDomains`: applies to all subdomains. Only enable when every subdomain serves HTTPS reliably.
-- `preload`: optional. Enables inclusion in browser preload lists. Once enabled, removal takes weeks. Only add when committed.
+- `preload`: optional. Enables inclusion in browser preload lists. Once enabled, removal takes months to reach users through a Chrome update, with no guarantee for other browsers. Only add when committed.
 
 **Common mistake:** Setting `includeSubDomains` before all subdomains are HTTPS-ready. Internal staging or admin subdomains break.
 

--- a/dist/pi/.agents/skills/seo-technical/references/audit-template.md
+++ b/dist/pi/.agents/skills/seo-technical/references/audit-template.md
@@ -227,7 +227,7 @@ If the site is multilingual or multi-region:
 - [ ] Both `https://www` and `https://` (and `http://` versions) verified as separate properties
 - [ ] Domain property verified (the recommended approach)
 - [ ] Sitemap submitted and showing "Success"
-- [ ] No critical issues in Coverage report
+- [ ] No critical issues in the Page indexing report
 - [ ] No manual actions or security issues
 - [ ] Crawl stats reviewed (sudden drops or spikes investigated)
 
@@ -288,7 +288,7 @@ For larger sites, server logs reveal what crawlers actually do, vs what the site
 
 ## Monitoring after fixes ship
 
-- [ ] GSC Coverage report rechecked weekly until stable
+- [ ] GSC Page indexing report rechecked weekly until stable
 - [ ] Position tracking for top queries to confirm no regression
 - [ ] Log analysis re-run 2-4 weeks after fixes ship
 - [ ] CWV field data tracked for affected page templates

--- a/skills/analytics-strategy/references/event-taxonomy-template.md
+++ b/skills/analytics-strategy/references/event-taxonomy-template.md
@@ -378,7 +378,7 @@ Common reserved names:
 Common compliance patterns:
 
 - **Consent before tracking.** Cookie banner, opt-in flow.
-- **Honor Do Not Track.** Browsers signal preferences.
+- **Honor Global Privacy Control (GPC).** Browsers signal the preference, and it is enforceable under CCPA and CPRA.
 - **Right to deletion.** User can request all their data deleted (GDPR, CCPA).
 - **Right to export.** User can request their data in machine-readable format.
 - **No cross-site tracking without consent.** Some jurisdictions require explicit opt-in.

--- a/skills/code-review-web/references/wordpress-headless-patterns.md
+++ b/skills/code-review-web/references/wordpress-headless-patterns.md
@@ -192,7 +192,7 @@ JWT plugins offer a more standard auth flow but add a plugin dependency.
 
 ### "API returns 403 from server-side fetch"
 
-**Cause 1:** A bot mitigation service (Cloudflare's "Attack Challenge Mode" or similar) is challenging the server-to-server request.
+**Cause 1:** A bot mitigation service (Cloudflare's "Under Attack mode" or similar) is challenging the server-to-server request.
 
 **Fix:** Disable bot mitigation challenges for the CMS API path, or whitelist the frontend's server IPs.
 

--- a/skills/security-baseline/SKILL.md
+++ b/skills/security-baseline/SKILL.md
@@ -252,7 +252,7 @@ When compliance applies, the baseline is necessary but not the full answer.
 
 **HSTS without `includeSubDomains`.** Attacker tricks browser into HTTP on a subdomain you haven't HTTPS'd yet.
 
-**HSTS preload without commitment.** Once preloaded, removing it takes weeks. Don't preload until HTTPS is solid across all subdomains forever.
+**HSTS preload without commitment.** Once preloaded, removing it takes months to reach users through a Chrome update, with no guarantee for other browsers. Don't preload until HTTPS is solid across all subdomains forever.
 
 **CSP with `unsafe-inline`.** Defeats most of CSP. Either go strict (nonce-based) or accept that CSP is providing limited protection.
 

--- a/skills/security-baseline/SKILL.md
+++ b/skills/security-baseline/SKILL.md
@@ -169,7 +169,7 @@ Strict CSP requires application changes (every inline script needs a nonce). The
 
 ### Step 1: Run a baseline scan
 
-Use a free scanner: securityheaders.com, observatory.mozilla.org. Get a current grade. This is the floor.
+Use a free scanner: securityheaders.com, or the MDN HTTP Observatory at developer.mozilla.org/en-US/observatory. Get a current grade. This is the floor.
 
 ### Step 2: Inventory the surface
 

--- a/skills/security-baseline/references/headers-checklist.md
+++ b/skills/security-baseline/references/headers-checklist.md
@@ -2,7 +2,7 @@
 
 Copy-paste reference for HTTP response headers that improve security. Organized by tier of importance.
 
-Test current headers with: securityheaders.com or observatory.mozilla.org.
+Test current headers with: securityheaders.com or the MDN HTTP Observatory at developer.mozilla.org/en-US/observatory.
 
 ---
 
@@ -140,8 +140,7 @@ Permissions-Policy:
   magnetometer=(),
   microphone=(),
   payment=(),
-  usb=(),
-  interest-cohort=()
+  usb=()
 ```
 
 This denies all listed features by default. Allow specific ones if needed:
@@ -149,8 +148,6 @@ This denies all listed features by default. Allow specific ones if needed:
 ```
 Permissions-Policy: camera=(self), geolocation=(self "https://maps.example.com")
 ```
-
-`interest-cohort=()` opts the site out of FLoC and similar third-party tracking.
 
 ---
 

--- a/skills/security-baseline/references/headers-checklist.md
+++ b/skills/security-baseline/references/headers-checklist.md
@@ -20,7 +20,7 @@ Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 - `max-age`: lifetime in seconds (31536000 = 1 year, recommended for stable HTTPS deployments)
 - `includeSubDomains`: applies to all subdomains. Only enable when every subdomain serves HTTPS reliably.
-- `preload`: optional. Enables inclusion in browser preload lists. Once enabled, removal takes weeks. Only add when committed.
+- `preload`: optional. Enables inclusion in browser preload lists. Once enabled, removal takes months to reach users through a Chrome update, with no guarantee for other browsers. Only add when committed.
 
 **Common mistake:** Setting `includeSubDomains` before all subdomains are HTTPS-ready. Internal staging or admin subdomains break.
 

--- a/skills/seo-technical/references/audit-template.md
+++ b/skills/seo-technical/references/audit-template.md
@@ -227,7 +227,7 @@ If the site is multilingual or multi-region:
 - [ ] Both `https://www` and `https://` (and `http://` versions) verified as separate properties
 - [ ] Domain property verified (the recommended approach)
 - [ ] Sitemap submitted and showing "Success"
-- [ ] No critical issues in Coverage report
+- [ ] No critical issues in the Page indexing report
 - [ ] No manual actions or security issues
 - [ ] Crawl stats reviewed (sudden drops or spikes investigated)
 
@@ -288,7 +288,7 @@ For larger sites, server logs reveal what crawlers actually do, vs what the site
 
 ## Monitoring after fixes ship
 
-- [ ] GSC Coverage report rechecked weekly until stable
+- [ ] GSC Page indexing report rechecked weekly until stable
 - [ ] Position tracking for top queries to confirm no regression
 - [ ] Log analysis re-run 2-4 weeks after fixes ship
 - [ ] CWV field data tracked for affected page templates


### PR DESCRIPTION
**Wave 1, PR c** of the currency-fix plan in `third-party-currency-inventory-2026-08.md` §6. Mechanical corrections only, no authorial rulings. Held as a draft: Andy merges W1-a through W1-e in order.

Scope is the privacy and security-header guidance: `security-baseline`, `analytics-strategy`, `code-review-web`, plus two approved orphan corrections (see below). 6 files, 10 line-level edits. Every verdict comes from Appendix C2 (verifier V2), **check date 2026-08-09**.

Note on file count: §6 estimates "3 (security-baseline, analytics-strategy)", but the Cloudflare item it assigns to this PR lives in `code-review-web/references/wordpress-headless-patterns.md`. Four files, same four items.

---

### 1. FLoC opt-out directive (R9)

**Before** (`security-baseline/references/headers-checklist.md:134-144`)
```
Permissions-Policy:
  accelerometer=(),
  ...
  payment=(),
  usb=(),
  interest-cohort=()
```
**After**
```
Permissions-Policy:
  accelerometer=(),
  ...
  payment=(),
  usb=()
```

**Before** (`:153`)
```
`interest-cohort=()` opts the site out of FLoC and similar third-party tracking.
```
**After** — line deleted.

**Verdict row** (§2.1 R9, RETIRED)
> FLoC was abandoned by Google in Jan 2022; Chrome dropped recognition of the `interest-cohort` directive (modern Chrome logs "Unrecognized feature: 'interest-cohort'"). Successor Topics API opt-out was `browsing-topics=()`, but on 2025-10-17 Google announced retirement of Topics, Protected Audience, Attribution Reporting and 7 other Privacy Sandbox APIs (removal Chrome 144 Jan 2026 to Chrome 150 Jul 2026), and confirmed third-party cookies remain in Chrome with no new prompt. **Correction: delete the directive from the template; it does nothing in any current browser and there is no successor directive worth adding.** Sources: github.com/orgs/community/discussions/160040 ; adexchanger.com/privacy/google-pulls-the-plug-on-topics-paapi-and-other-major-privacy-sandbox-apis-as-the-cma-says-cheerio/ ; usercentrics.com/knowledge-hub/what-is-google-privacy-sandbox/

The verdict is explicit that nothing replaces it, so no successor directive was substituted. The trailing comma on `usb=()` was dropped with it to keep the header syntactically valid.

---

### 2. Do Not Track (R10)

**Before** (`analytics-strategy/references/event-taxonomy-template.md:381`)
```
- **Honor Do Not Track.** Browsers signal preferences.
```
**After**
```
- **Honor Global Privacy Control (GPC).** Browsers signal the preference, and it is enforceable under CCPA and CPRA.
```
**Verdict row** (§2.1 R10, RETIRED)
> DNT is dead as a standard and as a browser feature: W3C work discontinued 2019, Safari removed it in 2019, and Firefox removed the DNT setting in Firefox 135 (Feb 2025) because sites ignore it and it added fingerprinting surface. Replacement: **Global Privacy Control (GPC)**, legally enforceable under CCPA/CPRA and honored by Firefox ("Tell websites not to sell or share my data"). **Correction: "Honor Global Privacy Control (GPC)".** Sources: windowsreport.com/mozilla-firefox-removes-do-not-track-feature-support-heres-what-it-means-for-your-privacy/ ; en.wikipedia.org/wiki/Do_Not_Track

This sits in a compliance checklist, so the old line told teams to honor a signal browsers no longer send while omitting the one that carries legal force.

---

### 3. Mozilla Observatory URL (R23)

**Before** (`security-baseline/SKILL.md:172`)
```
Use a free scanner: securityheaders.com, observatory.mozilla.org. Get a current grade. This is the floor.
```
**After**
```
Use a free scanner: securityheaders.com, or the MDN HTTP Observatory at developer.mozilla.org/en-US/observatory. Get a current grade. This is the floor.
```
**Before** (`security-baseline/references/headers-checklist.md:5`)
```
Test current headers with: securityheaders.com or observatory.mozilla.org.
```
**After**
```
Test current headers with: securityheaders.com or the MDN HTTP Observatory at developer.mozilla.org/en-US/observatory.
```
**Verdict row** (§2.1 R23, STALE)
> The Mozilla Observatory was deprecated and relaunched in 2024 as the **MDN HTTP Observatory** at https://developer.mozilla.org/en-US/observatory; the old JSON API shut down 2024-10-31. **Correction: update URL to developer.mozilla.org/en-US/observatory.** Sources: developer.mozilla.org/en-US/blog/mdn-http-observatory-launch ; github.com/mdn/mdn-http-observatory

`securityheaders.com` is left as-is: the same appendix classes it CURRENT, noting only that its **API** shut down in April 2026 while the manual scans the skill actually instructs still work.

---

### 4. Cloudflare "Attack Challenge Mode" (product name)

**Before** (`code-review-web/references/wordpress-headless-patterns.md:195`)
```
**Cause 1:** A bot mitigation service (Cloudflare's "Attack Challenge Mode" or similar) is challenging the server-to-server request.
```
**After**
```
**Cause 1:** A bot mitigation service (Cloudflare's "Under Attack mode" or similar) is challenging the server-to-server request.
```
**Verdict row** (Appendix C2, STALE)
> No Cloudflare feature by that name. The feature is **"Under Attack mode"** (security level "I'm Under Attack"), which serves a JS interstitial challenge against L7 DDoS. The described behavior (challenging server-to-server requests) is accurate for it. **Correction: rename to "Under Attack mode".** Source: developers.cloudflare.com/fundamentals/reference/under-attack-mode/

Name only. The verdict confirms the surrounding diagnosis was already right.

---

## Verified absent

A catalog-wide grep for `interest-cohort`, `FLoC`, `Do Not Track`, `observatory.mozilla`, and `Attack Challenge` now returns nothing across `skills/`. These four items had no other instances.

---

## Orphan corrections folded in on approval (second commit)

Two items the inventory verified but §6 assigned to no wave. Both approved to ride here, added in a second commit after the rebase onto `main` at `63d8377`.

**5. HSTS preload removal takes months, not weeks**

**Before** (`security-baseline/SKILL.md:255`)
```
**HSTS preload without commitment.** Once preloaded, removing it takes weeks. Don't preload until HTTPS is solid across all subdomains forever.
```
**After**
```
**HSTS preload without commitment.** Once preloaded, removing it takes months to reach users through a Chrome update, with no guarantee for other browsers. Don't preload until HTTPS is solid across all subdomains forever.
```
Same correction at `references/headers-checklist.md:23`.

**Verdict row** (Appendix C2, STALE, checked 2026-08-09)
> hstspreload.org: "Domains can be removed, but it takes **months** for a change to reach users with a Chrome update and we cannot make guarantees about other browsers". Correction: "months, with no guarantee for non-Chrome browsers". **The skill *understates* the commitment.**

**6. GSC "Coverage report" is now the "Page indexing" report**

**Before** (`seo-technical/references/audit-template.md:230, :291`)
```
- [ ] No critical issues in Coverage report
- [ ] GSC Coverage report rechecked weekly until stable
```
**After**
```
- [ ] No critical issues in the Page indexing report
- [ ] GSC Page indexing report rechecked weekly until stable
```
**Verdict row** (Appendix C1 S3, STALE (naming), checked 2026-08-09)
> Renamed: it is the **Page indexing** report (the "Coverage" name is gone from GSC). The underlying function and the "Discovered/Crawled - currently not indexed" reasons survive. Correction: rename references.

This one lands outside `security-baseline` because its owning PR (**W1-a, #113**) is already merged, and two lines did not justify their own PR.

---

## Checks

Run locally against this branch, all green:

| Check | Command | Result |
|---|---|---|
| Skills manifest | `tools/gen_skills_lock.py --check` | `SKILLS.lock is current.` |
| Distribution drift | `node scripts/build-pi.mjs --check` | `PASS: committed dist/pi/.agents/skills matches a fresh build (byte-identical).` |
| Distribution validate | `node scripts/build-pi.mjs --validate` | `VALIDATION PASS` (490 reference files) |
| Skill linter | `.github/scripts/lint_skills.py` | `PASSED: 103 skills validated, 1 warnings.` |

The single linter warning is pre-existing and unrelated (`documentation-strategy/SKILL.md` is 428 lines against a 400-line target). It is present on `main` and untouched here.

`SKILLS.lock` moves for exactly the 4 edited files. `dist/pi` is rebuilt in the same commit, as `dist-drift.yml` requires.

**Merge-order note.** This PR overlaps the other Wave 1 PRs and the Wave 3 anti-fabrication PR only in `SKILLS.lock` and `dist/pi`. Whichever merges second rebases and **regenerates both** (`py tools/gen_skills_lock.py` then `node scripts/build-pi.mjs`) rather than hand-merging either file.

**Writing law:** no em dashes introduced; replacements are declarative and name the current surface.

**Negative-claim audit:** every factual assertion added here (GPC's CCPA and CPRA enforceability, the MDN HTTP Observatory URL, the "Under Attack mode" name) is quoted from a verdict row above. Nothing asserts a fact the inventory did not verify on 2026-08-09.
